### PR TITLE
Close #560 - support custom validation tags

### DIFF
--- a/build/internal/TestStructure.ts
+++ b/build/internal/TestStructure.ts
@@ -7,4 +7,5 @@ export interface TestStructure<T> {
     ADDABLE?: boolean;
     JSONABLE?: boolean;
     PRIMITIVE?: boolean;
+    RANDOM?: boolean;
 }

--- a/build/test.ts
+++ b/build/test.ts
@@ -47,8 +47,7 @@ async function generate(
         else if (feat.jsonable && s.JSONABLE === false) continue;
         else if (feat.primitive && s.PRIMITIVE === false) continue;
         else if (feat.strict && s.ADDABLE === false) continue;
-        else if (feat.method === "random" && s.name === "UltimateUnion")
-            continue;
+        else if (feat.method === "random" && s.RANDOM === false) continue;
 
         const location: string = `${path}/test_${method}_${s.name}.ts`;
         await fs.promises.writeFile(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.6.10",
+  "version": "3.7.0-dev.20230331",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.6.10",
+  "version": "3.7.0-dev.20230331",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -74,6 +74,6 @@
     "src"
   ],
   "dependencies": {
-    "typia": "3.6.10"
+    "typia": "3.7.0-dev.20230331"
   }
 }

--- a/src/factories/MetadataTagFactory.ts
+++ b/src/factories/MetadataTagFactory.ts
@@ -28,7 +28,7 @@ export namespace MetadataTagFactory {
         tag: ts.JSDocTagInfo,
         output: IMetadataTag[],
     ): IMetadataTag | null {
-        const closure = PARSER[tag.name];
+        const closure = _PARSER[tag.name];
         if (closure === undefined) return null;
 
         const text = (tag.text || [])[0]?.text;
@@ -37,167 +37,193 @@ export namespace MetadataTagFactory {
 
         return closure(identifier, metadata, text, output);
     }
-}
 
-const PARSER: Record<
-    string,
-    (
-        identifier: () => string,
-        metadata: Metadata,
-        text: string,
-        output: IMetadataTag[],
-    ) => IMetadataTag | null
-> = {
-    /* -----------------------------------------------------------
+    /**
+     * @internal
+     */
+    export const _PARSER: Record<
+        string,
+        (
+            identifier: () => string,
+            metadata: Metadata,
+            text: string,
+            output: IMetadataTag[],
+        ) => IMetadataTag | null
+    > = {
+        /* -----------------------------------------------------------
         ARRAY
     ----------------------------------------------------------- */
-    items: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "items", "array", ["minItems"]);
-        return {
-            kind: "items",
-            value: parse_number(identifier, text),
-        };
-    },
-    minItems: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "minItems", "array", ["items"]);
-        return {
-            kind: "minItems",
-            value: parse_number(identifier, text),
-        };
-    },
-    maxItems: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "maxItems", "array", ["items"]);
-        return {
-            kind: "maxItems",
-            value: parse_number(identifier, text),
-        };
-    },
+        items: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "items", "array", [
+                "minItems",
+            ]);
+            return {
+                kind: "items",
+                value: parse_number(identifier, text),
+            };
+        },
+        minItems: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "minItems", "array", [
+                "items",
+            ]);
+            return {
+                kind: "minItems",
+                value: parse_number(identifier, text),
+            };
+        },
+        maxItems: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "maxItems", "array", [
+                "items",
+            ]);
+            return {
+                kind: "maxItems",
+                value: parse_number(identifier, text),
+            };
+        },
 
-    /* -----------------------------------------------------------
+        /* -----------------------------------------------------------
         NUMBER
     ----------------------------------------------------------- */
-    type: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "type", "number", []);
-        if (text !== "int" && text !== "uint")
-            throw new Error(`${LABEL}: invalid type tag on "${identifier()}".`);
-        return { kind: "type", value: text };
-    },
-    minimum: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "minimum", "number", [
-            "exclusiveMinimum",
-        ]);
-        return {
-            kind: "minimum",
-            value: parse_number(identifier, text),
-        };
-    },
-    maximum: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "maximum", "number", [
-            "exclusiveMaximum",
-        ]);
-        return {
-            kind: "maximum",
-            value: parse_number(identifier, text),
-        };
-    },
-    exclusiveMinimum: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "exclusiveMinimum", "number", [
-            "minimum",
-        ]);
-        return {
-            kind: "exclusiveMinimum",
-            value: parse_number(identifier, text),
-        };
-    },
-    exclusiveMaximum: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "exclusiveMaximum", "number", [
-            "maximum",
-        ]);
-        return {
-            kind: "exclusiveMaximum",
-            value: parse_number(identifier, text),
-        };
-    },
-    multipleOf: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "multipleOf", "number", [
-            "step",
-        ]);
-        return {
-            kind: "multipleOf",
-            value: parse_number(identifier, text),
-        };
-    },
-    step: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "step", "number", [
-            "multipleOf",
-        ]);
-
-        const minimum: boolean = output.some(
-            (tag) => tag.kind === "minimum" || tag.kind === "exclusiveMinimum",
-        );
-        if (minimum === undefined)
-            throw new Error(
-                `${LABEL}: step requires minimum or exclusiveMinimum tag on "${identifier()}".`,
+        type: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "type", "number", []);
+            if (text !== "int" && text !== "uint")
+                throw new Error(
+                    `${LABEL}: invalid type tag on "${identifier()}".`,
+                );
+            return { kind: "type", value: text };
+        },
+        minimum: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "minimum", "number", [
+                "exclusiveMinimum",
+            ]);
+            return {
+                kind: "minimum",
+                value: parse_number(identifier, text),
+            };
+        },
+        maximum: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "maximum", "number", [
+                "exclusiveMaximum",
+            ]);
+            return {
+                kind: "maximum",
+                value: parse_number(identifier, text),
+            };
+        },
+        exclusiveMinimum: (identifier, metadata, text, output) => {
+            validate(
+                identifier,
+                metadata,
+                output,
+                "exclusiveMinimum",
+                "number",
+                ["minimum"],
             );
+            return {
+                kind: "exclusiveMinimum",
+                value: parse_number(identifier, text),
+            };
+        },
+        exclusiveMaximum: (identifier, metadata, text, output) => {
+            validate(
+                identifier,
+                metadata,
+                output,
+                "exclusiveMaximum",
+                "number",
+                ["maximum"],
+            );
+            return {
+                kind: "exclusiveMaximum",
+                value: parse_number(identifier, text),
+            };
+        },
+        multipleOf: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "multipleOf", "number", [
+                "step",
+            ]);
+            return {
+                kind: "multipleOf",
+                value: parse_number(identifier, text),
+            };
+        },
+        step: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "step", "number", [
+                "multipleOf",
+            ]);
 
-        return {
-            kind: "step",
-            value: parse_number(identifier, text),
-        };
-    },
+            const minimum: boolean = output.some(
+                (tag) =>
+                    tag.kind === "minimum" || tag.kind === "exclusiveMinimum",
+            );
+            if (minimum === undefined)
+                throw new Error(
+                    `${LABEL}: step requires minimum or exclusiveMinimum tag on "${identifier()}".`,
+                );
 
-    /* -----------------------------------------------------------
+            return {
+                kind: "step",
+                value: parse_number(identifier, text),
+            };
+        },
+
+        /* -----------------------------------------------------------
         STRING
     ----------------------------------------------------------- */
-    format: (identifier, metadata, str, output) => {
-        validate(identifier, metadata, output, "format", "string", ["pattern"]);
+        format: (identifier, metadata, str, output) => {
+            validate(identifier, metadata, output, "format", "string", [
+                "pattern",
+            ]);
 
-        // Ignore arbitrary @format values in the internal metadata,
-        // these are currently only supported on the typia.application() API.
-        const value: IMetadataTag.IFormat["value"] | undefined =
-            FORMATS.get(str);
-        if (value === undefined) return null;
-        return {
-            kind: "format",
-            value,
-        };
-    },
-    pattern: (identifier, metadata, value, output) => {
-        validate(identifier, metadata, output, "pattern", "string", ["format"]);
-        return {
-            kind: "pattern",
-            value,
-        };
-    },
-    length: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "length", "string", [
-            "minLength",
-            "maxLength",
-        ]);
-        return {
-            kind: "length",
-            value: parse_number(identifier, text),
-        };
-    },
-    minLength: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "minLength", "string", [
-            "length",
-        ]);
-        return {
-            kind: "minLength",
-            value: parse_number(identifier, text),
-        };
-    },
-    maxLength: (identifier, metadata, text, output) => {
-        validate(identifier, metadata, output, "maxLength", "string", [
-            "length",
-        ]);
-        return {
-            kind: "maxLength",
-            value: parse_number(identifier, text),
-        };
-    },
-};
+            // Ignore arbitrary @format values in the internal metadata,
+            // these are currently only supported on the typia.application() API.
+            const value: IMetadataTag.IFormat["value"] | undefined =
+                FORMATS.get(str);
+            if (value === undefined) return null;
+            return {
+                kind: "format",
+                value,
+            };
+        },
+        pattern: (identifier, metadata, value, output) => {
+            validate(identifier, metadata, output, "pattern", "string", [
+                "format",
+            ]);
+            return {
+                kind: "pattern",
+                value,
+            };
+        },
+        length: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "length", "string", [
+                "minLength",
+                "maxLength",
+            ]);
+            return {
+                kind: "length",
+                value: parse_number(identifier, text),
+            };
+        },
+        minLength: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "minLength", "string", [
+                "length",
+            ]);
+            return {
+                kind: "minLength",
+                value: parse_number(identifier, text),
+            };
+        },
+        maxLength: (identifier, metadata, text, output) => {
+            validate(identifier, metadata, output, "maxLength", "string", [
+                "length",
+            ]);
+            return {
+                kind: "maxLength",
+                value: parse_number(identifier, text),
+            };
+        },
+    };
+}
 
 function parse_number(identifier: () => string, str: string): number {
     const value: number = Number(str);

--- a/src/functional/$dictionary.ts
+++ b/src/functional/$dictionary.ts
@@ -1,0 +1,17 @@
+import { Customizable } from "../typings/Customizable";
+
+export const $dictionary = (() => {
+    const glob: {
+        __typia_custom_validator: Map<
+            `${string}:${keyof Customizable}`,
+            (tagText: string) => (value: any) => boolean
+        >;
+    } =
+        typeof global === "object" &&
+        typeof global.process === "object" &&
+        typeof global.process.versions === "object" &&
+        typeof global.process.versions.node !== "undefined"
+            ? (global as any)
+            : (window as any);
+    return (glob.__typia_custom_validator ??= new Map());
+})();

--- a/src/functional/$is_custom.ts
+++ b/src/functional/$is_custom.ts
@@ -1,0 +1,14 @@
+import { Customizable } from "../typings/Customizable";
+
+import { $dictionary } from "./$dictionary";
+
+export function $is_custom<Type extends keyof Customizable>(
+    name: string,
+    type: Type,
+    text: string,
+    value: Customizable[Type],
+): boolean {
+    const validator = $dictionary.get(`${name}:${type}`);
+    if (validator === undefined) return true;
+    return validator(text)(value);
+}

--- a/src/functional/Namespace.ts
+++ b/src/functional/Namespace.ts
@@ -6,6 +6,7 @@ import { $any } from "./$any";
 import { $every } from "./$every";
 import { $guard } from "./$guard";
 import { $is_between } from "./$is_between";
+import { $is_custom } from "./$is_custom";
 import { $is_date } from "./$is_date";
 import { $is_datetime } from "./$is_datetime";
 import { $is_email } from "./$is_email";
@@ -33,6 +34,7 @@ export namespace Namespace {
         is_between: $is_between,
         is_date: $is_date,
         is_datetime: $is_datetime,
+        is_custom: $is_custom,
     });
 
     export const assert = (method: string) => ({

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,10 @@
+import { $dictionary } from "./functional/$dictionary";
 import { Namespace } from "./functional/Namespace";
 
 import { IMetadataApplication } from "./metadata/IMetadataApplication";
 import { IJsonApplication } from "./schemas/IJsonApplication";
+
+import { Customizable } from "./typings/Customizable";
 
 import { IRandomGenerator } from "./IRandomGenerator";
 import { IValidation } from "./IValidation";
@@ -409,6 +412,43 @@ export function validateEquals(): never {
     halt("validateEquals");
 }
 Object.assign(validateEquals, Namespace.validate());
+
+/**
+ * Add validation tag.
+ *
+ * If you want to add a custom validation logic, you can use this function.
+ *
+ * ```ts
+ * typia.addValidationTag("powerOf")("number")(
+ *     (text: string) => {
+ *         const denominator: number = Math.log(Number(text));
+ *         return (value: number) => {
+ *             value = Math.log(value) / denominator;
+ *             return value === Math.floor(value);
+ *         };
+ *     }
+ * );
+ * typia.addValidationTag("dollar")("string")(
+ *     () => (value: string) => value.startsWith("$"),
+ * );
+ * ```
+ *
+ * @param name Name of tag (`@name`)
+ * @returns Currying function
+ */
+export const addValidationTag =
+    (name: string) =>
+    /**
+     * @param type Type of target value
+     */
+    <Type extends keyof Customizable>(type: Type) =>
+    /**
+     * @param closure Closure function for custom validation
+     */
+    (closure: (text: string) => (value: Customizable[Type]) => boolean) => {
+        const key = `${name}:${type}` as const;
+        if (!$dictionary.has(key)) $dictionary.set(key, closure);
+    };
 
 /* -----------------------------------------------------------
     JSON FUNCTIONS

--- a/src/programmers/CloneProgrammer.ts
+++ b/src/programmers/CloneProgrammer.ts
@@ -109,6 +109,7 @@ export namespace CloneProgrammer {
                             })(),
                             explore,
                             [],
+                            [],
                         ),
                     value: () =>
                         decode_tuple(project, importer)(input, tuple, explore),
@@ -127,6 +128,7 @@ export namespace CloneProgrammer {
                                 ...explore,
                                 from: "array",
                             },
+                            [],
                             [],
                         ),
                 });

--- a/src/programmers/FeatureProgrammer.ts
+++ b/src/programmers/FeatureProgrammer.ts
@@ -6,6 +6,7 @@ import { StatementFactory } from "../factories/StatementFactory";
 import { TypeFactory } from "../factories/TypeFactory";
 import { ValueFactory } from "../factories/ValueFactory";
 
+import { IJsDocTagInfo } from "../metadata/IJsDocTagInfo";
 import { IMetadataTag } from "../metadata/IMetadataTag";
 import { Metadata } from "../metadata/Metadata";
 import { MetadataObject } from "../metadata/MetadataObject";
@@ -202,7 +203,8 @@ export namespace FeatureProgrammer {
             input: ts.Expression,
             target: T,
             explore: IExplore,
-            tags: IMetadataTag[],
+            metaTags: IMetadataTag[],
+            jsDocTags: ts.JSDocTagInfo[],
         ): Output;
     }
 
@@ -240,6 +242,7 @@ export namespace FeatureProgrammer {
                     from: "top",
                     postfix: '""',
                 },
+                [],
                 [],
             );
 
@@ -350,6 +353,7 @@ export namespace FeatureProgrammer {
                         postfix: "",
                     },
                     [],
+                    [],
                 ),
             );
     }
@@ -363,7 +367,8 @@ export namespace FeatureProgrammer {
         combiner: (
             input: ts.Expression,
             arrow: ts.ArrowFunction,
-            tags: IMetadataTag[],
+            metaTags: IMetadataTag[],
+            jsDocTags: ts.JSDocTagInfo[],
         ) => ts.Expression,
     ) {
         const rand: string = importer.increment().toString();
@@ -381,7 +386,8 @@ export namespace FeatureProgrammer {
             input: ts.Expression,
             meta: Metadata,
             explore: IExplore,
-            tags: IMetadataTag[],
+            metaTags: IMetadataTag[],
+            jsDocTags: IJsDocTagInfo[],
         ) => {
             const arrow: ts.ArrowFunction = ts.factory.createArrowFunction(
                 undefined,
@@ -406,10 +412,11 @@ export namespace FeatureProgrammer {
                             explore.postfix,
                         )(rand),
                     },
-                    tags,
+                    metaTags,
+                    jsDocTags,
                 ),
             );
-            return combiner(input, arrow, tags);
+            return combiner(input, arrow, metaTags, jsDocTags);
         };
     }
 

--- a/src/programmers/IsProgrammer.ts
+++ b/src/programmers/IsProgrammer.ts
@@ -105,7 +105,7 @@ export namespace IsProgrammer {
         })(importer);
         config.trace = equals;
 
-        config.decoder = (input, target, explore, tags) => {
+        config.decoder = (input, target, explore, tags, jsDocTags) => {
             if (
                 target.size() === 1 &&
                 target.objects.length === 1 &&
@@ -137,6 +137,7 @@ export namespace IsProgrammer {
                 target,
                 explore,
                 tags,
+                jsDocTags,
             );
         };
 

--- a/src/programmers/PruneProgrammer.ts
+++ b/src/programmers/PruneProgrammer.ts
@@ -88,6 +88,7 @@ export namespace PruneProgrammer {
                             })(),
                             explore,
                             [],
+                            [],
                         ),
                     value: () =>
                         decode_tuple(project, importer)(input, tuple, explore),
@@ -106,6 +107,7 @@ export namespace PruneProgrammer {
                                 ...explore,
                                 from: "array",
                             },
+                            [],
                             [],
                         ),
                 });

--- a/src/programmers/StringifyProgrammer.ts
+++ b/src/programmers/StringifyProgrammer.ts
@@ -172,6 +172,7 @@ export namespace StringifyProgrammer {
                                     partial,
                                     explore,
                                     [],
+                                    [],
                                 ),
                             value: () =>
                                 decode_atomic(project, importer)(
@@ -200,6 +201,7 @@ export namespace StringifyProgrammer {
                                 })(),
                                 explore,
                                 [],
+                                [],
                             ),
                         value: () =>
                             decode_atomic(project, importer)(
@@ -221,6 +223,7 @@ export namespace StringifyProgrammer {
                                     return partial;
                                 })(),
                                 explore,
+                                [],
                                 [],
                             ),
                         value: () =>
@@ -245,6 +248,7 @@ export namespace StringifyProgrammer {
                                     return partial;
                                 })(),
                                 explore,
+                                [],
                                 [],
                             ),
                         value: () =>
@@ -274,6 +278,7 @@ export namespace StringifyProgrammer {
                                 return partial;
                             })(),
                             explore,
+                            [],
                             [],
                         ),
                     value: () =>
@@ -310,6 +315,7 @@ export namespace StringifyProgrammer {
                                   ...explore,
                                   from: "array",
                               },
+                              [],
                               [],
                           );
 

--- a/src/programmers/helpers/UnionExplorer.ts
+++ b/src/programmers/helpers/UnionExplorer.ts
@@ -18,6 +18,7 @@ export namespace UnionExplorer {
             target: T,
             explore: FeatureProgrammer.IExplore,
             tags: IMetadataTag[],
+            jsDocTags: ts.JSDocTagInfo[],
         ): ts.Expression;
     }
     export type ObjectCombiner = Decoder<MetadataObject[]>;
@@ -32,6 +33,7 @@ export namespace UnionExplorer {
             targets: MetadataObject[],
             explore: FeatureProgrammer.IExplore,
             tags: IMetadataTag[],
+            jsDocTags: ts.JSDocTagInfo[],
         ): ts.Expression => {
             // BREAKER
             if (targets.length === 1)
@@ -40,6 +42,7 @@ export namespace UnionExplorer {
                     targets[0]!,
                     explore,
                     tags,
+                    jsDocTags,
                 );
 
             const expected: string = `(${targets
@@ -57,6 +60,7 @@ export namespace UnionExplorer {
                         tracable: false,
                     },
                     tags,
+                    jsDocTags,
                 );
                 return config.objector.full
                     ? config.objector.full(condition)(input, expected, explore)
@@ -85,6 +89,7 @@ export namespace UnionExplorer {
                                   postfix: IdentifierFactory.postfix(key),
                               },
                               tags,
+                              jsDocTags,
                           )
                         : (config.objector.required || ((exp) => exp))(
                               ExpressionFactory.isRequired(accessor),
@@ -97,6 +102,7 @@ export namespace UnionExplorer {
                                 spec.object,
                                 explore,
                                 tags,
+                                jsDocTags,
                             ),
                         ),
                     );
@@ -120,6 +126,7 @@ export namespace UnionExplorer {
                                           remained,
                                           explore,
                                           tags,
+                                          jsDocTags,
                                       ),
                                   )
                                 : config.objector.failure(

--- a/src/programmers/internal/check_array.ts
+++ b/src/programmers/internal/check_array.ts
@@ -2,21 +2,30 @@ import ts from "typescript";
 
 import { ExpressionFactory } from "../../factories/ExpressionFactory";
 
+import { IJsDocTagInfo } from "../../metadata/IJsDocTagInfo";
 import { IMetadataTag } from "../../metadata/IMetadataTag";
 
+import { FunctionImporter } from "../helpers/FunctionImporeter";
 import { check_array_length } from "./check_array_length";
+import { check_custom } from "./check_custom";
 
 /**
  * @internal
  */
-export function check_array(
-    input: ts.Expression,
-    tagList: IMetadataTag[],
-): ts.Expression {
-    const conditions: ts.Expression[] = [ExpressionFactory.isArray(input)];
+export const check_array =
+    (importer: FunctionImporter) =>
+    (
+        input: ts.Expression,
+        metaTags: IMetadataTag[],
+        jsDocTags: IJsDocTagInfo[],
+    ): ts.Expression => {
+        const conditions: ts.Expression[] = [ExpressionFactory.isArray(input)];
 
-    const length: ts.Expression | null = check_array_length(input, tagList);
-    if (length !== null) conditions.push(length);
-
-    return conditions.reduce((x, y) => ts.factory.createLogicalAnd(x, y));
-}
+        const length: ts.Expression | null = check_array_length(
+            input,
+            metaTags,
+        );
+        if (length !== null) conditions.push(length);
+        conditions.push(...check_custom("array")(importer)(input, jsDocTags));
+        return conditions.reduce((x, y) => ts.factory.createLogicalAnd(x, y));
+    };

--- a/src/programmers/internal/check_bigint.ts
+++ b/src/programmers/internal/check_bigint.ts
@@ -1,64 +1,84 @@
 import ts from "typescript";
 
+import { IJsDocTagInfo } from "../../metadata/IJsDocTagInfo";
 import { IMetadataTag } from "../../metadata/IMetadataTag";
 
-export function check_bigint(input: ts.Expression, tagList: IMetadataTag[]) {
-    const caster = (value: number) =>
-        ts.factory.createIdentifier(`${Math.floor(value)}n`);
+import { FunctionImporter } from "../helpers/FunctionImporeter";
+import { check_custom } from "./check_custom";
 
-    // TYPEOF STATEMENT
-    const conditions: ts.Expression[] = [
-        ts.factory.createStrictEquality(
-            ts.factory.createStringLiteral("bigint"),
-            ts.factory.createTypeOfExpression(input),
-        ),
-    ];
+export const check_bigint =
+    (importer: FunctionImporter) =>
+    (
+        input: ts.Expression,
+        metaTags: IMetadataTag[],
+        jsDocTags: IJsDocTagInfo[],
+    ): ts.Expression => {
+        const caster = (value: number) =>
+            ts.factory.createIdentifier(`${Math.floor(value)}n`);
 
-    // TAG (RANGE)
-    for (const tag of tagList)
-        if (tag.kind === "multipleOf")
-            conditions.push(
-                ts.factory.createStrictEquality(
-                    caster(0),
-                    ts.factory.createModulo(input, caster(tag.value)),
-                ),
-            );
-        else if (tag.kind === "step") {
-            const modulo = () =>
-                ts.factory.createModulo(input, caster(tag.value));
-            const minimum = (() => {
-                for (const tag of tagList)
-                    if (tag.kind === "minimum") return tag.value;
-                    else if (tag.kind === "exclusiveMinimum") return tag.value;
-                return undefined;
-            })();
-            conditions.push(
-                ts.factory.createStrictEquality(
-                    caster(0),
-                    minimum !== undefined
-                        ? ts.factory.createSubtract(modulo(), caster(minimum))
-                        : modulo(),
-                ),
-            );
-        } else if (tag.kind === "minimum")
-            conditions.push(
-                ts.factory.createLessThanEquals(caster(tag.value), input),
-            );
-        else if (tag.kind === "maximum")
-            conditions.push(
-                ts.factory.createGreaterThanEquals(caster(tag.value), input),
-            );
-        else if (tag.kind === "exclusiveMinimum")
-            conditions.push(
-                ts.factory.createLessThan(caster(tag.value), input),
-            );
-        else if (tag.kind === "exclusiveMaximum")
-            conditions.push(
-                ts.factory.createGreaterThan(caster(tag.value), input),
-            );
+        // TYPEOF STATEMENT
+        const conditions: ts.Expression[] = [
+            ts.factory.createStrictEquality(
+                ts.factory.createStringLiteral("bigint"),
+                ts.factory.createTypeOfExpression(input),
+            ),
+        ];
 
-    // COMBINATION
-    return conditions.length === 1
-        ? conditions[0]!
-        : conditions.reduce((x, y) => ts.factory.createLogicalAnd(x, y));
-}
+        // TAG (RANGE)
+        for (const tag of metaTags)
+            if (tag.kind === "multipleOf")
+                conditions.push(
+                    ts.factory.createStrictEquality(
+                        caster(0),
+                        ts.factory.createModulo(input, caster(tag.value)),
+                    ),
+                );
+            else if (tag.kind === "step") {
+                const modulo = () =>
+                    ts.factory.createModulo(input, caster(tag.value));
+                const minimum = (() => {
+                    for (const tag of metaTags)
+                        if (tag.kind === "minimum") return tag.value;
+                        else if (tag.kind === "exclusiveMinimum")
+                            return tag.value;
+                    return undefined;
+                })();
+                conditions.push(
+                    ts.factory.createStrictEquality(
+                        caster(0),
+                        minimum !== undefined
+                            ? ts.factory.createSubtract(
+                                  modulo(),
+                                  caster(minimum),
+                              )
+                            : modulo(),
+                    ),
+                );
+            } else if (tag.kind === "minimum")
+                conditions.push(
+                    ts.factory.createLessThanEquals(caster(tag.value), input),
+                );
+            else if (tag.kind === "maximum")
+                conditions.push(
+                    ts.factory.createGreaterThanEquals(
+                        caster(tag.value),
+                        input,
+                    ),
+                );
+            else if (tag.kind === "exclusiveMinimum")
+                conditions.push(
+                    ts.factory.createLessThan(caster(tag.value), input),
+                );
+            else if (tag.kind === "exclusiveMaximum")
+                conditions.push(
+                    ts.factory.createGreaterThan(caster(tag.value), input),
+                );
+
+        // CUSTOM TAGS
+        conditions.push(...check_custom("bigint")(importer)(input, jsDocTags));
+
+        // COMBINATION
+        return conditions.length === 1
+            ? conditions[0]!
+            : conditions.reduce((x, y) => ts.factory.createLogicalAnd(x, y));
+    };

--- a/src/programmers/internal/check_custom.ts
+++ b/src/programmers/internal/check_custom.ts
@@ -1,0 +1,32 @@
+import ts from "typescript";
+
+import { MetadataTagFactory } from "../../factories/MetadataTagFactory";
+
+import { IJsDocTagInfo } from "../../metadata/IJsDocTagInfo";
+
+import { FunctionImporter } from "../helpers/FunctionImporeter";
+
+export const check_custom =
+    (type: string) =>
+    (importer: FunctionImporter) =>
+    (input: ts.Expression, jsDocTags: IJsDocTagInfo[]) =>
+        jsDocTags
+            .filter(
+                (tag) =>
+                    tag.name !== "random" &&
+                    MetadataTagFactory._PARSER[tag.name] === undefined,
+            )
+            .map((tag) =>
+                ts.factory.createCallExpression(
+                    importer.use("is_custom"),
+                    undefined,
+                    [
+                        ts.factory.createStringLiteral(tag.name),
+                        ts.factory.createStringLiteral(type),
+                        ts.factory.createStringLiteral(
+                            tag.text?.[0]?.text ?? "",
+                        ),
+                        input,
+                    ],
+                ),
+            );

--- a/src/programmers/internal/check_string.ts
+++ b/src/programmers/internal/check_string.ts
@@ -3,19 +3,25 @@ import ts from "typescript";
 import { IMetadataTag } from "../../metadata/IMetadataTag";
 
 import { FunctionImporter } from "../helpers/FunctionImporeter";
+import { check_custom } from "./check_custom";
 import { check_string_tags } from "./check_string_tags";
 
 /**
  * @internal
  */
 export function check_string(importer: FunctionImporter) {
-    return function (input: ts.Expression, tagList: IMetadataTag[]) {
+    return function (
+        input: ts.Expression,
+        metaTags: IMetadataTag[],
+        jsDocTags: ts.JSDocTagInfo[],
+    ) {
         const conditions: ts.Expression[] = [
             ts.factory.createStrictEquality(
                 ts.factory.createStringLiteral("string"),
                 ts.factory.createTypeOfExpression(input),
             ),
-            ...check_string_tags(importer)(input, tagList),
+            ...check_string_tags(importer)(input, metaTags),
+            ...check_custom("string")(importer)(input, jsDocTags),
         ];
         return conditions.length === 1
             ? conditions[0]!

--- a/src/programmers/internal/check_union_array_like.ts
+++ b/src/programmers/internal/check_union_array_like.ts
@@ -18,6 +18,7 @@ export const check_union_array_like =
         targets: T[],
         explore: FeatureProgrammer.IExplore,
         tags: IMetadataTag[],
+        jsDocTags: ts.JSDocTagInfo[],
     ) => {
         // ONLY ONE TYPE
         if (targets.length === 1)
@@ -26,6 +27,7 @@ export const check_union_array_like =
                 targets[0]!,
                 explore,
                 tags,
+                jsDocTags,
             );
 
         //----
@@ -58,6 +60,7 @@ export const check_union_array_like =
                                         postfix: `"[0]"`,
                                     },
                                     tags,
+                                    jsDocTags,
                                     input,
                                 ),
                             ),
@@ -80,6 +83,7 @@ export const check_union_array_like =
                                         tracable: true,
                                     },
                                     tags,
+                                    jsDocTags,
                                 ),
                             ),
                         ]),
@@ -239,6 +243,7 @@ export namespace check_union_array_like {
             target: T,
             explore: FeatureProgrammer.IExplore,
             tags: IMetadataTag[],
+            jsDocTags: ts.JSDocTagInfo[],
             array: ts.Expression,
         ): ts.Expression;
         decoder: UnionExplorer.Decoder<T>;

--- a/src/programmers/internal/check_union_tuple.ts
+++ b/src/programmers/internal/check_union_tuple.ts
@@ -23,6 +23,7 @@ export const check_union_tuple =
         elements: Metadata[],
         explore: CheckerProgrammer.IExplore,
         tags: IMetadataTag[],
+        jsDocTags: ts.JSDocTagInfo[],
         array: ts.Expression,
     ) =>
         CheckerProgrammer.decode_tuple(project, config, importer, true)(
@@ -30,4 +31,5 @@ export const check_union_tuple =
             elements,
             explore,
             tags,
+            jsDocTags,
         );

--- a/src/programmers/internal/feature_object_entries.ts
+++ b/src/programmers/internal/feature_object_entries.ts
@@ -54,6 +54,7 @@ export const feature_object_entries =
                                   })(),
                     },
                     prop.tags,
+                    prop.jsDocTags,
                 ),
             };
         });

--- a/src/typings/Customizable.ts
+++ b/src/typings/Customizable.ts
@@ -1,0 +1,7 @@
+export type Customizable = {
+    boolean: boolean;
+    number: number;
+    string: string;
+    bigint: bigint;
+    array: any[];
+};

--- a/test/features/application/ajv/test_application_ajv_TagCustom.ts
+++ b/test/features/application/ajv/test_application_ajv_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_application } from "../../../internal/_test_application";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_application_ajv_TagCustom = _test_application("ajv")(
+    "TagCustom",
+    typia.application<[TagCustom], "ajv">(),
+);

--- a/test/features/application/swagger/test_application_swagger_TagCustom.ts
+++ b/test/features/application/swagger/test_application_swagger_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_application } from "../../../internal/_test_application";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_application_swagger_TagCustom = _test_application("swagger")(
+    "TagCustom",
+    typia.application<[TagCustom], "swagger">(),
+);

--- a/test/features/assert/test_assert_TagCustom.ts
+++ b/test/features/assert/test_assert_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_assert_TagCustom = _test_assert(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.assert(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/assertClone/test_assertClone_TagCustom.ts
+++ b/test/features/assertClone/test_assertClone_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertClone } from "../../internal/_test_assertClone";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_assertClone_TagCustom = _test_assertClone(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.assertClone(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/assertEquals/test_assertEquals_TagCustom.ts
+++ b/test/features/assertEquals/test_assertEquals_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_assertEquals_TagCustom = _test_assertEquals(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.assertEquals(input),
+);

--- a/test/features/assertParse/test_assertParse_TagCustom.ts
+++ b/test/features/assertParse/test_assertParse_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertParse } from "../../internal/_test_assertParse";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_assertParse_TagCustom = _test_assertParse(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.assertParse<TagCustom>(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/assertPrune/test_assertPrune_TagCustom.ts
+++ b/test/features/assertPrune/test_assertPrune_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertPrune } from "../../internal/_test_assertPrune";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_assertPrune_TagCustom = _test_assertPrune(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.assertPrune(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/assertStringify/test_assertStringify_TagCustom.ts
+++ b/test/features/assertStringify/test_assertStringify_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertStringify } from "../../internal/_test_assertStringify";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_assertStringify_TagCustom = _test_assertStringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.assertStringify(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/clone/test_clone_TagCustom.ts
+++ b/test/features/clone/test_clone_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_clone } from "../../internal/_test_clone";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_clone_TagCustom = _test_clone(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.clone(input),
+);

--- a/test/features/createAssert/test_createAssert_TagCustom.ts
+++ b/test/features/createAssert/test_createAssert_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createAssert_TagCustom = _test_assert(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createAssert<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createAssertClone/test_createAssertClone_TagCustom.ts
+++ b/test/features/createAssertClone/test_createAssertClone_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertClone } from "../../internal/_test_assertClone";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createAssertClone_TagCustom = _test_assertClone(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createAssertClone<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createAssertEquals/test_createAssertEquals_TagCustom.ts
+++ b/test/features/createAssertEquals/test_createAssertEquals_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createAssertEquals_TagCustom = _test_assertEquals(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createAssertEquals<TagCustom>(),
+);

--- a/test/features/createAssertParse/test_createAssertParse_TagCustom.ts
+++ b/test/features/createAssertParse/test_createAssertParse_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertParse } from "../../internal/_test_assertParse";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createAssertParse_TagCustom = _test_assertParse(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createAssertParse<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createAssertPrune/test_createAssertPrune_TagCustom.ts
+++ b/test/features/createAssertPrune/test_createAssertPrune_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertPrune } from "../../internal/_test_assertPrune";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createAssertPrune_TagCustom = _test_assertPrune(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createAssertPrune<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createAssertStringify/test_createAssertStringify_TagCustom.ts
+++ b/test/features/createAssertStringify/test_createAssertStringify_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertStringify } from "../../internal/_test_assertStringify";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createAssertStringify_TagCustom = _test_assertStringify(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createAssertStringify<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createClone/test_createClone_TagCustom.ts
+++ b/test/features/createClone/test_createClone_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_clone } from "../../internal/_test_clone";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createClone_TagCustom = _test_clone(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createClone<TagCustom>(),
+);

--- a/test/features/createEquals/test_createEquals_TagCustom.ts
+++ b/test/features/createEquals/test_createEquals_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createEquals_TagCustom = _test_equals(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createEquals<TagCustom>(),
+);

--- a/test/features/createIs/test_createIs_TagCustom.ts
+++ b/test/features/createIs/test_createIs_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createIs_TagCustom = _test_is(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createIs<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createIsClone/test_createIsClone_TagCustom.ts
+++ b/test/features/createIsClone/test_createIsClone_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isClone } from "../../internal/_test_isClone";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createIsClone_TagCustom = _test_isClone(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createIsClone<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createIsParse/test_createIsParse_TagCustom.ts
+++ b/test/features/createIsParse/test_createIsParse_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isParse } from "../../internal/_test_isParse";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createIsParse_TagCustom = _test_isParse(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createIsParse<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createIsPrune/test_createIsPrune_TagCustom.ts
+++ b/test/features/createIsPrune/test_createIsPrune_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isPrune } from "../../internal/_test_isPrune";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createIsPrune_TagCustom = _test_isPrune(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createIsPrune<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createIsStringify/test_createIsStringify_TagCustom.ts
+++ b/test/features/createIsStringify/test_createIsStringify_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isStringify } from "../../internal/_test_isStringify";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createIsStringify_TagCustom = _test_isStringify(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createIsStringify<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createPrune/test_createPrune_TagCustom.ts
+++ b/test/features/createPrune/test_createPrune_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_prune } from "../../internal/_test_prune";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createPrune_TagCustom = _test_prune(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createPrune<TagCustom>(),
+);

--- a/test/features/createStringify/test_createStringify_TagCustom.ts
+++ b/test/features/createStringify/test_createStringify_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_stringify } from "../../internal/_test_stringify";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createStringify_TagCustom = _test_stringify(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createStringify<TagCustom>(),
+);

--- a/test/features/createValidate/test_createValidate_TagCustom.ts
+++ b/test/features/createValidate/test_createValidate_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createValidate_TagCustom = _test_validate(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createValidate<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createValidateClone/test_createValidateClone_TagCustom.ts
+++ b/test/features/createValidateClone/test_createValidateClone_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateClone } from "../../internal/_test_validateClone";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createValidateClone_TagCustom = _test_validateClone(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createValidateClone<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createValidateEquals/test_createValidateEquals_TagCustom.ts
+++ b/test/features/createValidateEquals/test_createValidateEquals_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createValidateEquals_TagCustom = _test_validateEquals(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createValidateEquals<TagCustom>(),
+);

--- a/test/features/createValidateParse/test_createValidateParse_TagCustom.ts
+++ b/test/features/createValidateParse/test_createValidateParse_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateParse } from "../../internal/_test_validateParse";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createValidateParse_TagCustom = _test_validateParse(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createValidateParse<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createValidatePrune/test_createValidatePrune_TagCustom.ts
+++ b/test/features/createValidatePrune/test_createValidatePrune_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validatePrune } from "../../internal/_test_validatePrune";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createValidatePrune_TagCustom = _test_validatePrune(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createValidatePrune<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/createValidateStringify/test_createValidateStringify_TagCustom.ts
+++ b/test/features/createValidateStringify/test_createValidateStringify_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateStringify } from "../../internal/_test_validateStringify";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_createValidateStringify_TagCustom = _test_validateStringify(
+    "TagCustom",
+    TagCustom.generate,
+    typia.createValidateStringify<TagCustom>(),
+    TagCustom.SPOILERS,
+);

--- a/test/features/equals/test_equals_TagCustom.ts
+++ b/test/features/equals/test_equals_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_equals_TagCustom = _test_equals(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.equals(input),
+);

--- a/test/features/is/test_is_TagCustom.ts
+++ b/test/features/is/test_is_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_is_TagCustom = _test_is(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.is(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/isClone/test_isClone_TagCustom.ts
+++ b/test/features/isClone/test_isClone_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isClone } from "../../internal/_test_isClone";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_isClone_TagCustom = _test_isClone(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.isClone(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/isParse/test_isParse_TagCustom.ts
+++ b/test/features/isParse/test_isParse_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isParse } from "../../internal/_test_isParse";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_isParse_TagCustom = _test_isParse(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.isParse<TagCustom>(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/isPrune/test_isPrune_TagCustom.ts
+++ b/test/features/isPrune/test_isPrune_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isPrune } from "../../internal/_test_isPrune";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_isPrune_TagCustom = _test_isPrune(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.isPrune(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/isStringify/test_isStringify_TagCustom.ts
+++ b/test/features/isStringify/test_isStringify_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isStringify } from "../../internal/_test_isStringify";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_isStringify_TagCustom = _test_isStringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.isStringify(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/prune/test_prune_TagCustom.ts
+++ b/test/features/prune/test_prune_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_prune } from "../../internal/_test_prune";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_prune_TagCustom = _test_prune(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.prune(input),
+);

--- a/test/features/stringify/test_stringify_TagCustom.ts
+++ b/test/features/stringify/test_stringify_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_stringify } from "../../internal/_test_stringify";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_stringify_TagCustom = _test_stringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.stringify(input),
+);

--- a/test/features/validate/test_validate_TagCustom.ts
+++ b/test/features/validate/test_validate_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_validate_TagCustom = _test_validate(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.validate(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/validateClone/test_validateClone_TagCustom.ts
+++ b/test/features/validateClone/test_validateClone_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateClone } from "../../internal/_test_validateClone";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_validateClone_TagCustom = _test_validateClone(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.validateClone(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/validateEquals/test_validateEquals_TagCustom.ts
+++ b/test/features/validateEquals/test_validateEquals_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_validateEquals_TagCustom = _test_validateEquals(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.validateEquals(input),
+);

--- a/test/features/validateParse/test_validateParse_TagCustom.ts
+++ b/test/features/validateParse/test_validateParse_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateParse } from "../../internal/_test_validateParse";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_validateParse_TagCustom = _test_validateParse(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.validateParse<TagCustom>(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/validatePrune/test_validatePrune_TagCustom.ts
+++ b/test/features/validatePrune/test_validatePrune_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validatePrune } from "../../internal/_test_validatePrune";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_validatePrune_TagCustom = _test_validatePrune(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.validatePrune(input),
+    TagCustom.SPOILERS,
+);

--- a/test/features/validateStringify/test_validateStringify_TagCustom.ts
+++ b/test/features/validateStringify/test_validateStringify_TagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateStringify } from "../../internal/_test_validateStringify";
+import { TagCustom } from "../../structures/TagCustom";
+
+export const test_validateStringify_TagCustom = _test_validateStringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input) => typia.validateStringify(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/application/ajv/test_application_ajv_TagCustom.ts
+++ b/test/generated/output/application/ajv/test_application_ajv_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_application } from "../../../../internal/_test_application";
+import { TagCustom } from "../../../../structures/TagCustom";
+
+export const test_application_ajv_TagCustom = _test_application("ajv")(
+    "TagCustom",
+    typia.application<[TagCustom], "ajv">(),
+);

--- a/test/generated/output/application/swagger/test_application_swagger_TagCustom.ts
+++ b/test/generated/output/application/swagger/test_application_swagger_TagCustom.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_application } from "../../../../internal/_test_application";
+import { TagCustom } from "../../../../structures/TagCustom";
+
+export const test_application_swagger_TagCustom = _test_application("swagger")(
+    "TagCustom",
+    typia.application<[TagCustom], "swagger">(),
+);

--- a/test/generated/output/assert/test_assert_TagCustom.ts
+++ b/test/generated/output/assert/test_assert_TagCustom.ts
@@ -1,0 +1,70 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_assert_TagCustom = _test_assert(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): TagCustom => {
+            const $guard = (typia.assert as any).guard;
+            const $is_uuid = (typia.assert as any).is_uuid;
+            const $is_custom = (typia.assert as any).is_custom;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (("string" === typeof input.id &&
+                        true === $is_uuid(input.id)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".id",
+                            expected: "string",
+                            value: input.id,
+                        })) &&
+                    (("string" === typeof input.dolloar &&
+                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dolloar",
+                            expected: "string",
+                            value: input.dolloar,
+                        })) &&
+                    (("string" === typeof input.postfix &&
+                        $is_custom(
+                            "postfix",
+                            "string",
+                            "abcd",
+                            input.postfix,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".postfix",
+                            expected: "string",
+                            value: input.postfix,
+                        })) &&
+                    (("number" === typeof input.log &&
+                        Number.isFinite(input.log) &&
+                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".log",
+                            expected: "number",
+                            value: input.log,
+                        }));
+                return (
+                    (("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                    $ao0(input, _path + "", true)
+                );
+            })(input, "$input", true);
+            return input;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/assertClone/test_assertClone_TagCustom.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagCustom.ts
@@ -1,0 +1,93 @@
+import typia from "../../../../src";
+import { _test_assertClone } from "../../../internal/_test_assertClone";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_assertClone_TagCustom = _test_assertClone(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): typia.Primitive<TagCustom> => {
+            const assert = (input: any): TagCustom => {
+                const $guard = (typia.assertClone as any).guard;
+                const $is_uuid = (typia.assertClone as any).is_uuid;
+                const $is_custom = (typia.assertClone as any).is_custom;
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is TagCustom => {
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (("string" === typeof input.id &&
+                            true === $is_uuid(input.id)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string",
+                                value: input.id,
+                            })) &&
+                        (("string" === typeof input.dolloar &&
+                            $is_custom(
+                                "dollar",
+                                "string",
+                                "",
+                                input.dolloar,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dolloar",
+                                expected: "string",
+                                value: input.dolloar,
+                            })) &&
+                        (("string" === typeof input.postfix &&
+                            $is_custom(
+                                "postfix",
+                                "string",
+                                "abcd",
+                                input.postfix,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string",
+                                value: input.postfix,
+                            })) &&
+                        (("number" === typeof input.log &&
+                            Number.isFinite(input.log) &&
+                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number",
+                                value: input.log,
+                            }));
+                    return (
+                        (("object" === typeof input && null !== input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Resolve<TagCustom>",
+                                value: input,
+                            })) &&
+                        $ao0(input, _path + "", true)
+                    );
+                })(input, "$input", true);
+                return input;
+            };
+            const clone = (input: TagCustom): typia.Primitive<TagCustom> => {
+                const $is_uuid = (typia.assertClone as any).is_uuid;
+                const $is_custom = (typia.assertClone as any).is_custom;
+                const $co0 = (input: any): any => ({
+                    id: input.id as any,
+                    dolloar: input.dolloar as any,
+                    postfix: input.postfix as any,
+                    log: input.log as any,
+                });
+                return "object" === typeof input && null !== input
+                    ? $co0(input)
+                    : (input as any);
+            };
+            assert(input);
+            const output = clone(input);
+            return output;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/assertEquals/test_assertEquals_TagCustom.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagCustom.ts
@@ -1,0 +1,87 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_assertEquals_TagCustom = _test_assertEquals(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): TagCustom => {
+            const $guard = (typia.assertEquals as any).guard;
+            const $is_uuid = (typia.assertEquals as any).is_uuid;
+            const $is_custom = (typia.assertEquals as any).is_custom;
+            const $join = (typia.assertEquals as any).join;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (("string" === typeof input.id &&
+                        true === $is_uuid(input.id)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".id",
+                            expected: "string",
+                            value: input.id,
+                        })) &&
+                    (("string" === typeof input.dolloar &&
+                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dolloar",
+                            expected: "string",
+                            value: input.dolloar,
+                        })) &&
+                    (("string" === typeof input.postfix &&
+                        $is_custom(
+                            "postfix",
+                            "string",
+                            "abcd",
+                            input.postfix,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".postfix",
+                            expected: "string",
+                            value: input.postfix,
+                        })) &&
+                    (("number" === typeof input.log &&
+                        Number.isFinite(input.log) &&
+                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".log",
+                            expected: "number",
+                            value: input.log,
+                        })) &&
+                    (4 === Object.keys(input).length ||
+                        false === _exceptionable ||
+                        Object.keys(input).every((key) => {
+                            if (
+                                ["id", "dolloar", "postfix", "log"].some(
+                                    (prop) => key === prop,
+                                )
+                            )
+                                return true;
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            return $guard(_exceptionable, {
+                                path: _path + $join(key),
+                                expected: "undefined",
+                                value: value,
+                            });
+                        }));
+                return (
+                    (("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                    $ao0(input, _path + "", true)
+                );
+            })(input, "$input", true);
+            return input;
+        })(input),
+);

--- a/test/generated/output/assertParse/test_assertParse_TagCustom.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagCustom.ts
@@ -1,0 +1,79 @@
+import typia from "../../../../src";
+import { _test_assertParse } from "../../../internal/_test_assertParse";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_assertParse_TagCustom = _test_assertParse(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: string): typia.Primitive<TagCustom> => {
+            const assert = (input: any): TagCustom => {
+                const $guard = (typia.assertParse as any).guard;
+                const $is_uuid = (typia.assertParse as any).is_uuid;
+                const $is_custom = (typia.assertParse as any).is_custom;
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is TagCustom => {
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (("string" === typeof input.id &&
+                            true === $is_uuid(input.id)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string",
+                                value: input.id,
+                            })) &&
+                        (("string" === typeof input.dolloar &&
+                            $is_custom(
+                                "dollar",
+                                "string",
+                                "",
+                                input.dolloar,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dolloar",
+                                expected: "string",
+                                value: input.dolloar,
+                            })) &&
+                        (("string" === typeof input.postfix &&
+                            $is_custom(
+                                "postfix",
+                                "string",
+                                "abcd",
+                                input.postfix,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string",
+                                value: input.postfix,
+                            })) &&
+                        (("number" === typeof input.log &&
+                            Number.isFinite(input.log) &&
+                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number",
+                                value: input.log,
+                            }));
+                    return (
+                        (("object" === typeof input && null !== input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Resolve<TagCustom>",
+                                value: input,
+                            })) &&
+                        $ao0(input, _path + "", true)
+                    );
+                })(input, "$input", true);
+                return input;
+            };
+            input = JSON.parse(input);
+            return assert(input);
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/assertPrune/test_assertPrune_TagCustom.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagCustom.ts
@@ -1,0 +1,97 @@
+import typia from "../../../../src";
+import { _test_assertPrune } from "../../../internal/_test_assertPrune";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_assertPrune_TagCustom = _test_assertPrune(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): TagCustom => {
+            const assert = (input: any): TagCustom => {
+                const $guard = (typia.assertPrune as any).guard;
+                const $is_uuid = (typia.assertPrune as any).is_uuid;
+                const $is_custom = (typia.assertPrune as any).is_custom;
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is TagCustom => {
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (("string" === typeof input.id &&
+                            true === $is_uuid(input.id)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string",
+                                value: input.id,
+                            })) &&
+                        (("string" === typeof input.dolloar &&
+                            $is_custom(
+                                "dollar",
+                                "string",
+                                "",
+                                input.dolloar,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dolloar",
+                                expected: "string",
+                                value: input.dolloar,
+                            })) &&
+                        (("string" === typeof input.postfix &&
+                            $is_custom(
+                                "postfix",
+                                "string",
+                                "abcd",
+                                input.postfix,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string",
+                                value: input.postfix,
+                            })) &&
+                        (("number" === typeof input.log &&
+                            Number.isFinite(input.log) &&
+                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number",
+                                value: input.log,
+                            }));
+                    return (
+                        (("object" === typeof input && null !== input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Resolve<TagCustom>",
+                                value: input,
+                            })) &&
+                        $ao0(input, _path + "", true)
+                    );
+                })(input, "$input", true);
+                return input;
+            };
+            const prune = (input: TagCustom): void => {
+                const $is_uuid = (typia.assertPrune as any).is_uuid;
+                const $is_custom = (typia.assertPrune as any).is_custom;
+                const $po0 = (input: any): any => {
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "id" === key ||
+                            "dolloar" === key ||
+                            "postfix" === key ||
+                            "log" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                if ("object" === typeof input && null !== input) $po0(input);
+            };
+            assert(input);
+            prune(input);
+            return input;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/assertStringify/test_assertStringify_TagCustom.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagCustom.ts
@@ -1,0 +1,91 @@
+import typia from "../../../../src";
+import { _test_assertStringify } from "../../../internal/_test_assertStringify";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_assertStringify_TagCustom = _test_assertStringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): string => {
+            const assert = (input: any): TagCustom => {
+                const $guard = (typia.assertStringify as any).guard;
+                const $is_uuid = (typia.assertStringify as any).is_uuid;
+                const $is_custom = (typia.assertStringify as any).is_custom;
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is TagCustom => {
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (("string" === typeof input.id &&
+                            true === $is_uuid(input.id)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string",
+                                value: input.id,
+                            })) &&
+                        (("string" === typeof input.dolloar &&
+                            $is_custom(
+                                "dollar",
+                                "string",
+                                "",
+                                input.dolloar,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dolloar",
+                                expected: "string",
+                                value: input.dolloar,
+                            })) &&
+                        (("string" === typeof input.postfix &&
+                            $is_custom(
+                                "postfix",
+                                "string",
+                                "abcd",
+                                input.postfix,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string",
+                                value: input.postfix,
+                            })) &&
+                        (("number" === typeof input.log &&
+                            Number.isFinite(input.log) &&
+                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number",
+                                value: input.log,
+                            }));
+                    return (
+                        (("object" === typeof input && null !== input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Resolve<TagCustom>",
+                                value: input,
+                            })) &&
+                        $ao0(input, _path + "", true)
+                    );
+                })(input, "$input", true);
+                return input;
+            };
+            const stringify = (input: TagCustom): string => {
+                const $string = (typia.assertStringify as any).string;
+                const $number = (typia.assertStringify as any).number;
+                const $is_uuid = (typia.assertStringify as any).is_uuid;
+                const $is_custom = (typia.assertStringify as any).is_custom;
+                const $so0 = (input: any): any =>
+                    `{"id":${'"' + input.id + '"'},"dolloar":${$string(
+                        input.dolloar,
+                    )},"postfix":${$string(input.postfix)},"log":${$number(
+                        input.log,
+                    )}}`;
+                return $so0(input);
+            };
+            return stringify(assert(input));
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/clone/test_clone_TagCustom.ts
+++ b/test/generated/output/clone/test_clone_TagCustom.ts
@@ -1,0 +1,22 @@
+import typia from "../../../../src";
+import { _test_clone } from "../../../internal/_test_clone";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_clone_TagCustom = _test_clone(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: TagCustom): typia.Primitive<TagCustom> => {
+            const $is_uuid = (typia.clone as any).is_uuid;
+            const $is_custom = (typia.clone as any).is_custom;
+            const $co0 = (input: any): any => ({
+                id: input.id as any,
+                dolloar: input.dolloar as any,
+                postfix: input.postfix as any,
+                log: input.log as any,
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        })(input),
+);

--- a/test/generated/output/createAssert/test_createAssert_TagCustom.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagCustom.ts
@@ -1,0 +1,64 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createAssert_TagCustom = _test_assert(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): TagCustom => {
+        const $guard = (typia.createAssert as any).guard;
+        const $is_uuid = (typia.createAssert as any).is_uuid;
+        const $is_custom = (typia.createAssert as any).is_custom;
+        ((
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): input is TagCustom => {
+            const $ao0 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (("string" === typeof input.id &&
+                    true === $is_uuid(input.id)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".id",
+                        expected: "string",
+                        value: input.id,
+                    })) &&
+                (("string" === typeof input.dolloar &&
+                    $is_custom("dollar", "string", "", input.dolloar)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".dolloar",
+                        expected: "string",
+                        value: input.dolloar,
+                    })) &&
+                (("string" === typeof input.postfix &&
+                    $is_custom("postfix", "string", "abcd", input.postfix)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".postfix",
+                        expected: "string",
+                        value: input.postfix,
+                    })) &&
+                (("number" === typeof input.log &&
+                    Number.isFinite(input.log) &&
+                    $is_custom("powerOf", "number", "10", input.log)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".log",
+                        expected: "number",
+                        value: input.log,
+                    }));
+            return (
+                (("object" === typeof input && null !== input) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Resolve<TagCustom>",
+                        value: input,
+                    })) &&
+                $ao0(input, _path + "", true)
+            );
+        })(input, "$input", true);
+        return input;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagCustom.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagCustom.ts
@@ -1,0 +1,87 @@
+import typia from "../../../../src";
+import { _test_assertClone } from "../../../internal/_test_assertClone";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createAssertClone_TagCustom = _test_assertClone(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): typia.Primitive<TagCustom> => {
+        const assert = (input: any): TagCustom => {
+            const $guard = (typia.createAssertClone as any).guard;
+            const $is_uuid = (typia.createAssertClone as any).is_uuid;
+            const $is_custom = (typia.createAssertClone as any).is_custom;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (("string" === typeof input.id &&
+                        true === $is_uuid(input.id)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".id",
+                            expected: "string",
+                            value: input.id,
+                        })) &&
+                    (("string" === typeof input.dolloar &&
+                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dolloar",
+                            expected: "string",
+                            value: input.dolloar,
+                        })) &&
+                    (("string" === typeof input.postfix &&
+                        $is_custom(
+                            "postfix",
+                            "string",
+                            "abcd",
+                            input.postfix,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".postfix",
+                            expected: "string",
+                            value: input.postfix,
+                        })) &&
+                    (("number" === typeof input.log &&
+                        Number.isFinite(input.log) &&
+                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".log",
+                            expected: "number",
+                            value: input.log,
+                        }));
+                return (
+                    (("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                    $ao0(input, _path + "", true)
+                );
+            })(input, "$input", true);
+            return input;
+        };
+        const clone = (input: TagCustom): typia.Primitive<TagCustom> => {
+            const $is_uuid = (typia.createAssertClone as any).is_uuid;
+            const $is_custom = (typia.createAssertClone as any).is_custom;
+            const $co0 = (input: any): any => ({
+                id: input.id as any,
+                dolloar: input.dolloar as any,
+                postfix: input.postfix as any,
+                log: input.log as any,
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        assert(input);
+        const output = clone(input);
+        return output;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagCustom.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagCustom.ts
@@ -1,0 +1,81 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createAssertEquals_TagCustom = _test_assertEquals(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): TagCustom => {
+        const $guard = (typia.createAssertEquals as any).guard;
+        const $is_uuid = (typia.createAssertEquals as any).is_uuid;
+        const $is_custom = (typia.createAssertEquals as any).is_custom;
+        const $join = (typia.createAssertEquals as any).join;
+        ((
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): input is TagCustom => {
+            const $ao0 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (("string" === typeof input.id &&
+                    true === $is_uuid(input.id)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".id",
+                        expected: "string",
+                        value: input.id,
+                    })) &&
+                (("string" === typeof input.dolloar &&
+                    $is_custom("dollar", "string", "", input.dolloar)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".dolloar",
+                        expected: "string",
+                        value: input.dolloar,
+                    })) &&
+                (("string" === typeof input.postfix &&
+                    $is_custom("postfix", "string", "abcd", input.postfix)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".postfix",
+                        expected: "string",
+                        value: input.postfix,
+                    })) &&
+                (("number" === typeof input.log &&
+                    Number.isFinite(input.log) &&
+                    $is_custom("powerOf", "number", "10", input.log)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".log",
+                        expected: "number",
+                        value: input.log,
+                    })) &&
+                (4 === Object.keys(input).length ||
+                    false === _exceptionable ||
+                    Object.keys(input).every((key) => {
+                        if (
+                            ["id", "dolloar", "postfix", "log"].some(
+                                (prop) => key === prop,
+                            )
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return $guard(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                        });
+                    }));
+            return (
+                (("object" === typeof input && null !== input) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Resolve<TagCustom>",
+                        value: input,
+                    })) &&
+                $ao0(input, _path + "", true)
+            );
+        })(input, "$input", true);
+        return input;
+    },
+);

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagCustom.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagCustom.ts
@@ -1,0 +1,73 @@
+import typia from "../../../../src";
+import { _test_assertParse } from "../../../internal/_test_assertParse";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createAssertParse_TagCustom = _test_assertParse(
+    "TagCustom",
+    TagCustom.generate,
+    (input: string): typia.Primitive<TagCustom> => {
+        const assert = (input: any): TagCustom => {
+            const $guard = (typia.createAssertParse as any).guard;
+            const $is_uuid = (typia.createAssertParse as any).is_uuid;
+            const $is_custom = (typia.createAssertParse as any).is_custom;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (("string" === typeof input.id &&
+                        true === $is_uuid(input.id)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".id",
+                            expected: "string",
+                            value: input.id,
+                        })) &&
+                    (("string" === typeof input.dolloar &&
+                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dolloar",
+                            expected: "string",
+                            value: input.dolloar,
+                        })) &&
+                    (("string" === typeof input.postfix &&
+                        $is_custom(
+                            "postfix",
+                            "string",
+                            "abcd",
+                            input.postfix,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".postfix",
+                            expected: "string",
+                            value: input.postfix,
+                        })) &&
+                    (("number" === typeof input.log &&
+                        Number.isFinite(input.log) &&
+                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".log",
+                            expected: "number",
+                            value: input.log,
+                        }));
+                return (
+                    (("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                    $ao0(input, _path + "", true)
+                );
+            })(input, "$input", true);
+            return input;
+        };
+        input = JSON.parse(input);
+        return assert(input);
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagCustom.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagCustom.ts
@@ -1,0 +1,91 @@
+import typia from "../../../../src";
+import { _test_assertPrune } from "../../../internal/_test_assertPrune";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createAssertPrune_TagCustom = _test_assertPrune(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): TagCustom => {
+        const assert = (input: any): TagCustom => {
+            const $guard = (typia.createAssertPrune as any).guard;
+            const $is_uuid = (typia.createAssertPrune as any).is_uuid;
+            const $is_custom = (typia.createAssertPrune as any).is_custom;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (("string" === typeof input.id &&
+                        true === $is_uuid(input.id)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".id",
+                            expected: "string",
+                            value: input.id,
+                        })) &&
+                    (("string" === typeof input.dolloar &&
+                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dolloar",
+                            expected: "string",
+                            value: input.dolloar,
+                        })) &&
+                    (("string" === typeof input.postfix &&
+                        $is_custom(
+                            "postfix",
+                            "string",
+                            "abcd",
+                            input.postfix,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".postfix",
+                            expected: "string",
+                            value: input.postfix,
+                        })) &&
+                    (("number" === typeof input.log &&
+                        Number.isFinite(input.log) &&
+                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".log",
+                            expected: "number",
+                            value: input.log,
+                        }));
+                return (
+                    (("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                    $ao0(input, _path + "", true)
+                );
+            })(input, "$input", true);
+            return input;
+        };
+        const prune = (input: TagCustom): void => {
+            const $is_uuid = (typia.createAssertPrune as any).is_uuid;
+            const $is_custom = (typia.createAssertPrune as any).is_custom;
+            const $po0 = (input: any): any => {
+                for (const key of Object.keys(input)) {
+                    if (
+                        "id" === key ||
+                        "dolloar" === key ||
+                        "postfix" === key ||
+                        "log" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        assert(input);
+        prune(input);
+        return input;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagCustom.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagCustom.ts
@@ -1,0 +1,85 @@
+import typia from "../../../../src";
+import { _test_assertStringify } from "../../../internal/_test_assertStringify";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createAssertStringify_TagCustom = _test_assertStringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): string => {
+        const assert = (input: any): TagCustom => {
+            const $guard = (typia.createAssertStringify as any).guard;
+            const $is_uuid = (typia.createAssertStringify as any).is_uuid;
+            const $is_custom = (typia.createAssertStringify as any).is_custom;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (("string" === typeof input.id &&
+                        true === $is_uuid(input.id)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".id",
+                            expected: "string",
+                            value: input.id,
+                        })) &&
+                    (("string" === typeof input.dolloar &&
+                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dolloar",
+                            expected: "string",
+                            value: input.dolloar,
+                        })) &&
+                    (("string" === typeof input.postfix &&
+                        $is_custom(
+                            "postfix",
+                            "string",
+                            "abcd",
+                            input.postfix,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".postfix",
+                            expected: "string",
+                            value: input.postfix,
+                        })) &&
+                    (("number" === typeof input.log &&
+                        Number.isFinite(input.log) &&
+                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".log",
+                            expected: "number",
+                            value: input.log,
+                        }));
+                return (
+                    (("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                    $ao0(input, _path + "", true)
+                );
+            })(input, "$input", true);
+            return input;
+        };
+        const stringify = (input: TagCustom): string => {
+            const $string = (typia.createAssertStringify as any).string;
+            const $number = (typia.createAssertStringify as any).number;
+            const $is_uuid = (typia.createAssertStringify as any).is_uuid;
+            const $is_custom = (typia.createAssertStringify as any).is_custom;
+            const $so0 = (input: any): any =>
+                `{"id":${'"' + input.id + '"'},"dolloar":${$string(
+                    input.dolloar,
+                )},"postfix":${$string(input.postfix)},"log":${$number(
+                    input.log,
+                )}}`;
+            return $so0(input);
+        };
+        return stringify(assert(input));
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createClone/test_createClone_TagCustom.ts
+++ b/test/generated/output/createClone/test_createClone_TagCustom.ts
@@ -1,0 +1,21 @@
+import typia from "../../../../src";
+import { _test_clone } from "../../../internal/_test_clone";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createClone_TagCustom = _test_clone(
+    "TagCustom",
+    TagCustom.generate,
+    (input: TagCustom): typia.Primitive<TagCustom> => {
+        const $is_uuid = (typia.createClone as any).is_uuid;
+        const $is_custom = (typia.createClone as any).is_custom;
+        const $co0 = (input: any): any => ({
+            id: input.id as any,
+            dolloar: input.dolloar as any,
+            postfix: input.postfix as any,
+            log: input.log as any,
+        });
+        return "object" === typeof input && null !== input
+            ? $co0(input)
+            : (input as any);
+    },
+);

--- a/test/generated/output/createEquals/test_createEquals_TagCustom.ts
+++ b/test/generated/output/createEquals/test_createEquals_TagCustom.ts
@@ -1,0 +1,35 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createEquals_TagCustom = _test_equals(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any, _exceptionable: boolean = true): input is TagCustom => {
+        const $is_uuid = (typia.createEquals as any).is_uuid;
+        const $is_custom = (typia.createEquals as any).is_custom;
+        const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
+            "string" === typeof input.id &&
+            true === $is_uuid(input.id) &&
+            "string" === typeof input.dolloar &&
+            $is_custom("dollar", "string", "", input.dolloar) &&
+            "string" === typeof input.postfix &&
+            $is_custom("postfix", "string", "abcd", input.postfix) &&
+            "number" === typeof input.log &&
+            Number.isFinite(input.log) &&
+            $is_custom("powerOf", "number", "10", input.log) &&
+            (4 === Object.keys(input).length ||
+                Object.keys(input).every((key) => {
+                    if (
+                        ["id", "dolloar", "postfix", "log"].some(
+                            (prop) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        return "object" === typeof input && null !== input && $io0(input, true);
+    },
+);

--- a/test/generated/output/createIs/test_createIs_TagCustom.ts
+++ b/test/generated/output/createIs/test_createIs_TagCustom.ts
@@ -1,0 +1,24 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createIs_TagCustom = _test_is(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): input is TagCustom => {
+        const $is_uuid = (typia.createIs as any).is_uuid;
+        const $is_custom = (typia.createIs as any).is_custom;
+        const $io0 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            true === $is_uuid(input.id) &&
+            "string" === typeof input.dolloar &&
+            $is_custom("dollar", "string", "", input.dolloar) &&
+            "string" === typeof input.postfix &&
+            $is_custom("postfix", "string", "abcd", input.postfix) &&
+            "number" === typeof input.log &&
+            Number.isFinite(input.log) &&
+            $is_custom("powerOf", "number", "10", input.log);
+        return "object" === typeof input && null !== input && $io0(input);
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createIsClone/test_createIsClone_TagCustom.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_TagCustom.ts
@@ -1,0 +1,42 @@
+import typia from "../../../../src";
+import { _test_isClone } from "../../../internal/_test_isClone";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createIsClone_TagCustom = _test_isClone(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): typia.Primitive<TagCustom> | null => {
+        const is = (input: any): input is TagCustom => {
+            const $is_uuid = (typia.createIsClone as any).is_uuid;
+            const $is_custom = (typia.createIsClone as any).is_custom;
+            const $io0 = (input: any): boolean =>
+                "string" === typeof input.id &&
+                true === $is_uuid(input.id) &&
+                "string" === typeof input.dolloar &&
+                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.postfix &&
+                $is_custom("postfix", "string", "abcd", input.postfix) &&
+                "number" === typeof input.log &&
+                Number.isFinite(input.log) &&
+                $is_custom("powerOf", "number", "10", input.log);
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const clone = (input: TagCustom): typia.Primitive<TagCustom> => {
+            const $is_uuid = (typia.createIsClone as any).is_uuid;
+            const $is_custom = (typia.createIsClone as any).is_custom;
+            const $co0 = (input: any): any => ({
+                id: input.id as any,
+                dolloar: input.dolloar as any,
+                postfix: input.postfix as any,
+                log: input.log as any,
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        if (!is(input)) return null;
+        const output = clone(input);
+        return output;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createIsParse/test_createIsParse_TagCustom.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_TagCustom.ts
@@ -1,0 +1,28 @@
+import typia from "../../../../src";
+import { _test_isParse } from "../../../internal/_test_isParse";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createIsParse_TagCustom = _test_isParse(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): typia.Primitive<TagCustom> => {
+        const is = (input: any): input is TagCustom => {
+            const $is_uuid = (typia.createIsParse as any).is_uuid;
+            const $is_custom = (typia.createIsParse as any).is_custom;
+            const $io0 = (input: any): boolean =>
+                "string" === typeof input.id &&
+                true === $is_uuid(input.id) &&
+                "string" === typeof input.dolloar &&
+                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.postfix &&
+                $is_custom("postfix", "string", "abcd", input.postfix) &&
+                "number" === typeof input.log &&
+                Number.isFinite(input.log) &&
+                $is_custom("powerOf", "number", "10", input.log);
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        input = JSON.parse(input);
+        return is(input) ? (input as any) : null;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createIsPrune/test_createIsPrune_TagCustom.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TagCustom.ts
@@ -1,0 +1,46 @@
+import typia from "../../../../src";
+import { _test_isPrune } from "../../../internal/_test_isPrune";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createIsPrune_TagCustom = _test_isPrune(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): input is TagCustom => {
+        const is = (input: any): input is TagCustom => {
+            const $is_uuid = (typia.createIsPrune as any).is_uuid;
+            const $is_custom = (typia.createIsPrune as any).is_custom;
+            const $io0 = (input: any): boolean =>
+                "string" === typeof input.id &&
+                true === $is_uuid(input.id) &&
+                "string" === typeof input.dolloar &&
+                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.postfix &&
+                $is_custom("postfix", "string", "abcd", input.postfix) &&
+                "number" === typeof input.log &&
+                Number.isFinite(input.log) &&
+                $is_custom("powerOf", "number", "10", input.log);
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const prune = (input: TagCustom): void => {
+            const $is_uuid = (typia.createIsPrune as any).is_uuid;
+            const $is_custom = (typia.createIsPrune as any).is_custom;
+            const $po0 = (input: any): any => {
+                for (const key of Object.keys(input)) {
+                    if (
+                        "id" === key ||
+                        "dolloar" === key ||
+                        "postfix" === key ||
+                        "log" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        if (!is(input)) return false;
+        prune(input);
+        return true;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createIsStringify/test_createIsStringify_TagCustom.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_TagCustom.ts
@@ -1,0 +1,40 @@
+import typia from "../../../../src";
+import { _test_isStringify } from "../../../internal/_test_isStringify";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createIsStringify_TagCustom = _test_isStringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input: TagCustom): string | null => {
+        const is = (input: any): input is TagCustom => {
+            const $is_uuid = (typia.createIsStringify as any).is_uuid;
+            const $is_custom = (typia.createIsStringify as any).is_custom;
+            const $io0 = (input: any): boolean =>
+                "string" === typeof input.id &&
+                true === $is_uuid(input.id) &&
+                "string" === typeof input.dolloar &&
+                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.postfix &&
+                $is_custom("postfix", "string", "abcd", input.postfix) &&
+                "number" === typeof input.log &&
+                Number.isFinite(input.log) &&
+                $is_custom("powerOf", "number", "10", input.log);
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const stringify = (input: TagCustom): string => {
+            const $string = (typia.createIsStringify as any).string;
+            const $number = (typia.createIsStringify as any).number;
+            const $is_uuid = (typia.createIsStringify as any).is_uuid;
+            const $is_custom = (typia.createIsStringify as any).is_custom;
+            const $so0 = (input: any): any =>
+                `{"id":${'"' + input.id + '"'},"dolloar":${$string(
+                    input.dolloar,
+                )},"postfix":${$string(input.postfix)},"log":${$number(
+                    input.log,
+                )}}`;
+            return $so0(input);
+        };
+        return is(input) ? stringify(input) : null;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createPrune/test_createPrune_TagCustom.ts
+++ b/test/generated/output/createPrune/test_createPrune_TagCustom.ts
@@ -1,0 +1,25 @@
+import typia from "../../../../src";
+import { _test_prune } from "../../../internal/_test_prune";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createPrune_TagCustom = _test_prune(
+    "TagCustom",
+    TagCustom.generate,
+    (input: TagCustom): void => {
+        const $is_uuid = (typia.createPrune as any).is_uuid;
+        const $is_custom = (typia.createPrune as any).is_custom;
+        const $po0 = (input: any): any => {
+            for (const key of Object.keys(input)) {
+                if (
+                    "id" === key ||
+                    "dolloar" === key ||
+                    "postfix" === key ||
+                    "log" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        if ("object" === typeof input && null !== input) $po0(input);
+    },
+);

--- a/test/generated/output/createStringify/test_createStringify_TagCustom.ts
+++ b/test/generated/output/createStringify/test_createStringify_TagCustom.ts
@@ -1,0 +1,21 @@
+import typia from "../../../../src";
+import { _test_stringify } from "../../../internal/_test_stringify";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createStringify_TagCustom = _test_stringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input: TagCustom): string => {
+        const $string = (typia.createStringify as any).string;
+        const $number = (typia.createStringify as any).number;
+        const $is_uuid = (typia.createStringify as any).is_uuid;
+        const $is_custom = (typia.createStringify as any).is_custom;
+        const $so0 = (input: any): any =>
+            `{"id":${'"' + input.id + '"'},"dolloar":${$string(
+                input.dolloar,
+            )},"postfix":${$string(input.postfix)},"log":${$number(
+                input.log,
+            )}}`;
+        return $so0(input);
+    },
+);

--- a/test/generated/output/createValidate/test_createValidate_TagCustom.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagCustom.ts
@@ -1,0 +1,82 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createValidate_TagCustom = _test_validate(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): typia.IValidation<TagCustom> => {
+        const errors = [] as any[];
+        const $report = (typia.createValidate as any).report(errors);
+        const $is_uuid = (typia.createValidate as any).is_uuid;
+        const $is_custom = (typia.createValidate as any).is_custom;
+        ((
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): input is TagCustom => {
+            const $vo0 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                [
+                    ("string" === typeof input.id &&
+                        true === $is_uuid(input.id)) ||
+                        $report(_exceptionable, {
+                            path: _path + ".id",
+                            expected: "string",
+                            value: input.id,
+                        }),
+                    ("string" === typeof input.dolloar &&
+                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                        $report(_exceptionable, {
+                            path: _path + ".dolloar",
+                            expected: "string",
+                            value: input.dolloar,
+                        }),
+                    ("string" === typeof input.postfix &&
+                        $is_custom(
+                            "postfix",
+                            "string",
+                            "abcd",
+                            input.postfix,
+                        )) ||
+                        $report(_exceptionable, {
+                            path: _path + ".postfix",
+                            expected: "string",
+                            value: input.postfix,
+                        }),
+                    ("number" === typeof input.log &&
+                        Number.isFinite(input.log) &&
+                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        $report(_exceptionable, {
+                            path: _path + ".log",
+                            expected: "number",
+                            value: input.log,
+                        }),
+                ].every((flag: boolean) => flag);
+            return (
+                ((("object" === typeof input && null !== input) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Resolve<TagCustom>",
+                        value: input,
+                    })) &&
+                    $vo0(input, _path + "", true)) ||
+                $report(true, {
+                    path: _path + "",
+                    expected: "Resolve<TagCustom>",
+                    value: input,
+                })
+            );
+        })(input, "$input", true);
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagCustom.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagCustom.ts
@@ -1,0 +1,105 @@
+import typia from "../../../../src";
+import { _test_validateClone } from "../../../internal/_test_validateClone";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createValidateClone_TagCustom = _test_validateClone(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): typia.IValidation<typia.Primitive<TagCustom>> => {
+        const validate = (input: any): typia.IValidation<TagCustom> => {
+            const errors = [] as any[];
+            const $report = (typia.createValidateClone as any).report(errors);
+            const $is_uuid = (typia.createValidateClone as any).is_uuid;
+            const $is_custom = (typia.createValidateClone as any).is_custom;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        ("string" === typeof input.id &&
+                            true === $is_uuid(input.id)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string",
+                                value: input.id,
+                            }),
+                        ("string" === typeof input.dolloar &&
+                            $is_custom(
+                                "dollar",
+                                "string",
+                                "",
+                                input.dolloar,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".dolloar",
+                                expected: "string",
+                                value: input.dolloar,
+                            }),
+                        ("string" === typeof input.postfix &&
+                            $is_custom(
+                                "postfix",
+                                "string",
+                                "abcd",
+                                input.postfix,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string",
+                                value: input.postfix,
+                            }),
+                        ("number" === typeof input.log &&
+                            Number.isFinite(input.log) &&
+                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number",
+                                value: input.log,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Resolve<TagCustom>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const clone = (input: TagCustom): typia.Primitive<TagCustom> => {
+            const $is_uuid = (typia.createValidateClone as any).is_uuid;
+            const $is_custom = (typia.createValidateClone as any).is_custom;
+            const $co0 = (input: any): any => ({
+                id: input.id as any,
+                dolloar: input.dolloar as any,
+                postfix: input.postfix as any,
+                log: input.log as any,
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        const output = validate(input) as any;
+        if (output.success) output.data = clone(input);
+        return output;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagCustom.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagCustom.ts
@@ -1,0 +1,101 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createValidateEquals_TagCustom = _test_validateEquals(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): typia.IValidation<TagCustom> => {
+        const errors = [] as any[];
+        const $report = (typia.createValidateEquals as any).report(errors);
+        const $is_uuid = (typia.createValidateEquals as any).is_uuid;
+        const $is_custom = (typia.createValidateEquals as any).is_custom;
+        const $join = (typia.createValidateEquals as any).join;
+        ((
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): input is TagCustom => {
+            const $vo0 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                [
+                    ("string" === typeof input.id &&
+                        true === $is_uuid(input.id)) ||
+                        $report(_exceptionable, {
+                            path: _path + ".id",
+                            expected: "string",
+                            value: input.id,
+                        }),
+                    ("string" === typeof input.dolloar &&
+                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                        $report(_exceptionable, {
+                            path: _path + ".dolloar",
+                            expected: "string",
+                            value: input.dolloar,
+                        }),
+                    ("string" === typeof input.postfix &&
+                        $is_custom(
+                            "postfix",
+                            "string",
+                            "abcd",
+                            input.postfix,
+                        )) ||
+                        $report(_exceptionable, {
+                            path: _path + ".postfix",
+                            expected: "string",
+                            value: input.postfix,
+                        }),
+                    ("number" === typeof input.log &&
+                        Number.isFinite(input.log) &&
+                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        $report(_exceptionable, {
+                            path: _path + ".log",
+                            expected: "number",
+                            value: input.log,
+                        }),
+                    4 === Object.keys(input).length ||
+                        false === _exceptionable ||
+                        Object.keys(input)
+                            .map((key) => {
+                                if (
+                                    ["id", "dolloar", "postfix", "log"].some(
+                                        (prop) => key === prop,
+                                    )
+                                )
+                                    return true;
+                                const value = input[key];
+                                if (undefined === value) return true;
+                                return $report(_exceptionable, {
+                                    path: _path + $join(key),
+                                    expected: "undefined",
+                                    value: value,
+                                });
+                            })
+                            .every((flag: boolean) => flag),
+                ].every((flag: boolean) => flag);
+            return (
+                ((("object" === typeof input && null !== input) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Resolve<TagCustom>",
+                        value: input,
+                    })) &&
+                    $vo0(input, _path + "", true)) ||
+                $report(true, {
+                    path: _path + "",
+                    expected: "Resolve<TagCustom>",
+                    value: input,
+                })
+            );
+        })(input, "$input", true);
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    },
+);

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagCustom.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagCustom.ts
@@ -1,0 +1,92 @@
+import typia from "../../../../src";
+import { _test_validateParse } from "../../../internal/_test_validateParse";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createValidateParse_TagCustom = _test_validateParse(
+    "TagCustom",
+    TagCustom.generate,
+    (input: string): typia.IValidation<typia.Primitive<TagCustom>> => {
+        const validate = (input: any): typia.IValidation<TagCustom> => {
+            const errors = [] as any[];
+            const $report = (typia.createValidateParse as any).report(errors);
+            const $is_uuid = (typia.createValidateParse as any).is_uuid;
+            const $is_custom = (typia.createValidateParse as any).is_custom;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        ("string" === typeof input.id &&
+                            true === $is_uuid(input.id)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string",
+                                value: input.id,
+                            }),
+                        ("string" === typeof input.dolloar &&
+                            $is_custom(
+                                "dollar",
+                                "string",
+                                "",
+                                input.dolloar,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".dolloar",
+                                expected: "string",
+                                value: input.dolloar,
+                            }),
+                        ("string" === typeof input.postfix &&
+                            $is_custom(
+                                "postfix",
+                                "string",
+                                "abcd",
+                                input.postfix,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string",
+                                value: input.postfix,
+                            }),
+                        ("number" === typeof input.log &&
+                            Number.isFinite(input.log) &&
+                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number",
+                                value: input.log,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Resolve<TagCustom>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        input = JSON.parse(input);
+        const output = validate(input);
+        return output;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagCustom.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagCustom.ts
@@ -1,0 +1,109 @@
+import typia from "../../../../src";
+import { _test_validatePrune } from "../../../internal/_test_validatePrune";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createValidatePrune_TagCustom = _test_validatePrune(
+    "TagCustom",
+    TagCustom.generate,
+    (input: any): typia.IValidation<TagCustom> => {
+        const validate = (input: any): typia.IValidation<TagCustom> => {
+            const errors = [] as any[];
+            const $report = (typia.createValidatePrune as any).report(errors);
+            const $is_uuid = (typia.createValidatePrune as any).is_uuid;
+            const $is_custom = (typia.createValidatePrune as any).is_custom;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        ("string" === typeof input.id &&
+                            true === $is_uuid(input.id)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string",
+                                value: input.id,
+                            }),
+                        ("string" === typeof input.dolloar &&
+                            $is_custom(
+                                "dollar",
+                                "string",
+                                "",
+                                input.dolloar,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".dolloar",
+                                expected: "string",
+                                value: input.dolloar,
+                            }),
+                        ("string" === typeof input.postfix &&
+                            $is_custom(
+                                "postfix",
+                                "string",
+                                "abcd",
+                                input.postfix,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string",
+                                value: input.postfix,
+                            }),
+                        ("number" === typeof input.log &&
+                            Number.isFinite(input.log) &&
+                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number",
+                                value: input.log,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Resolve<TagCustom>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const prune = (input: TagCustom): void => {
+            const $is_uuid = (typia.createValidatePrune as any).is_uuid;
+            const $is_custom = (typia.createValidatePrune as any).is_custom;
+            const $po0 = (input: any): any => {
+                for (const key of Object.keys(input)) {
+                    if (
+                        "id" === key ||
+                        "dolloar" === key ||
+                        "postfix" === key ||
+                        "log" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        const output = validate(input);
+        if (output.success) prune(input);
+        return output;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagCustom.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagCustom.ts
@@ -1,0 +1,107 @@
+import typia from "../../../../src";
+import { _test_validateStringify } from "../../../internal/_test_validateStringify";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_createValidateStringify_TagCustom = _test_validateStringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input: TagCustom): typia.IValidation<string> => {
+        const validate = (input: any): typia.IValidation<TagCustom> => {
+            const errors = [] as any[];
+            const $report = (typia.createValidateStringify as any).report(
+                errors,
+            );
+            const $is_uuid = (typia.createValidateStringify as any).is_uuid;
+            const $is_custom = (typia.createValidateStringify as any).is_custom;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        ("string" === typeof input.id &&
+                            true === $is_uuid(input.id)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string",
+                                value: input.id,
+                            }),
+                        ("string" === typeof input.dolloar &&
+                            $is_custom(
+                                "dollar",
+                                "string",
+                                "",
+                                input.dolloar,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".dolloar",
+                                expected: "string",
+                                value: input.dolloar,
+                            }),
+                        ("string" === typeof input.postfix &&
+                            $is_custom(
+                                "postfix",
+                                "string",
+                                "abcd",
+                                input.postfix,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string",
+                                value: input.postfix,
+                            }),
+                        ("number" === typeof input.log &&
+                            Number.isFinite(input.log) &&
+                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number",
+                                value: input.log,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Resolve<TagCustom>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const stringify = (input: TagCustom): string => {
+            const $string = (typia.createValidateStringify as any).string;
+            const $number = (typia.createValidateStringify as any).number;
+            const $is_uuid = (typia.createValidateStringify as any).is_uuid;
+            const $is_custom = (typia.createValidateStringify as any).is_custom;
+            const $so0 = (input: any): any =>
+                `{"id":${'"' + input.id + '"'},"dolloar":${$string(
+                    input.dolloar,
+                )},"postfix":${$string(input.postfix)},"log":${$number(
+                    input.log,
+                )}}`;
+            return $so0(input);
+        };
+        const output = validate(input) as any;
+        if (output.success) output.data = stringify(input);
+        return output;
+    },
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/equals/test_equals_TagCustom.ts
+++ b/test/generated/output/equals/test_equals_TagCustom.ts
@@ -1,0 +1,41 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_equals_TagCustom = _test_equals(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any, _exceptionable: boolean = true): input is TagCustom => {
+            const $is_uuid = (typia.equals as any).is_uuid;
+            const $is_custom = (typia.equals as any).is_custom;
+            const $io0 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                "string" === typeof input.id &&
+                true === $is_uuid(input.id) &&
+                "string" === typeof input.dolloar &&
+                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.postfix &&
+                $is_custom("postfix", "string", "abcd", input.postfix) &&
+                "number" === typeof input.log &&
+                Number.isFinite(input.log) &&
+                $is_custom("powerOf", "number", "10", input.log) &&
+                (4 === Object.keys(input).length ||
+                    Object.keys(input).every((key) => {
+                        if (
+                            ["id", "dolloar", "postfix", "log"].some(
+                                (prop) => key === prop,
+                            )
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            return (
+                "object" === typeof input && null !== input && $io0(input, true)
+            );
+        })(input),
+);

--- a/test/generated/output/is/test_is_TagCustom.ts
+++ b/test/generated/output/is/test_is_TagCustom.ts
@@ -1,0 +1,25 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_is_TagCustom = _test_is(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): input is TagCustom => {
+            const $is_uuid = (typia.is as any).is_uuid;
+            const $is_custom = (typia.is as any).is_custom;
+            const $io0 = (input: any): boolean =>
+                "string" === typeof input.id &&
+                true === $is_uuid(input.id) &&
+                "string" === typeof input.dolloar &&
+                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.postfix &&
+                $is_custom("postfix", "string", "abcd", input.postfix) &&
+                "number" === typeof input.log &&
+                Number.isFinite(input.log) &&
+                $is_custom("powerOf", "number", "10", input.log);
+            return "object" === typeof input && null !== input && $io0(input);
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/isClone/test_isClone_TagCustom.ts
+++ b/test/generated/output/isClone/test_isClone_TagCustom.ts
@@ -1,0 +1,45 @@
+import typia from "../../../../src";
+import { _test_isClone } from "../../../internal/_test_isClone";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_isClone_TagCustom = _test_isClone(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): typia.Primitive<TagCustom> | null => {
+            const is = (input: any): input is TagCustom => {
+                const $is_uuid = (typia.isClone as any).is_uuid;
+                const $is_custom = (typia.isClone as any).is_custom;
+                const $io0 = (input: any): boolean =>
+                    "string" === typeof input.id &&
+                    true === $is_uuid(input.id) &&
+                    "string" === typeof input.dolloar &&
+                    $is_custom("dollar", "string", "", input.dolloar) &&
+                    "string" === typeof input.postfix &&
+                    $is_custom("postfix", "string", "abcd", input.postfix) &&
+                    "number" === typeof input.log &&
+                    Number.isFinite(input.log) &&
+                    $is_custom("powerOf", "number", "10", input.log);
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const clone = (input: TagCustom): typia.Primitive<TagCustom> => {
+                const $is_uuid = (typia.isClone as any).is_uuid;
+                const $is_custom = (typia.isClone as any).is_custom;
+                const $co0 = (input: any): any => ({
+                    id: input.id as any,
+                    dolloar: input.dolloar as any,
+                    postfix: input.postfix as any,
+                    log: input.log as any,
+                });
+                return "object" === typeof input && null !== input
+                    ? $co0(input)
+                    : (input as any);
+            };
+            if (!is(input)) return null;
+            const output = clone(input);
+            return output;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/isParse/test_isParse_TagCustom.ts
+++ b/test/generated/output/isParse/test_isParse_TagCustom.ts
@@ -1,0 +1,31 @@
+import typia from "../../../../src";
+import { _test_isParse } from "../../../internal/_test_isParse";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_isParse_TagCustom = _test_isParse(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): typia.Primitive<TagCustom> => {
+            const is = (input: any): input is TagCustom => {
+                const $is_uuid = (typia.isParse as any).is_uuid;
+                const $is_custom = (typia.isParse as any).is_custom;
+                const $io0 = (input: any): boolean =>
+                    "string" === typeof input.id &&
+                    true === $is_uuid(input.id) &&
+                    "string" === typeof input.dolloar &&
+                    $is_custom("dollar", "string", "", input.dolloar) &&
+                    "string" === typeof input.postfix &&
+                    $is_custom("postfix", "string", "abcd", input.postfix) &&
+                    "number" === typeof input.log &&
+                    Number.isFinite(input.log) &&
+                    $is_custom("powerOf", "number", "10", input.log);
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            input = JSON.parse(input);
+            return is(input) ? (input as any) : null;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/isPrune/test_isPrune_TagCustom.ts
+++ b/test/generated/output/isPrune/test_isPrune_TagCustom.ts
@@ -1,0 +1,49 @@
+import typia from "../../../../src";
+import { _test_isPrune } from "../../../internal/_test_isPrune";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_isPrune_TagCustom = _test_isPrune(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): input is TagCustom => {
+            const is = (input: any): input is TagCustom => {
+                const $is_uuid = (typia.isPrune as any).is_uuid;
+                const $is_custom = (typia.isPrune as any).is_custom;
+                const $io0 = (input: any): boolean =>
+                    "string" === typeof input.id &&
+                    true === $is_uuid(input.id) &&
+                    "string" === typeof input.dolloar &&
+                    $is_custom("dollar", "string", "", input.dolloar) &&
+                    "string" === typeof input.postfix &&
+                    $is_custom("postfix", "string", "abcd", input.postfix) &&
+                    "number" === typeof input.log &&
+                    Number.isFinite(input.log) &&
+                    $is_custom("powerOf", "number", "10", input.log);
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const prune = (input: TagCustom): void => {
+                const $is_uuid = (typia.isPrune as any).is_uuid;
+                const $is_custom = (typia.isPrune as any).is_custom;
+                const $po0 = (input: any): any => {
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "id" === key ||
+                            "dolloar" === key ||
+                            "postfix" === key ||
+                            "log" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                if ("object" === typeof input && null !== input) $po0(input);
+            };
+            if (!is(input)) return false;
+            prune(input);
+            return true;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/isStringify/test_isStringify_TagCustom.ts
+++ b/test/generated/output/isStringify/test_isStringify_TagCustom.ts
@@ -1,0 +1,43 @@
+import typia from "../../../../src";
+import { _test_isStringify } from "../../../internal/_test_isStringify";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_isStringify_TagCustom = _test_isStringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: TagCustom): string | null => {
+            const is = (input: any): input is TagCustom => {
+                const $is_uuid = (typia.isStringify as any).is_uuid;
+                const $is_custom = (typia.isStringify as any).is_custom;
+                const $io0 = (input: any): boolean =>
+                    "string" === typeof input.id &&
+                    true === $is_uuid(input.id) &&
+                    "string" === typeof input.dolloar &&
+                    $is_custom("dollar", "string", "", input.dolloar) &&
+                    "string" === typeof input.postfix &&
+                    $is_custom("postfix", "string", "abcd", input.postfix) &&
+                    "number" === typeof input.log &&
+                    Number.isFinite(input.log) &&
+                    $is_custom("powerOf", "number", "10", input.log);
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const stringify = (input: TagCustom): string => {
+                const $string = (typia.isStringify as any).string;
+                const $number = (typia.isStringify as any).number;
+                const $is_uuid = (typia.isStringify as any).is_uuid;
+                const $is_custom = (typia.isStringify as any).is_custom;
+                const $so0 = (input: any): any =>
+                    `{"id":${'"' + input.id + '"'},"dolloar":${$string(
+                        input.dolloar,
+                    )},"postfix":${$string(input.postfix)},"log":${$number(
+                        input.log,
+                    )}}`;
+                return $so0(input);
+            };
+            return is(input) ? stringify(input) : null;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/prune/test_prune_TagCustom.ts
+++ b/test/generated/output/prune/test_prune_TagCustom.ts
@@ -1,0 +1,26 @@
+import typia from "../../../../src";
+import { _test_prune } from "../../../internal/_test_prune";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_prune_TagCustom = _test_prune(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: TagCustom): void => {
+            const $is_uuid = (typia.prune as any).is_uuid;
+            const $is_custom = (typia.prune as any).is_custom;
+            const $po0 = (input: any): any => {
+                for (const key of Object.keys(input)) {
+                    if (
+                        "id" === key ||
+                        "dolloar" === key ||
+                        "postfix" === key ||
+                        "log" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        })(input),
+);

--- a/test/generated/output/stringify/test_stringify_TagCustom.ts
+++ b/test/generated/output/stringify/test_stringify_TagCustom.ts
@@ -1,0 +1,22 @@
+import typia from "../../../../src";
+import { _test_stringify } from "../../../internal/_test_stringify";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_stringify_TagCustom = _test_stringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: TagCustom): string => {
+            const $string = (typia.stringify as any).string;
+            const $number = (typia.stringify as any).number;
+            const $is_uuid = (typia.stringify as any).is_uuid;
+            const $is_custom = (typia.stringify as any).is_custom;
+            const $so0 = (input: any): any =>
+                `{"id":${'"' + input.id + '"'},"dolloar":${$string(
+                    input.dolloar,
+                )},"postfix":${$string(input.postfix)},"log":${$number(
+                    input.log,
+                )}}`;
+            return $so0(input);
+        })(input),
+);

--- a/test/generated/output/validate/test_validate_TagCustom.ts
+++ b/test/generated/output/validate/test_validate_TagCustom.ts
@@ -1,0 +1,88 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_validate_TagCustom = _test_validate(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): typia.IValidation<TagCustom> => {
+            const errors = [] as any[];
+            const $report = (typia.validate as any).report(errors);
+            const $is_uuid = (typia.validate as any).is_uuid;
+            const $is_custom = (typia.validate as any).is_custom;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        ("string" === typeof input.id &&
+                            true === $is_uuid(input.id)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string",
+                                value: input.id,
+                            }),
+                        ("string" === typeof input.dolloar &&
+                            $is_custom(
+                                "dollar",
+                                "string",
+                                "",
+                                input.dolloar,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".dolloar",
+                                expected: "string",
+                                value: input.dolloar,
+                            }),
+                        ("string" === typeof input.postfix &&
+                            $is_custom(
+                                "postfix",
+                                "string",
+                                "abcd",
+                                input.postfix,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string",
+                                value: input.postfix,
+                            }),
+                        ("number" === typeof input.log &&
+                            Number.isFinite(input.log) &&
+                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number",
+                                value: input.log,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Resolve<TagCustom>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/validateClone/test_validateClone_TagCustom.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagCustom.ts
@@ -1,0 +1,111 @@
+import typia from "../../../../src";
+import { _test_validateClone } from "../../../internal/_test_validateClone";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_validateClone_TagCustom = _test_validateClone(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): typia.IValidation<typia.Primitive<TagCustom>> => {
+            const validate = (input: any): typia.IValidation<TagCustom> => {
+                const errors = [] as any[];
+                const $report = (typia.validateClone as any).report(errors);
+                const $is_uuid = (typia.validateClone as any).is_uuid;
+                const $is_custom = (typia.validateClone as any).is_custom;
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is TagCustom => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            ("string" === typeof input.id &&
+                                true === $is_uuid(input.id)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string",
+                                    value: input.id,
+                                }),
+                            ("string" === typeof input.dolloar &&
+                                $is_custom(
+                                    "dollar",
+                                    "string",
+                                    "",
+                                    input.dolloar,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dolloar",
+                                    expected: "string",
+                                    value: input.dolloar,
+                                }),
+                            ("string" === typeof input.postfix &&
+                                $is_custom(
+                                    "postfix",
+                                    "string",
+                                    "abcd",
+                                    input.postfix,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string",
+                                    value: input.postfix,
+                                }),
+                            ("number" === typeof input.log &&
+                                Number.isFinite(input.log) &&
+                                $is_custom(
+                                    "powerOf",
+                                    "number",
+                                    "10",
+                                    input.log,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number",
+                                    value: input.log,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Resolve<TagCustom>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const clone = (input: TagCustom): typia.Primitive<TagCustom> => {
+                const $is_uuid = (typia.validateClone as any).is_uuid;
+                const $is_custom = (typia.validateClone as any).is_custom;
+                const $co0 = (input: any): any => ({
+                    id: input.id as any,
+                    dolloar: input.dolloar as any,
+                    postfix: input.postfix as any,
+                    log: input.log as any,
+                });
+                return "object" === typeof input && null !== input
+                    ? $co0(input)
+                    : (input as any);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = clone(input);
+            return output;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/validateEquals/test_validateEquals_TagCustom.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagCustom.ts
@@ -1,0 +1,110 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_validateEquals_TagCustom = _test_validateEquals(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): typia.IValidation<TagCustom> => {
+            const errors = [] as any[];
+            const $report = (typia.validateEquals as any).report(errors);
+            const $is_uuid = (typia.validateEquals as any).is_uuid;
+            const $is_custom = (typia.validateEquals as any).is_custom;
+            const $join = (typia.validateEquals as any).join;
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is TagCustom => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        ("string" === typeof input.id &&
+                            true === $is_uuid(input.id)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string",
+                                value: input.id,
+                            }),
+                        ("string" === typeof input.dolloar &&
+                            $is_custom(
+                                "dollar",
+                                "string",
+                                "",
+                                input.dolloar,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".dolloar",
+                                expected: "string",
+                                value: input.dolloar,
+                            }),
+                        ("string" === typeof input.postfix &&
+                            $is_custom(
+                                "postfix",
+                                "string",
+                                "abcd",
+                                input.postfix,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string",
+                                value: input.postfix,
+                            }),
+                        ("number" === typeof input.log &&
+                            Number.isFinite(input.log) &&
+                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number",
+                                value: input.log,
+                            }),
+                        4 === Object.keys(input).length ||
+                            false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key) => {
+                                    if (
+                                        [
+                                            "id",
+                                            "dolloar",
+                                            "postfix",
+                                            "log",
+                                        ].some((prop) => key === prop)
+                                    )
+                                        return true;
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    return $report(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected: "undefined",
+                                        value: value,
+                                    });
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Resolve<TagCustom>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        })(input),
+);

--- a/test/generated/output/validateParse/test_validateParse_TagCustom.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagCustom.ts
@@ -1,0 +1,98 @@
+import typia from "../../../../src";
+import { _test_validateParse } from "../../../internal/_test_validateParse";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_validateParse_TagCustom = _test_validateParse(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: string): typia.IValidation<typia.Primitive<TagCustom>> => {
+            const validate = (input: any): typia.IValidation<TagCustom> => {
+                const errors = [] as any[];
+                const $report = (typia.validateParse as any).report(errors);
+                const $is_uuid = (typia.validateParse as any).is_uuid;
+                const $is_custom = (typia.validateParse as any).is_custom;
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is TagCustom => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            ("string" === typeof input.id &&
+                                true === $is_uuid(input.id)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string",
+                                    value: input.id,
+                                }),
+                            ("string" === typeof input.dolloar &&
+                                $is_custom(
+                                    "dollar",
+                                    "string",
+                                    "",
+                                    input.dolloar,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dolloar",
+                                    expected: "string",
+                                    value: input.dolloar,
+                                }),
+                            ("string" === typeof input.postfix &&
+                                $is_custom(
+                                    "postfix",
+                                    "string",
+                                    "abcd",
+                                    input.postfix,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string",
+                                    value: input.postfix,
+                                }),
+                            ("number" === typeof input.log &&
+                                Number.isFinite(input.log) &&
+                                $is_custom(
+                                    "powerOf",
+                                    "number",
+                                    "10",
+                                    input.log,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number",
+                                    value: input.log,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Resolve<TagCustom>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            input = JSON.parse(input);
+            const output = validate(input);
+            return output;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/validatePrune/test_validatePrune_TagCustom.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagCustom.ts
@@ -1,0 +1,115 @@
+import typia from "../../../../src";
+import { _test_validatePrune } from "../../../internal/_test_validatePrune";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_validatePrune_TagCustom = _test_validatePrune(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: any): typia.IValidation<TagCustom> => {
+            const validate = (input: any): typia.IValidation<TagCustom> => {
+                const errors = [] as any[];
+                const $report = (typia.validatePrune as any).report(errors);
+                const $is_uuid = (typia.validatePrune as any).is_uuid;
+                const $is_custom = (typia.validatePrune as any).is_custom;
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is TagCustom => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            ("string" === typeof input.id &&
+                                true === $is_uuid(input.id)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string",
+                                    value: input.id,
+                                }),
+                            ("string" === typeof input.dolloar &&
+                                $is_custom(
+                                    "dollar",
+                                    "string",
+                                    "",
+                                    input.dolloar,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dolloar",
+                                    expected: "string",
+                                    value: input.dolloar,
+                                }),
+                            ("string" === typeof input.postfix &&
+                                $is_custom(
+                                    "postfix",
+                                    "string",
+                                    "abcd",
+                                    input.postfix,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string",
+                                    value: input.postfix,
+                                }),
+                            ("number" === typeof input.log &&
+                                Number.isFinite(input.log) &&
+                                $is_custom(
+                                    "powerOf",
+                                    "number",
+                                    "10",
+                                    input.log,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number",
+                                    value: input.log,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Resolve<TagCustom>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const prune = (input: TagCustom): void => {
+                const $is_uuid = (typia.validatePrune as any).is_uuid;
+                const $is_custom = (typia.validatePrune as any).is_custom;
+                const $po0 = (input: any): any => {
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "id" === key ||
+                            "dolloar" === key ||
+                            "postfix" === key ||
+                            "log" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                if ("object" === typeof input && null !== input) $po0(input);
+            };
+            const output = validate(input);
+            if (output.success) prune(input);
+            return output;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/generated/output/validateStringify/test_validateStringify_TagCustom.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagCustom.ts
@@ -1,0 +1,111 @@
+import typia from "../../../../src";
+import { _test_validateStringify } from "../../../internal/_test_validateStringify";
+import { TagCustom } from "../../../structures/TagCustom";
+
+export const test_validateStringify_TagCustom = _test_validateStringify(
+    "TagCustom",
+    TagCustom.generate,
+    (input) =>
+        ((input: TagCustom): typia.IValidation<string> => {
+            const validate = (input: any): typia.IValidation<TagCustom> => {
+                const errors = [] as any[];
+                const $report = (typia.validateStringify as any).report(errors);
+                const $is_uuid = (typia.validateStringify as any).is_uuid;
+                const $is_custom = (typia.validateStringify as any).is_custom;
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is TagCustom => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            ("string" === typeof input.id &&
+                                true === $is_uuid(input.id)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string",
+                                    value: input.id,
+                                }),
+                            ("string" === typeof input.dolloar &&
+                                $is_custom(
+                                    "dollar",
+                                    "string",
+                                    "",
+                                    input.dolloar,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dolloar",
+                                    expected: "string",
+                                    value: input.dolloar,
+                                }),
+                            ("string" === typeof input.postfix &&
+                                $is_custom(
+                                    "postfix",
+                                    "string",
+                                    "abcd",
+                                    input.postfix,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string",
+                                    value: input.postfix,
+                                }),
+                            ("number" === typeof input.log &&
+                                Number.isFinite(input.log) &&
+                                $is_custom(
+                                    "powerOf",
+                                    "number",
+                                    "10",
+                                    input.log,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number",
+                                    value: input.log,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Resolve<TagCustom>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Resolve<TagCustom>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const stringify = (input: TagCustom): string => {
+                const $string = (typia.validateStringify as any).string;
+                const $number = (typia.validateStringify as any).number;
+                const $is_uuid = (typia.validateStringify as any).is_uuid;
+                const $is_custom = (typia.validateStringify as any).is_custom;
+                const $so0 = (input: any): any =>
+                    `{"id":${'"' + input.id + '"'},"dolloar":${$string(
+                        input.dolloar,
+                    )},"postfix":${$string(input.postfix)},"log":${$number(
+                        input.log,
+                    )}}`;
+                return $so0(input);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = stringify(input);
+            return output;
+        })(input),
+    TagCustom.SPOILERS,
+);

--- a/test/issues/560.ts
+++ b/test/issues/560.ts
@@ -1,0 +1,31 @@
+import typia from "typia";
+import { v4 } from "uuid";
+
+import { TagCustom } from "../structures/TagCustom";
+
+TagCustom.generate;
+
+console.log(
+    typia.createIs<TagCustom>()({
+        id: v4(),
+        dolloar: "1234",
+        postfix: "abcdabcd",
+        log: 100,
+    }),
+);
+
+// (input) => {
+//     const $is_uuid = typia_1.default.createIs.is_uuid;
+//     const $is_custom = typia_1.default.createIs.is_custom;
+//     const $io0 = (input) =>
+//         "string" === typeof input.id &&
+//         true === $is_uuid(input.id) &&
+//         "string" === typeof input.dolloar &&
+//         $is_custom("dolloar", "string", "", input.dolloar) &&
+//         "string" === typeof input.postfix &&
+//         $is_custom("postfix", "string", "abcd", input.postfix) &&
+//         "number" === typeof input.log &&
+//         Number.isFinite(input.log) &&
+//         $is_custom("powerOf", "number", "10", input.log);
+//     return "object" === typeof input && null !== input && $io0(input);
+// };

--- a/test/issues/generate/output/532.ts
+++ b/test/issues/generate/output/532.ts
@@ -1,5 +1,6 @@
 import typia from "../../../../src";
 import { ObjectPrimitive } from "../../../structures/ObjectPrimitive";
+
 interface A {
     a: string;
 }
@@ -10,17 +11,34 @@ type Union = A | B;
 export const checkUnion = (input: any): input is Union => {
     const $io0 = (input: any): boolean => "string" === typeof input.a;
     const $io1 = (input: any): boolean => "string" === typeof input.b;
-    const $iu0 = (input: any): any => (() => {
-        if (undefined !== input.a)
-            return $io0(input);
-        if (undefined !== input.b)
-            return $io1(input);
-        return false;
-    })();
+    const $iu0 = (input: any): any =>
+        (() => {
+            if (undefined !== input.a) return $io0(input);
+            if (undefined !== input.b) return $io1(input);
+            return false;
+        })();
     return "object" === typeof input && null !== input && $iu0(input);
 };
 export const checkPrimitive = (input: any): input is ObjectPrimitive => {
-    const $io0 = (input: any): boolean => "string" === typeof input.id && ("md" === input.extension || "html" === input.extension || "txt" === input.extension) && "string" === typeof input.title && "string" === typeof input.body && (Array.isArray(input.files) && input.files.every((elem: any) => "object" === typeof elem && null !== elem && $io1(elem))) && "boolean" === typeof input.secret && "string" === typeof input.created_at;
-    const $io1 = (input: any): boolean => "string" === typeof input.id && "string" === typeof input.name && "string" === typeof input.extension && "string" === typeof input.url && "string" === typeof input.created_at;
+    const $io0 = (input: any): boolean =>
+        "string" === typeof input.id &&
+        ("md" === input.extension ||
+            "html" === input.extension ||
+            "txt" === input.extension) &&
+        "string" === typeof input.title &&
+        "string" === typeof input.body &&
+        Array.isArray(input.files) &&
+        input.files.every(
+            (elem: any) =>
+                "object" === typeof elem && null !== elem && $io1(elem),
+        ) &&
+        "boolean" === typeof input.secret &&
+        "string" === typeof input.created_at;
+    const $io1 = (input: any): boolean =>
+        "string" === typeof input.id &&
+        "string" === typeof input.name &&
+        "string" === typeof input.extension &&
+        "string" === typeof input.url &&
+        "string" === typeof input.created_at;
     return "object" === typeof input && null !== input && $io0(input);
 };

--- a/test/issues/generate/output/nestia-282.ts
+++ b/test/issues/generate/output/nestia-282.ts
@@ -1,30 +1,31 @@
 import typia from "../../../../src";
+
 const ERROR = {
     TOO_LONG_KEY_NAME1: {
         result: false,
         code: 4000,
-        data: "Error happens something1."
+        data: "Error happens something1.",
     },
     TOO_LONG_KEY_NAME2: {
         result: false,
         code: 4000,
-        data: "Error happens something2."
+        data: "Error happens something2.",
     },
     TOO_LONG_KEY_NAME3: {
         result: false,
         code: 4000,
-        data: "Error happens something3."
+        data: "Error happens something3.",
     },
     TOO_LONG_KEY_NAME4: {
         result: false,
         code: 4000,
-        data: "Error happens something4."
+        data: "Error happens something4.",
     },
     TOO_LONG_KEY_NAME5: {
         result: false,
         code: 4000,
-        data: "Error happens something5."
-    }
+        data: "Error happens something5.",
+    },
 } as const;
 type KeyOfError = keyof typeof ERROR;
 type ValueOfError = (typeof ERROR)[KeyOfError];
@@ -34,112 +35,248 @@ interface ResponseForm<T> {
     data: T;
 }
 type Try<T, E extends ValueOfError> = ResponseForm<T> | E;
-const input: Try<true, typeof ERROR.TOO_LONG_KEY_NAME1 | typeof ERROR.TOO_LONG_KEY_NAME2 | typeof ERROR.TOO_LONG_KEY_NAME3 | typeof ERROR.TOO_LONG_KEY_NAME4 | typeof ERROR.TOO_LONG_KEY_NAME5> = {} as any;
-((input: any): {    readonly result: false;    readonly code: 4000;    readonly data: 'Error happens something1.';} | {    readonly result: false;    readonly code: 4000;    readonly data: 'Error happens something2.';} | {    readonly result: false;    readonly code: 4000;    readonly data: 'Error happens something3.';} | {    readonly result: false;    readonly code: 4000;    readonly data: 'Error happens something4.';} | {    readonly result: false;    readonly code: 4000;    readonly data: 'Error happens something5.';} | ResponseForm<true> => {
+const input: Try<
+    true,
+    | typeof ERROR.TOO_LONG_KEY_NAME1
+    | typeof ERROR.TOO_LONG_KEY_NAME2
+    | typeof ERROR.TOO_LONG_KEY_NAME3
+    | typeof ERROR.TOO_LONG_KEY_NAME4
+    | typeof ERROR.TOO_LONG_KEY_NAME5
+> = {} as any;
+((
+    input: any,
+):
+    | {
+          readonly result: false;
+          readonly code: 4000;
+          readonly data: "Error happens something1.";
+      }
+    | {
+          readonly result: false;
+          readonly code: 4000;
+          readonly data: "Error happens something2.";
+      }
+    | {
+          readonly result: false;
+          readonly code: 4000;
+          readonly data: "Error happens something3.";
+      }
+    | {
+          readonly result: false;
+          readonly code: 4000;
+          readonly data: "Error happens something4.";
+      }
+    | {
+          readonly result: false;
+          readonly code: 4000;
+          readonly data: "Error happens something5.";
+      }
+    | ResponseForm<true> => {
     const $guard = (typia.assert as any).guard;
-    ((input: any, _path: string, _exceptionable: boolean = true): input is {    readonly result: false;    readonly code: 4000;    readonly data: 'Error happens something1.';} | {    readonly result: false;    readonly code: 4000;    readonly data: 'Error happens something2.';} | {    readonly result: false;    readonly code: 4000;    readonly data: 'Error happens something3.';} | {    readonly result: false;    readonly code: 4000;    readonly data: 'Error happens something4.';} | {    readonly result: false;    readonly code: 4000;    readonly data: 'Error happens something5.';} | ResponseForm<true> => {
-        const $ao0 = (input: any, _path: string, _exceptionable: boolean = true): boolean => (false === input.result || $guard(_exceptionable, {
-            path: _path + ".result",
-            expected: "false",
-            value: input.result
-        })) && (4000 === input.code || $guard(_exceptionable, {
-            path: _path + ".code",
-            expected: "4000",
-            value: input.code
-        })) && ("Error happens something1." === input.data || $guard(_exceptionable, {
-            path: _path + ".data",
-            expected: "\"Error happens something1.\"",
-            value: input.data
-        }));
-        const $ao1 = (input: any, _path: string, _exceptionable: boolean = true): boolean => (false === input.result || $guard(_exceptionable, {
-            path: _path + ".result",
-            expected: "false",
-            value: input.result
-        })) && (4000 === input.code || $guard(_exceptionable, {
-            path: _path + ".code",
-            expected: "4000",
-            value: input.code
-        })) && ("Error happens something2." === input.data || $guard(_exceptionable, {
-            path: _path + ".data",
-            expected: "\"Error happens something2.\"",
-            value: input.data
-        }));
-        const $ao2 = (input: any, _path: string, _exceptionable: boolean = true): boolean => (false === input.result || $guard(_exceptionable, {
-            path: _path + ".result",
-            expected: "false",
-            value: input.result
-        })) && (4000 === input.code || $guard(_exceptionable, {
-            path: _path + ".code",
-            expected: "4000",
-            value: input.code
-        })) && ("Error happens something3." === input.data || $guard(_exceptionable, {
-            path: _path + ".data",
-            expected: "\"Error happens something3.\"",
-            value: input.data
-        }));
-        const $ao3 = (input: any, _path: string, _exceptionable: boolean = true): boolean => (false === input.result || $guard(_exceptionable, {
-            path: _path + ".result",
-            expected: "false",
-            value: input.result
-        })) && (4000 === input.code || $guard(_exceptionable, {
-            path: _path + ".code",
-            expected: "4000",
-            value: input.code
-        })) && ("Error happens something4." === input.data || $guard(_exceptionable, {
-            path: _path + ".data",
-            expected: "\"Error happens something4.\"",
-            value: input.data
-        }));
-        const $ao4 = (input: any, _path: string, _exceptionable: boolean = true): boolean => (false === input.result || $guard(_exceptionable, {
-            path: _path + ".result",
-            expected: "false",
-            value: input.result
-        })) && (4000 === input.code || $guard(_exceptionable, {
-            path: _path + ".code",
-            expected: "4000",
-            value: input.code
-        })) && ("Error happens something5." === input.data || $guard(_exceptionable, {
-            path: _path + ".data",
-            expected: "\"Error happens something5.\"",
-            value: input.data
-        }));
-        const $ao5 = (input: any, _path: string, _exceptionable: boolean = true): boolean => (true === input.result || $guard(_exceptionable, {
-            path: _path + ".result",
-            expected: "true",
-            value: input.result
-        })) && (1000 === input.code || $guard(_exceptionable, {
-            path: _path + ".code",
-            expected: "1000",
-            value: input.code
-        })) && (true === input.data || $guard(_exceptionable, {
-            path: _path + ".data",
-            expected: "true",
-            value: input.data
-        }));
-        const $au0 = (input: any, _path: string, _exceptionable: boolean = true): any => (() => {
-            if ("Error happens something1." === input.data)
-                return $ao0(input, _path, true && _exceptionable);
-            if ("Error happens something2." === input.data)
-                return $ao1(input, _path, true && _exceptionable);
-            if ("Error happens something3." === input.data)
-                return $ao2(input, _path, true && _exceptionable);
-            if ("Error happens something4." === input.data)
-                return $ao3(input, _path, true && _exceptionable);
-            if ("Error happens something5." === input.data)
-                return $ao4(input, _path, true && _exceptionable);
-            if (true === input.result)
-                return $ao5(input, _path, true && _exceptionable);
-            return $guard(_exceptionable, {
-                path: _path,
-                expected: "(__object | __object.o1 | __object.o2 | __object.o3 | __object.o4 | ResponseForm<true>)",
-                value: input
-            });
-        })();
-        return ("object" === typeof input && null !== input || $guard(true, {
-            path: _path + "",
-            expected: "(Resolve<ResponseForm<true>> | Resolve<__object.o1> | Resolve<__object.o2> | Resolve<__object.o3> | Resolve<__object.o4> | Resolve<__object>)",
-            value: input
-        })) && $au0(input, _path + "", true);
+    ((
+        input: any,
+        _path: string,
+        _exceptionable: boolean = true,
+    ): input is
+        | {
+              readonly result: false;
+              readonly code: 4000;
+              readonly data: "Error happens something1.";
+          }
+        | {
+              readonly result: false;
+              readonly code: 4000;
+              readonly data: "Error happens something2.";
+          }
+        | {
+              readonly result: false;
+              readonly code: 4000;
+              readonly data: "Error happens something3.";
+          }
+        | {
+              readonly result: false;
+              readonly code: 4000;
+              readonly data: "Error happens something4.";
+          }
+        | {
+              readonly result: false;
+              readonly code: 4000;
+              readonly data: "Error happens something5.";
+          }
+        | ResponseForm<true> => {
+        const $ao0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): boolean =>
+            (false === input.result ||
+                $guard(_exceptionable, {
+                    path: _path + ".result",
+                    expected: "false",
+                    value: input.result,
+                })) &&
+            (4000 === input.code ||
+                $guard(_exceptionable, {
+                    path: _path + ".code",
+                    expected: "4000",
+                    value: input.code,
+                })) &&
+            ("Error happens something1." === input.data ||
+                $guard(_exceptionable, {
+                    path: _path + ".data",
+                    expected: '"Error happens something1."',
+                    value: input.data,
+                }));
+        const $ao1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): boolean =>
+            (false === input.result ||
+                $guard(_exceptionable, {
+                    path: _path + ".result",
+                    expected: "false",
+                    value: input.result,
+                })) &&
+            (4000 === input.code ||
+                $guard(_exceptionable, {
+                    path: _path + ".code",
+                    expected: "4000",
+                    value: input.code,
+                })) &&
+            ("Error happens something2." === input.data ||
+                $guard(_exceptionable, {
+                    path: _path + ".data",
+                    expected: '"Error happens something2."',
+                    value: input.data,
+                }));
+        const $ao2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): boolean =>
+            (false === input.result ||
+                $guard(_exceptionable, {
+                    path: _path + ".result",
+                    expected: "false",
+                    value: input.result,
+                })) &&
+            (4000 === input.code ||
+                $guard(_exceptionable, {
+                    path: _path + ".code",
+                    expected: "4000",
+                    value: input.code,
+                })) &&
+            ("Error happens something3." === input.data ||
+                $guard(_exceptionable, {
+                    path: _path + ".data",
+                    expected: '"Error happens something3."',
+                    value: input.data,
+                }));
+        const $ao3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): boolean =>
+            (false === input.result ||
+                $guard(_exceptionable, {
+                    path: _path + ".result",
+                    expected: "false",
+                    value: input.result,
+                })) &&
+            (4000 === input.code ||
+                $guard(_exceptionable, {
+                    path: _path + ".code",
+                    expected: "4000",
+                    value: input.code,
+                })) &&
+            ("Error happens something4." === input.data ||
+                $guard(_exceptionable, {
+                    path: _path + ".data",
+                    expected: '"Error happens something4."',
+                    value: input.data,
+                }));
+        const $ao4 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): boolean =>
+            (false === input.result ||
+                $guard(_exceptionable, {
+                    path: _path + ".result",
+                    expected: "false",
+                    value: input.result,
+                })) &&
+            (4000 === input.code ||
+                $guard(_exceptionable, {
+                    path: _path + ".code",
+                    expected: "4000",
+                    value: input.code,
+                })) &&
+            ("Error happens something5." === input.data ||
+                $guard(_exceptionable, {
+                    path: _path + ".data",
+                    expected: '"Error happens something5."',
+                    value: input.data,
+                }));
+        const $ao5 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): boolean =>
+            (true === input.result ||
+                $guard(_exceptionable, {
+                    path: _path + ".result",
+                    expected: "true",
+                    value: input.result,
+                })) &&
+            (1000 === input.code ||
+                $guard(_exceptionable, {
+                    path: _path + ".code",
+                    expected: "1000",
+                    value: input.code,
+                })) &&
+            (true === input.data ||
+                $guard(_exceptionable, {
+                    path: _path + ".data",
+                    expected: "true",
+                    value: input.data,
+                }));
+        const $au0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): any =>
+            (() => {
+                if ("Error happens something1." === input.data)
+                    return $ao0(input, _path, true && _exceptionable);
+                if ("Error happens something2." === input.data)
+                    return $ao1(input, _path, true && _exceptionable);
+                if ("Error happens something3." === input.data)
+                    return $ao2(input, _path, true && _exceptionable);
+                if ("Error happens something4." === input.data)
+                    return $ao3(input, _path, true && _exceptionable);
+                if ("Error happens something5." === input.data)
+                    return $ao4(input, _path, true && _exceptionable);
+                if (true === input.result)
+                    return $ao5(input, _path, true && _exceptionable);
+                return $guard(_exceptionable, {
+                    path: _path,
+                    expected:
+                        "(__object | __object.o1 | __object.o2 | __object.o3 | __object.o4 | ResponseForm<true>)",
+                    value: input,
+                });
+            })();
+        return (
+            (("object" === typeof input && null !== input) ||
+                $guard(true, {
+                    path: _path + "",
+                    expected:
+                        "(Resolve<ResponseForm<true>> | Resolve<__object.o1> | Resolve<__object.o2> | Resolve<__object.o3> | Resolve<__object.o4> | Resolve<__object>)",
+                    value: input,
+                })) &&
+            $au0(input, _path + "", true)
+        );
     })(input, "$input", true);
     return input;
 })(input);

--- a/test/schemas/json/ajv/TagCustom.json
+++ b/test/schemas/json/ajv/TagCustom.json
@@ -1,0 +1,96 @@
+{
+  "schemas": [
+    {
+      "$ref": "components#/schemas/TagCustom"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "TagCustom": {
+        "$id": "components#/schemas/TagCustom",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": false,
+            "description": "Regular feature supported by typia",
+            "x-typia-metaTags": [
+              {
+                "kind": "format",
+                "value": "uuid"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "format",
+                "text": [
+                  {
+                    "text": "uuid",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "format": "uuid"
+          },
+          "dolloar": {
+            "type": "string",
+            "nullable": false,
+            "description": "Custom feature composed with \"$\" + number",
+            "x-typia-jsDocTags": [
+              {
+                "name": "dollar"
+              }
+            ],
+            "x-typia-required": true
+          },
+          "postfix": {
+            "type": "string",
+            "nullable": false,
+            "description": "Custom feature composed with string + \"abcd\"",
+            "x-typia-jsDocTags": [
+              {
+                "name": "postfix",
+                "text": [
+                  {
+                    "text": "abcd",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true
+          },
+          "log": {
+            "type": "number",
+            "nullable": false,
+            "description": "Custom feature meaning x^y",
+            "x-typia-jsDocTags": [
+              {
+                "name": "powerOf",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true
+          }
+        },
+        "nullable": false,
+        "required": [
+          "id",
+          "dolloar",
+          "postfix",
+          "log"
+        ],
+        "x-typia-jsDocTags": []
+      }
+    }
+  },
+  "purpose": "ajv",
+  "prefix": "components#/schemas"
+}

--- a/test/schemas/json/swagger/TagCustom.json
+++ b/test/schemas/json/swagger/TagCustom.json
@@ -1,0 +1,95 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/TagCustom"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "TagCustom": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": false,
+            "description": "Regular feature supported by typia",
+            "x-typia-metaTags": [
+              {
+                "kind": "format",
+                "value": "uuid"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "format",
+                "text": [
+                  {
+                    "text": "uuid",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "format": "uuid"
+          },
+          "dolloar": {
+            "type": "string",
+            "nullable": false,
+            "description": "Custom feature composed with \"$\" + number",
+            "x-typia-jsDocTags": [
+              {
+                "name": "dollar"
+              }
+            ],
+            "x-typia-required": true
+          },
+          "postfix": {
+            "type": "string",
+            "nullable": false,
+            "description": "Custom feature composed with string + \"abcd\"",
+            "x-typia-jsDocTags": [
+              {
+                "name": "postfix",
+                "text": [
+                  {
+                    "text": "abcd",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true
+          },
+          "log": {
+            "type": "number",
+            "nullable": false,
+            "description": "Custom feature meaning x^y",
+            "x-typia-jsDocTags": [
+              {
+                "name": "powerOf",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true
+          }
+        },
+        "nullable": false,
+        "required": [
+          "id",
+          "dolloar",
+          "postfix",
+          "log"
+        ],
+        "x-typia-jsDocTags": []
+      }
+    }
+  },
+  "purpose": "swagger",
+  "prefix": "#/components/schemas"
+}

--- a/test/structures/TagCustom.ts
+++ b/test/structures/TagCustom.ts
@@ -1,0 +1,83 @@
+import { v4 } from "uuid";
+
+import { RandomGenerator } from "typia/lib/utils/RandomGenerator";
+
+import typia from "../../src";
+import { Spoiler } from "../helpers/Spoiler";
+
+export interface TagCustom {
+    /**
+     * Regular feature supported by typia
+     *
+     * @format uuid
+     */
+    id: string;
+
+    /**
+     * Custom feature composed with "$" + number
+     *
+     * @dollar
+     */
+    dolloar: string;
+
+    /**
+     * Custom feature composed with string + "abcd"
+     *
+     * @postfix abcd
+     */
+    postfix: string;
+
+    /**
+     * Custom feature meaning x^y
+     *
+     * @powerOf 10
+     */
+    log: number;
+}
+export namespace TagCustom {
+    export function generate(): TagCustom {
+        return {
+            id: v4(),
+            dolloar: "$" + RandomGenerator.integer(),
+            postfix: RandomGenerator.string() + "abcd",
+            log: 100,
+        };
+    }
+
+    export const SPOILERS: Spoiler<TagCustom>[] = [
+        (input) => {
+            input.id = "invalid";
+            return ["$input.id"];
+        },
+        (input) => {
+            input.dolloar = RandomGenerator.integer().toString();
+            return ["$input.dolloar"];
+        },
+        (input) => {
+            input.postfix = RandomGenerator.string() + "dcba";
+            return ["$input.postfix"];
+        },
+        (input) => {
+            input.log = 3;
+            return ["$input.log"];
+        },
+    ];
+
+    export const RANDOM = false;
+}
+
+typia.addValidationTag("dollar")("string")(
+    () => (value: string) =>
+        value.startsWith("$") &&
+        !isNaN(Number(value.substring(1).split(",").join(""))),
+);
+typia.addValidationTag("postfix")("string")(
+    (text: string) => (value: string) => value.endsWith(text),
+);
+typia.addValidationTag("powerOf")("number")((text: string) => {
+    const denominator: number = Math.log(Number(text));
+    return (value: number) => {
+        value = Math.log(value) / denominator;
+        return value === Math.floor(value);
+    };
+});

--- a/test/structures/UltimateUnion.ts
+++ b/test/structures/UltimateUnion.ts
@@ -46,4 +46,5 @@ export namespace UltimateUnion {
     ];
 
     export const ADDABLE = false;
+    export const RANDOM = false;
 }


### PR DESCRIPTION
From now on, `typia` supports custom validation tags like below.

If you want to feel it earlier, run `npm install --save typia@next` command.

```typescript
import typia from "typia";

export interface TagCustom {
    /**
     * Regular feature supported by typia
     *
     * @format uuid
     */
    id: string;

    /**
     * Custom feature composed with "$" + number
     *
     * @dollar
     */
    dolloar: string;

    /**
     * Custom feature composed with string + "abcd"
     *
     * @postfix abcd
     */
    postfix: string;

    /**
     * Custom feature meaning x^y
     *
     * @powerOf 10
     */
    log: number;
}

typia.addValidationTag("dollar")("string")(
    () => (value: string) =>
        value.startsWith("$") &&
        !isNaN(Number(value.substring(1).split(",").join(""))),
);

typia.addValidationTag("postfix")("string")(
    (text: string) => (value: string) => value.endsWith(text),
);

typia.addValidationTag("powerOf")("number")((text: string) => {
    const denominator: number = Math.log(Number(text));
    return (value: number) => {
        value = Math.log(value) / denominator;
        return value === Math.floor(value);
    };
});

```