### PR TITLE
Fix #197 - no superfluous property inspection when `undefined` value comes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Runtime type checkers and 5x faster JSON.stringify() function",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/programmers/internal/check_object.ts
+++ b/src/programmers/internal/check_object.ts
@@ -15,7 +15,7 @@ export function check_object(
 ) => (
     halter: (expr: ts.CallExpression) => ts.Expression,
 ) => (
-    wrapper?: (expr: ts.CallExpression) => ts.Expression,
+    wrapper?: (expr: ts.Expression) => ts.Expression,
 ) => (entries: IExpressionEntry[]) => ts.Expression;
 
 export function check_object(equals: true | false) {
@@ -37,7 +37,7 @@ export function check_object(equals: true | false) {
         };
 }
 
-type Wrapper = (expr: ts.CallExpression) => ts.Expression;
+type Wrapper = (expr: ts.Expression) => ts.Expression;
 const reduce = (assert: boolean) => (expressions: ts.Expression[]) =>
     assert
         ? expressions.reduce((x, y) => ts.factory.createLogicalAnd(x, y))


### PR DESCRIPTION
From no on, superfluous property inspection would not check the `undefined` value.