### PR TITLE
Fix: exact package.json exploration logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -57,7 +57,7 @@ Thanks for your support.
 
 Your donation would encourage `typia` development.
 
-[![Backers](https://opencollective.com/typia/backers.svg?width=1000)](https://opencollective.com/typia)
+[![Backers](https://opencollective.com/typia/backers.svg?avatarHeight=75&width=600))](https://opencollective.com/typia)
 
 
 

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -72,6 +72,6 @@
     "src"
   ],
   "dependencies": {
-    "typia": "3.5.7"
+    "typia": "3.5.8"
   }
 }

--- a/src/executable/setup/FileRetriever.ts
+++ b/src/executable/setup/FileRetriever.ts
@@ -4,11 +4,11 @@ import path from "path";
 export namespace FileRetriever {
     export const directory =
         (name: string) =>
-        (directory: string, depth: number = 0): string | null => {
-            const location: string = path.join(directory, name);
-            if (fs.existsSync(location)) return directory;
+        (dir: string, depth: number = 0): string | null => {
+            const location: string = path.join(dir, name);
+            if (fs.existsSync(location)) return dir;
             else if (depth > 2) return null;
-            return file(name)(path.join(directory, ".."), depth + 1);
+            return directory(name)(path.join(dir, ".."), depth + 1);
         };
 
     export const file =


### PR DESCRIPTION
Exact `package.json` exploration logic when running `npx nestia setup` command.