### PR TITLE
Close #476 - `ITransformOptions.undefined` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.4.22",
+  "version": "3.4.23",
   "description": "Runtime type checkers and 5x faster JSON.stringify() function",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -103,7 +103,7 @@
     "suppress-warnings": "^1.0.2",
     "ts-node": "^10.9.1",
     "ttypescript": "^1.5.15",
-    "typescript": "^4.9.4",
+    "typescript": "^4.9.5",
     "uuid": "^8.3.2",
     "zod": "^3.19.1"
   },

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -227,29 +227,63 @@ export function createAssertStringify<T>(): (input: T) => string;
 
 [Nestia](https://github.com/samchon/nestia) is a set of helper libraries for `NestJS`, supporting below features:
 
-  - [`@nestia/core`](https://github.com/samchon/nestia#nestiacore): **15,000x times faster** validation decorator using `typia`
-  - [`@nestia/sdk`](https://github.com/samchon/nestia#nestiasdk): evolved **SDK** and **Swagger** generator for `@nestia/core`
+  - `@nestia/core`: **15,000x times faster** validation decorators
+  - `@nestia/sdk`: evolved **SDK** and **Swagger** generators
+    - SDK (Software Development Kit)
+      - interaction library for client developers
+      - almost same with [tRPC](https://github.com/trpc/trpc)
   - `nestia`: just CLI (command line interface) tool
 
-```typescript
-import { Controller } from "@nestjs/common";
-import { TypedBody, TypedRoute } from "@nestia/core";
+![nestia-sdk-demo](https://user-images.githubusercontent.com/13158709/215004990-368c589d-7101-404e-b81b-fbc936382f05.gif)
 
-import type { IBbsArticle } from "@bbs-api/structures/IBbsArticle";
+### Reactia
+> Not published yet, but soon
 
-@Controller("bbs/articles")
-export class BbsArticlesController {
-    /** 
-     * Store a new content.
-     * 
-     * @param inupt Content to store
-     * @returns Newly archived article
-     */
-    @TypedRoute.Post() // 10x faster and safer JSON.stringify()
-    public async store(
-        @TypedBody() input: IBbsArticle.IStore // super-fast validator
-    ): Promise<IBbsArticle>; 
-        // do not need DTO class definition, 
-        // just fine with interface
-}
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/reactia/blob/master/LICENSE)
+[![Build Status](https://github.com/samchon/reactia/workflows/build/badge.svg)](https://github.com/samchon/reactia/actions?query=workflow%3Abuild)
+[![Guide Documents](https://img.shields.io/badge/wiki-documentation-forestgreen)](https://github.com/samchon/reactia/wiki)
+
+[Reactia](https://github.com/samchon/reactia) is an automatic React components generator, just by analyzing TypeScript type.
+
+  - `@reactia/core`: Core Library analyzing TypeScript type
+  - `@reactia/mui`: Material UI Theme for `core` and `nest`
+  - `@reactia/nest`: Automatic Frontend Application Builder for `NestJS`
+
+![Sample](https://user-images.githubusercontent.com/13158709/199074008-46b2dd67-02be-40b1-aa0f-74ac41f3e0a7.png)
+
+When you want to automate an individual component, just use `@reactia/core`.
+
+```tsx
+import ReactDOM from "react-dom";
+
+import typia from "typia";
+import { ReactiaComponent } from "@reactia/core";
+import { MuiInputTheme } from "@reactia/mui";
+
+const RequestInput = ReactiaComponent<IRequestDto>(MuiInputTheme());
+const input: IRequestDto = { ... };
+
+ReactDOM.render(
+    <RequestInput input={input} />,
+    document.body
+);
+```
+
+Otherwise, you can fully automate frontend application development through `@reactia/nest`.
+
+```tsx
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { ISwagger } "@nestia/swagger";
+import { MuiApplicationTheme } from "@reactia/mui";
+import { ReactiaApplication } from "@reactia/nest";
+
+const swagger: ISwagger = await import("./swagger.json");
+const App: React.FC = ReactiaApplication(MuiApplicationTheme())(swagger);
+
+ReactDOM.render(
+    <App />,
+    document.body
+);
 ```

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.4.22",
+  "version": "3.4.23",
   "description": "Runtime type checkers and 5x faster JSON.stringify() function",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
     "src"
   ],
   "dependencies": {
-    "typia": "3.4.22"
+    "typia": "3.4.23"
   }
 }

--- a/src/programmers/IsProgrammer.ts
+++ b/src/programmers/IsProgrammer.ts
@@ -51,6 +51,9 @@ export namespace IsProgrammer {
                 options?.object ||
                 check_object({
                     equals: !!options?.object,
+                    undefined: OptionPredicator.undefined({
+                        undefined: options?.undefined,
+                    }),
                     assert: true,
                     reduce: ts.factory.createLogicalAnd,
                     positive: ts.factory.createTrue(),
@@ -70,6 +73,7 @@ export namespace IsProgrammer {
     export namespace CONFIG {
         export interface IOptions {
             numeric: boolean;
+            undefined: boolean;
             object: (entries: IExpressionEntry[]) => ts.Expression;
         }
     }
@@ -88,6 +92,7 @@ export namespace IsProgrammer {
         const config = CONFIG({
             object: check_object({
                 equals,
+                undefined: OptionPredicator.undefined(project.options),
                 assert: true,
                 reduce: ts.factory.createLogicalAnd,
                 positive: ts.factory.createTrue(),

--- a/src/programmers/helpers/OptionPredicator.ts
+++ b/src/programmers/helpers/OptionPredicator.ts
@@ -12,4 +12,8 @@ export namespace OptionPredicator {
     export function finite(options: ITransformOptions): boolean {
         return options.finite === true;
     }
+
+    export function undefined(options: ITransformOptions): boolean {
+        return options.undefined !== false;
+    }
 }

--- a/src/programmers/internal/check_dynamic_properties.ts
+++ b/src/programmers/internal/check_dynamic_properties.ts
@@ -17,6 +17,24 @@ export const check_dynamic_properties =
         regular: IExpressionEntry[],
         dynamic: IExpressionEntry[],
     ): ts.Expression => {
+        if (
+            props.equals === true &&
+            props.undefined === false &&
+            regular.every((r) => r.meta.required) &&
+            dynamic.length === 0
+        )
+            return ts.factory.createStrictEquality(
+                ts.factory.createNumericLiteral(regular.length),
+                IdentifierFactory.join(
+                    ts.factory.createCallExpression(
+                        ts.factory.createIdentifier("Object.keys"),
+                        undefined,
+                        [ts.factory.createIdentifier("input")],
+                    ),
+                    "length",
+                ),
+            );
+
         const criteria = props.entries
             ? ts.factory.createCallExpression(props.entries, undefined, [
                   ts.factory.createCallExpression(

--- a/src/programmers/internal/check_object.ts
+++ b/src/programmers/internal/check_object.ts
@@ -26,6 +26,7 @@ export namespace check_object {
     export interface IProps {
         equals: boolean;
         assert: boolean;
+        undefined: boolean;
         halt?: (exp: ts.Expression) => ts.Expression;
         reduce: (a: ts.Expression, b: ts.Expression) => ts.Expression;
         positive: ts.Expression;

--- a/src/transformers/ITransformOptions.ts
+++ b/src/transformers/ITransformOptions.ts
@@ -44,4 +44,15 @@ export interface ITransformOptions {
      * @default false
      */
     functional?: boolean;
+
+    /**
+     * Whether to check undefined value or not.
+     *
+     * JavaScript can assign `undefined` value to a specific property and it is an
+     * issue when validating without allowing superfluous properties. Should undefined
+     * value assigned superfluous property be allowed or not?
+     *
+     * @default true
+     */
+    undefined?: boolean;
 }


### PR DESCRIPTION
```typescript
export interface ITransformOptions {
    /**
     * Whether to validate finite number or not.
     *
     * If configured true, number typed values would be validated by Number.isNaN().
     *
     * However, whatever you configure, it would be ignored when marshaling or parsing.
     *
     *   - when marshaling, always be true
     *     - assertStringify()
     *     - validateEncode()
     *   - when parsing, always be false
     *     - assertParse()
     *     - isDecode()
     *
     * @default false
     */
    finite?: boolean;

    /**
     * Whether to validate finite number or not.
     *
     * If configured true, number typed values would be validated by Number.isFinite().
     *
     * However, whatever you configure, it can be ignored in below case.
     *
     *   - when `finite` option is true, this option would be ignored
     *   - when marshaling, always be true
     *     - assertStringify()
     *     - validateEncode()
     *   - when parsing, always be false
     *     - assertParse()
     *     - isDecode()
     *
     * @default false
     */
    numeric?: boolean;

    /**
     * Whether to validate functional type or not.
     *
     * However, whatever you configure, it becomes false when marshaling or parsing.
     *
     * @default false
     */
    functional?: boolean;

    /**
     * Whether to check undefined value or not.
     *
     * JavaScript can assign `undefined` value to a specific property and it is an
     * issue when validating without allowing superfluous properties. Should undefined
     * value assigned superfluous property be allowed or not?
     *
     * @default true
     */
    undefined?: boolean;
}
```