### PR TITLE
Correct typo 'valiation' to 'validation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ https://github.com/samchon/nestia-helper
 
 Helper library of `NestJS`, using this `typescript-json`.
 
-`nestia-helper` is a helper library of `NestJS`, which boosts up the `JSON.stringify()` speed 5x times faster about the API responses, automatically. Also, `nestia-helper` supports automatic valiation of request body, too. 
+`nestia-helper` is a helper library of `NestJS`, which boosts up the `JSON.stringify()` speed 5x times faster about the API responses, automatically. Also, `nestia-helper` supports automatic validation of request body, too. 
 
 ```typescript
 import helper from "nestia-helper";


### PR DESCRIPTION
This pull request fixes a typo, `valiation` to `validation`.

When I searched `valiation`, I guess it was a typo of `validation` but if it wasn't incorrect word, please close this pull request. Thank you! 🙏🏻 