### PR TITLE
Fix #226 - consider meta-programmed class type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "description": "Runtime type checkers and 5x faster JSON.stringify() function",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/factories/internal/emplace_metadata_object.ts
+++ b/src/factories/internal/emplace_metadata_object.ts
@@ -30,6 +30,7 @@ export const emplace_metadata_object =
         const pred: (node: ts.Declaration) => boolean = isClass
             ? (node) => ts.isParameter(node) || ts.isPropertyDeclaration(node)
             : (node) =>
+                  ts.isPropertyDeclaration(node) ||
                   ts.isPropertyAssignment(node) ||
                   ts.isPropertySignature(node) ||
                   ts.isTypeLiteralNode(node);

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -8,6 +8,7 @@ export default function transform(
     program: ts.Program,
     options?: ITransformOptions,
 ): ts.TransformerFactory<ts.SourceFile> {
+    program.getSourceFiles().map(file => file.fileName);
     const project: IProject = {
         program,
         compilerOptions: program.getCompilerOptions(),

--- a/test/issues/226.ts
+++ b/test/issues/226.ts
@@ -1,0 +1,43 @@
+import TSON from "../../src";
+
+type DeepPartial<T> = T extends object
+    ? {
+          [P in keyof T]?: DeepPartial<T[P]>;
+      }
+    : T;
+
+const input = { a: "valid" };
+
+console.log("Works with interface:");
+
+interface TestInterface {
+    a: string;
+}
+
+const res = TSON.validateEquals<TestInterface>(input);
+console.log("valid:", res);
+
+const res2 = TSON.validateEquals<Partial<TestInterface>>(input);
+console.log("valid:", res2);
+
+const res3 = TSON.validateEquals<DeepPartial<TestInterface>>(input);
+console.log("valid:", res3);
+
+console.log("");
+console.log("---------------------------");
+console.log("");
+
+console.log("Does not work with declare class:");
+
+declare class TestClass {
+    a: string;
+}
+
+const res4 = TSON.validateEquals<TestClass>(input);
+console.log("valid:", res4);
+
+const res5 = TSON.validateEquals<Partial<TestClass>>(input);
+console.log("should be valid:", res5);
+
+const res6 = TSON.validateEquals<DeepPartial<TestClass>>(input);
+console.log("should be invalid:", res6);


### PR DESCRIPTION
Thanks @tjhiggins

Now, meta-programmed class type like `Partial<SomeClass>` would not occur any bug.