### PR TITLE
Close #218 - support `IJsonComponents.IObject.patternProperties`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.3.2",
+  "version": "3.4.0-dev.20221002",
   "description": "Runtime type checkers and 5x faster JSON.stringify() function",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/metadata/MetadataProperty.ts
+++ b/src/metadata/MetadataProperty.ts
@@ -19,21 +19,19 @@ export class MetadataProperty {
     /**
      * @hidden
      */
-    private constructor(
-        props: Omit<ClassProperties<MetadataProperty>, "tags" | "jsDocTags">,
-    ) {
+    private constructor(props: ClassProperties<MetadataProperty>) {
         this.key = props.key;
         this.value = props.value;
         this.description = props.description;
-        this.tags = [];
-        this.jsDocTags = [];
+        this.tags = props.tags;
+        this.jsDocTags = props.jsDocTags;
     }
 
     /**
      * @internal
      */
     public static create(
-        props: Omit<ClassProperties<MetadataProperty>, "tags" | "jsDocTags">,
+        props: ClassProperties<MetadataProperty>,
     ): MetadataProperty {
         return new MetadataProperty(props);
     }
@@ -45,14 +43,13 @@ export class MetadataProperty {
         property: IMetadataProperty,
         objects: Map<string, MetadataObject>,
     ) {
-        const obj = this.create({
+        return this.create({
             key: Metadata._From(property.key, objects),
             value: Metadata._From(property.value, objects),
             description: property.description,
+            tags: property.tags.slice(),
+            jsDocTags: property.jsDocTags.slice(),
         });
-        obj.tags.push(...property.tags.slice());
-        obj.jsDocTags.push(...property.jsDocTags.slice());
-        return obj;
     }
 
     public toJSON(): IMetadataProperty {

--- a/src/schemas/IJsonComponents.ts
+++ b/src/schemas/IJsonComponents.ts
@@ -3,17 +3,17 @@ import { IJsDocTagInfo } from "../metadata/IJsDocTagInfo";
 import { IJsonSchema } from "./IJsonSchema";
 
 export interface IJsonComponents {
-    schemas: IJsonComponents.ISchemas;
+    schemas: Record<string, IJsonComponents.IObject>;
 }
 export namespace IJsonComponents {
-    export type ISchemas = Record<string, IJsonComponents.IObject>;
-
     export interface IObject {
         $id?: string;
         type: "object";
         nullable: boolean;
 
         properties: Record<string, IJsonSchema>;
+        patternProperties?: Record<string, IJsonSchema>;
+
         required?: string[];
         description?: string;
         jsDocTags?: IJsDocTagInfo[];

--- a/test/features/application/test_application_dynamic_composite.ts
+++ b/test/features/application/test_application_dynamic_composite.ts
@@ -1,0 +1,71 @@
+import TSON from "../../../src";
+import { DynamicComposite } from "../../structures/DynamicComposite";
+import { _test_application } from "./_test_application";
+
+export const test_application_dynamic_composite = _test_application(
+    "dynamic composite",
+    TSON.application<[DynamicComposite]>(),
+    {
+        schemas: [
+            {
+                $ref: "#/components/schemas/DynamicComposite",
+            },
+        ],
+        components: {
+            schemas: {
+                DynamicComposite: {
+                    type: "object",
+                    properties: {
+                        id: {
+                            type: "string",
+                            nullable: false,
+                        },
+                        name: {
+                            type: "string",
+                            nullable: false,
+                        },
+                    },
+                    patternProperties: {
+                        "\\d+(\\.\\d+)?": {
+                            type: "number",
+                            nullable: false,
+                        },
+                        "(prefix_(.*))": {
+                            type: "string",
+                            nullable: false,
+                        },
+                        "((.*)_postfix)": {
+                            type: "string",
+                            nullable: false,
+                        },
+                        "(value_\\d+(\\.\\d+)?)": {
+                            oneOf: [
+                                {
+                                    type: "string",
+                                    nullable: false,
+                                },
+                                {
+                                    type: "number",
+                                    nullable: false,
+                                },
+                                {
+                                    type: "boolean",
+                                    nullable: false,
+                                },
+                            ],
+                        },
+                        "(between_(.*)_and_\\d+(\\.\\d+)?)": {
+                            type: "boolean",
+                            nullable: false,
+                        },
+                    },
+                    nullable: false,
+                    required: ["id", "name"],
+                    jsDocTags: [],
+                },
+            },
+        },
+        purpose: "swagger",
+        prefix: "#/components/schemas",
+    },
+);

--- a/test/features/application/test_application_dynamic_simple.ts
+++ b/test/features/application/test_application_dynamic_simple.ts
@@ -1,0 +1,33 @@
+import TSON from "../../../src";
+import { DynamicSimple } from "../../structures/DynamicSimple";
+import { _test_application } from "./_test_application";
+
+export const test_application_dynamic_simple = _test_application(
+    "dynamic simple",
+    TSON.application<[DynamicSimple]>(),
+    {
+        schemas: [
+            {
+                $ref: "#/components/schemas/DynamicSimple",
+            },
+        ],
+        components: {
+            schemas: {
+                DynamicSimple: {
+                    type: "object",
+                    properties: {},
+                    patternProperties: {
+                        "(.*)": {
+                            type: "number",
+                            nullable: false,
+                        },
+                    },
+                    nullable: false,
+                    jsDocTags: [],
+                },
+            },
+        },
+        purpose: "swagger",
+        prefix: "#/components/schemas",
+    },
+);

--- a/test/features/application/test_application_dynamic_template.ts
+++ b/test/features/application/test_application_dynamic_template.ts
@@ -1,0 +1,45 @@
+import TSON from "../../../src";
+import { DynamicTemplate } from "../../structures/DynamicTemplate";
+import { _test_application } from "./_test_application";
+
+export const test_application_dynamic_template = _test_application(
+    "dynamic template",
+    TSON.application<[DynamicTemplate]>(),
+    {
+        schemas: [
+            {
+                $ref: "#/components/schemas/DynamicTemplate",
+            },
+        ],
+        components: {
+            schemas: {
+                DynamicTemplate: {
+                    type: "object",
+                    properties: {},
+                    patternProperties: {
+                        "(prefix_(.*))": {
+                            type: "string",
+                            nullable: false,
+                        },
+                        "((.*)_postfix)": {
+                            type: "string",
+                            nullable: false,
+                        },
+                        "(value_\\d+(\\.\\d+)?)": {
+                            type: "number",
+                            nullable: false,
+                        },
+                        "(between_(.*)_and_\\d+(\\.\\d+)?)": {
+                            type: "boolean",
+                            nullable: false,
+                        },
+                    },
+                    nullable: false,
+                    jsDocTags: [],
+                },
+            },
+        },
+        purpose: "swagger",
+        prefix: "#/components/schemas",
+    },
+);

--- a/test/features/application/test_application_dynamic_union.ts
+++ b/test/features/application/test_application_dynamic_union.ts
@@ -1,0 +1,45 @@
+import TSON from "../../../src";
+import { DynamicUnion } from "../../structures/DynamicUnion";
+import { _test_application } from "./_test_application";
+
+export const test_application_dynamic_union = _test_application(
+    "dynamic union",
+    TSON.application<[DynamicUnion]>(),
+    {
+        schemas: [
+            {
+                $ref: "#/components/schemas/DynamicUnion",
+            },
+        ],
+        components: {
+            schemas: {
+                DynamicUnion: {
+                    type: "object",
+                    properties: {},
+                    patternProperties: {
+                        "\\d+(\\.\\d+)?": {
+                            type: "string",
+                            nullable: false,
+                        },
+                        "(prefix_(.*))": {
+                            type: "string",
+                            nullable: false,
+                        },
+                        "((.*)_postfix)": {
+                            type: "string",
+                            nullable: false,
+                        },
+                        "(value_between_\\d+(\\.\\d+)?_and_\\d+(\\.\\d+)?)": {
+                            type: "number",
+                            nullable: false,
+                        },
+                    },
+                    nullable: false,
+                    jsDocTags: [],
+                },
+            },
+        },
+        purpose: "swagger",
+        prefix: "#/components/schemas",
+    },
+);

--- a/test/features/application/test_application_ultimate_union.ts
+++ b/test/features/application/test_application_ultimate_union.ts
@@ -1627,6 +1627,115 @@ export const test_application_ultimate_union = _test_application(
                 __type: {
                     type: "object",
                     properties: {},
+                    patternProperties: {
+                        "(.*)": {
+                            $ref: "#/components/schemas/IJsonComponents.IObject",
+                        },
+                    },
+                    nullable: false,
+                    jsDocTags: [],
+                },
+                "IJsonComponents.IObject": {
+                    type: "object",
+                    properties: {
+                        $id: {
+                            type: "string",
+                            nullable: false,
+                        },
+                        type: {
+                            type: "string",
+                            enum: ["object"],
+                            nullable: false,
+                        },
+                        nullable: {
+                            type: "boolean",
+                            nullable: false,
+                        },
+                        properties: {
+                            $ref: "#/components/schemas/__type.o1",
+                        },
+                        patternProperties: {
+                            $ref: "#/components/schemas/__type.o1",
+                        },
+                        required: {
+                            type: "array",
+                            items: {
+                                type: "string",
+                                nullable: false,
+                            },
+                            nullable: false,
+                        },
+                        description: {
+                            type: "string",
+                            nullable: false,
+                        },
+                        jsDocTags: {
+                            type: "array",
+                            items: {
+                                $ref: "#/components/schemas/IJsDocTagInfo",
+                            },
+                            nullable: false,
+                        },
+                        $recursiveAnchor: {
+                            type: "boolean",
+                            nullable: false,
+                        },
+                    },
+                    nullable: false,
+                    required: ["type", "nullable", "properties"],
+                    jsDocTags: [],
+                },
+                "__type.o1": {
+                    type: "object",
+                    properties: {},
+                    patternProperties: {
+                        "(.*)": {
+                            oneOf: [
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IEnumeration_lt_boolean_gt_",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IEnumeration_lt_number_gt_",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IEnumeration_lt_bigint_gt_",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IEnumeration_lt_string_gt_",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IBoolean",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.INumber",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IBigInt",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IString",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IArray",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.ITuple",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IOneOf",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IReference",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IRecursiveReference",
+                                },
+                                {
+                                    $ref: "#/components/schemas/IJsonSchema.IUnkown",
+                                },
+                            ],
+                        },
+                    },
                     nullable: false,
                     jsDocTags: [],
                 },

--- a/test/manual.js
+++ b/test/manual.js
@@ -7,6 +7,6 @@ runner.register({
     compiler: "ttypescript",
 });
 
-const program = require("./features/application/test_application_tag_format.ts");
+const program = require("./features/application/test_application_dynamic_composite.ts");
 for (const value of Object.values(program))
     if (typeof value === "function") value();

--- a/test/structures/DynamicComposite.ts
+++ b/test/structures/DynamicComposite.ts
@@ -1,0 +1,34 @@
+import { ArrayUtil } from "../../src/utils/ArrayUtil";
+
+import { RandomGenerator } from "../internal/RandomGenerator";
+
+export interface DynamicComposite {
+    id: string;
+    name: string;
+    [index: number]: number;
+    [key: `prefix_${string}`]: string;
+    [key: `${string}_postfix`]: string;
+    [key: `value_${number}`]: boolean | string | number;
+    [key: `between_${string}_and_${number}`]: boolean;
+}
+export namespace DynamicComposite {
+    export function generate(): DynamicComposite {
+        const number = () => Math.random() - 0.5;
+        const string = () => RandomGenerator.string();
+        const output: DynamicComposite = {
+            id: "id",
+            name: "name",
+        };
+
+        ArrayUtil.repeat(RandomGenerator.integer(3, 10), () => {
+            output[number()] = number();
+            output[`prefix_${string()}`] = string();
+            output[`${string()}_postfix`] = string();
+            output[`value_${number()}`] = number() < 0;
+            output[`value_${number()}`] = number();
+            output[`value_${number()}`] = string();
+            output[`between_${string()}_and_${number()}`] = number() > 0;
+        });
+        return output;
+    }
+}

--- a/test/structures/DynamicSimple.ts
+++ b/test/structures/DynamicSimple.ts
@@ -1,0 +1,16 @@
+import { ArrayUtil } from "../../src/utils/ArrayUtil";
+
+import { RandomGenerator } from "../internal/RandomGenerator";
+
+export interface DynamicSimple {
+    [key: string]: number;
+}
+export namespace DynamicSimple {
+    export function generate(): DynamicSimple {
+        const output: DynamicSimple = {};
+        ArrayUtil.repeat(RandomGenerator.integer(3, 10), () => {
+            output[RandomGenerator.string()] = Math.random();
+        });
+        return output;
+    }
+}

--- a/test/structures/DynamicTemplate.ts
+++ b/test/structures/DynamicTemplate.ts
@@ -1,0 +1,25 @@
+import { ArrayUtil } from "../../src/utils/ArrayUtil";
+
+import { RandomGenerator } from "../internal/RandomGenerator";
+
+export interface DynamicTemplate {
+    [key: `prefix_${string}`]: string;
+    [key: `${string}_postfix`]: string;
+    [key: `value_${number}`]: number;
+    [key: `between_${string}_and_${number}`]: boolean;
+}
+export namespace DynamicTemplate {
+    export function generate(): DynamicTemplate {
+        const number = () => Math.random() - 0.5;
+        const string = () => RandomGenerator.string();
+        const output: DynamicTemplate = {};
+
+        ArrayUtil.repeat(RandomGenerator.integer(3, 10), () => {
+            output[`prefix_${string()}`] = string();
+            output[`${string()}_postfix`] = string();
+            output[`value_${number()}`] = number();
+            output[`between_${string()}_and_${number() - 0.5}`] = number() > 0;
+        });
+        return output;
+    }
+}

--- a/test/structures/DynamicUnion.ts
+++ b/test/structures/DynamicUnion.ts
@@ -1,0 +1,23 @@
+import { ArrayUtil } from "../../src/utils/ArrayUtil";
+
+import { RandomGenerator } from "../internal/RandomGenerator";
+
+export interface DynamicUnion {
+    [key: number | `prefix_${string}` | `${string}_postfix`]: string;
+    [key: `value_between_${number}_and_${number}`]: number;
+}
+export namespace DynamicUnion {
+    export function generate(): DynamicUnion {
+        const number = () => Math.random() - 0.5;
+        const string = () => RandomGenerator.string();
+        const output: DynamicUnion = {};
+
+        ArrayUtil.repeat(RandomGenerator.integer(3, 10), () => {
+            output[Math.random()] = string();
+            output[`prefix_${string()}`] = string();
+            output[`${string()}_postfix`] = string();
+            output[`value_between_${number()}_and_${number()}`] = number();
+        });
+        return output;
+    }
+}


### PR DESCRIPTION
Succeded to implement dynamic properties' archiving in the `MetadataObject.key`.

Also, succeeded to support those dynamic properties at JSON schema first.

Therefore, validators and stringifier would support them, soon.