### PR TITLE
benchmark: specify type to avoid TSError

### DIFF
--- a/benchmark/internal/AssertBenchmarker.ts
+++ b/benchmark/internal/AssertBenchmarker.ts
@@ -33,7 +33,7 @@ export namespace AssertBenchmarker {
             };
             suite.run();
             suite.map((elem: benchmark) => {
-                (output as any)[elem.name] = elem.count / elem.times.elapsed;
+                (output as any)[elem.name as string] = elem.count / elem.times.elapsed;
             });
             return output;
         };

--- a/benchmark/internal/IsBenchmarker.ts
+++ b/benchmark/internal/IsBenchmarker.ts
@@ -38,7 +38,7 @@ export namespace IsBenchmarker {
             };
             suite.run();
             suite.map((elem: benchmark) => {
-                (output as any)[elem.name] = elem.count / elem.times.elapsed;
+                (output as any)[elem.name as string] = elem.count / elem.times.elapsed;
             });
             return output;
         };

--- a/benchmark/internal/OptimizerBenchmarker.ts
+++ b/benchmark/internal/OptimizerBenchmarker.ts
@@ -37,7 +37,7 @@ export namespace OptimizerBenchmarker {
             };
             suite.run();
             suite.map((elem: benchmark) => {
-                (output as any)[elem.name] = elem.count / elem.times.elapsed;
+                (output as any)[elem.name as string] = elem.count / elem.times.elapsed;
             });
             return output;
         };

--- a/benchmark/internal/StringifyBenchmarker.ts
+++ b/benchmark/internal/StringifyBenchmarker.ts
@@ -36,7 +36,7 @@ export namespace StringifyBenchmarker {
             };
             suite.run();
             suite.map((elem: benchmark) => {
-                (output as any)[elem.name] = elem.count / elem.times.elapsed;
+                (output as any)[elem.name as string] = elem.count / elem.times.elapsed;
             });
             return output;
         };


### PR DESCRIPTION
When I run benchmark, I faced TSError below:

```sh
$ npm run benchmark

> typescript-json@3.1.1 benchmark
> node benchmark/index.js

/home/ubuntu/typescript-json/node_modules/ts-node/src/index.ts:859
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: ⨯ Unable to compile TypeScript:
benchmark/internal/AssertBenchmarker.ts:36:33 - error TS2538: Type 'undefined' cannot be used as an index type.

36                 (output as any)[elem.name] = elem.count / elem.times.elapsed;
                                   ~~~~~~~~~

    at createTSError (/home/ubuntu/typescript-json/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/home/ubuntu/typescript-json/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/home/ubuntu/typescript-json/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/home/ubuntu/typescript-json/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/home/ubuntu/typescript-json/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1180:10)
    at require.extensions.<computed> (/home/ubuntu/typescript-json/node_modules/ts-node/src/index.ts:1621:12)
    at Object.require.extensions.<computed> [as .ts] (/home/ubuntu/typescript-json/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1004:32)
    at Function.Module._load (node:internal/modules/cjs/loader:839:12) {
  diagnosticCodes: [ 2538 ]
}
```

I can run benchmark after specifying type 'string'.