### PR TITLE
JSON Schema | TypeBox Benchmark

### DIFF
--- a/benchmark/features/benchmark_assert.ts
+++ b/benchmark/features/benchmark_assert.ts
@@ -30,6 +30,15 @@ import { IoTsObjectHierarchical } from "../structures/io-ts/IoTsObjectHierarchic
 import { IoTsObjectRecursive } from "../structures/io-ts/IoTsObjectRecursive";
 import { IoTsObjectUnionExplicit } from "../structures/io-ts/IoTsObjectUnionExplicit";
 import { IoTsObjectUnionImplicit } from "../structures/io-ts/IoTsObjectUnionImplicit";
+// TYPEBOX TYPES
+import { TypeBoxArrayRecursive } from "../structures/typebox/TypeBoxArrayRecursive";
+import { TypeBoxArrayRecursiveUnionExplicit } from "../structures/typebox/TypeBoxArrayRecursiveUnionExplicit";
+import { TypeBoxArrayRecursiveUnionImplicit } from "../structures/typebox/TypeBoxArrayRecursiveUnionImplicit";
+import { TypeBoxObjectHierarchical } from "../structures/typebox/TypeBoxObjectHierarchical";
+import { TypeBoxObjectRecursive } from "../structures/typebox/TypeBoxObjectRecursive";
+import { TypeBoxObjectUnionExplicit } from "../structures/typebox/TypeBoxObjectUnionExplicit";
+import { TypeBoxObjectUnionImplicit } from "../structures/typebox/TypeBoxObjectUnionImplicit";
+import { TypeBoxUltimateUnion } from "../structures/typebox/TypeBoxUltimateUnion";
 // ZOD TYPES
 import { ZodArrayRecursive } from "../structures/zod/ZodArrayRecursive";
 import { ZodArrayRecursiveUnionExplicit } from "../structures/zod/ZodArrayRecursiveUnionExplicit";
@@ -51,6 +60,11 @@ const assert = () => [
                 return cv.validateSync(cla);
             },
             zod: (input) => ZodObjectHierarchical.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxObjectHierarchical.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     AssertBenchmarker.prepare(
@@ -64,6 +78,11 @@ const assert = () => [
                 return cv.validateSync(cla);
             },
             zod: (input) => ZodObjectRecursive.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxObjectRecursive.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     AssertBenchmarker.prepare(
@@ -79,6 +98,11 @@ const assert = () => [
                 return classes.map((clas) => cv.validateSync(clas));
             },
             zod: (input) => ZodObjectUnionExplicit.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxObjectUnionExplicit.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     AssertBenchmarker.prepare(
@@ -94,6 +118,11 @@ const assert = () => [
                 return classes.map((clas) => cv.validateSync(clas));
             },
             zod: (input) => ZodObjectUnionImplicit.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxObjectUnionImplicit.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     AssertBenchmarker.prepare(
@@ -107,6 +136,10 @@ const assert = () => [
                 return cv.validateSync(cla);
             },
             zod: (input) => ZodArrayRecursive.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxArrayRecursive.Check(input)) throw Error("invalid");
+                return input;
+            },
         },
     ),
     AssertBenchmarker.prepare(
@@ -122,6 +155,11 @@ const assert = () => [
                 return classes.map((clas) => cv.validateSync(clas));
             },
             zod: (input) => ZodArrayRecursiveUnionExplicit.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxArrayRecursiveUnionExplicit.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     AssertBenchmarker.prepare(
@@ -137,6 +175,11 @@ const assert = () => [
                 return classes.map((clas) => cv.validateSync(clas));
             },
             zod: (input) => ZodArrayRecursiveUnionImplicit.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxArrayRecursiveUnionImplicit.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     AssertBenchmarker.prepare(
@@ -147,6 +190,10 @@ const assert = () => [
             "io-ts": null,
             "class-validator": null,
             zod: null,
+            typebox: (input) => {
+                if (!TypeBoxUltimateUnion.Check(input)) throw Error("invalid");
+                return input;
+            },
         },
     ),
 ];

--- a/benchmark/features/benchmark_is.ts
+++ b/benchmark/features/benchmark_is.ts
@@ -32,6 +32,15 @@ import { IoTsObjectRecursive } from "../structures/io-ts/IoTsObjectRecursive";
 import { IoTsObjectUnionExplicit } from "../structures/io-ts/IoTsObjectUnionExplicit";
 import { IoTsObjectUnionImplicit } from "../structures/io-ts/IoTsObjectUnionImplicit";
 import { IoTsUltimateUnion } from "../structures/io-ts/IoTsUltimateUnion";
+// TYPEBOX TYPES
+import { TypeBoxArrayRecursive } from "../structures/typebox/TypeBoxArrayRecursive";
+import { TypeBoxArrayRecursiveUnionExplicit } from "../structures/typebox/TypeBoxArrayRecursiveUnionExplicit";
+import { TypeBoxArrayRecursiveUnionImplicit } from "../structures/typebox/TypeBoxArrayRecursiveUnionImplicit";
+import { TypeBoxObjectHierarchical } from "../structures/typebox/TypeBoxObjectHierarchical";
+import { TypeBoxObjectRecursive } from "../structures/typebox/TypeBoxObjectRecursive";
+import { TypeBoxObjectUnionExplicit } from "../structures/typebox/TypeBoxObjectUnionExplicit";
+import { TypeBoxObjectUnionImplicit } from "../structures/typebox/TypeBoxObjectUnionImplicit";
+import { TypeBoxUltimateUnion } from "../structures/typebox/TypeBoxUltimateUnion";
 // ZOD TYPES
 import { ZodArrayRecursive } from "../structures/zod/ZodArrayRecursive";
 import { ZodArrayRecursiveUnionExplicit } from "../structures/zod/ZodArrayRecursiveUnionExplicit";
@@ -96,6 +105,9 @@ const is = () => [
                 ObjectHierarchical.generate(),
                 (input) => ZodObjectHierarchical.safeParse(input).success,
             ),
+            typebox: wrap(ObjectHierarchical.generate(), (input) =>
+                TypeBoxObjectHierarchical.Check(input),
+            ),
             ajv: byAjv(
                 ObjectHierarchical.generate(),
                 TSON.application<[ObjectHierarchical], "ajv">(),
@@ -117,6 +129,9 @@ const is = () => [
             zod: wrap(
                 ObjectRecursive.generate(),
                 (input) => ZodObjectRecursive.safeParse(input).success,
+            ),
+            typebox: wrap(ObjectRecursive.generate(), (input) =>
+                TypeBoxObjectRecursive.Check(input),
             ),
             ajv: byAjv(
                 ObjectRecursive.generate(),
@@ -144,6 +159,9 @@ const is = () => [
                 ObjectUnionExplicit.generate(),
                 (input) => ZodObjectUnionExplicit.safeParse(input).success,
             ),
+            typebox: wrap(ObjectUnionExplicit.generate(), (input) =>
+                TypeBoxObjectUnionExplicit.Check(input),
+            ),
             ajv: byAjv(
                 ObjectUnionExplicit.generate(),
                 TSON.application<[ObjectUnionExplicit], "ajv">(),
@@ -170,6 +188,9 @@ const is = () => [
                 ObjectUnionImplicit.generate(),
                 (input) => ZodObjectUnionImplicit.safeParse(input).success,
             ),
+            typebox: wrap(ObjectUnionImplicit.generate(), (input) =>
+                TypeBoxObjectUnionImplicit.Check(input),
+            ),
             ajv: byAjv(
                 ObjectUnionImplicit.generate(),
                 TSON.application<[ObjectUnionImplicit], "ajv">(),
@@ -191,6 +212,9 @@ const is = () => [
             zod: wrap(
                 ArrayRecursive.generate(),
                 (input) => ZodArrayRecursive.safeParse(input).success,
+            ),
+            typebox: wrap(ArrayRecursive.generate(), (input) =>
+                TypeBoxArrayRecursive.Check(input),
             ),
             ajv: byAjv(
                 ArrayRecursive.generate(),
@@ -219,6 +243,9 @@ const is = () => [
                 (input) =>
                     ZodArrayRecursiveUnionExplicit.safeParse(input).success,
             ),
+            typebox: wrap(ArrayRecursiveUnionExplicit.generate(), (input) =>
+                TypeBoxArrayRecursiveUnionExplicit.Check(input),
+            ),
             ajv: byAjv(
                 ArrayRecursiveUnionExplicit.generate(),
                 TSON.application<[ArrayRecursiveUnionExplicit], "ajv">(),
@@ -246,6 +273,9 @@ const is = () => [
                 (input) =>
                     ZodArrayRecursiveUnionImplicit.safeParse(input).success,
             ),
+            typebox: wrap(ArrayRecursiveUnionImplicit.generate(), (input) =>
+                TypeBoxArrayRecursiveUnionImplicit.Check(input),
+            ),
             ajv: byAjv(
                 ArrayRecursiveUnionImplicit.generate(),
                 TSON.application<[ArrayRecursiveUnionImplicit], "ajv">(),
@@ -261,6 +291,9 @@ const is = () => [
         zod: wrap(
             UltimateUnion.generate(),
             (input) => ZodUltimateUnion.safeParse(input).success,
+        ),
+        typebox: wrap(UltimateUnion.generate(), (input) =>
+            TypeBoxUltimateUnion.Check(input),
         ),
         ajv: byAjv(
             UltimateUnion.generate(),

--- a/benchmark/features/benchmark_validate.ts
+++ b/benchmark/features/benchmark_validate.ts
@@ -30,6 +30,15 @@ import { IoTsObjectHierarchical } from "../structures/io-ts/IoTsObjectHierarchic
 import { IoTsObjectRecursive } from "../structures/io-ts/IoTsObjectRecursive";
 import { IoTsObjectUnionExplicit } from "../structures/io-ts/IoTsObjectUnionExplicit";
 import { IoTsObjectUnionImplicit } from "../structures/io-ts/IoTsObjectUnionImplicit";
+// TYPEBOX TYPES
+import { TypeBoxArrayRecursive } from "../structures/typebox/TypeBoxArrayRecursive";
+import { TypeBoxArrayRecursiveUnionExplicit } from "../structures/typebox/TypeBoxArrayRecursiveUnionExplicit";
+import { TypeBoxArrayRecursiveUnionImplicit } from "../structures/typebox/TypeBoxArrayRecursiveUnionImplicit";
+import { TypeBoxObjectHierarchical } from "../structures/typebox/TypeBoxObjectHierarchical";
+import { TypeBoxObjectRecursive } from "../structures/typebox/TypeBoxObjectRecursive";
+import { TypeBoxObjectUnionExplicit } from "../structures/typebox/TypeBoxObjectUnionExplicit";
+import { TypeBoxObjectUnionImplicit } from "../structures/typebox/TypeBoxObjectUnionImplicit";
+import { TypeBoxUltimateUnion } from "../structures/typebox/TypeBoxUltimateUnion";
 // ZOD TYPES
 import { ZodArrayRecursive } from "../structures/zod/ZodArrayRecursive";
 import { ZodArrayRecursiveUnionExplicit } from "../structures/zod/ZodArrayRecursiveUnionExplicit";
@@ -51,6 +60,11 @@ const valiadate = () => [
                 return cv.validateSync(cla);
             },
             zod: (input) => ZodObjectHierarchical.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxObjectHierarchical.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     ValidateBenchmarker.prepare(
@@ -64,6 +78,11 @@ const valiadate = () => [
                 return cv.validateSync(cla);
             },
             zod: (input) => ZodObjectRecursive.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxObjectRecursive.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     ValidateBenchmarker.prepare(
@@ -79,6 +98,11 @@ const valiadate = () => [
                 return classes.map((clas) => cv.validateSync(clas));
             },
             zod: (input) => ZodObjectUnionExplicit.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxObjectUnionExplicit.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     ValidateBenchmarker.prepare(
@@ -94,6 +118,11 @@ const valiadate = () => [
                 return classes.map((clas) => cv.validateSync(clas));
             },
             zod: (input) => ZodObjectUnionImplicit.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxObjectUnionImplicit.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     ValidateBenchmarker.prepare(
@@ -107,6 +136,10 @@ const valiadate = () => [
                 return cv.validateSync(cla);
             },
             zod: (input) => ZodArrayRecursive.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxArrayRecursive.Check(input)) throw Error("invalid");
+                return input;
+            },
         },
     ),
     ValidateBenchmarker.prepare(
@@ -122,6 +155,11 @@ const valiadate = () => [
                 return classes.map((clas) => cv.validateSync(clas));
             },
             zod: (input) => ZodArrayRecursiveUnionExplicit.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxArrayRecursiveUnionExplicit.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     ValidateBenchmarker.prepare(
@@ -137,6 +175,11 @@ const valiadate = () => [
                 return classes.map((clas) => cv.validateSync(clas));
             },
             zod: (input) => ZodArrayRecursiveUnionImplicit.safeParse(input),
+            typebox: (input) => {
+                if (!TypeBoxArrayRecursiveUnionImplicit.Check(input))
+                    throw Error("invalid");
+                return input;
+            },
         },
     ),
     ValidateBenchmarker.prepare(
@@ -147,6 +190,10 @@ const valiadate = () => [
             "io-ts": null,
             "class-validator": null,
             zod: null,
+            typebox: (input) => {
+                if (!TypeBoxUltimateUnion.Check(input)) throw Error("invalid");
+                return input;
+            },
         },
     ),
 ];

--- a/benchmark/internal/AssertBenchmarker.ts
+++ b/benchmark/internal/AssertBenchmarker.ts
@@ -7,12 +7,14 @@ export namespace AssertBenchmarker {
         "io-ts": number | null;
         "class-validator": number | null;
         zod: number | null;
+        typebox: number | null;
     }
     export interface IParameters<T> {
         "typescript-json": (input: T) => any;
         "io-ts": null | ((input: T) => any);
         "class-validator": null | ((input: T) => any);
         zod: null | ((input: T) => any);
+        typebox: null | ((input: T) => any);
     }
 
     export function prepare<T>(
@@ -27,6 +29,8 @@ export namespace AssertBenchmarker {
             suite.add("io-ts", () => parameters["io-ts"]!(data));
         if (parameters["zod"] !== null)
             suite.add("zod", () => parameters["zod"]!(data));
+        if (parameters["typebox"] !== null)
+            suite.add("typebox", () => parameters["typebox"]!(data));
         if (parameters["class-validator"] !== null)
             suite.add("class-validator", () =>
                 parameters["class-validator"]!(data),
@@ -40,6 +44,7 @@ export namespace AssertBenchmarker {
                 "class-validator": null,
                 "io-ts": null,
                 zod: null,
+                typebox: null,
             };
             suite.run();
             suite.map((elem: benchmark) => {

--- a/benchmark/internal/IsBenchmarker.ts
+++ b/benchmark/internal/IsBenchmarker.ts
@@ -6,6 +6,7 @@ export namespace IsBenchmarker {
         "typescript-json": number;
         "io-ts": number | null;
         zod: number | null;
+        typebox: number | null;
         "class-validator": number | null;
         ajv: number | null;
     }
@@ -14,6 +15,7 @@ export namespace IsBenchmarker {
         "io-ts": null | ((input: T) => any);
         "class-validator": null | ((input: T) => any);
         zod: null | ((input: T) => any);
+        typebox: null | ((input: T) => any);
         ajv: null | ((input: T) => any);
     }
 
@@ -31,6 +33,8 @@ export namespace IsBenchmarker {
             suite.add("io-ts", () => parameters["io-ts"]!(data));
         if (parameters.zod !== null)
             suite.add("zod", () => parameters.zod!(data));
+        if (parameters.typebox !== null)
+            suite.add("typebox", () => parameters.typebox!(data));
         if (parameters["class-validator"] !== null)
             suite.add("class-validator", () =>
                 parameters["class-validator"]!(data),
@@ -44,6 +48,7 @@ export namespace IsBenchmarker {
                 "io-ts": null,
                 "class-validator": null,
                 zod: null,
+                typebox: null,
                 ajv: null,
             };
             suite.run();

--- a/benchmark/internal/ValidateBenchmarker.ts
+++ b/benchmark/internal/ValidateBenchmarker.ts
@@ -7,12 +7,14 @@ export namespace ValidateBenchmarker {
         "io-ts": number | null;
         "class-validator": number | null;
         zod: number | null;
+        typebox: number | null;
     }
     export interface IParameters<T> {
         "typescript-json": (input: T) => any;
         "io-ts": null | ((input: T) => any);
         "class-validator": null | ((input: T) => any);
         zod: null | ((input: T) => any);
+        typebox: null | ((input: T) => any);
     }
 
     export function prepare<T>(
@@ -27,6 +29,8 @@ export namespace ValidateBenchmarker {
             suite.add("io-ts", () => parameters["io-ts"]!(data));
         if (parameters["zod"] !== null)
             suite.add("zod", () => parameters["zod"]!(data));
+        if (parameters["typebox"] !== null)
+            suite.add("typebox", () => parameters["typebox"]!(data));
         if (parameters["class-validator"] !== null)
             suite.add("class-validator", () =>
                 parameters["class-validator"]!(data),
@@ -40,6 +44,7 @@ export namespace ValidateBenchmarker {
                 "class-validator": null,
                 "io-ts": null,
                 zod: null,
+                typebox: null,
             };
             suite.run();
             suite.map((elem: benchmark) => {

--- a/benchmark/results/AMD Ryzen 7 3700X 8-Core Processor.md
+++ b/benchmark/results/AMD Ryzen 7 3700X 8-Core Processor.md
@@ -1,0 +1,468 @@
+# Benchmark of `typescript-json`
+> CPU: AMD Ryzen 7 3700X 8-Core Processor
+> Memory: 16,333 MB
+> NodeJS version: v16.17.1
+> TypeScript-JSON version: 3.3.12
+
+
+## is
+ Components | typescript-json | io-ts | class-validator | zod | typebox | ajv 
+------------|-----------------|-------|-----------------|-----|---------|-----
+object (hierarchical) | 71770.39055404178 | 6367.729155411489 | 51.85185185185185 | 336.0205203371198 | 126776.67354209638 | 54065.18572469046
+object (recursive) | 65843.33874166217 | 3629.730713245997 | 34.02003402003402 | 55.89374654122855 | 74190.39642657732 | Failed
+object (union, explicit) | 10545.989304812834 | 2309.319715484224 | 13.430127041742287 | 28.11320754716981 | 10360.830424398311 | 978.6652078774617
+object (union, implicit) | 11122.193595877807 | 2329.3900184842882 | 14.123768816205166 | 42.660208643815196 | 13257.987513771575 | Failed
+array (recursive) | 6006.049495875343 | 364.0630867442734 | 3.2063372312334972 | 7.231596513999629 | 5464.279121284844 | Failed
+array (union, explicit) | 2852.642819006941 | 284.8124767916821 | 6.578947368421052 | 2.4390243902439024 | 1629.147571035747 | Failed
+array (union, implicit) | 3105.658304339864 | 313.82405745062835 | 7.482229704451926 | 3.018867924528302 | 1916.3078075266803 | Failed
+ultimate union | 496.86693697014374 | Failed | Failed | 0.1820498816675769 | 726.2669521770164 | Failed
+
+
+```mermaid
+pie title is - object (hierarchical)
+  "typescript-json": 71770.39055404178
+  "io-ts": 6367.729155411489
+  "class-validator": 51.85185185185185
+  "zod": 336.0205203371198
+  "typebox": 126776.67354209638
+  "ajv": 54065.18572469046
+```
+
+
+```mermaid
+pie title is - object (recursive)
+  "typescript-json": 65843.33874166217
+  "io-ts": 3629.730713245997
+  "class-validator": 34.02003402003402
+  "zod": 55.89374654122855
+  "typebox": 74190.39642657732
+  "ajv": 0
+```
+
+
+```mermaid
+pie title is - object (union, explicit)
+  "typescript-json": 10545.989304812834
+  "io-ts": 2309.319715484224
+  "class-validator": 13.430127041742287
+  "zod": 28.11320754716981
+  "typebox": 10360.830424398311
+  "ajv": 978.6652078774617
+```
+
+
+```mermaid
+pie title is - object (union, implicit)
+  "typescript-json": 11122.193595877807
+  "io-ts": 2329.3900184842882
+  "class-validator": 14.123768816205166
+  "zod": 42.660208643815196
+  "typebox": 13257.987513771575
+  "ajv": 0
+```
+
+
+```mermaid
+pie title is - array (recursive)
+  "typescript-json": 6006.049495875343
+  "io-ts": 364.0630867442734
+  "class-validator": 3.2063372312334972
+  "zod": 7.231596513999629
+  "typebox": 5464.279121284844
+  "ajv": 0
+```
+
+
+```mermaid
+pie title is - array (union, explicit)
+  "typescript-json": 2852.642819006941
+  "io-ts": 284.8124767916821
+  "class-validator": 6.578947368421052
+  "zod": 2.4390243902439024
+  "typebox": 1629.147571035747
+  "ajv": 0
+```
+
+
+```mermaid
+pie title is - array (union, implicit)
+  "typescript-json": 3105.658304339864
+  "io-ts": 313.82405745062835
+  "class-validator": 7.482229704451926
+  "zod": 3.018867924528302
+  "typebox": 1916.3078075266803
+  "ajv": 0
+```
+
+
+```mermaid
+pie title is - ultimate union
+  "typescript-json": 496.86693697014374
+  "io-ts": 0
+  "class-validator": 0
+  "zod": 0.1820498816675769
+  "typebox": 726.2669521770164
+  "ajv": 0
+```
+
+
+
+
+
+
+## assert
+ Components | typescript-json | class-validator | io-ts | zod | typebox 
+------------|-----------------|-----------------|-------|-----|---------
+object (hierarchical) | 15806.161745827983 | 52.18356772760918 | 2700.422716412424 | 351.7719857491093 | 108401.20097579283
+object (recursive) | 24031.191632424354 | 32.335550628233555 | 1353.2538955087075 | 57.20218991882198 | 66719.12315095348
+object (union, explicit) | 4039.9133104569264 | 13.873473917869035 | 813.4287286736379 | 28.52285606346808 | 10117.571533382245
+object (union, implicit) | 3975.974866013676 | 14.495481927710843 | 616.0473882606354 | 42.99453139732227 | 11248.092313418947
+array (recursive) | 1281.9129140305174 | 3.0331753554502368 | 121.65137614678899 | 7.317073170731708 | 5512.892376681614
+array (union, explicit) | 1512.439658373561 | 6.460193805814175 | 61.206281227694504 | 2.2522522522522523 | 1702.5870091196723
+array (union, implicit) | 1399.2402315484806 | 7.277477141257697 | 78.16561455625695 | 3.0109145652992098 | 1817.3702808257394
+ultimate union | 216.1968037349614 | Failed | Failed | Failed | 743.9956331877729
+
+
+```mermaid
+pie title assert - object (hierarchical)
+  "typescript-json": 15806.161745827983
+  "class-validator": 52.18356772760918
+  "io-ts": 2700.422716412424
+  "zod": 351.7719857491093
+  "typebox": 108401.20097579283
+```
+
+
+```mermaid
+pie title assert - object (recursive)
+  "typescript-json": 24031.191632424354
+  "class-validator": 32.335550628233555
+  "io-ts": 1353.2538955087075
+  "zod": 57.20218991882198
+  "typebox": 66719.12315095348
+```
+
+
+```mermaid
+pie title assert - object (union, explicit)
+  "typescript-json": 4039.9133104569264
+  "class-validator": 13.873473917869035
+  "io-ts": 813.4287286736379
+  "zod": 28.52285606346808
+  "typebox": 10117.571533382245
+```
+
+
+```mermaid
+pie title assert - object (union, implicit)
+  "typescript-json": 3975.974866013676
+  "class-validator": 14.495481927710843
+  "io-ts": 616.0473882606354
+  "zod": 42.99453139732227
+  "typebox": 11248.092313418947
+```
+
+
+```mermaid
+pie title assert - array (recursive)
+  "typescript-json": 1281.9129140305174
+  "class-validator": 3.0331753554502368
+  "io-ts": 121.65137614678899
+  "zod": 7.317073170731708
+  "typebox": 5512.892376681614
+```
+
+
+```mermaid
+pie title assert - array (union, explicit)
+  "typescript-json": 1512.439658373561
+  "class-validator": 6.460193805814175
+  "io-ts": 61.206281227694504
+  "zod": 2.2522522522522523
+  "typebox": 1702.5870091196723
+```
+
+
+```mermaid
+pie title assert - array (union, implicit)
+  "typescript-json": 1399.2402315484806
+  "class-validator": 7.277477141257697
+  "io-ts": 78.16561455625695
+  "zod": 3.0109145652992098
+  "typebox": 1817.3702808257394
+```
+
+
+```mermaid
+pie title assert - ultimate union
+  "typescript-json": 216.1968037349614
+  "class-validator": 0
+  "io-ts": 0
+  "zod": 0
+  "typebox": 743.9956331877729
+```
+
+
+
+
+
+
+## valiadate
+ Components | typescript-json | class-validator | io-ts | zod | typebox 
+------------|-----------------|-----------------|-------|-----|---------
+object (hierarchical) | 11593.896713615022 | 51.50452279859701 | 2452.5230602278893 | 335.50670640834574 | 109539.30700447093
+object (recursive) | 14371.096586782862 | 33.548142532221384 | 1331.119719608928 | 58.768306421329335 | 73515.16272189349
+object (union, explicit) | 3335.1759719918928 | 13.807069219440352 | 913.632986627043 | 28.996422519299568 | 10028.793915248098
+object (union, implicit) | 3732.427968434575 | 14.346934972983044 | 649.5757356923633 | 43.94568087514146 | 11127.926267281106
+array (recursive) | 890.9935004642526 | 2.992891881780771 | 134.88460083238746 | 7.714016933207901 | 5423.415170392085
+array (union, explicit) | 1182.608695652174 | 6.042296072507552 | 63.837570879824405 | 2.446368084305608 | 1688.1400111711039
+array (union, implicit) | 1194.123048668503 | 7.245030652052758 | 85.08224617129893 | 2.935779816513761 | 1976.323639075317
+ultimate union | 116.70440689775302 | Failed | Failed | Failed | 715.0817904008629
+
+
+```mermaid
+pie title valiadate - object (hierarchical)
+  "typescript-json": 11593.896713615022
+  "class-validator": 51.50452279859701
+  "io-ts": 2452.5230602278893
+  "zod": 335.50670640834574
+  "typebox": 109539.30700447093
+```
+
+
+```mermaid
+pie title valiadate - object (recursive)
+  "typescript-json": 14371.096586782862
+  "class-validator": 33.548142532221384
+  "io-ts": 1331.119719608928
+  "zod": 58.768306421329335
+  "typebox": 73515.16272189349
+```
+
+
+```mermaid
+pie title valiadate - object (union, explicit)
+  "typescript-json": 3335.1759719918928
+  "class-validator": 13.807069219440352
+  "io-ts": 913.632986627043
+  "zod": 28.996422519299568
+  "typebox": 10028.793915248098
+```
+
+
+```mermaid
+pie title valiadate - object (union, implicit)
+  "typescript-json": 3732.427968434575
+  "class-validator": 14.346934972983044
+  "io-ts": 649.5757356923633
+  "zod": 43.94568087514146
+  "typebox": 11127.926267281106
+```
+
+
+```mermaid
+pie title valiadate - array (recursive)
+  "typescript-json": 890.9935004642526
+  "class-validator": 2.992891881780771
+  "io-ts": 134.88460083238746
+  "zod": 7.714016933207901
+  "typebox": 5423.415170392085
+```
+
+
+```mermaid
+pie title valiadate - array (union, explicit)
+  "typescript-json": 1182.608695652174
+  "class-validator": 6.042296072507552
+  "io-ts": 63.837570879824405
+  "zod": 2.446368084305608
+  "typebox": 1688.1400111711039
+```
+
+
+```mermaid
+pie title valiadate - array (union, implicit)
+  "typescript-json": 1194.123048668503
+  "class-validator": 7.245030652052758
+  "io-ts": 85.08224617129893
+  "zod": 2.935779816513761
+  "typebox": 1976.323639075317
+```
+
+
+```mermaid
+pie title valiadate - ultimate union
+  "typescript-json": 116.70440689775302
+  "class-validator": 0
+  "io-ts": 0
+  "zod": 0
+  "typebox": 715.0817904008629
+```
+
+
+
+
+
+
+## optimizer
+ Components | typescript-json | fast-json-stringify | JSON.stringify() 
+------------|-----------------|---------------------|------------------
+object (simple) | 60480.10130246021 | 26.785714285714285 | 4269.949676491732
+object (hierarchical) | 3973.087557603687 | 9.983361064891847 | 1213.5976287513895
+object (recursive) | 4318.291550603529 | 58.33782085801472 | 892.4250884049878
+object (union) | 1663.0889576132436 | 1.0869565217391306 | 724.5883021010789
+array (hierarchical) | 147.33823265818248 | 10.0151171579743 | 69.60385042576823
+array (recursive) | 176.7676767676768 | 38.42566685319903 | 103.76822571482674
+array (union) | 243.47343084613962 | 2.4271844660194177 | 194.79800774764803
+ultimate union | 99.71202303815694 | 0.16286644951140067 | 136.65624425234503
+
+
+```mermaid
+pie title optimizer - object (simple)
+  "typescript-json": 60480.10130246021
+  "fast-json-stringify": 26.785714285714285
+  "JSON.stringify()": 4269.949676491732
+```
+
+
+```mermaid
+pie title optimizer - object (hierarchical)
+  "typescript-json": 3973.087557603687
+  "fast-json-stringify": 9.983361064891847
+  "JSON.stringify()": 1213.5976287513895
+```
+
+
+```mermaid
+pie title optimizer - object (recursive)
+  "typescript-json": 4318.291550603529
+  "fast-json-stringify": 58.33782085801472
+  "JSON.stringify()": 892.4250884049878
+```
+
+
+```mermaid
+pie title optimizer - object (union)
+  "typescript-json": 1663.0889576132436
+  "fast-json-stringify": 1.0869565217391306
+  "JSON.stringify()": 724.5883021010789
+```
+
+
+```mermaid
+pie title optimizer - array (hierarchical)
+  "typescript-json": 147.33823265818248
+  "fast-json-stringify": 10.0151171579743
+  "JSON.stringify()": 69.60385042576823
+```
+
+
+```mermaid
+pie title optimizer - array (recursive)
+  "typescript-json": 176.7676767676768
+  "fast-json-stringify": 38.42566685319903
+  "JSON.stringify()": 103.76822571482674
+```
+
+
+```mermaid
+pie title optimizer - array (union)
+  "typescript-json": 243.47343084613962
+  "fast-json-stringify": 2.4271844660194177
+  "JSON.stringify()": 194.79800774764803
+```
+
+
+```mermaid
+pie title optimizer - ultimate union
+  "typescript-json": 99.71202303815694
+  "fast-json-stringify": 0.16286644951140067
+  "JSON.stringify()": 136.65624425234503
+```
+
+
+
+
+
+
+## stringify
+ Components | typescript-json | fast-json-stringify | JSON.stringify() 
+------------|-----------------|---------------------|------------------
+object (simple) | 63901.56278067181 | 22761.4361217423 | 4361.73365438044
+object (hierarchical) | 3708.6247086247085 | 3692.566305565932 | 1212.318570896911
+object (recursive) | 4108.113102938459 | 877.9498525073745 | 888.622090875508
+object (union) | 1615.850302696753 | 1176.7758096260511 | 702.9520295202952
+array (hierarchical) | 116.36363636363636 | 155.47196847572988 | 58.133035215204025
+array (recursive) | 196.55797101449278 | 97.75670253510852 | 98.32402234636871
+array (union) | 256.7567567567568 | 177.45225292045245 | 197.66346335029206
+ultimate union | 103.19016218142934 | 58.30852740325687 | 140.2461767997016
+
+
+```mermaid
+pie title stringify - object (simple)
+  "typescript-json": 63901.56278067181
+  "fast-json-stringify": 22761.4361217423
+  "JSON.stringify()": 4361.73365438044
+```
+
+
+```mermaid
+pie title stringify - object (hierarchical)
+  "typescript-json": 3708.6247086247085
+  "fast-json-stringify": 3692.566305565932
+  "JSON.stringify()": 1212.318570896911
+```
+
+
+```mermaid
+pie title stringify - object (recursive)
+  "typescript-json": 4108.113102938459
+  "fast-json-stringify": 877.9498525073745
+  "JSON.stringify()": 888.622090875508
+```
+
+
+```mermaid
+pie title stringify - object (union)
+  "typescript-json": 1615.850302696753
+  "fast-json-stringify": 1176.7758096260511
+  "JSON.stringify()": 702.9520295202952
+```
+
+
+```mermaid
+pie title stringify - array (hierarchical)
+  "typescript-json": 116.36363636363636
+  "fast-json-stringify": 155.47196847572988
+  "JSON.stringify()": 58.133035215204025
+```
+
+
+```mermaid
+pie title stringify - array (recursive)
+  "typescript-json": 196.55797101449278
+  "fast-json-stringify": 97.75670253510852
+  "JSON.stringify()": 98.32402234636871
+```
+
+
+```mermaid
+pie title stringify - array (union)
+  "typescript-json": 256.7567567567568
+  "fast-json-stringify": 177.45225292045245
+  "JSON.stringify()": 197.66346335029206
+```
+
+
+```mermaid
+pie title stringify - ultimate union
+  "typescript-json": 103.19016218142934
+  "fast-json-stringify": 58.30852740325687
+  "JSON.stringify()": 140.2461767997016
+```
+
+
+
+
+
+

--- a/benchmark/structures/typebox/TypeBoxArrayRecursive.ts
+++ b/benchmark/structures/typebox/TypeBoxArrayRecursive.ts
@@ -1,0 +1,22 @@
+import { Type } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
+
+const Timestamp = Type.Object({
+    time: Type.Number(),
+    zone: Type.Number(),
+});
+
+const Category = Type.Recursive((Category) =>
+    Type.Object({
+        children: Type.Array(Category),
+        id: Type.Number(),
+        code: Type.String(),
+        sequence: Type.Number(),
+        created_at: Timestamp,
+    }),
+);
+
+export const __TypeBoxArrayRecursive = Category;
+export const TypeBoxArrayRecursive = TypeCompiler.Compile(
+    __TypeBoxArrayRecursive,
+);

--- a/benchmark/structures/typebox/TypeBoxArrayRecursiveUnionExplicit.ts
+++ b/benchmark/structures/typebox/TypeBoxArrayRecursiveUnionExplicit.ts
@@ -1,0 +1,68 @@
+import { TSchema, Type } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
+
+const ImageFile = Type.Object({
+    id: Type.Number(),
+    name: Type.String(),
+    path: Type.String(),
+    width: Type.Number(),
+    height: Type.Number(),
+    url: Type.String(),
+    size: Type.Number(),
+    type: Type.Literal("file"),
+    extension: Type.Literal("jpg"),
+});
+
+const TextFile = Type.Object({
+    id: Type.Number(),
+    name: Type.String(),
+    path: Type.String(),
+    size: Type.Number(),
+    content: Type.String(),
+    type: Type.Literal("file"),
+    extension: Type.Literal("txt"),
+});
+
+const ZipFile = Type.Object({
+    id: Type.Number(),
+    name: Type.String(),
+    path: Type.String(),
+    size: Type.Number(),
+    count: Type.Number(),
+    type: Type.Literal("file"),
+    extension: Type.Literal("zip"),
+});
+
+const Shortcut = <T extends TSchema>(bucket: T) =>
+    Type.Object({
+        id: Type.Number(),
+        name: Type.String(),
+        path: Type.String(),
+        target: bucket,
+        type: Type.Literal("file"),
+        extension: Type.Literal("lnk"),
+    });
+
+const Directory = (bucket: TSchema) =>
+    Type.Object({
+        id: Type.Number(),
+        name: Type.String(),
+        path: Type.String(),
+        children: Type.Array(bucket),
+        type: Type.Literal("directory"),
+    });
+
+const Bucket = Type.Recursive((Bucket) =>
+    Type.Union([
+        ImageFile,
+        TextFile,
+        ZipFile,
+        Shortcut(Bucket),
+        Directory(Bucket),
+    ]),
+);
+
+export const __TypeBoxArrayRecursiveUnionExplicit = Type.Array(Bucket);
+export const TypeBoxArrayRecursiveUnionExplicit = TypeCompiler.Compile(
+    __TypeBoxArrayRecursiveUnionExplicit,
+);

--- a/benchmark/structures/typebox/TypeBoxArrayRecursiveUnionImplicit.ts
+++ b/benchmark/structures/typebox/TypeBoxArrayRecursiveUnionImplicit.ts
@@ -1,0 +1,59 @@
+import { TSchema, Type } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
+
+const ImageFile = Type.Object({
+    id: Type.Number(),
+    name: Type.String(),
+    path: Type.String(),
+    width: Type.Number(),
+    height: Type.Number(),
+    url: Type.String(),
+    size: Type.Number(),
+});
+
+const TextFile = Type.Object({
+    id: Type.Number(),
+    name: Type.String(),
+    path: Type.String(),
+    size: Type.Number(),
+    content: Type.String(),
+});
+
+const ZipFile = Type.Object({
+    id: Type.Number(),
+    name: Type.String(),
+    path: Type.String(),
+    size: Type.Number(),
+    count: Type.Number(),
+});
+
+const Shortcut = <T extends TSchema>(bucket: T) =>
+    Type.Object({
+        id: Type.Number(),
+        name: Type.String(),
+        path: Type.String(),
+        target: bucket,
+    });
+
+const Directory = (bucket: TSchema) =>
+    Type.Object({
+        id: Type.Number(),
+        name: Type.String(),
+        path: Type.String(),
+        children: Type.Array(bucket),
+    });
+
+const Bucket = Type.Recursive((Bucket) =>
+    Type.Union([
+        ImageFile,
+        TextFile,
+        ZipFile,
+        Shortcut(Bucket),
+        Directory(Bucket),
+    ]),
+);
+
+export const __TypeBoxArrayRecursiveUnionImplicit = Type.Array(Bucket);
+export const TypeBoxArrayRecursiveUnionImplicit = TypeCompiler.Compile(
+    __TypeBoxArrayRecursiveUnionImplicit,
+);

--- a/benchmark/structures/typebox/TypeBoxObjectHierarchical.ts
+++ b/benchmark/structures/typebox/TypeBoxObjectHierarchical.ts
@@ -1,0 +1,61 @@
+import { Type } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
+
+const Timestamp = Type.Object({
+    time: Type.Number(),
+    zone: Type.Number(),
+});
+
+const Channel = Type.Object({
+    id: Type.Number(),
+    code: Type.String(),
+    name: Type.String(),
+    sequence: Type.Number(),
+    exclusive: Type.Boolean(),
+    priority: Type.Number(),
+    created_at: Timestamp,
+});
+
+const Account = Type.Object({
+    id: Type.Number(),
+    code: Type.String(),
+    created_at: Timestamp,
+});
+
+const Enterprise = Type.Object({
+    id: Type.Number(),
+    account: Account,
+    name: Type.String(),
+    grade: Type.Number(),
+    created_at: Timestamp,
+});
+
+const Member = Type.Object({
+    id: Type.Number(),
+    account: Account,
+    enterprise: Type.Union([Type.Null(), Enterprise]),
+    emails: Type.Array(Type.String()),
+    created_at: Timestamp,
+    authorized: Type.Boolean(),
+});
+
+const Customer = Type.Object({
+    id: Type.Number(),
+    channel: Channel,
+    member: Type.Union([Type.Null(), Member]),
+    account: Type.Union([Type.Null(), Account]),
+    href: Type.String(),
+    referrer: Type.String(),
+    ip: Type.Tuple([
+        Type.Number(),
+        Type.Number(),
+        Type.Number(),
+        Type.Number(),
+    ]),
+    created_at: Timestamp,
+});
+
+export const __TypeBoxObjectHierarchical = Customer;
+export const TypeBoxObjectHierarchical = TypeCompiler.Compile(
+    __TypeBoxObjectHierarchical,
+);

--- a/benchmark/structures/typebox/TypeBoxObjectRecursive.ts
+++ b/benchmark/structures/typebox/TypeBoxObjectRecursive.ts
@@ -1,0 +1,23 @@
+import { Type } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
+
+const Timestamp = Type.Object({
+    time: Type.Number(),
+    zone: Type.Number(),
+});
+
+const Department = Type.Recursive((Department) =>
+    Type.Object({
+        parent: Type.Union([Department, Type.Null()]),
+        id: Type.Number(),
+        code: Type.String(),
+        name: Type.String(),
+        sequence: Type.Number(),
+        created_at: Timestamp,
+    }),
+);
+
+export const __TypeBoxObjectRecursive = Department;
+export const TypeBoxObjectRecursive = TypeCompiler.Compile(
+    __TypeBoxObjectRecursive,
+);

--- a/benchmark/structures/typebox/TypeBoxObjectUnionExplicit.ts
+++ b/benchmark/structures/typebox/TypeBoxObjectUnionExplicit.ts
@@ -1,0 +1,85 @@
+import { Type } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
+
+const Point = Type.Object({
+    x: Type.Number(),
+    y: Type.Number(),
+});
+const Circle = Type.Object({
+    centroid: Point,
+    radius: Type.Number(),
+});
+const Line = Type.Object({
+    p1: Point,
+    p2: Point,
+});
+const Triangle = Type.Object({
+    p1: Point,
+    p2: Point,
+    p3: Point,
+});
+const Rectangle = Type.Object({
+    p1: Point,
+    p2: Point,
+    p3: Point,
+    p4: Point,
+});
+
+const Polyline = Type.Object({
+    points: Type.Array(Point),
+});
+
+const Polygon = Type.Object({
+    outer: Polyline,
+    inner: Type.Array(Polyline),
+});
+
+const Union = Type.Union([
+    Type.Intersect([
+        Point,
+        Type.Object({
+            type: Type.Literal("point"),
+        }),
+    ]),
+    Type.Intersect([
+        Line,
+        Type.Object({
+            type: Type.Literal("line"),
+        }),
+    ]),
+    Type.Intersect([
+        Triangle,
+        Type.Object({
+            type: Type.Literal("triangle"),
+        }),
+    ]),
+    Type.Intersect([
+        Rectangle,
+        Type.Object({
+            type: Type.Literal("rectangle"),
+        }),
+    ]),
+    Type.Intersect([
+        Polyline,
+        Type.Object({
+            type: Type.Literal("polyline"),
+        }),
+    ]),
+    Type.Intersect([
+        Polygon,
+        Type.Object({
+            type: Type.Literal("polygon"),
+        }),
+    ]),
+    Type.Intersect([
+        Circle,
+        Type.Object({
+            type: Type.Literal("circle"),
+        }),
+    ]),
+]);
+
+export const __TypeBoxObjectUnionExplicit = Type.Array(Union);
+export const TypeBoxObjectUnionExplicit = TypeCompiler.Compile(
+    __TypeBoxObjectUnionExplicit,
+);

--- a/benchmark/structures/typebox/TypeBoxObjectUnionImplicit.ts
+++ b/benchmark/structures/typebox/TypeBoxObjectUnionImplicit.ts
@@ -1,0 +1,48 @@
+import { Type } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
+
+const Point = Type.Object({
+    x: Type.Number(),
+    y: Type.Number(),
+});
+const Circle = Type.Object({
+    centroid: Point,
+    radius: Type.Number(),
+});
+const Line = Type.Object({
+    p1: Point,
+    p2: Point,
+});
+const Triangle = Type.Object({
+    p1: Point,
+    p2: Point,
+    p3: Point,
+});
+const Rectangle = Type.Object({
+    p1: Point,
+    p2: Point,
+    p3: Point,
+    p4: Point,
+});
+const Polyline = Type.Object({
+    points: Type.Array(Point),
+});
+const Polygon = Type.Object({
+    outer: Polyline,
+    inner: Type.Array(Polyline),
+});
+
+const Union = Type.Union([
+    Point,
+    Line,
+    Triangle,
+    Rectangle,
+    Polyline,
+    Polygon,
+    Circle,
+]);
+
+export const __TypeBoxObjectUnionImplicit = Type.Array(Union);
+export const TypeBoxObjectUnionImplicit = TypeCompiler.Compile(
+    __TypeBoxObjectUnionImplicit,
+);

--- a/benchmark/structures/typebox/TypeBoxUltimateUnion.ts
+++ b/benchmark/structures/typebox/TypeBoxUltimateUnion.ts
@@ -1,0 +1,111 @@
+import { TSchema, Type } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
+
+const Unknown = Type.Object({});
+
+const Atomic = Type.Object({
+    type: Type.Union([
+        Type.Literal("boolean"),
+        Type.Literal("number"),
+        Type.Literal("bigint"),
+        Type.Literal("string"),
+    ]),
+    nullable: Type.Boolean(),
+    description: Type.Optional(Type.String()),
+    default: Type.Optional(
+        Type.Union([
+            Type.String(),
+            Type.Number(),
+            Type.Boolean(),
+            // z.bigint(),  // bigint not supported
+        ]),
+    ),
+});
+
+const Constant = Type.Integer([
+    Atomic,
+    Type.Object({
+        constant: Type.Array(
+            Type.Union([
+                Type.Boolean(),
+                Type.Number(),
+                // z.bigint(), // bigint not supported
+                Type.String(),
+            ]),
+        ),
+    }),
+]);
+
+const Array = <T extends TSchema>(schema: T) =>
+    Type.Object({
+        type: Type.Literal("array"),
+        items: schema,
+        nullable: Type.Boolean(),
+        description: Type.Optional(Type.String()),
+    });
+
+const Tuple = <T extends TSchema>(schema: T) =>
+    Type.Object({
+        type: Type.Literal("array"),
+        items: Type.Array(schema),
+        nullable: Type.Boolean(),
+        description: Type.Optional(Type.String()),
+    });
+
+const Reference = Type.Object({
+    $ref: Type.String(),
+    description: Type.Optional(Type.String()),
+});
+
+const RecursiveReference = Type.Object({
+    $recursiveRef: Type.String(),
+    description: Type.Optional(Type.String()),
+});
+
+const OneOf = <T extends TSchema>(schema: T) =>
+    Type.Object({
+        oneOf: Type.Array(schema),
+        description: Type.Optional(Type.String()),
+    });
+
+const ObjectDef = <T extends TSchema>(schema: T) =>
+    Type.Object({
+        $id: Type.String(),
+        type: Type.Literal("object"),
+        nullable: Type.Boolean(),
+        properties: Type.Record(Type.String(), Schema),
+        patternProperties: Type.Optional(Type.Record(Type.String(), schema)),
+        required: Type.Optional(Type.Array(Type.String())),
+        description: Type.Optional(Type.String()),
+    });
+
+const Components = <T extends TSchema>(schema: T) =>
+    Type.Object({
+        schemas: Type.Record(Type.String(), ObjectDef(schema)),
+    });
+
+const Application = <T extends TSchema>(schema: T) =>
+    Type.Object({
+        schemas: Type.Array(schema),
+        components: Components(schema),
+        purpose: Type.Union([Type.Literal("swagger"), Type.Literal("ajv")]),
+        prefix: Type.String(),
+    });
+
+const Schema = Type.Recursive((schema) =>
+    Type.Union([
+        Atomic,
+        Constant,
+        Array(schema),
+        Tuple(schema),
+        Reference,
+        RecursiveReference,
+        OneOf(schema),
+        Unknown,
+    ]),
+);
+
+export const __TypeBoxUltimateUnion = Type.Array(Application(Schema));
+export const TypeBoxUltimateUnion = TypeCompiler.Compile(
+    __TypeBoxUltimateUnion,
+);

--- a/benchmark/structures/zod/ZodUltimateUnion.ts
+++ b/benchmark/structures/zod/ZodUltimateUnion.ts
@@ -95,7 +95,7 @@ const Application: z.ZodType<IJsonApplication> = z.lazy(() =>
     z.object({
         schemas: z.array(Schema),
         components: Components,
-        purpose: z.literal("swagger"),
+        purpose: z.union([z.literal("ajv"), z.literal("swagger")]),
         prefix: z.string(),
     }),
 );

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "homepage": "https://github.com/samchon/typescript-json#readme",
   "devDependencies": {
+    "@sinclair/typebox": "^0.24.47",
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "@types/benchmark": "^2.1.2",
     "@types/cli": "^0.11.20",


### PR DESCRIPTION
This PR implements benchmarks for JSON Schema comparative benchmarking. The benchmarks are implemented using the TypeBox type compiler for reference. As TypeBox generates JSON Schema Draft 6 compatible schemas, it should be possible to pass these schemas directly to Ajv for compilation also (see update below)

> Note: This PR also provides a small fix for the `ZodUltimateUnion` by adding an additional literal type `ajv` for the `Application` `purpose` property. This should enable Zod to participate in the ultimate union benchmark.

This PR is submitted both for comparative benchmarking, and to potentially provide a reference model for JSON Schema generation in `typescript-json`. The new benchmarks should pass all current `is`, `validate` and `assert` measurements, however it would be good to replace the TypeBox type compiler with Ajv to get good visibility on performance deltas there.

Submitting for consideration

> Update: Have since tested the schemas against Ajv version 6.12.6 (currently installed) and all benchmarks are passing with results (including the ultimate union). It should be possible to compare the TB schemas with the output of `TSON.application<[...], "ajv">()`. There may be a way to update the schema generation in `typescript-json` to get better Ajv compatibility for some of these more complex types. I'm hopeful these reference TB schemas may help.


