### PR TITLE
Fixing #351 - stop using TS 4.9 for a while

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.3.39",
+  "version": "3.3.40",
   "description": "Runtime type checkers and 5x faster JSON.stringify() function",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -52,6 +52,9 @@
     "url": "https://github.com/samchon/typescript-json/issues"
   },
   "homepage": "https://github.com/samchon/typescript-json#readme",
+  "peerDependencies": {
+    "typescript": "4.6.x || 4.7.x || 4.8.x"
+  },
   "devDependencies": {
     "@fastify/type-provider-typebox": "^2.3.0",
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",

--- a/src/programmers/internal/application_number.ts
+++ b/src/programmers/internal/application_number.ts
@@ -33,6 +33,8 @@ export const application_number = (
                     output.maximum = tag.maximum.value;
                 else output.exclusiveMaximum = tag.maximum.value;
         }
+        // MULTIPLE-OF
+        else if (tag.kind === "multipleOf") output.multipleOf = tag.value;
     }
 
     // WHEN UNSIGNED INT
@@ -64,6 +66,8 @@ export const application_number = (
             conditions.push(value > output.exclusiveMinimum);
         if (output.exclusiveMaximum !== undefined)
             conditions.push(value < output.exclusiveMaximum);
+        if (output.multipleOf !== undefined)
+            conditions.push(value % output.multipleOf === 0);
         return conditions.every((cond) => cond);
     })((str) => Number(str));
 

--- a/src/schemas/IJsonSchema.ts
+++ b/src/schemas/IJsonSchema.ts
@@ -43,6 +43,7 @@ export namespace IJsonSchema {
         maximum?: number;
         exclusiveMinimum?: number;
         exclusiveMaximum?: number;
+        multipleOf?: number;
     }
     export interface IBoolean extends IAtomic<"boolean"> {}
     export interface IBigInt extends IAtomic<"bigint"> {}

--- a/test/features/application/ajv/test_application_ajv_TagStep.ts
+++ b/test/features/application/ajv/test_application_ajv_TagStep.ts
@@ -157,6 +157,7 @@ export const test_application_ajv_TagStep = _test_application("ajv")(
                                 },
                             ],
                             "x-tson-required": true,
+                            multipleOf: 5,
                         },
                     },
                     nullable: false,

--- a/test/features/application/ajv/test_application_ajv_UltimateUnion.ts
+++ b/test/features/application/ajv/test_application_ajv_UltimateUnion.ts
@@ -1214,6 +1214,11 @@ export const test_application_ajv_UltimateUnion = _test_application("ajv")(
                             nullable: false,
                             "x-tson-required": false,
                         },
+                        multipleOf: {
+                            type: "number",
+                            nullable: false,
+                            "x-tson-required": false,
+                        },
                         default: {
                             type: "number",
                             nullable: false,

--- a/test/features/application/replace.js
+++ b/test/features/application/replace.js
@@ -15,7 +15,11 @@ function replace(type, file, schema) {
 
     const newContent =
         content.substring(0, first) + symbol + schema + "\n" + ");";
-    fs.writeFileSync(file, newContent, "utf8");
+    fs.writeFileSync(
+        file, 
+        newContent.split("\r\n").join("\n"), 
+        "utf8"
+    );
 }
 
 function iterate(type) {

--- a/test/features/application/swagger/test_application_swagger_TagStep.ts
+++ b/test/features/application/swagger/test_application_swagger_TagStep.ts
@@ -156,6 +156,7 @@ export const test_application_swagger_TagStep = _test_application("swagger")(
                                 },
                             ],
                             "x-tson-required": true,
+                            multipleOf: 5,
                         },
                     },
                     nullable: false,

--- a/test/features/application/swagger/test_application_swagger_UltimateUnion.ts
+++ b/test/features/application/swagger/test_application_swagger_UltimateUnion.ts
@@ -1184,6 +1184,11 @@ export const test_application_swagger_UltimateUnion = _test_application(
                         nullable: false,
                         "x-tson-required": false,
                     },
+                    multipleOf: {
+                        type: "number",
+                        nullable: false,
+                        "x-tson-required": false,
+                    },
                     default: {
                         type: "number",
                         nullable: false,


### PR DESCRIPTION
TS 4.9.4 patch has been delayed for a long time.

Therefore, blocked TS 4.9 by `peerDependencies`