### PR TITLE
Correct typo 'Undefied' to 'Undefined'

### DIFF
--- a/test/features/application/ajv/test_application_ajv_object_undefined.ts
+++ b/test/features/application/ajv/test_application_ajv_object_undefined.ts
@@ -1,24 +1,24 @@
 import TSON from "../../../../src";
-import { ObjectUndefied } from "../../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../../structures/ObjectUndefined";
 import { _test_application_ajv } from "./_test_application_ajv";
 
 export const test_application_ajv_object_undefined = _test_application_ajv(
     "undefined object",
-    TSON.application<[ObjectUndefied], "ajv">(),
+    TSON.application<[ObjectUndefined], "ajv">(),
     {
         schemas: [
             {
                 type: "array",
                 items: {
-                    $ref: "components#/schemas/ObjectUndefied.ILecture",
+                    $ref: "components#/schemas/ObjectUndefined.ILecture",
                 },
                 nullable: false,
             },
         ],
         components: {
             schemas: {
-                "ObjectUndefied.ILecture": {
-                    $id: "components#/schemas/ObjectUndefied.ILecture",
+                "ObjectUndefined.ILecture": {
+                    $id: "components#/schemas/ObjectUndefined.ILecture",
                     type: "object",
                     properties: {
                         name: {
@@ -38,7 +38,7 @@ export const test_application_ajv_object_undefined = _test_application_ajv(
                             ],
                         },
                         classroom: {
-                            $ref: "components#/schemas/ObjectUndefied.IClassroom",
+                            $ref: "components#/schemas/ObjectUndefined.IClassroom",
                         },
                         grade: {
                             type: "number",
@@ -49,8 +49,8 @@ export const test_application_ajv_object_undefined = _test_application_ajv(
                     required: ["name"],
                     "x-tson_jsDocTags": [],
                 },
-                "ObjectUndefied.IClassroom": {
-                    $id: "components#/schemas/ObjectUndefied.IClassroom",
+                "ObjectUndefined.IClassroom": {
+                    $id: "components#/schemas/ObjectUndefined.IClassroom",
                     type: "object",
                     properties: {
                         id: {

--- a/test/features/application/swagger/test_application_swagger_object_undefined.ts
+++ b/test/features/application/swagger/test_application_swagger_object_undefined.ts
@@ -1,24 +1,24 @@
 import TSON from "../../../../src";
-import { ObjectUndefied } from "../../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../../structures/ObjectUndefined";
 import { _test_application_swagger } from "./_test_application_swagger";
 
 export const test_application_swagger_object_undefined =
     _test_application_swagger(
         "undefined object",
-        TSON.application<[ObjectUndefied], "swagger">(),
+        TSON.application<[ObjectUndefined], "swagger">(),
         {
             schemas: [
                 {
                     type: "array",
                     items: {
-                        $ref: "#/components/schemas/ObjectUndefied.ILecture",
+                        $ref: "#/components/schemas/ObjectUndefined.ILecture",
                     },
                     nullable: false,
                 },
             ],
             components: {
                 schemas: {
-                    "ObjectUndefied.ILecture": {
+                    "ObjectUndefined.ILecture": {
                         type: "object",
                         properties: {
                             name: {
@@ -38,7 +38,7 @@ export const test_application_swagger_object_undefined =
                                 ],
                             },
                             classroom: {
-                                $ref: "#/components/schemas/ObjectUndefied.IClassroom",
+                                $ref: "#/components/schemas/ObjectUndefined.IClassroom",
                             },
                             grade: {
                                 type: "number",
@@ -49,7 +49,7 @@ export const test_application_swagger_object_undefined =
                         required: ["name"],
                         "x-tson_jsDocTags": [],
                     },
-                    "ObjectUndefied.IClassroom": {
+                    "ObjectUndefined.IClassroom": {
                         type: "object",
                         properties: {
                             id: {

--- a/test/features/assert/test_assert_object_undefined.ts
+++ b/test/features/assert/test_assert_object_undefined.ts
@@ -1,10 +1,10 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_assert } from "./_test_assert";
 
 export const test_assert_object_undefined = _test_assert(
     "undefined object",
-    ObjectUndefied.generate,
+    ObjectUndefined.generate,
     (input) => TSON.assertType(input),
-    ObjectUndefied.SPOILERS,
+    ObjectUndefined.SPOILERS,
 );

--- a/test/features/assert_equals/test_assert_equals_object_undefined.ts
+++ b/test/features/assert_equals/test_assert_equals_object_undefined.ts
@@ -1,9 +1,9 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_assert_equals } from "./_test_assert_equals";
 
 export const test_assert_equals_object_undefined = _test_assert_equals(
     "undefined object",
-    ObjectUndefied.generate,
+    ObjectUndefined.generate,
     (input) => TSON.assertEquals(input),
 );

--- a/test/features/assert_stringify/test_assert_stringify_object_undefined.ts
+++ b/test/features/assert_stringify/test_assert_stringify_object_undefined.ts
@@ -1,10 +1,10 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_assert_stringify } from "./_test_assert_stringify";
 
 export const test_assert_stringify_object_undefined = _test_assert_stringify(
     "undefined object",
-    ObjectUndefied.generate,
+    ObjectUndefined.generate,
     (input) => TSON.assertStringify(input),
-    ObjectUndefied.SPOILERS,
+    ObjectUndefined.SPOILERS,
 );

--- a/test/features/create_assert/test_create_assert_object_undefined.ts
+++ b/test/features/create_assert/test_create_assert_object_undefined.ts
@@ -1,10 +1,10 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_assert } from "./../assert/_test_assert";
 
 export const test_create_assert_object_undefined = _test_assert(
     "undefined object",
-    ObjectUndefied.generate,
-    TSON.createAssertType<ObjectUndefied>(),
-    ObjectUndefied.SPOILERS,
+    ObjectUndefined.generate,
+    TSON.createAssertType<ObjectUndefined>(),
+    ObjectUndefined.SPOILERS,
 );

--- a/test/features/create_assert_equals/test_create_assert_equals_object_undefined.ts
+++ b/test/features/create_assert_equals/test_create_assert_equals_object_undefined.ts
@@ -1,9 +1,9 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_assert_equals } from "./../assert_equals/_test_assert_equals";
 
 export const test_create_assert_equals_object_undefined = _test_assert_equals(
     "undefined object",
-    ObjectUndefied.generate,
-    TSON.createAssertEquals<ObjectUndefied>(),
+    ObjectUndefined.generate,
+    TSON.createAssertEquals<ObjectUndefined>(),
 );

--- a/test/features/create_assert_stringify/test_create_assert_stringify_object_undefined.ts
+++ b/test/features/create_assert_stringify/test_create_assert_stringify_object_undefined.ts
@@ -1,11 +1,11 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_assert_stringify } from "./../assert_stringify/_test_assert_stringify";
 
 export const test_create_assert_stringify_object_undefined =
     _test_assert_stringify(
         "undefined object",
-        ObjectUndefied.generate,
-        TSON.createAssertStringify<ObjectUndefied>(),
-        ObjectUndefied.SPOILERS,
+        ObjectUndefined.generate,
+        TSON.createAssertStringify<ObjectUndefined>(),
+        ObjectUndefined.SPOILERS,
     );

--- a/test/features/create_equals/test_create_equals_object_undefined.ts
+++ b/test/features/create_equals/test_create_equals_object_undefined.ts
@@ -1,9 +1,9 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_equals } from "./../equals/_test_equals";
 
 export const test_create_equals_object_undefined = _test_equals(
     "undefined object",
-    ObjectUndefied.generate,
-    TSON.createEquals<ObjectUndefied>(),
+    ObjectUndefined.generate,
+    TSON.createEquals<ObjectUndefined>(),
 );

--- a/test/features/create_is/test_create_is_object_undefined.ts
+++ b/test/features/create_is/test_create_is_object_undefined.ts
@@ -1,10 +1,10 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_is } from "./../is/_test_is";
 
 export const test_create_is_object_undefined = _test_is(
     "undefined object",
-    ObjectUndefied.generate,
-    TSON.createIs<ObjectUndefied>(),
-    ObjectUndefied.SPOILERS,
+    ObjectUndefined.generate,
+    TSON.createIs<ObjectUndefined>(),
+    ObjectUndefined.SPOILERS,
 );

--- a/test/features/create_is_stringify/test_create_is_stringify_object_undefined.ts
+++ b/test/features/create_is_stringify/test_create_is_stringify_object_undefined.ts
@@ -1,10 +1,10 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_is_stringify } from "./../is_stringify/_test_is_stringify";
 
 export const test_create_is_stringify_object_undefined = _test_is_stringify(
     "undefined object",
-    ObjectUndefied.generate,
-    TSON.createIsStringify<ObjectUndefied>(),
-    ObjectUndefied.SPOILERS,
+    ObjectUndefined.generate,
+    TSON.createIsStringify<ObjectUndefined>(),
+    ObjectUndefined.SPOILERS,
 );

--- a/test/features/create_stringify/test_create_stringify_object_undefined.ts
+++ b/test/features/create_stringify/test_create_stringify_object_undefined.ts
@@ -1,9 +1,9 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_stringify } from "./../stringify/_test_stringify";
 
 export const test_create_stringify_object_undefined = _test_stringify(
     "undefined object",
-    ObjectUndefied.generate,
-    TSON.createStringify<ObjectUndefied>(),
+    ObjectUndefined.generate,
+    TSON.createStringify<ObjectUndefined>(),
 );

--- a/test/features/create_validate/test_create_validate_object_undefined.ts
+++ b/test/features/create_validate/test_create_validate_object_undefined.ts
@@ -1,10 +1,10 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_validate } from "./../validate/_test_validate";
 
 export const test_create_validate_object_undefined = _test_validate(
     "undefined object",
-    ObjectUndefied.generate,
-    TSON.createValidate<ObjectUndefied>(),
-    ObjectUndefied.SPOILERS,
+    ObjectUndefined.generate,
+    TSON.createValidate<ObjectUndefined>(),
+    ObjectUndefined.SPOILERS,
 );

--- a/test/features/create_validate_equals/test_create_validate_equals_object_undefined.ts
+++ b/test/features/create_validate_equals/test_create_validate_equals_object_undefined.ts
@@ -1,10 +1,10 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_validate_equals } from "./../validate_equals/_test_validate_equals";
 
 export const test_create_validate_equals_object_undefined =
     _test_validate_equals(
         "undefined object",
-        ObjectUndefied.generate,
-        TSON.createValidateEquals<ObjectUndefied>(),
+        ObjectUndefined.generate,
+        TSON.createValidateEquals<ObjectUndefined>(),
     );

--- a/test/features/equals/test_equals_object_undefined.ts
+++ b/test/features/equals/test_equals_object_undefined.ts
@@ -1,9 +1,9 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_equals } from "./_test_equals";
 
 export const test_equals_object_undefined = _test_equals(
     "undefined object",
-    ObjectUndefied.generate,
+    ObjectUndefined.generate,
     (input) => TSON.equals(input),
 );

--- a/test/features/is/test_is_object_undefined.ts
+++ b/test/features/is/test_is_object_undefined.ts
@@ -1,10 +1,10 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_is } from "./_test_is";
 
 export const test_is_object_undefined = _test_is(
     "undefined object",
-    ObjectUndefied.generate,
+    ObjectUndefined.generate,
     (input) => TSON.is(input),
-    ObjectUndefied.SPOILERS,
+    ObjectUndefined.SPOILERS,
 );

--- a/test/features/is_stringify/test_is_stringify_object_undefined.ts
+++ b/test/features/is_stringify/test_is_stringify_object_undefined.ts
@@ -1,10 +1,10 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_is_stringify } from "./_test_is_stringify";
 
 export const test_is_stringify_object_undefined = _test_is_stringify(
     "undefined object",
-    ObjectUndefied.generate,
+    ObjectUndefined.generate,
     (input) => TSON.isStringify(input),
-    ObjectUndefied.SPOILERS,
+    ObjectUndefined.SPOILERS,
 );

--- a/test/features/stringify/test_stringify_object_undefined.ts
+++ b/test/features/stringify/test_stringify_object_undefined.ts
@@ -1,9 +1,9 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_stringify } from "./_test_stringify";
 
 export const test_stringify_object_undefined = _test_stringify(
     "undefined object",
-    ObjectUndefied.generate,
+    ObjectUndefined.generate,
     (input) => TSON.stringify(input),
 );

--- a/test/features/validate/test_validate_object_undefined.ts
+++ b/test/features/validate/test_validate_object_undefined.ts
@@ -1,10 +1,10 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_validate } from "./_test_validate";
 
 export const test_validate_object_undefined = _test_validate(
     "undefined object",
-    ObjectUndefied.generate,
+    ObjectUndefined.generate,
     (input) => TSON.validate(input),
-    ObjectUndefied.SPOILERS,
+    ObjectUndefined.SPOILERS,
 );

--- a/test/features/validate_equals/test_validate_equals_object_undefined.ts
+++ b/test/features/validate_equals/test_validate_equals_object_undefined.ts
@@ -1,9 +1,9 @@
 import TSON from "../../../src";
-import { ObjectUndefied } from "../../structures/ObjectUndefied";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
 import { _test_validate_equals } from "./_test_validate_equals";
 
 export const test_validate_equals_object_undefined = _test_validate_equals(
     "undefined object",
-    ObjectUndefied.generate,
+    ObjectUndefined.generate,
     (input) => TSON.validateEquals(input),
 );

--- a/test/structures/ObjectUndefined.ts
+++ b/test/structures/ObjectUndefined.ts
@@ -1,7 +1,7 @@
 import { Spoiler } from "../internal/Spoiler";
 
-export type ObjectUndefied = ObjectUndefied.ILecture[];
-export namespace ObjectUndefied {
+export type ObjectUndefined = ObjectUndefined.ILecture[];
+export namespace ObjectUndefined {
     export interface ILecture {
         name: string;
         professor?: string | number;
@@ -15,7 +15,7 @@ export namespace ObjectUndefied {
     }
 
     export function generate() {
-        const output: ObjectUndefied = [];
+        const output: ObjectUndefined = [];
         const name: string = "someone";
         const nothing: undefined = undefined;
 
@@ -38,7 +38,7 @@ export namespace ObjectUndefied {
         return output;
     }
 
-    export const SPOILERS: Spoiler<ObjectUndefied>[] = [
+    export const SPOILERS: Spoiler<ObjectUndefined>[] = [
         (input) => {
             input[0].name = null!;
             return ["$input[0].name"];


### PR DESCRIPTION
This revision includes:
- Correct typo 'Undefied' to 'Undefined'