### PR TITLE
Use cache in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,12 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16.x
+      - uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - run: npm install
       - run: npm run build
       - run: npm run build:test


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated workflows to cache dependencies using [actions/cache](https://github.com/actions/cache).

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

**AS-IS**

```yaml
- uses: actions/setup-node@v1
  with:
    node-version: 16.x
```

**TO-BE**

```yaml
- uses: actions/setup-node@v1
  with:
    node-version: 16.x
- uses: actions/cache@v3
  with:
  path: ~/.npm
  key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
  restore-keys: |
    ${{ runner.os }}-node-
```

> There was no lockfile, so the hash was calculated using `package.json`.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
