### PR TITLE
Fix #455 - exact error message when comment tag comes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.7.0-dev.20230331",
+  "version": "3.7.0-dev.20230401",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.7.0-dev.20230401",
+  "version": "3.7.0-dev.20230401-2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.7.0-dev.20230331",
+  "version": "3.7.0-dev.20230401",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -74,6 +74,6 @@
     "src"
   ],
   "dependencies": {
-    "typia": "3.7.0-dev.20230331"
+    "typia": "3.7.0-dev.20230401"
   }
 }

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.7.0-dev.20230401",
+  "version": "3.7.0-dev.20230401-2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -74,6 +74,6 @@
     "src"
   ],
   "dependencies": {
-    "typia": "3.7.0-dev.20230401"
+    "typia": "3.7.0-dev.20230401-2"
   }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -431,6 +431,18 @@ Object.assign(validateEquals, Namespace.validate());
  * typia.addValidationTag("dollar")("string")(
  *     () => (value: string) => value.startsWith("$"),
  * );
+ *
+ * interface TagCustom {
+ *    /**
+ *     * @powerOf 10
+ *     *\/
+ *    powerOf: number;
+ *
+ *    /**
+ *     * @dollar
+ *     *\/
+ *    dollar: string;
+ * }
  * ```
  *
  * @param name Name of tag (`@name`)
@@ -447,7 +459,10 @@ export const addValidationTag =
      */
     (closure: (text: string) => (value: Customizable[Type]) => boolean) => {
         const key = `${name}:${type}` as const;
-        if (!$dictionary.has(key)) $dictionary.set(key, closure);
+        if (!$dictionary.has(key)) return false;
+
+        $dictionary.set(key, closure);
+        return true;
     };
 
 /* -----------------------------------------------------------

--- a/src/module.ts
+++ b/src/module.ts
@@ -459,7 +459,7 @@ export const addValidationTag =
      */
     (closure: (text: string) => (value: Customizable[Type]) => boolean) => {
         const key = `${name}:${type}` as const;
-        if (!$dictionary.has(key)) return false;
+        if ($dictionary.has(key)) return false;
 
         $dictionary.set(key, closure);
         return true;

--- a/src/programmers/AssertProgrammer.ts
+++ b/src/programmers/AssertProgrammer.ts
@@ -30,6 +30,30 @@ export namespace AssertProgrammer {
                     trace: true,
                     numeric: OptionPredicator.numeric(project.options),
                     equals,
+                    atomist: (explore) => (tuple) => (input) =>
+                        [
+                            tuple.expression,
+                            ...tuple.tags.map((tag) =>
+                                ts.factory.createLogicalOr(
+                                    tag.expression,
+                                    create_guard_call(importer)(
+                                        explore.from === "top"
+                                            ? ts.factory.createTrue()
+                                            : ts.factory.createIdentifier(
+                                                  "_exceptionable",
+                                              ),
+                                    )(
+                                        ts.factory.createIdentifier(
+                                            explore.postfix
+                                                ? `_path + ${explore.postfix}`
+                                                : "_path",
+                                        ),
+                                        tag.expected,
+                                        input,
+                                    ),
+                                ),
+                            ),
+                        ].reduce((x, y) => ts.factory.createLogicalAnd(x, y)),
                     combiner: combiner(equals)(importer),
                     joiner: joiner(equals)(importer),
                     success: ts.factory.createTrue(),

--- a/src/programmers/IsProgrammer.ts
+++ b/src/programmers/IsProgrammer.ts
@@ -27,6 +27,11 @@ export namespace IsProgrammer {
             numeric: OptionPredicator.numeric({
                 numeric: options?.numeric,
             }),
+            atomist: () => (entry) => () =>
+                [
+                    entry.expression,
+                    ...entry.tags.map((tag) => tag.expression),
+                ].reduce((x, y) => ts.factory.createLogicalAnd(x, y)),
             combiner: () => (type: "and" | "or") => {
                 const initial: ts.TrueLiteral | ts.FalseLiteral =
                     type === "and"

--- a/src/programmers/ValidateProgrammer.ts
+++ b/src/programmers/ValidateProgrammer.ts
@@ -31,6 +31,30 @@ export namespace ValidateProgrammer {
                     trace: true,
                     numeric: OptionPredicator.numeric(project.options),
                     equals,
+                    atomist: (explore) => (tuple) => (input) =>
+                        [
+                            tuple.expression,
+                            ...tuple.tags.map((tag) =>
+                                ts.factory.createLogicalOr(
+                                    tag.expression,
+                                    create_report_call(
+                                        explore.from === "top"
+                                            ? ts.factory.createTrue()
+                                            : ts.factory.createIdentifier(
+                                                  "_exceptionable",
+                                              ),
+                                    )(
+                                        ts.factory.createIdentifier(
+                                            explore.postfix
+                                                ? `_path + ${explore.postfix}`
+                                                : "_path",
+                                        ),
+                                        tag.expected,
+                                        input,
+                                    ),
+                                ),
+                            ),
+                        ].reduce((x, y) => ts.factory.createLogicalAnd(x, y)),
                     combiner: combine(equals)(importer),
                     joiner: joiner(equals)(importer),
                     success: ts.factory.createTrue(),

--- a/src/programmers/helpers/ICheckEntry.ts
+++ b/src/programmers/helpers/ICheckEntry.ts
@@ -1,0 +1,12 @@
+import ts from "typescript";
+
+export interface ICheckEntry {
+    expression: ts.Expression;
+    tags: ICheckEntry.ITag[];
+}
+export namespace ICheckEntry {
+    export interface ITag {
+        expected: string;
+        expression: ts.Expression;
+    }
+}

--- a/src/programmers/internal/check_array.ts
+++ b/src/programmers/internal/check_array.ts
@@ -6,6 +6,7 @@ import { IJsDocTagInfo } from "../../metadata/IJsDocTagInfo";
 import { IMetadataTag } from "../../metadata/IMetadataTag";
 
 import { FunctionImporter } from "../helpers/FunctionImporeter";
+import { ICheckEntry } from "../helpers/ICheckEntry";
 import { check_array_length } from "./check_array_length";
 import { check_custom } from "./check_custom";
 
@@ -14,18 +15,12 @@ import { check_custom } from "./check_custom";
  */
 export const check_array =
     (importer: FunctionImporter) =>
-    (
-        input: ts.Expression,
-        metaTags: IMetadataTag[],
-        jsDocTags: IJsDocTagInfo[],
-    ): ts.Expression => {
-        const conditions: ts.Expression[] = [ExpressionFactory.isArray(input)];
-
-        const length: ts.Expression | null = check_array_length(
-            input,
-            metaTags,
-        );
-        if (length !== null) conditions.push(length);
-        conditions.push(...check_custom("array")(importer)(input, jsDocTags));
-        return conditions.reduce((x, y) => ts.factory.createLogicalAnd(x, y));
-    };
+    (metaTags: IMetadataTag[]) =>
+    (jsDocTags: IJsDocTagInfo[]) =>
+    (input: ts.Expression): ICheckEntry => ({
+        expression: ExpressionFactory.isArray(input),
+        tags: [
+            ...check_array_length(metaTags)(input),
+            ...check_custom("array", "Array")(importer)(jsDocTags)(input),
+        ],
+    });

--- a/src/programmers/internal/check_array_length.ts
+++ b/src/programmers/internal/check_array_length.ts
@@ -4,41 +4,37 @@ import { IdentifierFactory } from "../../factories/IdentifierFactory";
 
 import { IMetadataTag } from "../../metadata/IMetadataTag";
 
+import { ICheckEntry } from "../helpers/ICheckEntry";
+
 /**
  * @internal
  */
-export function check_array_length(
-    input: ts.Expression,
-    tagList: IMetadataTag[],
-): ts.Expression | null {
-    const conditions: ts.Expression[] = [];
-
-    // CHECK TAGS
-    for (const tag of tagList)
-        if (tag.kind === "items")
-            conditions.push(
-                ts.factory.createStrictEquality(
-                    ts.factory.createNumericLiteral(tag.value),
-                    IdentifierFactory.join(input, "length"),
-                ),
-            );
-        else if (tag.kind === "minItems")
-            conditions.push(
-                ts.factory.createLessThanEquals(
-                    ts.factory.createNumericLiteral(tag.value),
-                    IdentifierFactory.join(input, "length"),
-                ),
-            );
-        else if (tag.kind === "maxItems")
-            conditions.push(
-                ts.factory.createGreaterThanEquals(
-                    ts.factory.createNumericLiteral(tag.value),
-                    IdentifierFactory.join(input, "length"),
-                ),
-            );
-
-    // COMBINATION
-    return conditions.length
-        ? conditions.reduce((x, y) => ts.factory.createLogicalAnd(x, y))
-        : null;
-}
+export const check_array_length =
+    (tagList: IMetadataTag[]) =>
+    (input: ts.Expression): ICheckEntry.ITag[] =>
+        tagList
+            .map((tag) => ({
+                tag,
+                expression:
+                    tag.kind === "items"
+                        ? ts.factory.createStrictEquality(
+                              ts.factory.createNumericLiteral(tag.value),
+                              IdentifierFactory.join(input, "length"),
+                          )
+                        : tag.kind === "minItems"
+                        ? ts.factory.createLessThanEquals(
+                              ts.factory.createNumericLiteral(tag.value),
+                              IdentifierFactory.join(input, "length"),
+                          )
+                        : tag.kind === "maxItems"
+                        ? ts.factory.createGreaterThanEquals(
+                              ts.factory.createNumericLiteral(tag.value),
+                              IdentifierFactory.join(input, "length"),
+                          )
+                        : null!,
+            }))
+            .filter((tuple) => tuple.expression !== null)
+            .map(({ tag, expression }) => ({
+                expected: `Array.length (@${tag.kind} ${tag.value})`,
+                expression,
+            }));

--- a/src/programmers/internal/check_bigint.ts
+++ b/src/programmers/internal/check_bigint.ts
@@ -4,81 +4,79 @@ import { IJsDocTagInfo } from "../../metadata/IJsDocTagInfo";
 import { IMetadataTag } from "../../metadata/IMetadataTag";
 
 import { FunctionImporter } from "../helpers/FunctionImporeter";
+import { ICheckEntry } from "../helpers/ICheckEntry";
 import { check_custom } from "./check_custom";
 
+/**
+ * @internal
+ */
 export const check_bigint =
     (importer: FunctionImporter) =>
-    (
-        input: ts.Expression,
-        metaTags: IMetadataTag[],
-        jsDocTags: IJsDocTagInfo[],
-    ): ts.Expression => {
-        const caster = (value: number) =>
-            ts.factory.createIdentifier(`${Math.floor(value)}n`);
-
-        // TYPEOF STATEMENT
-        const conditions: ts.Expression[] = [
-            ts.factory.createStrictEquality(
+    (metaTags: IMetadataTag[]) =>
+    (jsDocTag: IJsDocTagInfo[]) =>
+    (input: ts.Expression): ICheckEntry => {
+        const entries: [IMetadataTag, ts.Expression][] = [];
+        for (const tag of metaTags) {
+            if (tag.kind === "multipleOf")
+                entries.push([
+                    tag,
+                    ts.factory.createStrictEquality(
+                        cast(0),
+                        ts.factory.createModulo(input, cast(tag.value)),
+                    ),
+                ]);
+            else if (tag.kind === "step") {
+                const modulo = ts.factory.createModulo(input, cast(tag.value));
+                const minimum =
+                    (metaTags.find(
+                        (tag) =>
+                            tag.kind === "minimum" ||
+                            tag.kind === "exclusiveMinimum",
+                    )?.value as number | undefined) ?? undefined;
+                entries.push([
+                    tag,
+                    ts.factory.createStrictEquality(
+                        cast(0),
+                        minimum !== undefined
+                            ? ts.factory.createSubtract(modulo, cast(minimum))
+                            : modulo,
+                    ),
+                ]);
+            } else if (tag.kind === "minimum")
+                entries.push([
+                    tag,
+                    ts.factory.createLessThanEquals(cast(tag.value), input),
+                ]);
+            else if (tag.kind === "maximum")
+                entries.push([
+                    tag,
+                    ts.factory.createGreaterThanEquals(cast(tag.value), input),
+                ]);
+            else if (tag.kind === "exclusiveMinimum")
+                entries.push([
+                    tag,
+                    ts.factory.createLessThan(cast(tag.value), input),
+                ]);
+            else if (tag.kind === "exclusiveMaximum")
+                entries.push([
+                    tag,
+                    ts.factory.createGreaterThan(cast(tag.value), input),
+                ]);
+        }
+        return {
+            expression: ts.factory.createStrictEquality(
                 ts.factory.createStringLiteral("bigint"),
                 ts.factory.createTypeOfExpression(input),
             ),
-        ];
-
-        // TAG (RANGE)
-        for (const tag of metaTags)
-            if (tag.kind === "multipleOf")
-                conditions.push(
-                    ts.factory.createStrictEquality(
-                        caster(0),
-                        ts.factory.createModulo(input, caster(tag.value)),
-                    ),
-                );
-            else if (tag.kind === "step") {
-                const modulo = () =>
-                    ts.factory.createModulo(input, caster(tag.value));
-                const minimum = (() => {
-                    for (const tag of metaTags)
-                        if (tag.kind === "minimum") return tag.value;
-                        else if (tag.kind === "exclusiveMinimum")
-                            return tag.value;
-                    return undefined;
-                })();
-                conditions.push(
-                    ts.factory.createStrictEquality(
-                        caster(0),
-                        minimum !== undefined
-                            ? ts.factory.createSubtract(
-                                  modulo(),
-                                  caster(minimum),
-                              )
-                            : modulo(),
-                    ),
-                );
-            } else if (tag.kind === "minimum")
-                conditions.push(
-                    ts.factory.createLessThanEquals(caster(tag.value), input),
-                );
-            else if (tag.kind === "maximum")
-                conditions.push(
-                    ts.factory.createGreaterThanEquals(
-                        caster(tag.value),
-                        input,
-                    ),
-                );
-            else if (tag.kind === "exclusiveMinimum")
-                conditions.push(
-                    ts.factory.createLessThan(caster(tag.value), input),
-                );
-            else if (tag.kind === "exclusiveMaximum")
-                conditions.push(
-                    ts.factory.createGreaterThan(caster(tag.value), input),
-                );
-
-        // CUSTOM TAGS
-        conditions.push(...check_custom("bigint")(importer)(input, jsDocTags));
-
-        // COMBINATION
-        return conditions.length === 1
-            ? conditions[0]!
-            : conditions.reduce((x, y) => ts.factory.createLogicalAnd(x, y));
+            tags: [
+                ...entries.map(([tag, expression]) => ({
+                    expected: `bigint (@${tag.kind} ${tag.value})`,
+                    expression,
+                })),
+                ...check_custom("bigint")(importer)(jsDocTag)(input),
+            ],
+        };
     };
+
+const cast = (value: number) =>
+    ts.factory.createIdentifier(`${Math.floor(value)}n`);

--- a/src/programmers/internal/check_custom.ts
+++ b/src/programmers/internal/check_custom.ts
@@ -5,28 +5,37 @@ import { MetadataTagFactory } from "../../factories/MetadataTagFactory";
 import { IJsDocTagInfo } from "../../metadata/IJsDocTagInfo";
 
 import { FunctionImporter } from "../helpers/FunctionImporeter";
+import { ICheckEntry } from "../helpers/ICheckEntry";
 
 export const check_custom =
-    (type: string) =>
+    (type: string, alias?: string) =>
     (importer: FunctionImporter) =>
-    (input: ts.Expression, jsDocTags: IJsDocTagInfo[]) =>
+    (jsDocTags: IJsDocTagInfo[]) =>
+    (input: ts.Expression): ICheckEntry.ITag[] =>
         jsDocTags
             .filter(
                 (tag) =>
                     tag.name !== "random" &&
+                    (!tag.text?.length ||
+                        (tag.text?.length === 1 &&
+                            tag.text?.[0]?.kind === "text")) &&
                     MetadataTagFactory._PARSER[tag.name] === undefined,
             )
-            .map((tag) =>
-                ts.factory.createCallExpression(
-                    importer.use("is_custom"),
-                    undefined,
-                    [
-                        ts.factory.createStringLiteral(tag.name),
-                        ts.factory.createStringLiteral(type),
-                        ts.factory.createStringLiteral(
-                            tag.text?.[0]?.text ?? "",
-                        ),
-                        input,
-                    ],
-                ),
-            );
+            .map((tag) => {
+                const text: string | undefined = tag.text?.[0]?.text ?? "";
+                return {
+                    expected: `${alias ?? type} (@${tag.name}${
+                        text.length ? ` ${text}` : ""
+                    })`,
+                    expression: ts.factory.createCallExpression(
+                        importer.use("is_custom"),
+                        undefined,
+                        [
+                            ts.factory.createStringLiteral(tag.name),
+                            ts.factory.createStringLiteral(type),
+                            ts.factory.createStringLiteral(text),
+                            input,
+                        ],
+                    ),
+                };
+            });

--- a/src/programmers/internal/check_string.ts
+++ b/src/programmers/internal/check_string.ts
@@ -9,22 +9,17 @@ import { check_string_tags } from "./check_string_tags";
 /**
  * @internal
  */
-export function check_string(importer: FunctionImporter) {
-    return function (
-        input: ts.Expression,
-        metaTags: IMetadataTag[],
-        jsDocTags: ts.JSDocTagInfo[],
-    ) {
-        const conditions: ts.Expression[] = [
-            ts.factory.createStrictEquality(
-                ts.factory.createStringLiteral("string"),
-                ts.factory.createTypeOfExpression(input),
-            ),
-            ...check_string_tags(importer)(input, metaTags),
-            ...check_custom("string")(importer)(input, jsDocTags),
-        ];
-        return conditions.length === 1
-            ? conditions[0]!
-            : conditions.reduce((x, y) => ts.factory.createLogicalAnd(x, y));
-    };
-}
+export const check_string =
+    (importer: FunctionImporter) =>
+    (metaTags: IMetadataTag[]) =>
+    (jsDocTags: ts.JSDocTagInfo[]) =>
+    (input: ts.Expression) => ({
+        expression: ts.factory.createStrictEquality(
+            ts.factory.createStringLiteral("string"),
+            ts.factory.createTypeOfExpression(input),
+        ),
+        tags: [
+            ...check_string_tags(importer)(metaTags)(input),
+            ...check_custom("string")(importer)(jsDocTags)(input),
+        ],
+    });

--- a/src/programmers/internal/check_string_tags.ts
+++ b/src/programmers/internal/check_string_tags.ts
@@ -5,17 +5,20 @@ import { IdentifierFactory } from "../../factories/IdentifierFactory";
 import { IMetadataTag } from "../../metadata/IMetadataTag";
 
 import { FunctionImporter } from "../helpers/FunctionImporeter";
+import { ICheckEntry } from "../helpers/ICheckEntry";
 
 /**
  * @internal
  */
 export const check_string_tags =
     (importer: FunctionImporter) =>
-    (input: ts.Expression, tagList: IMetadataTag[]) => {
-        const conditions: ts.Expression[] = [];
+    (tagList: IMetadataTag[]) =>
+    (input: ts.Expression): ICheckEntry.ITag[] => {
+        const conditions: [IMetadataTag, ts.Expression][] = [];
         for (const tag of tagList)
             if (tag.kind === "format")
-                conditions.push(
+                conditions.push([
+                    tag,
                     ts.factory.createStrictEquality(
                         ts.factory.createTrue(),
                         ts.factory.createCallExpression(
@@ -24,9 +27,10 @@ export const check_string_tags =
                             [input],
                         ),
                     ),
-                );
+                ]);
             else if (tag.kind === "pattern")
-                conditions.push(
+                conditions.push([
+                    tag,
                     ts.factory.createStrictEquality(
                         ts.factory.createTrue(),
                         ts.factory.createCallExpression(
@@ -37,27 +41,33 @@ export const check_string_tags =
                             [input],
                         ),
                     ),
-                );
+                ]);
             else if (tag.kind === "length")
-                conditions.push(
+                conditions.push([
+                    tag,
                     ts.factory.createStrictEquality(
                         ts.factory.createNumericLiteral(tag.value),
                         IdentifierFactory.join(input, "length"),
                     ),
-                );
+                ]);
             else if (tag.kind === "minLength")
-                conditions.push(
+                conditions.push([
+                    tag,
                     ts.factory.createLessThanEquals(
                         ts.factory.createNumericLiteral(tag.value),
                         IdentifierFactory.join(input, "length"),
                     ),
-                );
+                ]);
             else if (tag.kind === "maxLength")
-                conditions.push(
+                conditions.push([
+                    tag,
                     ts.factory.createGreaterThanEquals(
                         ts.factory.createNumericLiteral(tag.value),
                         IdentifierFactory.join(input, "length"),
                     ),
-                );
-        return conditions;
+                ]);
+        return conditions.map(([tag, expression]) => ({
+            expected: `string (@${tag.kind} ${tag.value})`,
+            expression,
+        }));
     };

--- a/src/programmers/internal/check_template.ts
+++ b/src/programmers/internal/check_template.ts
@@ -1,9 +1,12 @@
 import ts from "typescript";
 
+import { IJsDocTagInfo } from "../../metadata/IJsDocTagInfo";
 import { IMetadataTag } from "../../metadata/IMetadataTag";
 import { Metadata } from "../../metadata/Metadata";
 
 import { FunctionImporter } from "../helpers/FunctionImporeter";
+import { ICheckEntry } from "../helpers/ICheckEntry";
+import { check_custom } from "./check_custom";
 import { check_string_tags } from "./check_string_tags";
 import { template_to_pattern } from "./template_to_pattern";
 
@@ -12,18 +15,16 @@ import { template_to_pattern } from "./template_to_pattern";
  */
 export const check_template =
     (importer: FunctionImporter) =>
-    (
-        input: ts.Expression,
-        templates: Metadata[][],
-        tagList: IMetadataTag[],
-    ) => {
+    (metaTags: IMetadataTag[]) =>
+    (jsDocTags: IJsDocTagInfo[]) =>
+    (templates: Metadata[][]) =>
+    (input: ts.Expression): ICheckEntry => {
         // TYPEOF STRING & TAGS
         const conditions: ts.Expression[] = [
             ts.factory.createStrictEquality(
                 ts.factory.createStringLiteral("string"),
                 ts.factory.createTypeOfExpression(input),
             ),
-            ...check_string_tags(importer)(input, tagList),
         ];
 
         // TEMPLATES
@@ -46,5 +47,13 @@ export const check_template =
         );
 
         // COMBINATION
-        return conditions.reduce((x, y) => ts.factory.createLogicalAnd(x, y));
+        return {
+            expression: conditions.reduce((x, y) =>
+                ts.factory.createLogicalAnd(x, y),
+            ),
+            tags: [
+                ...check_string_tags(importer)(metaTags)(input),
+                ...check_custom("string")(importer)(jsDocTags)(input),
+            ],
+        };
     };

--- a/src/typings/Customizable.ts
+++ b/src/typings/Customizable.ts
@@ -1,5 +1,4 @@
 export type Customizable = {
-    boolean: boolean;
     number: number;
     string: string;
     bigint: bigint;

--- a/test/generated/output/assert/test_assert_TagArray.ts
+++ b/test/generated/output/assert/test_assert_TagArray.ts
@@ -19,7 +19,13 @@ export const test_assert_TagArray = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ((Array.isArray(input.items) && 3 === input.items.length) ||
+                    ((Array.isArray(input.items) &&
+                        (3 === input.items.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected: "Array.length (@items 3)",
+                                value: input.items,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected: "Array<string>",
@@ -28,7 +34,12 @@ export const test_assert_TagArray = _test_assert(
                     input.items.every(
                         (elem: any, _index2: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".items[" + _index2 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items[" + _index2 + "]",
                                 expected: "string",
@@ -36,7 +47,12 @@ export const test_assert_TagArray = _test_assert(
                             }),
                     ) &&
                     ((Array.isArray(input.minItems) &&
-                        3 <= input.minItems.length) ||
+                        (3 <= input.minItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.minItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "Array<number>",
@@ -46,7 +62,16 @@ export const test_assert_TagArray = _test_assert(
                         (elem: any, _index3: number) =>
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                3 <= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".minItems[" +
+                                            _index3 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems[" + _index3 + "]",
                                 expected: "number",
@@ -54,7 +79,12 @@ export const test_assert_TagArray = _test_assert(
                             }),
                     ) &&
                     ((Array.isArray(input.maxItems) &&
-                        7 >= input.maxItems.length) ||
+                        (7 >= input.maxItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.maxItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "Array<(number | string)>",
@@ -62,10 +92,29 @@ export const test_assert_TagArray = _test_assert(
                         })) &&
                     input.maxItems.every(
                         (elem: any, _index4: number) =>
-                            ("string" === typeof elem && 7 >= elem.length) ||
+                            ("string" === typeof elem &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                7 >= elem) ||
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems[" + _index4 + "]",
                                 expected: "(number | string)",
@@ -73,8 +122,18 @@ export const test_assert_TagArray = _test_assert(
                             }),
                     ) &&
                     ((Array.isArray(input.both) &&
-                        3 <= input.both.length &&
-                        7 >= input.both.length) ||
+                        (3 <= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.both,
+                            })) &&
+                        (7 >= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.both,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".both",
                             expected: "Array<string>",
@@ -83,7 +142,12 @@ export const test_assert_TagArray = _test_assert(
                     input.both.every(
                         (elem: any, _index5: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".both[" + _index5 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".both[" + _index5 + "]",
                                 expected: "string",

--- a/test/generated/output/assert/test_assert_TagAtomicUnion.ts
+++ b/test/generated/output/assert/test_assert_TagAtomicUnion.ts
@@ -19,11 +19,26 @@ export const test_assert_TagAtomicUnion = _test_assert(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "(number | string)",

--- a/test/generated/output/assert/test_assert_TagBigInt.ts
+++ b/test/generated/output/assert/test_assert_TagBigInt.ts
@@ -25,29 +25,54 @@ export const test_assert_TagBigInt = _test_assert(
                             value: input.value,
                         })) &&
                     (("bigint" === typeof input.ranged &&
-                        0n <= input.ranged &&
-                        100n >= input.ranged) ||
+                        (0n <= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "bigint (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100n >= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "bigint (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "bigint",
                             value: input.ranged,
                         })) &&
                     (("bigint" === typeof input.minimum &&
-                        0n <= input.minimum) ||
+                        (0n <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "bigint (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "bigint",
                             value: input.minimum,
                         })) &&
                     (("bigint" === typeof input.maximum &&
-                        100n >= input.maximum) ||
+                        (100n >= input.maximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "bigint (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "bigint",
                             value: input.maximum,
                         })) &&
                     (("bigint" === typeof input.multipleOf &&
-                        0n === input.multipleOf % 3n) ||
+                        (0n === input.multipleOf % 3n ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "bigint (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "bigint",

--- a/test/generated/output/assert/test_assert_TagCustom.ts
+++ b/test/generated/output/assert/test_assert_TagCustom.ts
@@ -21,26 +21,41 @@ export const test_assert_TagCustom = _test_assert(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.id &&
-                        true === $is_uuid(input.id)) ||
+                        (true === $is_uuid(input.id) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string (@format uuid)",
+                                value: input.id,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".id",
                             expected: "string",
                             value: input.id,
                         })) &&
-                    (("string" === typeof input.dolloar &&
-                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                    (("string" === typeof input.dollar &&
+                        ($is_custom("dollar", "string", "", input.dollar) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dollar",
+                                expected: "string (@dollar)",
+                                value: input.dollar,
+                            }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".dolloar",
+                            path: _path + ".dollar",
                             expected: "string",
-                            value: input.dolloar,
+                            value: input.dollar,
                         })) &&
                     (("string" === typeof input.postfix &&
-                        $is_custom(
+                        ($is_custom(
                             "postfix",
                             "string",
                             "abcd",
                             input.postfix,
-                        )) ||
+                        ) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string (@postfix abcd)",
+                                value: input.postfix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".postfix",
                             expected: "string",
@@ -48,7 +63,12 @@ export const test_assert_TagCustom = _test_assert(
                         })) &&
                     (("number" === typeof input.log &&
                         Number.isFinite(input.log) &&
-                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        ($is_custom("powerOf", "number", "10", input.log) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number (@powerOf 10)",
+                                value: input.log,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".log",
                             expected: "number",

--- a/test/generated/output/assert/test_assert_TagFormat.ts
+++ b/test/generated/output/assert/test_assert_TagFormat.ts
@@ -26,63 +26,108 @@ export const test_assert_TagFormat = _test_assert(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true === $is_uuid(input.uuid)) ||
+                        (true === $is_uuid(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected: "string (@format uuid)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true === $is_email(input.email)) ||
+                        (true === $is_email(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected: "string (@format email)",
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.url &&
-                        true === $is_url(input.url)) ||
+                        (true === $is_url(input.url) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".url",
+                                expected: "string (@format url)",
+                                value: input.url,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".url",
                             expected: "string",
                             value: input.url,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true === $is_ipv4(input.ipv4)) ||
+                        (true === $is_ipv4(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected: "string (@format ipv4)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true === $is_ipv6(input.ipv6)) ||
+                        (true === $is_ipv6(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected: "string (@format ipv6)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",
                             value: input.ipv6,
                         })) &&
                     (("string" === typeof input.date &&
-                        true === $is_date(input.date)) ||
+                        (true === $is_date(input.date) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date",
+                                expected: "string (@format date)",
+                                value: input.date,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date",
                             expected: "string",
                             value: input.date,
                         })) &&
                     (("string" === typeof input.date_time &&
-                        true === $is_datetime(input.date_time)) ||
+                        (true === $is_datetime(input.date_time) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date_time",
+                                expected: "string (@format datetime)",
+                                value: input.date_time,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date_time",
                             expected: "string",
                             value: input.date_time,
                         })) &&
                     (("string" === typeof input.datetime &&
-                        true === $is_datetime(input.datetime)) ||
+                        (true === $is_datetime(input.datetime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".datetime",
+                                expected: "string (@format datetime)",
+                                value: input.datetime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".datetime",
                             expected: "string",
                             value: input.datetime,
                         })) &&
                     (("string" === typeof input.dateTime &&
-                        true === $is_datetime(input.dateTime)) ||
+                        (true === $is_datetime(input.dateTime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dateTime",
+                                expected: "string (@format datetime)",
+                                value: input.dateTime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".dateTime",
                             expected: "string",

--- a/test/generated/output/assert/test_assert_TagInfinite.ts
+++ b/test/generated/output/assert/test_assert_TagInfinite.ts
@@ -26,8 +26,18 @@ export const test_assert_TagInfinite = _test_assert(
                             value: input.value,
                         })) &&
                     (("number" === typeof input.ranged &&
-                        0 <= input.ranged &&
-                        100 >= input.ranged) ||
+                        (0 <= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100 >= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "number",
@@ -35,7 +45,12 @@ export const test_assert_TagInfinite = _test_assert(
                         })) &&
                     (("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        0 <= input.minimum) ||
+                        (0 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
@@ -43,14 +58,24 @@ export const test_assert_TagInfinite = _test_assert(
                         })) &&
                     (("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        100 >= input.maximum) ||
+                        (100 >= input.maximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "number",
                             value: input.maximum,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 3) ||
+                        (0 === input.multipleOf % 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",
@@ -58,7 +83,12 @@ export const test_assert_TagInfinite = _test_assert(
                         })) &&
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
-                        parseInt(input.typed) === input.typed) ||
+                        (parseInt(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".typed",
                             expected: "number",

--- a/test/generated/output/assert/test_assert_TagLength.ts
+++ b/test/generated/output/assert/test_assert_TagLength.ts
@@ -19,29 +19,54 @@ export const test_assert_TagLength = _test_assert(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.fixed &&
-                        5 === input.fixed.length) ||
+                        (5 === input.fixed.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".fixed",
+                                expected: "string (@length 5)",
+                                value: input.fixed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".fixed",
                             expected: "string",
                             value: input.fixed,
                         })) &&
                     (("string" === typeof input.minimum &&
-                        3 <= input.minimum.length) ||
+                        (3 <= input.minimum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "string",
                             value: input.minimum,
                         })) &&
                     (("string" === typeof input.maximum &&
-                        7 >= input.maximum.length) ||
+                        (7 >= input.maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "string",
                             value: input.maximum,
                         })) &&
                     (("string" === typeof input.minimum_and_maximum &&
-                        3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length) ||
+                        (3 <= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum_and_maximum,
+                            })) &&
+                        (7 >= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.minimum_and_maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum_and_maximum",
                             expected: "string",

--- a/test/generated/output/assert/test_assert_TagMatrix.ts
+++ b/test/generated/output/assert/test_assert_TagMatrix.ts
@@ -20,7 +20,12 @@ export const test_assert_TagMatrix = _test_assert(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ((Array.isArray(input.matrix) &&
-                        3 === input.matrix.length) ||
+                        (3 === input.matrix.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".matrix",
+                                expected: "Array.length (@items 3)",
+                                value: input.matrix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".matrix",
                             expected: "Array<Array<string>>",
@@ -28,7 +33,14 @@ export const test_assert_TagMatrix = _test_assert(
                         })) &&
                     input.matrix.every(
                         (elem: any, _index1: number) =>
-                            ((Array.isArray(elem) && 3 === elem.length) ||
+                            ((Array.isArray(elem) &&
+                                (3 === elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".matrix[" + _index1 + "]",
+                                        expected: "Array.length (@items 3)",
+                                        value: elem,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".matrix[" + _index1 + "]",
                                     expected: "Array<string>",
@@ -37,7 +49,19 @@ export const test_assert_TagMatrix = _test_assert(
                             elem.every(
                                 (elem: any, _index2: number) =>
                                     ("string" === typeof elem &&
-                                        true === $is_uuid(elem)) ||
+                                        (true === $is_uuid(elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".matrix[" +
+                                                    _index1 +
+                                                    "][" +
+                                                    _index2 +
+                                                    "]",
+                                                expected:
+                                                    "string (@format uuid)",
+                                                value: elem,
+                                            }))) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +

--- a/test/generated/output/assert/test_assert_TagNaN.ts
+++ b/test/generated/output/assert/test_assert_TagNaN.ts
@@ -26,8 +26,18 @@ export const test_assert_TagNaN = _test_assert(
                             value: input.value,
                         })) &&
                     (("number" === typeof input.ranged &&
-                        0 <= input.ranged &&
-                        100 >= input.ranged) ||
+                        (0 <= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100 >= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "number",
@@ -35,7 +45,12 @@ export const test_assert_TagNaN = _test_assert(
                         })) &&
                     (("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        0 <= input.minimum) ||
+                        (0 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
@@ -43,14 +58,24 @@ export const test_assert_TagNaN = _test_assert(
                         })) &&
                     (("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        100 >= input.maximum) ||
+                        (100 >= input.maximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "number",
                             value: input.maximum,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 3) ||
+                        (0 === input.multipleOf % 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",
@@ -58,7 +83,12 @@ export const test_assert_TagNaN = _test_assert(
                         })) &&
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
-                        parseInt(input.typed) === input.typed) ||
+                        (parseInt(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".typed",
                             expected: "number",

--- a/test/generated/output/assert/test_assert_TagObjectUnion.ts
+++ b/test/generated/output/assert/test_assert_TagObjectUnion.ts
@@ -20,7 +20,12 @@ export const test_assert_TagObjectUnion = _test_assert(
                 ): boolean =>
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "number",
@@ -32,8 +37,18 @@ export const test_assert_TagObjectUnion = _test_assert(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "string",

--- a/test/generated/output/assert/test_assert_TagPattern.ts
+++ b/test/generated/output/assert/test_assert_TagPattern.ts
@@ -19,40 +19,64 @@ export const test_assert_TagPattern = _test_assert(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                            ).test(input.uuid)) ||
+                            ).test(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected:
+                                    "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                            ).test(input.email)) ||
+                            ).test(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected:
+                                    'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                            ).test(input.ipv4)) ||
+                            ).test(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected:
+                                    "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                            ).test(input.ipv6)) ||
+                            ).test(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected:
+                                    "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",

--- a/test/generated/output/assert/test_assert_TagRange.ts
+++ b/test/generated/output/assert/test_assert_TagRange.ts
@@ -20,7 +20,12 @@ export const test_assert_TagRange = _test_assert(
                 ): boolean =>
                     (("number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
-                        3 < input.greater) ||
+                        (3 < input.greater ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater",
                             expected: "number",
@@ -28,7 +33,12 @@ export const test_assert_TagRange = _test_assert(
                         })) &&
                     (("number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
-                        3 <= input.greater_equal) ||
+                        (3 <= input.greater_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal",
                             expected: "number",
@@ -36,7 +46,12 @@ export const test_assert_TagRange = _test_assert(
                         })) &&
                     (("number" === typeof input.less &&
                         Number.isFinite(input.less) &&
-                        7 > input.less) ||
+                        (7 > input.less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less",
                             expected: "number",
@@ -44,39 +59,84 @@ export const test_assert_TagRange = _test_assert(
                         })) &&
                     (("number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
-                        7 >= input.less_equal) ||
+                        (7 >= input.less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less_equal",
                             expected: "number",
                             value: input.less_equal,
                         })) &&
                     (("number" === typeof input.greater_less &&
-                        3 < input.greater_less &&
-                        7 > input.greater_less) ||
+                        (3 < input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less,
+                            })) &&
+                        (7 > input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less",
                             expected: "number",
                             value: input.greater_less,
                         })) &&
                     (("number" === typeof input.greater_equal_less &&
-                        3 <= input.greater_equal_less &&
-                        7 > input.greater_equal_less) ||
+                        (3 <= input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less,
+                            })) &&
+                        (7 > input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_equal_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less",
                             expected: "number",
                             value: input.greater_equal_less,
                         })) &&
                     (("number" === typeof input.greater_less_equal &&
-                        3 < input.greater_less_equal &&
-                        7 >= input.greater_less_equal) ||
+                        (3 < input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        (7 >= input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less_equal",
                             expected: "number",
                             value: input.greater_less_equal,
                         })) &&
                     (("number" === typeof input.greater_equal_less_equal &&
-                        3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal) ||
+                        (3 <= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
+                        (7 >= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_equal_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",

--- a/test/generated/output/assert/test_assert_TagStep.ts
+++ b/test/generated/output/assert/test_assert_TagStep.ts
@@ -19,34 +19,84 @@ export const test_assert_TagStep = _test_assert(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("number" === typeof input.exclusiveMinimum &&
-                        0 === (input.exclusiveMinimum % 5) - 3 &&
-                        3 < input.exclusiveMinimum) ||
+                        (0 === (input.exclusiveMinimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@step 5)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (3 < input.exclusiveMinimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.exclusiveMinimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".exclusiveMinimum",
                             expected: "number",
                             value: input.exclusiveMinimum,
                         })) &&
                     (("number" === typeof input.minimum &&
-                        0 === (input.minimum % 5) - 3 &&
-                        3 <= input.minimum) ||
+                        (0 === (input.minimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@step 5)",
+                                value: input.minimum,
+                            })) &&
+                        (3 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
                             value: input.minimum,
                         })) &&
                     (("number" === typeof input.range &&
-                        0 === (input.range % 5) - 0 &&
-                        0 < input.range &&
-                        100 > input.range) ||
+                        (0 === (input.range % 5) - 0 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@step 5)",
+                                value: input.range,
+                            })) &&
+                        (0 < input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMinimum 0)",
+                                value: input.range,
+                            })) &&
+                        (100 > input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMaximum 100)",
+                                value: input.range,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".range",
                             expected: "number",
                             value: input.range,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 5 &&
-                        3 <= input.multipleOf &&
-                        99 >= input.multipleOf) ||
+                        (0 === input.multipleOf % 5 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 5)",
+                                value: input.multipleOf,
+                            })) &&
+                        (3 <= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@minimum 3)",
+                                value: input.multipleOf,
+                            })) &&
+                        (99 >= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@maximum 99)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",

--- a/test/generated/output/assert/test_assert_TagTuple.ts
+++ b/test/generated/output/assert/test_assert_TagTuple.ts
@@ -33,24 +33,54 @@ export const test_assert_TagTuple = _test_assert(
                             value: input.tuple,
                         })) &&
                     (("string" === typeof input.tuple[0] &&
-                        3 <= input.tuple[0].length &&
-                        7 >= input.tuple[0].length) ||
+                        (3 <= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@minLength 3)",
+                                value: input.tuple[0],
+                            })) &&
+                        (7 >= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@maxLength 7)",
+                                value: input.tuple[0],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[0]",
                             expected: "string",
                             value: input.tuple[0],
                         })) &&
                     (("number" === typeof input.tuple[1] &&
-                        3 <= input.tuple[1] &&
-                        7 >= input.tuple[1]) ||
+                        (3 <= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@minimum 3)",
+                                value: input.tuple[1],
+                            })) &&
+                        (7 >= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@maximum 7)",
+                                value: input.tuple[1],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[1]",
                             expected: "number",
                             value: input.tuple[1],
                         })) &&
                     ((Array.isArray(input.tuple[2]) &&
-                        3 <= input.tuple[2].length &&
-                        7 >= input.tuple[2].length) ||
+                        (3 <= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[2],
+                            })) &&
+                        (7 >= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[2],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[2]",
                             expected: "Array<string>",
@@ -59,8 +89,26 @@ export const test_assert_TagTuple = _test_assert(
                     input.tuple[2].every(
                         (elem: any, _index1: number) =>
                             ("string" === typeof elem &&
-                                3 <= elem.length &&
-                                7 >= elem.length) ||
+                                (3 <= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@minLength 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[2][" + _index1 + "]",
                                 expected: "string",
@@ -68,8 +116,18 @@ export const test_assert_TagTuple = _test_assert(
                             }),
                     ) &&
                     ((Array.isArray(input.tuple[3]) &&
-                        3 <= input.tuple[3].length &&
-                        7 >= input.tuple[3].length) ||
+                        (3 <= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[3],
+                            })) &&
+                        (7 >= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[3],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[3]",
                             expected: "Array<number>",
@@ -78,8 +136,26 @@ export const test_assert_TagTuple = _test_assert(
                     input.tuple[3].every(
                         (elem: any, _index2: number) =>
                             ("number" === typeof elem &&
-                                3 <= elem &&
-                                7 >= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[3][" + _index2 + "]",
                                 expected: "number",

--- a/test/generated/output/assert/test_assert_TagType.ts
+++ b/test/generated/output/assert/test_assert_TagType.ts
@@ -20,7 +20,12 @@ export const test_assert_TagType = _test_assert(
                 ): boolean =>
                     (("number" === typeof input.int &&
                         Number.isFinite(input.int) &&
-                        parseInt(input.int) === input.int) ||
+                        (parseInt(input.int) === input.int ||
+                            $guard(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".int",
                             expected: "number",
@@ -28,8 +33,18 @@ export const test_assert_TagType = _test_assert(
                         })) &&
                     (("number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
-                        parseInt(input.uint) === input.uint &&
-                        0 <= input.uint) ||
+                        (parseInt(input.uint) === input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (0 <= input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uint",
                             expected: "number",

--- a/test/generated/output/assert/test_assert_UltimateUnion.ts
+++ b/test/generated/output/assert/test_assert_UltimateUnion.ts
@@ -934,7 +934,12 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            parseInt(input.minimum) === input.minimum) ||
+                            (parseInt(input.minimum) === input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "(number | undefined)",
@@ -943,7 +948,12 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            parseInt(input.maximum) === input.maximum) ||
+                            (parseInt(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "(number | undefined)",
@@ -966,7 +976,12 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            parseInt(input.multipleOf) === input.multipleOf) ||
+                            (parseInt(input.multipleOf) === input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "(number | undefined)",
@@ -1255,8 +1270,18 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
-                            parseInt(input.minLength) === input.minLength &&
-                            0 <= input.minLength) ||
+                            (parseInt(input.minLength) === input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                })) &&
+                            (0 <= input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minLength",
                             expected: "(number | undefined)",
@@ -1265,8 +1290,18 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
-                            parseInt(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength) ||
+                            (parseInt(input.maxLength) === input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxLength",
                             expected: "(number | undefined)",
@@ -1423,8 +1458,18 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
-                            parseInt(input.minItems) === input.minItems &&
-                            0 <= input.minItems) ||
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "(number | undefined)",
@@ -1433,8 +1478,18 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
-                            parseInt(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems) ||
+                            (parseInt(input.maxItems) === input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "(number | undefined)",

--- a/test/generated/output/assertClone/test_assertClone_TagArray.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagArray.ts
@@ -21,7 +21,12 @@ export const test_assertClone_TagArray = _test_assertClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ((Array.isArray(input.items) &&
-                            3 === input.items.length) ||
+                            (3 === input.items.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.items,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected: "Array<string>",
@@ -30,7 +35,16 @@ export const test_assertClone_TagArray = _test_assertClone(
                         input.items.every(
                             (elem: any, _index2: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".items[" + _index2 + "]",
                                     expected: "string",
@@ -38,7 +52,12 @@ export const test_assertClone_TagArray = _test_assertClone(
                                 }),
                         ) &&
                         ((Array.isArray(input.minItems) &&
-                            3 <= input.minItems.length) ||
+                            (3 <= input.minItems.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.minItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "Array<number>",
@@ -48,7 +67,16 @@ export const test_assertClone_TagArray = _test_assertClone(
                             (elem: any, _index3: number) =>
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem) &&
-                                    3 <= elem) ||
+                                    (3 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".minItems[" +
+                                                _index3 +
+                                                "]",
+                                            expected: "number (@minimum 3)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems[" + _index3 + "]",
                                     expected: "number",
@@ -56,7 +84,12 @@ export const test_assertClone_TagArray = _test_assertClone(
                                 }),
                         ) &&
                         ((Array.isArray(input.maxItems) &&
-                            7 >= input.maxItems.length) ||
+                            (7 >= input.maxItems.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.maxItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "Array<(number | string)>",
@@ -65,10 +98,28 @@ export const test_assertClone_TagArray = _test_assertClone(
                         input.maxItems.every(
                             (elem: any, _index4: number) =>
                                 ("string" === typeof elem &&
-                                    7 >= elem.length) ||
+                                    (7 >= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".maxItems[" +
+                                                _index4 +
+                                                "]",
+                                            expected: "string (@maxLength 7)",
+                                            value: elem,
+                                        }))) ||
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem) &&
-                                    7 >= elem) ||
+                                    (7 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".maxItems[" +
+                                                _index4 +
+                                                "]",
+                                            expected: "number (@maximum 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems[" + _index4 + "]",
                                     expected: "(number | string)",
@@ -76,8 +127,18 @@ export const test_assertClone_TagArray = _test_assertClone(
                                 }),
                         ) &&
                         ((Array.isArray(input.both) &&
-                            3 <= input.both.length &&
-                            7 >= input.both.length) ||
+                            (3 <= input.both.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.both,
+                                })) &&
+                            (7 >= input.both.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.both,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".both",
                                 expected: "Array<string>",
@@ -86,7 +147,16 @@ export const test_assertClone_TagArray = _test_assertClone(
                         input.both.every(
                             (elem: any, _index5: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".both[" +
+                                                _index5 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".both[" + _index5 + "]",
                                     expected: "string",

--- a/test/generated/output/assertClone/test_assertClone_TagAtomicUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagAtomicUnion.ts
@@ -20,11 +20,26 @@ export const test_assertClone_TagAtomicUnion = _test_assertClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "(number | string)",

--- a/test/generated/output/assertClone/test_assertClone_TagCustom.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagCustom.ts
@@ -22,31 +22,41 @@ export const test_assertClone_TagCustom = _test_assertClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.id &&
-                            true === $is_uuid(input.id)) ||
+                            (true === $is_uuid(input.id) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string (@format uuid)",
+                                    value: input.id,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".id",
                                 expected: "string",
                                 value: input.id,
                             })) &&
-                        (("string" === typeof input.dolloar &&
-                            $is_custom(
-                                "dollar",
-                                "string",
-                                "",
-                                input.dolloar,
-                            )) ||
+                        (("string" === typeof input.dollar &&
+                            ($is_custom("dollar", "string", "", input.dollar) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".dollar",
+                                    expected: "string (@dollar)",
+                                    value: input.dollar,
+                                }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".dolloar",
+                                path: _path + ".dollar",
                                 expected: "string",
-                                value: input.dolloar,
+                                value: input.dollar,
                             })) &&
                         (("string" === typeof input.postfix &&
-                            $is_custom(
+                            ($is_custom(
                                 "postfix",
                                 "string",
                                 "abcd",
                                 input.postfix,
-                            )) ||
+                            ) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string (@postfix abcd)",
+                                    value: input.postfix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected: "string",
@@ -54,7 +64,12 @@ export const test_assertClone_TagCustom = _test_assertClone(
                             })) &&
                         (("number" === typeof input.log &&
                             Number.isFinite(input.log) &&
-                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            ($is_custom("powerOf", "number", "10", input.log) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number (@powerOf 10)",
+                                    value: input.log,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".log",
                                 expected: "number",
@@ -77,7 +92,7 @@ export const test_assertClone_TagCustom = _test_assertClone(
                 const $is_custom = (typia.assertClone as any).is_custom;
                 const $co0 = (input: any): any => ({
                     id: input.id as any,
-                    dolloar: input.dolloar as any,
+                    dollar: input.dollar as any,
                     postfix: input.postfix as any,
                     log: input.log as any,
                 });

--- a/test/generated/output/assertClone/test_assertClone_TagFormat.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagFormat.ts
@@ -27,63 +27,108 @@ export const test_assertClone_TagFormat = _test_assertClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.uuid &&
-                            true === $is_uuid(input.uuid)) ||
+                            (true === $is_uuid(input.uuid) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected: "string (@format uuid)",
+                                    value: input.uuid,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             })) &&
                         (("string" === typeof input.email &&
-                            true === $is_email(input.email)) ||
+                            (true === $is_email(input.email) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected: "string (@format email)",
+                                    value: input.email,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             })) &&
                         (("string" === typeof input.url &&
-                            true === $is_url(input.url)) ||
+                            (true === $is_url(input.url) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".url",
+                                    expected: "string (@format url)",
+                                    value: input.url,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".url",
                                 expected: "string",
                                 value: input.url,
                             })) &&
                         (("string" === typeof input.ipv4 &&
-                            true === $is_ipv4(input.ipv4)) ||
+                            (true === $is_ipv4(input.ipv4) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected: "string (@format ipv4)",
+                                    value: input.ipv4,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             })) &&
                         (("string" === typeof input.ipv6 &&
-                            true === $is_ipv6(input.ipv6)) ||
+                            (true === $is_ipv6(input.ipv6) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected: "string (@format ipv6)",
+                                    value: input.ipv6,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",
                                 value: input.ipv6,
                             })) &&
                         (("string" === typeof input.date &&
-                            true === $is_date(input.date)) ||
+                            (true === $is_date(input.date) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".date",
+                                    expected: "string (@format date)",
+                                    value: input.date,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".date",
                                 expected: "string",
                                 value: input.date,
                             })) &&
                         (("string" === typeof input.date_time &&
-                            true === $is_datetime(input.date_time)) ||
+                            (true === $is_datetime(input.date_time) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".date_time",
+                                    expected: "string (@format datetime)",
+                                    value: input.date_time,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".date_time",
                                 expected: "string",
                                 value: input.date_time,
                             })) &&
                         (("string" === typeof input.datetime &&
-                            true === $is_datetime(input.datetime)) ||
+                            (true === $is_datetime(input.datetime) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".datetime",
+                                    expected: "string (@format datetime)",
+                                    value: input.datetime,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".datetime",
                                 expected: "string",
                                 value: input.datetime,
                             })) &&
                         (("string" === typeof input.dateTime &&
-                            true === $is_datetime(input.dateTime)) ||
+                            (true === $is_datetime(input.dateTime) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".dateTime",
+                                    expected: "string (@format datetime)",
+                                    value: input.dateTime,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".dateTime",
                                 expected: "string",

--- a/test/generated/output/assertClone/test_assertClone_TagLength.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagLength.ts
@@ -20,29 +20,54 @@ export const test_assertClone_TagLength = _test_assertClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.fixed &&
-                            5 === input.fixed.length) ||
+                            (5 === input.fixed.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".fixed",
+                                    expected: "string (@length 5)",
+                                    value: input.fixed,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".fixed",
                                 expected: "string",
                                 value: input.fixed,
                             })) &&
                         (("string" === typeof input.minimum &&
-                            3 <= input.minimum.length) ||
+                            (3 <= input.minimum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "string",
                                 value: input.minimum,
                             })) &&
                         (("string" === typeof input.maximum &&
-                            7 >= input.maximum.length) ||
+                            (7 >= input.maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "string",
                                 value: input.maximum,
                             })) &&
                         (("string" === typeof input.minimum_and_maximum &&
-                            3 <= input.minimum_and_maximum.length &&
-                            7 >= input.minimum_and_maximum.length) ||
+                            (3 <= input.minimum_and_maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum_and_maximum,
+                                })) &&
+                            (7 >= input.minimum_and_maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.minimum_and_maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",

--- a/test/generated/output/assertClone/test_assertClone_TagMatrix.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagMatrix.ts
@@ -21,7 +21,12 @@ export const test_assertClone_TagMatrix = _test_assertClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ((Array.isArray(input.matrix) &&
-                            3 === input.matrix.length) ||
+                            (3 === input.matrix.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".matrix",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.matrix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".matrix",
                                 expected: "Array<Array<string>>",
@@ -29,7 +34,17 @@ export const test_assertClone_TagMatrix = _test_assertClone(
                             })) &&
                         input.matrix.every(
                             (elem: any, _index1: number) =>
-                                ((Array.isArray(elem) && 3 === elem.length) ||
+                                ((Array.isArray(elem) &&
+                                    (3 === elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".matrix[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "Array.length (@items 3)",
+                                            value: elem,
+                                        }))) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path + ".matrix[" + _index1 + "]",
@@ -39,7 +54,19 @@ export const test_assertClone_TagMatrix = _test_assertClone(
                                 elem.every(
                                     (elem: any, _index2: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".matrix[" +
+                                                        _index1 +
+                                                        "][" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +

--- a/test/generated/output/assertClone/test_assertClone_TagObjectUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagObjectUnion.ts
@@ -21,7 +21,12 @@ export const test_assertClone_TagObjectUnion = _test_assertClone(
                     ): boolean =>
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "number",
@@ -33,8 +38,18 @@ export const test_assertClone_TagObjectUnion = _test_assertClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "string",

--- a/test/generated/output/assertClone/test_assertClone_TagPattern.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagPattern.ts
@@ -20,40 +20,64 @@ export const test_assertClone_TagPattern = _test_assertClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.uuid &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                ).test(input.uuid)) ||
+                                ).test(input.uuid) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected:
+                                        "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                    value: input.uuid,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             })) &&
                         (("string" === typeof input.email &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                ).test(input.email)) ||
+                                ).test(input.email) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected:
+                                        'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                    value: input.email,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             })) &&
                         (("string" === typeof input.ipv4 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                ).test(input.ipv4)) ||
+                                ).test(input.ipv4) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected:
+                                        "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                    value: input.ipv4,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             })) &&
                         (("string" === typeof input.ipv6 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                ).test(input.ipv6)) ||
+                                ).test(input.ipv6) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected:
+                                        "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                    value: input.ipv6,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",

--- a/test/generated/output/assertClone/test_assertClone_TagRange.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagRange.ts
@@ -21,7 +21,12 @@ export const test_assertClone_TagRange = _test_assertClone(
                     ): boolean =>
                         (("number" === typeof input.greater &&
                             Number.isFinite(input.greater) &&
-                            3 < input.greater) ||
+                            (3 < input.greater ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater",
                                 expected: "number",
@@ -29,7 +34,12 @@ export const test_assertClone_TagRange = _test_assertClone(
                             })) &&
                         (("number" === typeof input.greater_equal &&
                             Number.isFinite(input.greater_equal) &&
-                            3 <= input.greater_equal) ||
+                            (3 <= input.greater_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number",
@@ -37,7 +47,12 @@ export const test_assertClone_TagRange = _test_assertClone(
                             })) &&
                         (("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
-                            7 > input.less) ||
+                            (7 > input.less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".less",
                                 expected: "number",
@@ -45,39 +60,84 @@ export const test_assertClone_TagRange = _test_assertClone(
                             })) &&
                         (("number" === typeof input.less_equal &&
                             Number.isFinite(input.less_equal) &&
-                            7 >= input.less_equal) ||
+                            (7 >= input.less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".less_equal",
                                 expected: "number",
                                 value: input.less_equal,
                             })) &&
                         (("number" === typeof input.greater_less &&
-                            3 < input.greater_less &&
-                            7 > input.greater_less) ||
+                            (3 < input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less,
+                                })) &&
+                            (7 > input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number",
                                 value: input.greater_less,
                             })) &&
                         (("number" === typeof input.greater_equal_less &&
-                            3 <= input.greater_equal_less &&
-                            7 > input.greater_equal_less) ||
+                            (3 <= input.greater_equal_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less,
+                                })) &&
+                            (7 > input.greater_equal_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_equal_less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less",
                                 expected: "number",
                                 value: input.greater_equal_less,
                             })) &&
                         (("number" === typeof input.greater_less_equal &&
-                            3 < input.greater_less_equal &&
-                            7 >= input.greater_less_equal) ||
+                            (3 < input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            (7 >= input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number",
                                 value: input.greater_less_equal,
                             })) &&
                         (("number" === typeof input.greater_equal_less_equal &&
-                            3 <= input.greater_equal_less_equal &&
-                            7 >= input.greater_equal_less_equal) ||
+                            (3 <= input.greater_equal_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
+                            (7 >= input.greater_equal_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_equal_less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",

--- a/test/generated/output/assertClone/test_assertClone_TagStep.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagStep.ts
@@ -20,34 +20,84 @@ export const test_assertClone_TagStep = _test_assertClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("number" === typeof input.exclusiveMinimum &&
-                            0 === (input.exclusiveMinimum % 5) - 3 &&
-                            3 < input.exclusiveMinimum) ||
+                            (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@step 5)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (3 < input.exclusiveMinimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.exclusiveMinimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".exclusiveMinimum",
                                 expected: "number",
                                 value: input.exclusiveMinimum,
                             })) &&
                         (("number" === typeof input.minimum &&
-                            0 === (input.minimum % 5) - 3 &&
-                            3 <= input.minimum) ||
+                            (0 === (input.minimum % 5) - 3 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@step 5)",
+                                    value: input.minimum,
+                                })) &&
+                            (3 <= input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
                                 value: input.minimum,
                             })) &&
                         (("number" === typeof input.range &&
-                            0 === (input.range % 5) - 0 &&
-                            0 < input.range &&
-                            100 > input.range) ||
+                            (0 === (input.range % 5) - 0 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@step 5)",
+                                    value: input.range,
+                                })) &&
+                            (0 < input.range ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMinimum 0)",
+                                    value: input.range,
+                                })) &&
+                            (100 > input.range ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMaximum 100)",
+                                    value: input.range,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".range",
                                 expected: "number",
                                 value: input.range,
                             })) &&
                         (("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 5 &&
-                            3 <= input.multipleOf &&
-                            99 >= input.multipleOf) ||
+                            (0 === input.multipleOf % 5 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 5)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (3 <= input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@minimum 3)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (99 >= input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@maximum 99)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",

--- a/test/generated/output/assertClone/test_assertClone_TagTuple.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagTuple.ts
@@ -34,24 +34,54 @@ export const test_assertClone_TagTuple = _test_assertClone(
                                 value: input.tuple,
                             })) &&
                         (("string" === typeof input.tuple[0] &&
-                            3 <= input.tuple[0].length &&
-                            7 >= input.tuple[0].length) ||
+                            (3 <= input.tuple[0].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[0]",
+                                    expected: "string (@minLength 3)",
+                                    value: input.tuple[0],
+                                })) &&
+                            (7 >= input.tuple[0].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[0]",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.tuple[0],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[0]",
                                 expected: "string",
                                 value: input.tuple[0],
                             })) &&
                         (("number" === typeof input.tuple[1] &&
-                            3 <= input.tuple[1] &&
-                            7 >= input.tuple[1]) ||
+                            (3 <= input.tuple[1] ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[1]",
+                                    expected: "number (@minimum 3)",
+                                    value: input.tuple[1],
+                                })) &&
+                            (7 >= input.tuple[1] ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[1]",
+                                    expected: "number (@maximum 7)",
+                                    value: input.tuple[1],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[1]",
                                 expected: "number",
                                 value: input.tuple[1],
                             })) &&
                         ((Array.isArray(input.tuple[2]) &&
-                            3 <= input.tuple[2].length &&
-                            7 >= input.tuple[2].length) ||
+                            (3 <= input.tuple[2].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2]",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.tuple[2],
+                                })) &&
+                            (7 >= input.tuple[2].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2]",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.tuple[2],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[2]",
                                 expected: "Array<string>",
@@ -60,8 +90,26 @@ export const test_assertClone_TagTuple = _test_assertClone(
                         input.tuple[2].every(
                             (elem: any, _index1: number) =>
                                 ("string" === typeof elem &&
-                                    3 <= elem.length &&
-                                    7 >= elem.length) ||
+                                    (3 <= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[2][" +
+                                                _index1 +
+                                                "]",
+                                            expected: "string (@minLength 3)",
+                                            value: elem,
+                                        })) &&
+                                    (7 >= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[2][" +
+                                                _index1 +
+                                                "]",
+                                            expected: "string (@maxLength 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".tuple[2][" + _index1 + "]",
                                     expected: "string",
@@ -69,8 +117,18 @@ export const test_assertClone_TagTuple = _test_assertClone(
                                 }),
                         ) &&
                         ((Array.isArray(input.tuple[3]) &&
-                            3 <= input.tuple[3].length &&
-                            7 >= input.tuple[3].length) ||
+                            (3 <= input.tuple[3].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3]",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.tuple[3],
+                                })) &&
+                            (7 >= input.tuple[3].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3]",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.tuple[3],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[3]",
                                 expected: "Array<number>",
@@ -79,8 +137,26 @@ export const test_assertClone_TagTuple = _test_assertClone(
                         input.tuple[3].every(
                             (elem: any, _index2: number) =>
                                 ("number" === typeof elem &&
-                                    3 <= elem &&
-                                    7 >= elem) ||
+                                    (3 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[3][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number (@minimum 3)",
+                                            value: elem,
+                                        })) &&
+                                    (7 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[3][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number (@maximum 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".tuple[3][" + _index2 + "]",
                                     expected: "number",

--- a/test/generated/output/assertClone/test_assertClone_TagType.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagType.ts
@@ -21,7 +21,12 @@ export const test_assertClone_TagType = _test_assertClone(
                     ): boolean =>
                         (("number" === typeof input.int &&
                             Number.isFinite(input.int) &&
-                            parseInt(input.int) === input.int) ||
+                            (parseInt(input.int) === input.int ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".int",
                                 expected: "number",
@@ -29,8 +34,18 @@ export const test_assertClone_TagType = _test_assertClone(
                             })) &&
                         (("number" === typeof input.uint &&
                             Number.isFinite(input.uint) &&
-                            parseInt(input.uint) === input.uint &&
-                            0 <= input.uint) ||
+                            (parseInt(input.uint) === input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (0 <= input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number",

--- a/test/generated/output/assertClone/test_assertClone_UltimateUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_UltimateUnion.ts
@@ -940,7 +940,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                parseInt(input.minimum) === input.minimum) ||
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -949,7 +954,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                parseInt(input.maximum) === input.maximum) ||
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -972,8 +982,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
-                                parseInt(input.multipleOf) ===
-                                    input.multipleOf) ||
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -1264,8 +1279,19 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
-                                parseInt(input.minLength) === input.minLength &&
-                                0 <= input.minLength) ||
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
                                 expected: "(number | undefined)",
@@ -1274,8 +1300,19 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
-                                parseInt(input.maxLength) === input.maxLength &&
-                                0 <= input.maxLength) ||
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxLength",
                                 expected: "(number | undefined)",
@@ -1433,8 +1470,18 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input.minItems ||
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
-                                parseInt(input.minItems) === input.minItems &&
-                                0 <= input.minItems) ||
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "(number | undefined)",
@@ -1443,8 +1490,18 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
-                                parseInt(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems) ||
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",

--- a/test/generated/output/assertEquals/test_assertEquals_TagArray.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagArray.ts
@@ -20,7 +20,13 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ((Array.isArray(input.items) && 3 === input.items.length) ||
+                    ((Array.isArray(input.items) &&
+                        (3 === input.items.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected: "Array.length (@items 3)",
+                                value: input.items,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected: "Array<string>",
@@ -29,7 +35,12 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                     input.items.every(
                         (elem: any, _index2: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".items[" + _index2 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items[" + _index2 + "]",
                                 expected: "string",
@@ -37,7 +48,12 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                             }),
                     ) &&
                     ((Array.isArray(input.minItems) &&
-                        3 <= input.minItems.length) ||
+                        (3 <= input.minItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.minItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "Array<number>",
@@ -47,7 +63,16 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                         (elem: any, _index3: number) =>
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                3 <= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".minItems[" +
+                                            _index3 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems[" + _index3 + "]",
                                 expected: "number",
@@ -55,7 +80,12 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                             }),
                     ) &&
                     ((Array.isArray(input.maxItems) &&
-                        7 >= input.maxItems.length) ||
+                        (7 >= input.maxItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.maxItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "Array<(number | string)>",
@@ -63,10 +93,29 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                         })) &&
                     input.maxItems.every(
                         (elem: any, _index4: number) =>
-                            ("string" === typeof elem && 7 >= elem.length) ||
+                            ("string" === typeof elem &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                7 >= elem) ||
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems[" + _index4 + "]",
                                 expected: "(number | string)",
@@ -74,8 +123,18 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                             }),
                     ) &&
                     ((Array.isArray(input.both) &&
-                        3 <= input.both.length &&
-                        7 >= input.both.length) ||
+                        (3 <= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.both,
+                            })) &&
+                        (7 >= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.both,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".both",
                             expected: "Array<string>",
@@ -84,7 +143,12 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                     input.both.every(
                         (elem: any, _index5: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".both[" + _index5 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".both[" + _index5 + "]",
                                 expected: "string",

--- a/test/generated/output/assertEquals/test_assertEquals_TagAtomicUnion.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagAtomicUnion.ts
@@ -20,11 +20,26 @@ export const test_assertEquals_TagAtomicUnion = _test_assertEquals(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "(number | string)",

--- a/test/generated/output/assertEquals/test_assertEquals_TagBigInt.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagBigInt.ts
@@ -26,29 +26,54 @@ export const test_assertEquals_TagBigInt = _test_assertEquals(
                             value: input.value,
                         })) &&
                     (("bigint" === typeof input.ranged &&
-                        0n <= input.ranged &&
-                        100n >= input.ranged) ||
+                        (0n <= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "bigint (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100n >= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "bigint (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "bigint",
                             value: input.ranged,
                         })) &&
                     (("bigint" === typeof input.minimum &&
-                        0n <= input.minimum) ||
+                        (0n <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "bigint (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "bigint",
                             value: input.minimum,
                         })) &&
                     (("bigint" === typeof input.maximum &&
-                        100n >= input.maximum) ||
+                        (100n >= input.maximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "bigint (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "bigint",
                             value: input.maximum,
                         })) &&
                     (("bigint" === typeof input.multipleOf &&
-                        0n === input.multipleOf % 3n) ||
+                        (0n === input.multipleOf % 3n ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "bigint (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "bigint",

--- a/test/generated/output/assertEquals/test_assertEquals_TagCustom.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagCustom.ts
@@ -22,26 +22,41 @@ export const test_assertEquals_TagCustom = _test_assertEquals(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.id &&
-                        true === $is_uuid(input.id)) ||
+                        (true === $is_uuid(input.id) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string (@format uuid)",
+                                value: input.id,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".id",
                             expected: "string",
                             value: input.id,
                         })) &&
-                    (("string" === typeof input.dolloar &&
-                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                    (("string" === typeof input.dollar &&
+                        ($is_custom("dollar", "string", "", input.dollar) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dollar",
+                                expected: "string (@dollar)",
+                                value: input.dollar,
+                            }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".dolloar",
+                            path: _path + ".dollar",
                             expected: "string",
-                            value: input.dolloar,
+                            value: input.dollar,
                         })) &&
                     (("string" === typeof input.postfix &&
-                        $is_custom(
+                        ($is_custom(
                             "postfix",
                             "string",
                             "abcd",
                             input.postfix,
-                        )) ||
+                        ) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string (@postfix abcd)",
+                                value: input.postfix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".postfix",
                             expected: "string",
@@ -49,7 +64,12 @@ export const test_assertEquals_TagCustom = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.log &&
                         Number.isFinite(input.log) &&
-                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        ($is_custom("powerOf", "number", "10", input.log) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number (@powerOf 10)",
+                                value: input.log,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".log",
                             expected: "number",
@@ -59,7 +79,7 @@ export const test_assertEquals_TagCustom = _test_assertEquals(
                         false === _exceptionable ||
                         Object.keys(input).every((key) => {
                             if (
-                                ["id", "dolloar", "postfix", "log"].some(
+                                ["id", "dollar", "postfix", "log"].some(
                                     (prop) => key === prop,
                                 )
                             )

--- a/test/generated/output/assertEquals/test_assertEquals_TagFormat.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagFormat.ts
@@ -27,63 +27,108 @@ export const test_assertEquals_TagFormat = _test_assertEquals(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true === $is_uuid(input.uuid)) ||
+                        (true === $is_uuid(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected: "string (@format uuid)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true === $is_email(input.email)) ||
+                        (true === $is_email(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected: "string (@format email)",
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.url &&
-                        true === $is_url(input.url)) ||
+                        (true === $is_url(input.url) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".url",
+                                expected: "string (@format url)",
+                                value: input.url,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".url",
                             expected: "string",
                             value: input.url,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true === $is_ipv4(input.ipv4)) ||
+                        (true === $is_ipv4(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected: "string (@format ipv4)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true === $is_ipv6(input.ipv6)) ||
+                        (true === $is_ipv6(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected: "string (@format ipv6)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",
                             value: input.ipv6,
                         })) &&
                     (("string" === typeof input.date &&
-                        true === $is_date(input.date)) ||
+                        (true === $is_date(input.date) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date",
+                                expected: "string (@format date)",
+                                value: input.date,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date",
                             expected: "string",
                             value: input.date,
                         })) &&
                     (("string" === typeof input.date_time &&
-                        true === $is_datetime(input.date_time)) ||
+                        (true === $is_datetime(input.date_time) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date_time",
+                                expected: "string (@format datetime)",
+                                value: input.date_time,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date_time",
                             expected: "string",
                             value: input.date_time,
                         })) &&
                     (("string" === typeof input.datetime &&
-                        true === $is_datetime(input.datetime)) ||
+                        (true === $is_datetime(input.datetime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".datetime",
+                                expected: "string (@format datetime)",
+                                value: input.datetime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".datetime",
                             expected: "string",
                             value: input.datetime,
                         })) &&
                     (("string" === typeof input.dateTime &&
-                        true === $is_datetime(input.dateTime)) ||
+                        (true === $is_datetime(input.dateTime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dateTime",
+                                expected: "string (@format datetime)",
+                                value: input.dateTime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".dateTime",
                             expected: "string",

--- a/test/generated/output/assertEquals/test_assertEquals_TagInfinite.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagInfinite.ts
@@ -27,8 +27,18 @@ export const test_assertEquals_TagInfinite = _test_assertEquals(
                             value: input.value,
                         })) &&
                     (("number" === typeof input.ranged &&
-                        0 <= input.ranged &&
-                        100 >= input.ranged) ||
+                        (0 <= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100 >= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "number",
@@ -36,7 +46,12 @@ export const test_assertEquals_TagInfinite = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        0 <= input.minimum) ||
+                        (0 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
@@ -44,14 +59,24 @@ export const test_assertEquals_TagInfinite = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        100 >= input.maximum) ||
+                        (100 >= input.maximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "number",
                             value: input.maximum,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 3) ||
+                        (0 === input.multipleOf % 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",
@@ -59,7 +84,12 @@ export const test_assertEquals_TagInfinite = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
-                        parseInt(input.typed) === input.typed) ||
+                        (parseInt(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".typed",
                             expected: "number",

--- a/test/generated/output/assertEquals/test_assertEquals_TagLength.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagLength.ts
@@ -20,29 +20,54 @@ export const test_assertEquals_TagLength = _test_assertEquals(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.fixed &&
-                        5 === input.fixed.length) ||
+                        (5 === input.fixed.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".fixed",
+                                expected: "string (@length 5)",
+                                value: input.fixed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".fixed",
                             expected: "string",
                             value: input.fixed,
                         })) &&
                     (("string" === typeof input.minimum &&
-                        3 <= input.minimum.length) ||
+                        (3 <= input.minimum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "string",
                             value: input.minimum,
                         })) &&
                     (("string" === typeof input.maximum &&
-                        7 >= input.maximum.length) ||
+                        (7 >= input.maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "string",
                             value: input.maximum,
                         })) &&
                     (("string" === typeof input.minimum_and_maximum &&
-                        3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length) ||
+                        (3 <= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum_and_maximum,
+                            })) &&
+                        (7 >= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.minimum_and_maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum_and_maximum",
                             expected: "string",

--- a/test/generated/output/assertEquals/test_assertEquals_TagMatrix.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagMatrix.ts
@@ -21,7 +21,12 @@ export const test_assertEquals_TagMatrix = _test_assertEquals(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ((Array.isArray(input.matrix) &&
-                        3 === input.matrix.length) ||
+                        (3 === input.matrix.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".matrix",
+                                expected: "Array.length (@items 3)",
+                                value: input.matrix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".matrix",
                             expected: "Array<Array<string>>",
@@ -29,7 +34,14 @@ export const test_assertEquals_TagMatrix = _test_assertEquals(
                         })) &&
                     input.matrix.every(
                         (elem: any, _index1: number) =>
-                            ((Array.isArray(elem) && 3 === elem.length) ||
+                            ((Array.isArray(elem) &&
+                                (3 === elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".matrix[" + _index1 + "]",
+                                        expected: "Array.length (@items 3)",
+                                        value: elem,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".matrix[" + _index1 + "]",
                                     expected: "Array<string>",
@@ -38,7 +50,19 @@ export const test_assertEquals_TagMatrix = _test_assertEquals(
                             elem.every(
                                 (elem: any, _index2: number) =>
                                     ("string" === typeof elem &&
-                                        true === $is_uuid(elem)) ||
+                                        (true === $is_uuid(elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".matrix[" +
+                                                    _index1 +
+                                                    "][" +
+                                                    _index2 +
+                                                    "]",
+                                                expected:
+                                                    "string (@format uuid)",
+                                                value: elem,
+                                            }))) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +

--- a/test/generated/output/assertEquals/test_assertEquals_TagNaN.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagNaN.ts
@@ -27,8 +27,18 @@ export const test_assertEquals_TagNaN = _test_assertEquals(
                             value: input.value,
                         })) &&
                     (("number" === typeof input.ranged &&
-                        0 <= input.ranged &&
-                        100 >= input.ranged) ||
+                        (0 <= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100 >= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "number",
@@ -36,7 +46,12 @@ export const test_assertEquals_TagNaN = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        0 <= input.minimum) ||
+                        (0 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
@@ -44,14 +59,24 @@ export const test_assertEquals_TagNaN = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        100 >= input.maximum) ||
+                        (100 >= input.maximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "number",
                             value: input.maximum,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 3) ||
+                        (0 === input.multipleOf % 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",
@@ -59,7 +84,12 @@ export const test_assertEquals_TagNaN = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
-                        parseInt(input.typed) === input.typed) ||
+                        (parseInt(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".typed",
                             expected: "number",

--- a/test/generated/output/assertEquals/test_assertEquals_TagObjectUnion.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagObjectUnion.ts
@@ -21,7 +21,12 @@ export const test_assertEquals_TagObjectUnion = _test_assertEquals(
                 ): boolean =>
                     (("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "number",
@@ -46,8 +51,18 @@ export const test_assertEquals_TagObjectUnion = _test_assertEquals(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "string",

--- a/test/generated/output/assertEquals/test_assertEquals_TagPattern.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagPattern.ts
@@ -20,40 +20,64 @@ export const test_assertEquals_TagPattern = _test_assertEquals(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                            ).test(input.uuid)) ||
+                            ).test(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected:
+                                    "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                            ).test(input.email)) ||
+                            ).test(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected:
+                                    'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                            ).test(input.ipv4)) ||
+                            ).test(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected:
+                                    "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                            ).test(input.ipv6)) ||
+                            ).test(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected:
+                                    "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",

--- a/test/generated/output/assertEquals/test_assertEquals_TagRange.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagRange.ts
@@ -21,7 +21,12 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                 ): boolean =>
                     (("number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
-                        3 < input.greater) ||
+                        (3 < input.greater ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater",
                             expected: "number",
@@ -29,7 +34,12 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
-                        3 <= input.greater_equal) ||
+                        (3 <= input.greater_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal",
                             expected: "number",
@@ -37,7 +47,12 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.less &&
                         Number.isFinite(input.less) &&
-                        7 > input.less) ||
+                        (7 > input.less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less",
                             expected: "number",
@@ -45,39 +60,84 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
-                        7 >= input.less_equal) ||
+                        (7 >= input.less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less_equal",
                             expected: "number",
                             value: input.less_equal,
                         })) &&
                     (("number" === typeof input.greater_less &&
-                        3 < input.greater_less &&
-                        7 > input.greater_less) ||
+                        (3 < input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less,
+                            })) &&
+                        (7 > input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less",
                             expected: "number",
                             value: input.greater_less,
                         })) &&
                     (("number" === typeof input.greater_equal_less &&
-                        3 <= input.greater_equal_less &&
-                        7 > input.greater_equal_less) ||
+                        (3 <= input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less,
+                            })) &&
+                        (7 > input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_equal_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less",
                             expected: "number",
                             value: input.greater_equal_less,
                         })) &&
                     (("number" === typeof input.greater_less_equal &&
-                        3 < input.greater_less_equal &&
-                        7 >= input.greater_less_equal) ||
+                        (3 < input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        (7 >= input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less_equal",
                             expected: "number",
                             value: input.greater_less_equal,
                         })) &&
                     (("number" === typeof input.greater_equal_less_equal &&
-                        3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal) ||
+                        (3 <= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
+                        (7 >= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_equal_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",

--- a/test/generated/output/assertEquals/test_assertEquals_TagStep.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagStep.ts
@@ -20,34 +20,84 @@ export const test_assertEquals_TagStep = _test_assertEquals(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("number" === typeof input.exclusiveMinimum &&
-                        0 === (input.exclusiveMinimum % 5) - 3 &&
-                        3 < input.exclusiveMinimum) ||
+                        (0 === (input.exclusiveMinimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@step 5)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (3 < input.exclusiveMinimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.exclusiveMinimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".exclusiveMinimum",
                             expected: "number",
                             value: input.exclusiveMinimum,
                         })) &&
                     (("number" === typeof input.minimum &&
-                        0 === (input.minimum % 5) - 3 &&
-                        3 <= input.minimum) ||
+                        (0 === (input.minimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@step 5)",
+                                value: input.minimum,
+                            })) &&
+                        (3 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
                             value: input.minimum,
                         })) &&
                     (("number" === typeof input.range &&
-                        0 === (input.range % 5) - 0 &&
-                        0 < input.range &&
-                        100 > input.range) ||
+                        (0 === (input.range % 5) - 0 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@step 5)",
+                                value: input.range,
+                            })) &&
+                        (0 < input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMinimum 0)",
+                                value: input.range,
+                            })) &&
+                        (100 > input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMaximum 100)",
+                                value: input.range,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".range",
                             expected: "number",
                             value: input.range,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 5 &&
-                        3 <= input.multipleOf &&
-                        99 >= input.multipleOf) ||
+                        (0 === input.multipleOf % 5 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 5)",
+                                value: input.multipleOf,
+                            })) &&
+                        (3 <= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@minimum 3)",
+                                value: input.multipleOf,
+                            })) &&
+                        (99 >= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@maximum 99)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",

--- a/test/generated/output/assertEquals/test_assertEquals_TagTuple.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagTuple.ts
@@ -34,24 +34,54 @@ export const test_assertEquals_TagTuple = _test_assertEquals(
                             value: input.tuple,
                         })) &&
                     (("string" === typeof input.tuple[0] &&
-                        3 <= input.tuple[0].length &&
-                        7 >= input.tuple[0].length) ||
+                        (3 <= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@minLength 3)",
+                                value: input.tuple[0],
+                            })) &&
+                        (7 >= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@maxLength 7)",
+                                value: input.tuple[0],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[0]",
                             expected: "string",
                             value: input.tuple[0],
                         })) &&
                     (("number" === typeof input.tuple[1] &&
-                        3 <= input.tuple[1] &&
-                        7 >= input.tuple[1]) ||
+                        (3 <= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@minimum 3)",
+                                value: input.tuple[1],
+                            })) &&
+                        (7 >= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@maximum 7)",
+                                value: input.tuple[1],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[1]",
                             expected: "number",
                             value: input.tuple[1],
                         })) &&
                     ((Array.isArray(input.tuple[2]) &&
-                        3 <= input.tuple[2].length &&
-                        7 >= input.tuple[2].length) ||
+                        (3 <= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[2],
+                            })) &&
+                        (7 >= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[2],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[2]",
                             expected: "Array<string>",
@@ -60,8 +90,26 @@ export const test_assertEquals_TagTuple = _test_assertEquals(
                     input.tuple[2].every(
                         (elem: any, _index1: number) =>
                             ("string" === typeof elem &&
-                                3 <= elem.length &&
-                                7 >= elem.length) ||
+                                (3 <= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@minLength 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[2][" + _index1 + "]",
                                 expected: "string",
@@ -69,8 +117,18 @@ export const test_assertEquals_TagTuple = _test_assertEquals(
                             }),
                     ) &&
                     ((Array.isArray(input.tuple[3]) &&
-                        3 <= input.tuple[3].length &&
-                        7 >= input.tuple[3].length) ||
+                        (3 <= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[3],
+                            })) &&
+                        (7 >= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[3],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[3]",
                             expected: "Array<number>",
@@ -79,8 +137,26 @@ export const test_assertEquals_TagTuple = _test_assertEquals(
                     input.tuple[3].every(
                         (elem: any, _index2: number) =>
                             ("number" === typeof elem &&
-                                3 <= elem &&
-                                7 >= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[3][" + _index2 + "]",
                                 expected: "number",

--- a/test/generated/output/assertEquals/test_assertEquals_TagType.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagType.ts
@@ -21,7 +21,12 @@ export const test_assertEquals_TagType = _test_assertEquals(
                 ): boolean =>
                     (("number" === typeof input.int &&
                         Number.isFinite(input.int) &&
-                        parseInt(input.int) === input.int) ||
+                        (parseInt(input.int) === input.int ||
+                            $guard(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".int",
                             expected: "number",
@@ -29,8 +34,18 @@ export const test_assertEquals_TagType = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
-                        parseInt(input.uint) === input.uint &&
-                        0 <= input.uint) ||
+                        (parseInt(input.uint) === input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (0 <= input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uint",
                             expected: "number",

--- a/test/generated/output/assertParse/test_assertParse_TagArray.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagArray.ts
@@ -21,7 +21,12 @@ export const test_assertParse_TagArray = _test_assertParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ((Array.isArray(input.items) &&
-                            3 === input.items.length) ||
+                            (3 === input.items.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.items,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected: "Array<string>",
@@ -30,7 +35,16 @@ export const test_assertParse_TagArray = _test_assertParse(
                         input.items.every(
                             (elem: any, _index2: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".items[" + _index2 + "]",
                                     expected: "string",
@@ -38,7 +52,12 @@ export const test_assertParse_TagArray = _test_assertParse(
                                 }),
                         ) &&
                         ((Array.isArray(input.minItems) &&
-                            3 <= input.minItems.length) ||
+                            (3 <= input.minItems.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.minItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "Array<number>",
@@ -48,7 +67,16 @@ export const test_assertParse_TagArray = _test_assertParse(
                             (elem: any, _index3: number) =>
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem) &&
-                                    3 <= elem) ||
+                                    (3 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".minItems[" +
+                                                _index3 +
+                                                "]",
+                                            expected: "number (@minimum 3)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems[" + _index3 + "]",
                                     expected: "number",
@@ -56,7 +84,12 @@ export const test_assertParse_TagArray = _test_assertParse(
                                 }),
                         ) &&
                         ((Array.isArray(input.maxItems) &&
-                            7 >= input.maxItems.length) ||
+                            (7 >= input.maxItems.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.maxItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "Array<(number | string)>",
@@ -65,10 +98,28 @@ export const test_assertParse_TagArray = _test_assertParse(
                         input.maxItems.every(
                             (elem: any, _index4: number) =>
                                 ("string" === typeof elem &&
-                                    7 >= elem.length) ||
+                                    (7 >= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".maxItems[" +
+                                                _index4 +
+                                                "]",
+                                            expected: "string (@maxLength 7)",
+                                            value: elem,
+                                        }))) ||
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem) &&
-                                    7 >= elem) ||
+                                    (7 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".maxItems[" +
+                                                _index4 +
+                                                "]",
+                                            expected: "number (@maximum 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems[" + _index4 + "]",
                                     expected: "(number | string)",
@@ -76,8 +127,18 @@ export const test_assertParse_TagArray = _test_assertParse(
                                 }),
                         ) &&
                         ((Array.isArray(input.both) &&
-                            3 <= input.both.length &&
-                            7 >= input.both.length) ||
+                            (3 <= input.both.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.both,
+                                })) &&
+                            (7 >= input.both.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.both,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".both",
                                 expected: "Array<string>",
@@ -86,7 +147,16 @@ export const test_assertParse_TagArray = _test_assertParse(
                         input.both.every(
                             (elem: any, _index5: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".both[" +
+                                                _index5 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".both[" + _index5 + "]",
                                     expected: "string",

--- a/test/generated/output/assertParse/test_assertParse_TagAtomicUnion.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagAtomicUnion.ts
@@ -20,11 +20,26 @@ export const test_assertParse_TagAtomicUnion = _test_assertParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "(number | string)",

--- a/test/generated/output/assertParse/test_assertParse_TagCustom.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagCustom.ts
@@ -22,31 +22,41 @@ export const test_assertParse_TagCustom = _test_assertParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.id &&
-                            true === $is_uuid(input.id)) ||
+                            (true === $is_uuid(input.id) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string (@format uuid)",
+                                    value: input.id,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".id",
                                 expected: "string",
                                 value: input.id,
                             })) &&
-                        (("string" === typeof input.dolloar &&
-                            $is_custom(
-                                "dollar",
-                                "string",
-                                "",
-                                input.dolloar,
-                            )) ||
+                        (("string" === typeof input.dollar &&
+                            ($is_custom("dollar", "string", "", input.dollar) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".dollar",
+                                    expected: "string (@dollar)",
+                                    value: input.dollar,
+                                }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".dolloar",
+                                path: _path + ".dollar",
                                 expected: "string",
-                                value: input.dolloar,
+                                value: input.dollar,
                             })) &&
                         (("string" === typeof input.postfix &&
-                            $is_custom(
+                            ($is_custom(
                                 "postfix",
                                 "string",
                                 "abcd",
                                 input.postfix,
-                            )) ||
+                            ) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string (@postfix abcd)",
+                                    value: input.postfix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected: "string",
@@ -54,7 +64,12 @@ export const test_assertParse_TagCustom = _test_assertParse(
                             })) &&
                         (("number" === typeof input.log &&
                             Number.isFinite(input.log) &&
-                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            ($is_custom("powerOf", "number", "10", input.log) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number (@powerOf 10)",
+                                    value: input.log,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".log",
                                 expected: "number",

--- a/test/generated/output/assertParse/test_assertParse_TagFormat.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagFormat.ts
@@ -27,63 +27,108 @@ export const test_assertParse_TagFormat = _test_assertParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.uuid &&
-                            true === $is_uuid(input.uuid)) ||
+                            (true === $is_uuid(input.uuid) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected: "string (@format uuid)",
+                                    value: input.uuid,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             })) &&
                         (("string" === typeof input.email &&
-                            true === $is_email(input.email)) ||
+                            (true === $is_email(input.email) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected: "string (@format email)",
+                                    value: input.email,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             })) &&
                         (("string" === typeof input.url &&
-                            true === $is_url(input.url)) ||
+                            (true === $is_url(input.url) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".url",
+                                    expected: "string (@format url)",
+                                    value: input.url,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".url",
                                 expected: "string",
                                 value: input.url,
                             })) &&
                         (("string" === typeof input.ipv4 &&
-                            true === $is_ipv4(input.ipv4)) ||
+                            (true === $is_ipv4(input.ipv4) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected: "string (@format ipv4)",
+                                    value: input.ipv4,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             })) &&
                         (("string" === typeof input.ipv6 &&
-                            true === $is_ipv6(input.ipv6)) ||
+                            (true === $is_ipv6(input.ipv6) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected: "string (@format ipv6)",
+                                    value: input.ipv6,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",
                                 value: input.ipv6,
                             })) &&
                         (("string" === typeof input.date &&
-                            true === $is_date(input.date)) ||
+                            (true === $is_date(input.date) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".date",
+                                    expected: "string (@format date)",
+                                    value: input.date,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".date",
                                 expected: "string",
                                 value: input.date,
                             })) &&
                         (("string" === typeof input.date_time &&
-                            true === $is_datetime(input.date_time)) ||
+                            (true === $is_datetime(input.date_time) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".date_time",
+                                    expected: "string (@format datetime)",
+                                    value: input.date_time,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".date_time",
                                 expected: "string",
                                 value: input.date_time,
                             })) &&
                         (("string" === typeof input.datetime &&
-                            true === $is_datetime(input.datetime)) ||
+                            (true === $is_datetime(input.datetime) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".datetime",
+                                    expected: "string (@format datetime)",
+                                    value: input.datetime,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".datetime",
                                 expected: "string",
                                 value: input.datetime,
                             })) &&
                         (("string" === typeof input.dateTime &&
-                            true === $is_datetime(input.dateTime)) ||
+                            (true === $is_datetime(input.dateTime) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".dateTime",
+                                    expected: "string (@format datetime)",
+                                    value: input.dateTime,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".dateTime",
                                 expected: "string",

--- a/test/generated/output/assertParse/test_assertParse_TagLength.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagLength.ts
@@ -20,29 +20,54 @@ export const test_assertParse_TagLength = _test_assertParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.fixed &&
-                            5 === input.fixed.length) ||
+                            (5 === input.fixed.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".fixed",
+                                    expected: "string (@length 5)",
+                                    value: input.fixed,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".fixed",
                                 expected: "string",
                                 value: input.fixed,
                             })) &&
                         (("string" === typeof input.minimum &&
-                            3 <= input.minimum.length) ||
+                            (3 <= input.minimum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "string",
                                 value: input.minimum,
                             })) &&
                         (("string" === typeof input.maximum &&
-                            7 >= input.maximum.length) ||
+                            (7 >= input.maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "string",
                                 value: input.maximum,
                             })) &&
                         (("string" === typeof input.minimum_and_maximum &&
-                            3 <= input.minimum_and_maximum.length &&
-                            7 >= input.minimum_and_maximum.length) ||
+                            (3 <= input.minimum_and_maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum_and_maximum,
+                                })) &&
+                            (7 >= input.minimum_and_maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.minimum_and_maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",

--- a/test/generated/output/assertParse/test_assertParse_TagMatrix.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagMatrix.ts
@@ -21,7 +21,12 @@ export const test_assertParse_TagMatrix = _test_assertParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ((Array.isArray(input.matrix) &&
-                            3 === input.matrix.length) ||
+                            (3 === input.matrix.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".matrix",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.matrix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".matrix",
                                 expected: "Array<Array<string>>",
@@ -29,7 +34,17 @@ export const test_assertParse_TagMatrix = _test_assertParse(
                             })) &&
                         input.matrix.every(
                             (elem: any, _index1: number) =>
-                                ((Array.isArray(elem) && 3 === elem.length) ||
+                                ((Array.isArray(elem) &&
+                                    (3 === elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".matrix[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "Array.length (@items 3)",
+                                            value: elem,
+                                        }))) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path + ".matrix[" + _index1 + "]",
@@ -39,7 +54,19 @@ export const test_assertParse_TagMatrix = _test_assertParse(
                                 elem.every(
                                     (elem: any, _index2: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".matrix[" +
+                                                        _index1 +
+                                                        "][" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +

--- a/test/generated/output/assertParse/test_assertParse_TagObjectUnion.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagObjectUnion.ts
@@ -21,7 +21,12 @@ export const test_assertParse_TagObjectUnion = _test_assertParse(
                     ): boolean =>
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "number",
@@ -33,8 +38,18 @@ export const test_assertParse_TagObjectUnion = _test_assertParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "string",

--- a/test/generated/output/assertParse/test_assertParse_TagPattern.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagPattern.ts
@@ -20,40 +20,64 @@ export const test_assertParse_TagPattern = _test_assertParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.uuid &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                ).test(input.uuid)) ||
+                                ).test(input.uuid) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected:
+                                        "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                    value: input.uuid,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             })) &&
                         (("string" === typeof input.email &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                ).test(input.email)) ||
+                                ).test(input.email) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected:
+                                        'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                    value: input.email,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             })) &&
                         (("string" === typeof input.ipv4 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                ).test(input.ipv4)) ||
+                                ).test(input.ipv4) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected:
+                                        "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                    value: input.ipv4,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             })) &&
                         (("string" === typeof input.ipv6 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                ).test(input.ipv6)) ||
+                                ).test(input.ipv6) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected:
+                                        "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                    value: input.ipv6,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",

--- a/test/generated/output/assertParse/test_assertParse_TagRange.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagRange.ts
@@ -21,7 +21,12 @@ export const test_assertParse_TagRange = _test_assertParse(
                     ): boolean =>
                         (("number" === typeof input.greater &&
                             Number.isFinite(input.greater) &&
-                            3 < input.greater) ||
+                            (3 < input.greater ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater",
                                 expected: "number",
@@ -29,7 +34,12 @@ export const test_assertParse_TagRange = _test_assertParse(
                             })) &&
                         (("number" === typeof input.greater_equal &&
                             Number.isFinite(input.greater_equal) &&
-                            3 <= input.greater_equal) ||
+                            (3 <= input.greater_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number",
@@ -37,7 +47,12 @@ export const test_assertParse_TagRange = _test_assertParse(
                             })) &&
                         (("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
-                            7 > input.less) ||
+                            (7 > input.less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".less",
                                 expected: "number",
@@ -45,39 +60,84 @@ export const test_assertParse_TagRange = _test_assertParse(
                             })) &&
                         (("number" === typeof input.less_equal &&
                             Number.isFinite(input.less_equal) &&
-                            7 >= input.less_equal) ||
+                            (7 >= input.less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".less_equal",
                                 expected: "number",
                                 value: input.less_equal,
                             })) &&
                         (("number" === typeof input.greater_less &&
-                            3 < input.greater_less &&
-                            7 > input.greater_less) ||
+                            (3 < input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less,
+                                })) &&
+                            (7 > input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number",
                                 value: input.greater_less,
                             })) &&
                         (("number" === typeof input.greater_equal_less &&
-                            3 <= input.greater_equal_less &&
-                            7 > input.greater_equal_less) ||
+                            (3 <= input.greater_equal_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less,
+                                })) &&
+                            (7 > input.greater_equal_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_equal_less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less",
                                 expected: "number",
                                 value: input.greater_equal_less,
                             })) &&
                         (("number" === typeof input.greater_less_equal &&
-                            3 < input.greater_less_equal &&
-                            7 >= input.greater_less_equal) ||
+                            (3 < input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            (7 >= input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number",
                                 value: input.greater_less_equal,
                             })) &&
                         (("number" === typeof input.greater_equal_less_equal &&
-                            3 <= input.greater_equal_less_equal &&
-                            7 >= input.greater_equal_less_equal) ||
+                            (3 <= input.greater_equal_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
+                            (7 >= input.greater_equal_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_equal_less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",

--- a/test/generated/output/assertParse/test_assertParse_TagStep.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagStep.ts
@@ -20,34 +20,84 @@ export const test_assertParse_TagStep = _test_assertParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("number" === typeof input.exclusiveMinimum &&
-                            0 === (input.exclusiveMinimum % 5) - 3 &&
-                            3 < input.exclusiveMinimum) ||
+                            (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@step 5)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (3 < input.exclusiveMinimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.exclusiveMinimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".exclusiveMinimum",
                                 expected: "number",
                                 value: input.exclusiveMinimum,
                             })) &&
                         (("number" === typeof input.minimum &&
-                            0 === (input.minimum % 5) - 3 &&
-                            3 <= input.minimum) ||
+                            (0 === (input.minimum % 5) - 3 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@step 5)",
+                                    value: input.minimum,
+                                })) &&
+                            (3 <= input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
                                 value: input.minimum,
                             })) &&
                         (("number" === typeof input.range &&
-                            0 === (input.range % 5) - 0 &&
-                            0 < input.range &&
-                            100 > input.range) ||
+                            (0 === (input.range % 5) - 0 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@step 5)",
+                                    value: input.range,
+                                })) &&
+                            (0 < input.range ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMinimum 0)",
+                                    value: input.range,
+                                })) &&
+                            (100 > input.range ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMaximum 100)",
+                                    value: input.range,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".range",
                                 expected: "number",
                                 value: input.range,
                             })) &&
                         (("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 5 &&
-                            3 <= input.multipleOf &&
-                            99 >= input.multipleOf) ||
+                            (0 === input.multipleOf % 5 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 5)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (3 <= input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@minimum 3)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (99 >= input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@maximum 99)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",

--- a/test/generated/output/assertParse/test_assertParse_TagTuple.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagTuple.ts
@@ -34,24 +34,54 @@ export const test_assertParse_TagTuple = _test_assertParse(
                                 value: input.tuple,
                             })) &&
                         (("string" === typeof input.tuple[0] &&
-                            3 <= input.tuple[0].length &&
-                            7 >= input.tuple[0].length) ||
+                            (3 <= input.tuple[0].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[0]",
+                                    expected: "string (@minLength 3)",
+                                    value: input.tuple[0],
+                                })) &&
+                            (7 >= input.tuple[0].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[0]",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.tuple[0],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[0]",
                                 expected: "string",
                                 value: input.tuple[0],
                             })) &&
                         (("number" === typeof input.tuple[1] &&
-                            3 <= input.tuple[1] &&
-                            7 >= input.tuple[1]) ||
+                            (3 <= input.tuple[1] ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[1]",
+                                    expected: "number (@minimum 3)",
+                                    value: input.tuple[1],
+                                })) &&
+                            (7 >= input.tuple[1] ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[1]",
+                                    expected: "number (@maximum 7)",
+                                    value: input.tuple[1],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[1]",
                                 expected: "number",
                                 value: input.tuple[1],
                             })) &&
                         ((Array.isArray(input.tuple[2]) &&
-                            3 <= input.tuple[2].length &&
-                            7 >= input.tuple[2].length) ||
+                            (3 <= input.tuple[2].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2]",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.tuple[2],
+                                })) &&
+                            (7 >= input.tuple[2].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2]",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.tuple[2],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[2]",
                                 expected: "Array<string>",
@@ -60,8 +90,26 @@ export const test_assertParse_TagTuple = _test_assertParse(
                         input.tuple[2].every(
                             (elem: any, _index1: number) =>
                                 ("string" === typeof elem &&
-                                    3 <= elem.length &&
-                                    7 >= elem.length) ||
+                                    (3 <= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[2][" +
+                                                _index1 +
+                                                "]",
+                                            expected: "string (@minLength 3)",
+                                            value: elem,
+                                        })) &&
+                                    (7 >= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[2][" +
+                                                _index1 +
+                                                "]",
+                                            expected: "string (@maxLength 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".tuple[2][" + _index1 + "]",
                                     expected: "string",
@@ -69,8 +117,18 @@ export const test_assertParse_TagTuple = _test_assertParse(
                                 }),
                         ) &&
                         ((Array.isArray(input.tuple[3]) &&
-                            3 <= input.tuple[3].length &&
-                            7 >= input.tuple[3].length) ||
+                            (3 <= input.tuple[3].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3]",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.tuple[3],
+                                })) &&
+                            (7 >= input.tuple[3].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3]",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.tuple[3],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[3]",
                                 expected: "Array<number>",
@@ -79,8 +137,26 @@ export const test_assertParse_TagTuple = _test_assertParse(
                         input.tuple[3].every(
                             (elem: any, _index2: number) =>
                                 ("number" === typeof elem &&
-                                    3 <= elem &&
-                                    7 >= elem) ||
+                                    (3 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[3][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number (@minimum 3)",
+                                            value: elem,
+                                        })) &&
+                                    (7 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[3][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number (@maximum 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".tuple[3][" + _index2 + "]",
                                     expected: "number",

--- a/test/generated/output/assertParse/test_assertParse_TagType.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagType.ts
@@ -21,7 +21,12 @@ export const test_assertParse_TagType = _test_assertParse(
                     ): boolean =>
                         (("number" === typeof input.int &&
                             Number.isFinite(input.int) &&
-                            parseInt(input.int) === input.int) ||
+                            (parseInt(input.int) === input.int ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".int",
                                 expected: "number",
@@ -29,8 +34,18 @@ export const test_assertParse_TagType = _test_assertParse(
                             })) &&
                         (("number" === typeof input.uint &&
                             Number.isFinite(input.uint) &&
-                            parseInt(input.uint) === input.uint &&
-                            0 <= input.uint) ||
+                            (parseInt(input.uint) === input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (0 <= input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number",

--- a/test/generated/output/assertParse/test_assertParse_UltimateUnion.ts
+++ b/test/generated/output/assertParse/test_assertParse_UltimateUnion.ts
@@ -940,7 +940,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                parseInt(input.minimum) === input.minimum) ||
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -949,7 +954,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                parseInt(input.maximum) === input.maximum) ||
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -972,8 +982,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
-                                parseInt(input.multipleOf) ===
-                                    input.multipleOf) ||
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -1264,8 +1279,19 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
-                                parseInt(input.minLength) === input.minLength &&
-                                0 <= input.minLength) ||
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
                                 expected: "(number | undefined)",
@@ -1274,8 +1300,19 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
-                                parseInt(input.maxLength) === input.maxLength &&
-                                0 <= input.maxLength) ||
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxLength",
                                 expected: "(number | undefined)",
@@ -1433,8 +1470,18 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input.minItems ||
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
-                                parseInt(input.minItems) === input.minItems &&
-                                0 <= input.minItems) ||
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "(number | undefined)",
@@ -1443,8 +1490,18 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
-                                parseInt(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems) ||
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",

--- a/test/generated/output/assertPrune/test_assertPrune_TagArray.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagArray.ts
@@ -21,7 +21,12 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ((Array.isArray(input.items) &&
-                            3 === input.items.length) ||
+                            (3 === input.items.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.items,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected: "Array<string>",
@@ -30,7 +35,16 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                         input.items.every(
                             (elem: any, _index2: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".items[" + _index2 + "]",
                                     expected: "string",
@@ -38,7 +52,12 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                                 }),
                         ) &&
                         ((Array.isArray(input.minItems) &&
-                            3 <= input.minItems.length) ||
+                            (3 <= input.minItems.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.minItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "Array<number>",
@@ -48,7 +67,16 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                             (elem: any, _index3: number) =>
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem) &&
-                                    3 <= elem) ||
+                                    (3 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".minItems[" +
+                                                _index3 +
+                                                "]",
+                                            expected: "number (@minimum 3)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems[" + _index3 + "]",
                                     expected: "number",
@@ -56,7 +84,12 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                                 }),
                         ) &&
                         ((Array.isArray(input.maxItems) &&
-                            7 >= input.maxItems.length) ||
+                            (7 >= input.maxItems.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.maxItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "Array<(number | string)>",
@@ -65,10 +98,28 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                         input.maxItems.every(
                             (elem: any, _index4: number) =>
                                 ("string" === typeof elem &&
-                                    7 >= elem.length) ||
+                                    (7 >= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".maxItems[" +
+                                                _index4 +
+                                                "]",
+                                            expected: "string (@maxLength 7)",
+                                            value: elem,
+                                        }))) ||
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem) &&
-                                    7 >= elem) ||
+                                    (7 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".maxItems[" +
+                                                _index4 +
+                                                "]",
+                                            expected: "number (@maximum 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems[" + _index4 + "]",
                                     expected: "(number | string)",
@@ -76,8 +127,18 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                                 }),
                         ) &&
                         ((Array.isArray(input.both) &&
-                            3 <= input.both.length &&
-                            7 >= input.both.length) ||
+                            (3 <= input.both.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.both,
+                                })) &&
+                            (7 >= input.both.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.both,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".both",
                                 expected: "Array<string>",
@@ -86,7 +147,16 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                         input.both.every(
                             (elem: any, _index5: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".both[" +
+                                                _index5 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".both[" + _index5 + "]",
                                     expected: "string",

--- a/test/generated/output/assertPrune/test_assertPrune_TagAtomicUnion.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagAtomicUnion.ts
@@ -20,11 +20,26 @@ export const test_assertPrune_TagAtomicUnion = _test_assertPrune(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "(number | string)",

--- a/test/generated/output/assertPrune/test_assertPrune_TagBigInt.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagBigInt.ts
@@ -26,29 +26,54 @@ export const test_assertPrune_TagBigInt = _test_assertPrune(
                                 value: input.value,
                             })) &&
                         (("bigint" === typeof input.ranged &&
-                            0n <= input.ranged &&
-                            100n >= input.ranged) ||
+                            (0n <= input.ranged ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "bigint (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100n >= input.ranged ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "bigint (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "bigint",
                                 value: input.ranged,
                             })) &&
                         (("bigint" === typeof input.minimum &&
-                            0n <= input.minimum) ||
+                            (0n <= input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "bigint (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "bigint",
                                 value: input.minimum,
                             })) &&
                         (("bigint" === typeof input.maximum &&
-                            100n >= input.maximum) ||
+                            (100n >= input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "bigint (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "bigint",
                                 value: input.maximum,
                             })) &&
                         (("bigint" === typeof input.multipleOf &&
-                            0n === input.multipleOf % 3n) ||
+                            (0n === input.multipleOf % 3n ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "bigint (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "bigint",

--- a/test/generated/output/assertPrune/test_assertPrune_TagCustom.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagCustom.ts
@@ -22,31 +22,41 @@ export const test_assertPrune_TagCustom = _test_assertPrune(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.id &&
-                            true === $is_uuid(input.id)) ||
+                            (true === $is_uuid(input.id) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string (@format uuid)",
+                                    value: input.id,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".id",
                                 expected: "string",
                                 value: input.id,
                             })) &&
-                        (("string" === typeof input.dolloar &&
-                            $is_custom(
-                                "dollar",
-                                "string",
-                                "",
-                                input.dolloar,
-                            )) ||
+                        (("string" === typeof input.dollar &&
+                            ($is_custom("dollar", "string", "", input.dollar) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".dollar",
+                                    expected: "string (@dollar)",
+                                    value: input.dollar,
+                                }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".dolloar",
+                                path: _path + ".dollar",
                                 expected: "string",
-                                value: input.dolloar,
+                                value: input.dollar,
                             })) &&
                         (("string" === typeof input.postfix &&
-                            $is_custom(
+                            ($is_custom(
                                 "postfix",
                                 "string",
                                 "abcd",
                                 input.postfix,
-                            )) ||
+                            ) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string (@postfix abcd)",
+                                    value: input.postfix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected: "string",
@@ -54,7 +64,12 @@ export const test_assertPrune_TagCustom = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.log &&
                             Number.isFinite(input.log) &&
-                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            ($is_custom("powerOf", "number", "10", input.log) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number (@powerOf 10)",
+                                    value: input.log,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".log",
                                 expected: "number",
@@ -79,7 +94,7 @@ export const test_assertPrune_TagCustom = _test_assertPrune(
                     for (const key of Object.keys(input)) {
                         if (
                             "id" === key ||
-                            "dolloar" === key ||
+                            "dollar" === key ||
                             "postfix" === key ||
                             "log" === key
                         )

--- a/test/generated/output/assertPrune/test_assertPrune_TagFormat.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagFormat.ts
@@ -27,63 +27,108 @@ export const test_assertPrune_TagFormat = _test_assertPrune(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.uuid &&
-                            true === $is_uuid(input.uuid)) ||
+                            (true === $is_uuid(input.uuid) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected: "string (@format uuid)",
+                                    value: input.uuid,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             })) &&
                         (("string" === typeof input.email &&
-                            true === $is_email(input.email)) ||
+                            (true === $is_email(input.email) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected: "string (@format email)",
+                                    value: input.email,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             })) &&
                         (("string" === typeof input.url &&
-                            true === $is_url(input.url)) ||
+                            (true === $is_url(input.url) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".url",
+                                    expected: "string (@format url)",
+                                    value: input.url,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".url",
                                 expected: "string",
                                 value: input.url,
                             })) &&
                         (("string" === typeof input.ipv4 &&
-                            true === $is_ipv4(input.ipv4)) ||
+                            (true === $is_ipv4(input.ipv4) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected: "string (@format ipv4)",
+                                    value: input.ipv4,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             })) &&
                         (("string" === typeof input.ipv6 &&
-                            true === $is_ipv6(input.ipv6)) ||
+                            (true === $is_ipv6(input.ipv6) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected: "string (@format ipv6)",
+                                    value: input.ipv6,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",
                                 value: input.ipv6,
                             })) &&
                         (("string" === typeof input.date &&
-                            true === $is_date(input.date)) ||
+                            (true === $is_date(input.date) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".date",
+                                    expected: "string (@format date)",
+                                    value: input.date,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".date",
                                 expected: "string",
                                 value: input.date,
                             })) &&
                         (("string" === typeof input.date_time &&
-                            true === $is_datetime(input.date_time)) ||
+                            (true === $is_datetime(input.date_time) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".date_time",
+                                    expected: "string (@format datetime)",
+                                    value: input.date_time,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".date_time",
                                 expected: "string",
                                 value: input.date_time,
                             })) &&
                         (("string" === typeof input.datetime &&
-                            true === $is_datetime(input.datetime)) ||
+                            (true === $is_datetime(input.datetime) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".datetime",
+                                    expected: "string (@format datetime)",
+                                    value: input.datetime,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".datetime",
                                 expected: "string",
                                 value: input.datetime,
                             })) &&
                         (("string" === typeof input.dateTime &&
-                            true === $is_datetime(input.dateTime)) ||
+                            (true === $is_datetime(input.dateTime) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".dateTime",
+                                    expected: "string (@format datetime)",
+                                    value: input.dateTime,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".dateTime",
                                 expected: "string",

--- a/test/generated/output/assertPrune/test_assertPrune_TagInfinite.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagInfinite.ts
@@ -27,8 +27,18 @@ export const test_assertPrune_TagInfinite = _test_assertPrune(
                                 value: input.value,
                             })) &&
                         (("number" === typeof input.ranged &&
-                            0 <= input.ranged &&
-                            100 >= input.ranged) ||
+                            (0 <= input.ranged ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100 >= input.ranged ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "number",
@@ -36,7 +46,12 @@ export const test_assertPrune_TagInfinite = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            0 <= input.minimum) ||
+                            (0 <= input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
@@ -44,14 +59,24 @@ export const test_assertPrune_TagInfinite = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            100 >= input.maximum) ||
+                            (100 >= input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "number",
                                 value: input.maximum,
                             })) &&
                         (("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 3) ||
+                            (0 === input.multipleOf % 3 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",
@@ -59,7 +84,12 @@ export const test_assertPrune_TagInfinite = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
-                            parseInt(input.typed) === input.typed) ||
+                            (parseInt(input.typed) === input.typed ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number",

--- a/test/generated/output/assertPrune/test_assertPrune_TagLength.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagLength.ts
@@ -20,29 +20,54 @@ export const test_assertPrune_TagLength = _test_assertPrune(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.fixed &&
-                            5 === input.fixed.length) ||
+                            (5 === input.fixed.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".fixed",
+                                    expected: "string (@length 5)",
+                                    value: input.fixed,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".fixed",
                                 expected: "string",
                                 value: input.fixed,
                             })) &&
                         (("string" === typeof input.minimum &&
-                            3 <= input.minimum.length) ||
+                            (3 <= input.minimum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "string",
                                 value: input.minimum,
                             })) &&
                         (("string" === typeof input.maximum &&
-                            7 >= input.maximum.length) ||
+                            (7 >= input.maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "string",
                                 value: input.maximum,
                             })) &&
                         (("string" === typeof input.minimum_and_maximum &&
-                            3 <= input.minimum_and_maximum.length &&
-                            7 >= input.minimum_and_maximum.length) ||
+                            (3 <= input.minimum_and_maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum_and_maximum,
+                                })) &&
+                            (7 >= input.minimum_and_maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.minimum_and_maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",

--- a/test/generated/output/assertPrune/test_assertPrune_TagMatrix.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagMatrix.ts
@@ -21,7 +21,12 @@ export const test_assertPrune_TagMatrix = _test_assertPrune(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ((Array.isArray(input.matrix) &&
-                            3 === input.matrix.length) ||
+                            (3 === input.matrix.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".matrix",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.matrix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".matrix",
                                 expected: "Array<Array<string>>",
@@ -29,7 +34,17 @@ export const test_assertPrune_TagMatrix = _test_assertPrune(
                             })) &&
                         input.matrix.every(
                             (elem: any, _index1: number) =>
-                                ((Array.isArray(elem) && 3 === elem.length) ||
+                                ((Array.isArray(elem) &&
+                                    (3 === elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".matrix[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "Array.length (@items 3)",
+                                            value: elem,
+                                        }))) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path + ".matrix[" + _index1 + "]",
@@ -39,7 +54,19 @@ export const test_assertPrune_TagMatrix = _test_assertPrune(
                                 elem.every(
                                     (elem: any, _index2: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".matrix[" +
+                                                        _index1 +
+                                                        "][" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +

--- a/test/generated/output/assertPrune/test_assertPrune_TagNaN.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagNaN.ts
@@ -27,8 +27,18 @@ export const test_assertPrune_TagNaN = _test_assertPrune(
                                 value: input.value,
                             })) &&
                         (("number" === typeof input.ranged &&
-                            0 <= input.ranged &&
-                            100 >= input.ranged) ||
+                            (0 <= input.ranged ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100 >= input.ranged ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "number",
@@ -36,7 +46,12 @@ export const test_assertPrune_TagNaN = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            0 <= input.minimum) ||
+                            (0 <= input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
@@ -44,14 +59,24 @@ export const test_assertPrune_TagNaN = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            100 >= input.maximum) ||
+                            (100 >= input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "number",
                                 value: input.maximum,
                             })) &&
                         (("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 3) ||
+                            (0 === input.multipleOf % 3 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",
@@ -59,7 +84,12 @@ export const test_assertPrune_TagNaN = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
-                            parseInt(input.typed) === input.typed) ||
+                            (parseInt(input.typed) === input.typed ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number",

--- a/test/generated/output/assertPrune/test_assertPrune_TagObjectUnion.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagObjectUnion.ts
@@ -21,7 +21,12 @@ export const test_assertPrune_TagObjectUnion = _test_assertPrune(
                     ): boolean =>
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "number",
@@ -33,8 +38,18 @@ export const test_assertPrune_TagObjectUnion = _test_assertPrune(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "string",

--- a/test/generated/output/assertPrune/test_assertPrune_TagPattern.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagPattern.ts
@@ -20,40 +20,64 @@ export const test_assertPrune_TagPattern = _test_assertPrune(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.uuid &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                ).test(input.uuid)) ||
+                                ).test(input.uuid) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected:
+                                        "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                    value: input.uuid,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             })) &&
                         (("string" === typeof input.email &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                ).test(input.email)) ||
+                                ).test(input.email) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected:
+                                        'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                    value: input.email,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             })) &&
                         (("string" === typeof input.ipv4 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                ).test(input.ipv4)) ||
+                                ).test(input.ipv4) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected:
+                                        "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                    value: input.ipv4,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             })) &&
                         (("string" === typeof input.ipv6 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                ).test(input.ipv6)) ||
+                                ).test(input.ipv6) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected:
+                                        "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                    value: input.ipv6,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",

--- a/test/generated/output/assertPrune/test_assertPrune_TagRange.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagRange.ts
@@ -21,7 +21,12 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                     ): boolean =>
                         (("number" === typeof input.greater &&
                             Number.isFinite(input.greater) &&
-                            3 < input.greater) ||
+                            (3 < input.greater ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater",
                                 expected: "number",
@@ -29,7 +34,12 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.greater_equal &&
                             Number.isFinite(input.greater_equal) &&
-                            3 <= input.greater_equal) ||
+                            (3 <= input.greater_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number",
@@ -37,7 +47,12 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
-                            7 > input.less) ||
+                            (7 > input.less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".less",
                                 expected: "number",
@@ -45,39 +60,84 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.less_equal &&
                             Number.isFinite(input.less_equal) &&
-                            7 >= input.less_equal) ||
+                            (7 >= input.less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".less_equal",
                                 expected: "number",
                                 value: input.less_equal,
                             })) &&
                         (("number" === typeof input.greater_less &&
-                            3 < input.greater_less &&
-                            7 > input.greater_less) ||
+                            (3 < input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less,
+                                })) &&
+                            (7 > input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number",
                                 value: input.greater_less,
                             })) &&
                         (("number" === typeof input.greater_equal_less &&
-                            3 <= input.greater_equal_less &&
-                            7 > input.greater_equal_less) ||
+                            (3 <= input.greater_equal_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less,
+                                })) &&
+                            (7 > input.greater_equal_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_equal_less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less",
                                 expected: "number",
                                 value: input.greater_equal_less,
                             })) &&
                         (("number" === typeof input.greater_less_equal &&
-                            3 < input.greater_less_equal &&
-                            7 >= input.greater_less_equal) ||
+                            (3 < input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            (7 >= input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number",
                                 value: input.greater_less_equal,
                             })) &&
                         (("number" === typeof input.greater_equal_less_equal &&
-                            3 <= input.greater_equal_less_equal &&
-                            7 >= input.greater_equal_less_equal) ||
+                            (3 <= input.greater_equal_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
+                            (7 >= input.greater_equal_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_equal_less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",

--- a/test/generated/output/assertPrune/test_assertPrune_TagStep.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagStep.ts
@@ -20,34 +20,84 @@ export const test_assertPrune_TagStep = _test_assertPrune(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("number" === typeof input.exclusiveMinimum &&
-                            0 === (input.exclusiveMinimum % 5) - 3 &&
-                            3 < input.exclusiveMinimum) ||
+                            (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@step 5)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (3 < input.exclusiveMinimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.exclusiveMinimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".exclusiveMinimum",
                                 expected: "number",
                                 value: input.exclusiveMinimum,
                             })) &&
                         (("number" === typeof input.minimum &&
-                            0 === (input.minimum % 5) - 3 &&
-                            3 <= input.minimum) ||
+                            (0 === (input.minimum % 5) - 3 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@step 5)",
+                                    value: input.minimum,
+                                })) &&
+                            (3 <= input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
                                 value: input.minimum,
                             })) &&
                         (("number" === typeof input.range &&
-                            0 === (input.range % 5) - 0 &&
-                            0 < input.range &&
-                            100 > input.range) ||
+                            (0 === (input.range % 5) - 0 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@step 5)",
+                                    value: input.range,
+                                })) &&
+                            (0 < input.range ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMinimum 0)",
+                                    value: input.range,
+                                })) &&
+                            (100 > input.range ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMaximum 100)",
+                                    value: input.range,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".range",
                                 expected: "number",
                                 value: input.range,
                             })) &&
                         (("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 5 &&
-                            3 <= input.multipleOf &&
-                            99 >= input.multipleOf) ||
+                            (0 === input.multipleOf % 5 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 5)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (3 <= input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@minimum 3)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (99 >= input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@maximum 99)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",

--- a/test/generated/output/assertPrune/test_assertPrune_TagTuple.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagTuple.ts
@@ -34,24 +34,54 @@ export const test_assertPrune_TagTuple = _test_assertPrune(
                                 value: input.tuple,
                             })) &&
                         (("string" === typeof input.tuple[0] &&
-                            3 <= input.tuple[0].length &&
-                            7 >= input.tuple[0].length) ||
+                            (3 <= input.tuple[0].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[0]",
+                                    expected: "string (@minLength 3)",
+                                    value: input.tuple[0],
+                                })) &&
+                            (7 >= input.tuple[0].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[0]",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.tuple[0],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[0]",
                                 expected: "string",
                                 value: input.tuple[0],
                             })) &&
                         (("number" === typeof input.tuple[1] &&
-                            3 <= input.tuple[1] &&
-                            7 >= input.tuple[1]) ||
+                            (3 <= input.tuple[1] ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[1]",
+                                    expected: "number (@minimum 3)",
+                                    value: input.tuple[1],
+                                })) &&
+                            (7 >= input.tuple[1] ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[1]",
+                                    expected: "number (@maximum 7)",
+                                    value: input.tuple[1],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[1]",
                                 expected: "number",
                                 value: input.tuple[1],
                             })) &&
                         ((Array.isArray(input.tuple[2]) &&
-                            3 <= input.tuple[2].length &&
-                            7 >= input.tuple[2].length) ||
+                            (3 <= input.tuple[2].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2]",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.tuple[2],
+                                })) &&
+                            (7 >= input.tuple[2].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2]",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.tuple[2],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[2]",
                                 expected: "Array<string>",
@@ -60,8 +90,26 @@ export const test_assertPrune_TagTuple = _test_assertPrune(
                         input.tuple[2].every(
                             (elem: any, _index1: number) =>
                                 ("string" === typeof elem &&
-                                    3 <= elem.length &&
-                                    7 >= elem.length) ||
+                                    (3 <= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[2][" +
+                                                _index1 +
+                                                "]",
+                                            expected: "string (@minLength 3)",
+                                            value: elem,
+                                        })) &&
+                                    (7 >= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[2][" +
+                                                _index1 +
+                                                "]",
+                                            expected: "string (@maxLength 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".tuple[2][" + _index1 + "]",
                                     expected: "string",
@@ -69,8 +117,18 @@ export const test_assertPrune_TagTuple = _test_assertPrune(
                                 }),
                         ) &&
                         ((Array.isArray(input.tuple[3]) &&
-                            3 <= input.tuple[3].length &&
-                            7 >= input.tuple[3].length) ||
+                            (3 <= input.tuple[3].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3]",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.tuple[3],
+                                })) &&
+                            (7 >= input.tuple[3].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3]",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.tuple[3],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[3]",
                                 expected: "Array<number>",
@@ -79,8 +137,26 @@ export const test_assertPrune_TagTuple = _test_assertPrune(
                         input.tuple[3].every(
                             (elem: any, _index2: number) =>
                                 ("number" === typeof elem &&
-                                    3 <= elem &&
-                                    7 >= elem) ||
+                                    (3 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[3][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number (@minimum 3)",
+                                            value: elem,
+                                        })) &&
+                                    (7 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[3][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number (@maximum 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".tuple[3][" + _index2 + "]",
                                     expected: "number",

--- a/test/generated/output/assertPrune/test_assertPrune_TagType.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagType.ts
@@ -21,7 +21,12 @@ export const test_assertPrune_TagType = _test_assertPrune(
                     ): boolean =>
                         (("number" === typeof input.int &&
                             Number.isFinite(input.int) &&
-                            parseInt(input.int) === input.int) ||
+                            (parseInt(input.int) === input.int ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".int",
                                 expected: "number",
@@ -29,8 +34,18 @@ export const test_assertPrune_TagType = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.uint &&
                             Number.isFinite(input.uint) &&
-                            parseInt(input.uint) === input.uint &&
-                            0 <= input.uint) ||
+                            (parseInt(input.uint) === input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (0 <= input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number",

--- a/test/generated/output/assertStringify/test_assertStringify_TagArray.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagArray.ts
@@ -21,7 +21,12 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ((Array.isArray(input.items) &&
-                            3 === input.items.length) ||
+                            (3 === input.items.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.items,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected: "Array<string>",
@@ -30,7 +35,16 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                         input.items.every(
                             (elem: any, _index2: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".items[" + _index2 + "]",
                                     expected: "string",
@@ -38,7 +52,12 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                                 }),
                         ) &&
                         ((Array.isArray(input.minItems) &&
-                            3 <= input.minItems.length) ||
+                            (3 <= input.minItems.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.minItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "Array<number>",
@@ -48,7 +67,16 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                             (elem: any, _index3: number) =>
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem) &&
-                                    3 <= elem) ||
+                                    (3 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".minItems[" +
+                                                _index3 +
+                                                "]",
+                                            expected: "number (@minimum 3)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems[" + _index3 + "]",
                                     expected: "number",
@@ -56,7 +84,12 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                                 }),
                         ) &&
                         ((Array.isArray(input.maxItems) &&
-                            7 >= input.maxItems.length) ||
+                            (7 >= input.maxItems.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.maxItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "Array<(number | string)>",
@@ -65,10 +98,28 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                         input.maxItems.every(
                             (elem: any, _index4: number) =>
                                 ("string" === typeof elem &&
-                                    7 >= elem.length) ||
+                                    (7 >= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".maxItems[" +
+                                                _index4 +
+                                                "]",
+                                            expected: "string (@maxLength 7)",
+                                            value: elem,
+                                        }))) ||
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem) &&
-                                    7 >= elem) ||
+                                    (7 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".maxItems[" +
+                                                _index4 +
+                                                "]",
+                                            expected: "number (@maximum 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems[" + _index4 + "]",
                                     expected: "(number | string)",
@@ -76,8 +127,18 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                                 }),
                         ) &&
                         ((Array.isArray(input.both) &&
-                            3 <= input.both.length &&
-                            7 >= input.both.length) ||
+                            (3 <= input.both.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.both,
+                                })) &&
+                            (7 >= input.both.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.both,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".both",
                                 expected: "Array<string>",
@@ -86,7 +147,16 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                         input.both.every(
                             (elem: any, _index5: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".both[" +
+                                                _index5 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".both[" + _index5 + "]",
                                     expected: "string",

--- a/test/generated/output/assertStringify/test_assertStringify_TagAtomicUnion.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagAtomicUnion.ts
@@ -20,11 +20,26 @@ export const test_assertStringify_TagAtomicUnion = _test_assertStringify(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "(number | string)",

--- a/test/generated/output/assertStringify/test_assertStringify_TagCustom.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagCustom.ts
@@ -22,31 +22,41 @@ export const test_assertStringify_TagCustom = _test_assertStringify(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.id &&
-                            true === $is_uuid(input.id)) ||
+                            (true === $is_uuid(input.id) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string (@format uuid)",
+                                    value: input.id,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".id",
                                 expected: "string",
                                 value: input.id,
                             })) &&
-                        (("string" === typeof input.dolloar &&
-                            $is_custom(
-                                "dollar",
-                                "string",
-                                "",
-                                input.dolloar,
-                            )) ||
+                        (("string" === typeof input.dollar &&
+                            ($is_custom("dollar", "string", "", input.dollar) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".dollar",
+                                    expected: "string (@dollar)",
+                                    value: input.dollar,
+                                }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".dolloar",
+                                path: _path + ".dollar",
                                 expected: "string",
-                                value: input.dolloar,
+                                value: input.dollar,
                             })) &&
                         (("string" === typeof input.postfix &&
-                            $is_custom(
+                            ($is_custom(
                                 "postfix",
                                 "string",
                                 "abcd",
                                 input.postfix,
-                            )) ||
+                            ) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string (@postfix abcd)",
+                                    value: input.postfix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected: "string",
@@ -54,7 +64,12 @@ export const test_assertStringify_TagCustom = _test_assertStringify(
                             })) &&
                         (("number" === typeof input.log &&
                             Number.isFinite(input.log) &&
-                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            ($is_custom("powerOf", "number", "10", input.log) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number (@powerOf 10)",
+                                    value: input.log,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".log",
                                 expected: "number",
@@ -78,8 +93,8 @@ export const test_assertStringify_TagCustom = _test_assertStringify(
                 const $is_uuid = (typia.assertStringify as any).is_uuid;
                 const $is_custom = (typia.assertStringify as any).is_custom;
                 const $so0 = (input: any): any =>
-                    `{"id":${'"' + input.id + '"'},"dolloar":${$string(
-                        input.dolloar,
+                    `{"id":${'"' + input.id + '"'},"dollar":${$string(
+                        input.dollar,
                     )},"postfix":${$string(input.postfix)},"log":${$number(
                         input.log,
                     )}}`;

--- a/test/generated/output/assertStringify/test_assertStringify_TagFormat.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagFormat.ts
@@ -27,63 +27,108 @@ export const test_assertStringify_TagFormat = _test_assertStringify(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.uuid &&
-                            true === $is_uuid(input.uuid)) ||
+                            (true === $is_uuid(input.uuid) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected: "string (@format uuid)",
+                                    value: input.uuid,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             })) &&
                         (("string" === typeof input.email &&
-                            true === $is_email(input.email)) ||
+                            (true === $is_email(input.email) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected: "string (@format email)",
+                                    value: input.email,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             })) &&
                         (("string" === typeof input.url &&
-                            true === $is_url(input.url)) ||
+                            (true === $is_url(input.url) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".url",
+                                    expected: "string (@format url)",
+                                    value: input.url,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".url",
                                 expected: "string",
                                 value: input.url,
                             })) &&
                         (("string" === typeof input.ipv4 &&
-                            true === $is_ipv4(input.ipv4)) ||
+                            (true === $is_ipv4(input.ipv4) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected: "string (@format ipv4)",
+                                    value: input.ipv4,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             })) &&
                         (("string" === typeof input.ipv6 &&
-                            true === $is_ipv6(input.ipv6)) ||
+                            (true === $is_ipv6(input.ipv6) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected: "string (@format ipv6)",
+                                    value: input.ipv6,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",
                                 value: input.ipv6,
                             })) &&
                         (("string" === typeof input.date &&
-                            true === $is_date(input.date)) ||
+                            (true === $is_date(input.date) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".date",
+                                    expected: "string (@format date)",
+                                    value: input.date,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".date",
                                 expected: "string",
                                 value: input.date,
                             })) &&
                         (("string" === typeof input.date_time &&
-                            true === $is_datetime(input.date_time)) ||
+                            (true === $is_datetime(input.date_time) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".date_time",
+                                    expected: "string (@format datetime)",
+                                    value: input.date_time,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".date_time",
                                 expected: "string",
                                 value: input.date_time,
                             })) &&
                         (("string" === typeof input.datetime &&
-                            true === $is_datetime(input.datetime)) ||
+                            (true === $is_datetime(input.datetime) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".datetime",
+                                    expected: "string (@format datetime)",
+                                    value: input.datetime,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".datetime",
                                 expected: "string",
                                 value: input.datetime,
                             })) &&
                         (("string" === typeof input.dateTime &&
-                            true === $is_datetime(input.dateTime)) ||
+                            (true === $is_datetime(input.dateTime) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".dateTime",
+                                    expected: "string (@format datetime)",
+                                    value: input.dateTime,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".dateTime",
                                 expected: "string",

--- a/test/generated/output/assertStringify/test_assertStringify_TagLength.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagLength.ts
@@ -20,29 +20,54 @@ export const test_assertStringify_TagLength = _test_assertStringify(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.fixed &&
-                            5 === input.fixed.length) ||
+                            (5 === input.fixed.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".fixed",
+                                    expected: "string (@length 5)",
+                                    value: input.fixed,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".fixed",
                                 expected: "string",
                                 value: input.fixed,
                             })) &&
                         (("string" === typeof input.minimum &&
-                            3 <= input.minimum.length) ||
+                            (3 <= input.minimum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "string",
                                 value: input.minimum,
                             })) &&
                         (("string" === typeof input.maximum &&
-                            7 >= input.maximum.length) ||
+                            (7 >= input.maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "string",
                                 value: input.maximum,
                             })) &&
                         (("string" === typeof input.minimum_and_maximum &&
-                            3 <= input.minimum_and_maximum.length &&
-                            7 >= input.minimum_and_maximum.length) ||
+                            (3 <= input.minimum_and_maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum_and_maximum,
+                                })) &&
+                            (7 >= input.minimum_and_maximum.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.minimum_and_maximum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",

--- a/test/generated/output/assertStringify/test_assertStringify_TagMatrix.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagMatrix.ts
@@ -21,7 +21,12 @@ export const test_assertStringify_TagMatrix = _test_assertStringify(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ((Array.isArray(input.matrix) &&
-                            3 === input.matrix.length) ||
+                            (3 === input.matrix.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".matrix",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.matrix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".matrix",
                                 expected: "Array<Array<string>>",
@@ -29,7 +34,17 @@ export const test_assertStringify_TagMatrix = _test_assertStringify(
                             })) &&
                         input.matrix.every(
                             (elem: any, _index1: number) =>
-                                ((Array.isArray(elem) && 3 === elem.length) ||
+                                ((Array.isArray(elem) &&
+                                    (3 === elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".matrix[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "Array.length (@items 3)",
+                                            value: elem,
+                                        }))) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path + ".matrix[" + _index1 + "]",
@@ -39,7 +54,19 @@ export const test_assertStringify_TagMatrix = _test_assertStringify(
                                 elem.every(
                                     (elem: any, _index2: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".matrix[" +
+                                                        _index1 +
+                                                        "][" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +

--- a/test/generated/output/assertStringify/test_assertStringify_TagObjectUnion.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagObjectUnion.ts
@@ -21,7 +21,12 @@ export const test_assertStringify_TagObjectUnion = _test_assertStringify(
                     ): boolean =>
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "number",
@@ -33,8 +38,18 @@ export const test_assertStringify_TagObjectUnion = _test_assertStringify(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".value",
                             expected: "string",

--- a/test/generated/output/assertStringify/test_assertStringify_TagPattern.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagPattern.ts
@@ -20,40 +20,64 @@ export const test_assertStringify_TagPattern = _test_assertStringify(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("string" === typeof input.uuid &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                ).test(input.uuid)) ||
+                                ).test(input.uuid) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected:
+                                        "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                    value: input.uuid,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             })) &&
                         (("string" === typeof input.email &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                ).test(input.email)) ||
+                                ).test(input.email) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected:
+                                        'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                    value: input.email,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             })) &&
                         (("string" === typeof input.ipv4 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                ).test(input.ipv4)) ||
+                                ).test(input.ipv4) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected:
+                                        "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                    value: input.ipv4,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             })) &&
                         (("string" === typeof input.ipv6 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                ).test(input.ipv6)) ||
+                                ).test(input.ipv6) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected:
+                                        "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                    value: input.ipv6,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",

--- a/test/generated/output/assertStringify/test_assertStringify_TagRange.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagRange.ts
@@ -21,7 +21,12 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                     ): boolean =>
                         (("number" === typeof input.greater &&
                             Number.isFinite(input.greater) &&
-                            3 < input.greater) ||
+                            (3 < input.greater ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater",
                                 expected: "number",
@@ -29,7 +34,12 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                             })) &&
                         (("number" === typeof input.greater_equal &&
                             Number.isFinite(input.greater_equal) &&
-                            3 <= input.greater_equal) ||
+                            (3 <= input.greater_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number",
@@ -37,7 +47,12 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                             })) &&
                         (("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
-                            7 > input.less) ||
+                            (7 > input.less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".less",
                                 expected: "number",
@@ -45,39 +60,84 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                             })) &&
                         (("number" === typeof input.less_equal &&
                             Number.isFinite(input.less_equal) &&
-                            7 >= input.less_equal) ||
+                            (7 >= input.less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".less_equal",
                                 expected: "number",
                                 value: input.less_equal,
                             })) &&
                         (("number" === typeof input.greater_less &&
-                            3 < input.greater_less &&
-                            7 > input.greater_less) ||
+                            (3 < input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less,
+                                })) &&
+                            (7 > input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number",
                                 value: input.greater_less,
                             })) &&
                         (("number" === typeof input.greater_equal_less &&
-                            3 <= input.greater_equal_less &&
-                            7 > input.greater_equal_less) ||
+                            (3 <= input.greater_equal_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less,
+                                })) &&
+                            (7 > input.greater_equal_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_equal_less,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less",
                                 expected: "number",
                                 value: input.greater_equal_less,
                             })) &&
                         (("number" === typeof input.greater_less_equal &&
-                            3 < input.greater_less_equal &&
-                            7 >= input.greater_less_equal) ||
+                            (3 < input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            (7 >= input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number",
                                 value: input.greater_less_equal,
                             })) &&
                         (("number" === typeof input.greater_equal_less_equal &&
-                            3 <= input.greater_equal_less_equal &&
-                            7 >= input.greater_equal_less_equal) ||
+                            (3 <= input.greater_equal_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
+                            (7 >= input.greater_equal_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_equal_less_equal,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",

--- a/test/generated/output/assertStringify/test_assertStringify_TagStep.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagStep.ts
@@ -20,34 +20,84 @@ export const test_assertStringify_TagStep = _test_assertStringify(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         (("number" === typeof input.exclusiveMinimum &&
-                            0 === (input.exclusiveMinimum % 5) - 3 &&
-                            3 < input.exclusiveMinimum) ||
+                            (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@step 5)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (3 < input.exclusiveMinimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.exclusiveMinimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".exclusiveMinimum",
                                 expected: "number",
                                 value: input.exclusiveMinimum,
                             })) &&
                         (("number" === typeof input.minimum &&
-                            0 === (input.minimum % 5) - 3 &&
-                            3 <= input.minimum) ||
+                            (0 === (input.minimum % 5) - 3 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@step 5)",
+                                    value: input.minimum,
+                                })) &&
+                            (3 <= input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
                                 value: input.minimum,
                             })) &&
                         (("number" === typeof input.range &&
-                            0 === (input.range % 5) - 0 &&
-                            0 < input.range &&
-                            100 > input.range) ||
+                            (0 === (input.range % 5) - 0 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@step 5)",
+                                    value: input.range,
+                                })) &&
+                            (0 < input.range ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMinimum 0)",
+                                    value: input.range,
+                                })) &&
+                            (100 > input.range ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMaximum 100)",
+                                    value: input.range,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".range",
                                 expected: "number",
                                 value: input.range,
                             })) &&
                         (("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 5 &&
-                            3 <= input.multipleOf &&
-                            99 >= input.multipleOf) ||
+                            (0 === input.multipleOf % 5 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 5)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (3 <= input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@minimum 3)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (99 >= input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@maximum 99)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",

--- a/test/generated/output/assertStringify/test_assertStringify_TagTuple.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagTuple.ts
@@ -34,24 +34,54 @@ export const test_assertStringify_TagTuple = _test_assertStringify(
                                 value: input.tuple,
                             })) &&
                         (("string" === typeof input.tuple[0] &&
-                            3 <= input.tuple[0].length &&
-                            7 >= input.tuple[0].length) ||
+                            (3 <= input.tuple[0].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[0]",
+                                    expected: "string (@minLength 3)",
+                                    value: input.tuple[0],
+                                })) &&
+                            (7 >= input.tuple[0].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[0]",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.tuple[0],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[0]",
                                 expected: "string",
                                 value: input.tuple[0],
                             })) &&
                         (("number" === typeof input.tuple[1] &&
-                            3 <= input.tuple[1] &&
-                            7 >= input.tuple[1]) ||
+                            (3 <= input.tuple[1] ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[1]",
+                                    expected: "number (@minimum 3)",
+                                    value: input.tuple[1],
+                                })) &&
+                            (7 >= input.tuple[1] ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[1]",
+                                    expected: "number (@maximum 7)",
+                                    value: input.tuple[1],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[1]",
                                 expected: "number",
                                 value: input.tuple[1],
                             })) &&
                         ((Array.isArray(input.tuple[2]) &&
-                            3 <= input.tuple[2].length &&
-                            7 >= input.tuple[2].length) ||
+                            (3 <= input.tuple[2].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2]",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.tuple[2],
+                                })) &&
+                            (7 >= input.tuple[2].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2]",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.tuple[2],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[2]",
                                 expected: "Array<string>",
@@ -60,8 +90,26 @@ export const test_assertStringify_TagTuple = _test_assertStringify(
                         input.tuple[2].every(
                             (elem: any, _index1: number) =>
                                 ("string" === typeof elem &&
-                                    3 <= elem.length &&
-                                    7 >= elem.length) ||
+                                    (3 <= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[2][" +
+                                                _index1 +
+                                                "]",
+                                            expected: "string (@minLength 3)",
+                                            value: elem,
+                                        })) &&
+                                    (7 >= elem.length ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[2][" +
+                                                _index1 +
+                                                "]",
+                                            expected: "string (@maxLength 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".tuple[2][" + _index1 + "]",
                                     expected: "string",
@@ -69,8 +117,18 @@ export const test_assertStringify_TagTuple = _test_assertStringify(
                                 }),
                         ) &&
                         ((Array.isArray(input.tuple[3]) &&
-                            3 <= input.tuple[3].length &&
-                            7 >= input.tuple[3].length) ||
+                            (3 <= input.tuple[3].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3]",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.tuple[3],
+                                })) &&
+                            (7 >= input.tuple[3].length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3]",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.tuple[3],
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[3]",
                                 expected: "Array<number>",
@@ -79,8 +137,26 @@ export const test_assertStringify_TagTuple = _test_assertStringify(
                         input.tuple[3].every(
                             (elem: any, _index2: number) =>
                                 ("number" === typeof elem &&
-                                    3 <= elem &&
-                                    7 >= elem) ||
+                                    (3 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[3][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number (@minimum 3)",
+                                            value: elem,
+                                        })) &&
+                                    (7 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".tuple[3][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number (@maximum 7)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".tuple[3][" + _index2 + "]",
                                     expected: "number",

--- a/test/generated/output/assertStringify/test_assertStringify_TagType.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagType.ts
@@ -21,7 +21,12 @@ export const test_assertStringify_TagType = _test_assertStringify(
                     ): boolean =>
                         (("number" === typeof input.int &&
                             Number.isFinite(input.int) &&
-                            parseInt(input.int) === input.int) ||
+                            (parseInt(input.int) === input.int ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".int",
                                 expected: "number",
@@ -29,8 +34,18 @@ export const test_assertStringify_TagType = _test_assertStringify(
                             })) &&
                         (("number" === typeof input.uint &&
                             Number.isFinite(input.uint) &&
-                            parseInt(input.uint) === input.uint &&
-                            0 <= input.uint) ||
+                            (parseInt(input.uint) === input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (0 <= input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number",

--- a/test/generated/output/assertStringify/test_assertStringify_UltimateUnion.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_UltimateUnion.ts
@@ -940,7 +940,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                parseInt(input.minimum) === input.minimum) ||
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -949,7 +954,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                parseInt(input.maximum) === input.maximum) ||
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -972,8 +982,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
-                                parseInt(input.multipleOf) ===
-                                    input.multipleOf) ||
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -1264,8 +1279,19 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
-                                parseInt(input.minLength) === input.minLength &&
-                                0 <= input.minLength) ||
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
                                 expected: "(number | undefined)",
@@ -1274,8 +1300,19 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
-                                parseInt(input.maxLength) === input.maxLength &&
-                                0 <= input.maxLength) ||
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxLength",
                                 expected: "(number | undefined)",
@@ -1433,8 +1470,18 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input.minItems ||
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
-                                parseInt(input.minItems) === input.minItems &&
-                                0 <= input.minItems) ||
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "(number | undefined)",
@@ -1443,8 +1490,18 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
-                                parseInt(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems) ||
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",

--- a/test/generated/output/clone/test_clone_TagCustom.ts
+++ b/test/generated/output/clone/test_clone_TagCustom.ts
@@ -11,7 +11,7 @@ export const test_clone_TagCustom = _test_clone(
             const $is_custom = (typia.clone as any).is_custom;
             const $co0 = (input: any): any => ({
                 id: input.id as any,
-                dolloar: input.dolloar as any,
+                dollar: input.dollar as any,
                 postfix: input.postfix as any,
                 log: input.log as any,
             });

--- a/test/generated/output/createAssert/test_createAssert_TagArray.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagArray.ts
@@ -18,7 +18,13 @@ export const test_createAssert_TagArray = _test_assert(
                 _path: string,
                 _exceptionable: boolean = true,
             ): boolean =>
-                ((Array.isArray(input.items) && 3 === input.items.length) ||
+                ((Array.isArray(input.items) &&
+                    (3 === input.items.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".items",
+                            expected: "Array.length (@items 3)",
+                            value: input.items,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".items",
                         expected: "Array<string>",
@@ -26,7 +32,13 @@ export const test_createAssert_TagArray = _test_assert(
                     })) &&
                 input.items.every(
                     (elem: any, _index2: number) =>
-                        ("string" === typeof elem && true === $is_uuid(elem)) ||
+                        ("string" === typeof elem &&
+                            (true === $is_uuid(elem) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items[" + _index2 + "]",
+                                    expected: "string (@format uuid)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".items[" + _index2 + "]",
                             expected: "string",
@@ -34,7 +46,12 @@ export const test_createAssert_TagArray = _test_assert(
                         }),
                 ) &&
                 ((Array.isArray(input.minItems) &&
-                    3 <= input.minItems.length) ||
+                    (3 <= input.minItems.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minItems",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.minItems,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minItems",
                         expected: "Array<number>",
@@ -44,7 +61,12 @@ export const test_createAssert_TagArray = _test_assert(
                     (elem: any, _index3: number) =>
                         ("number" === typeof elem &&
                             Number.isFinite(elem) &&
-                            3 <= elem) ||
+                            (3 <= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems[" + _index3 + "]",
+                                    expected: "number (@minimum 3)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems[" + _index3 + "]",
                             expected: "number",
@@ -52,7 +74,12 @@ export const test_createAssert_TagArray = _test_assert(
                         }),
                 ) &&
                 ((Array.isArray(input.maxItems) &&
-                    7 >= input.maxItems.length) ||
+                    (7 >= input.maxItems.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maxItems",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.maxItems,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maxItems",
                         expected: "Array<(number | string)>",
@@ -60,10 +87,21 @@ export const test_createAssert_TagArray = _test_assert(
                     })) &&
                 input.maxItems.every(
                     (elem: any, _index4: number) =>
-                        ("string" === typeof elem && 7 >= elem.length) ||
+                        ("string" === typeof elem &&
+                            (7 >= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems[" + _index4 + "]",
+                                    expected: "string (@maxLength 7)",
+                                    value: elem,
+                                }))) ||
                         ("number" === typeof elem &&
                             Number.isFinite(elem) &&
-                            7 >= elem) ||
+                            (7 >= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems[" + _index4 + "]",
+                                    expected: "number (@maximum 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems[" + _index4 + "]",
                             expected: "(number | string)",
@@ -71,8 +109,18 @@ export const test_createAssert_TagArray = _test_assert(
                         }),
                 ) &&
                 ((Array.isArray(input.both) &&
-                    3 <= input.both.length &&
-                    7 >= input.both.length) ||
+                    (3 <= input.both.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".both",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.both,
+                        })) &&
+                    (7 >= input.both.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".both",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.both,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".both",
                         expected: "Array<string>",
@@ -80,7 +128,13 @@ export const test_createAssert_TagArray = _test_assert(
                     })) &&
                 input.both.every(
                     (elem: any, _index5: number) =>
-                        ("string" === typeof elem && true === $is_uuid(elem)) ||
+                        ("string" === typeof elem &&
+                            (true === $is_uuid(elem) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both[" + _index5 + "]",
+                                    expected: "string (@format uuid)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".both[" + _index5 + "]",
                             expected: "string",

--- a/test/generated/output/createAssert/test_createAssert_TagAtomicUnion.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagAtomicUnion.ts
@@ -18,11 +18,26 @@ export const test_createAssert_TagAtomicUnion = _test_assert(
                 _exceptionable: boolean = true,
             ): boolean =>
                 ("string" === typeof input.value &&
-                    3 <= input.value.length &&
-                    7 >= input.value.length) ||
+                    (3 <= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@minLength 3)",
+                            value: input.value,
+                        })) &&
+                    (7 >= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@maxLength 7)",
+                            value: input.value,
+                        }))) ||
                 ("number" === typeof input.value &&
                     Number.isFinite(input.value) &&
-                    3 <= input.value) ||
+                    (3 <= input.value ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "number (@minimum 3)",
+                            value: input.value,
+                        }))) ||
                 $guard(_exceptionable, {
                     path: _path + ".value",
                     expected: "(number | string)",

--- a/test/generated/output/createAssert/test_createAssert_TagBigInt.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagBigInt.ts
@@ -24,27 +24,54 @@ export const test_createAssert_TagBigInt = _test_assert(
                         value: input.value,
                     })) &&
                 (("bigint" === typeof input.ranged &&
-                    0n <= input.ranged &&
-                    100n >= input.ranged) ||
+                    (0n <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "bigint (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100n >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "bigint (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "bigint",
                         value: input.ranged,
                     })) &&
-                (("bigint" === typeof input.minimum && 0n <= input.minimum) ||
+                (("bigint" === typeof input.minimum &&
+                    (0n <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "bigint (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "bigint",
                         value: input.minimum,
                     })) &&
-                (("bigint" === typeof input.maximum && 100n >= input.maximum) ||
+                (("bigint" === typeof input.maximum &&
+                    (100n >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "bigint (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "bigint",
                         value: input.maximum,
                     })) &&
                 (("bigint" === typeof input.multipleOf &&
-                    0n === input.multipleOf % 3n) ||
+                    (0n === input.multipleOf % 3n ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "bigint (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "bigint",

--- a/test/generated/output/createAssert/test_createAssert_TagCustom.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagCustom.ts
@@ -20,21 +20,36 @@ export const test_createAssert_TagCustom = _test_assert(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.id &&
-                    true === $is_uuid(input.id)) ||
+                    (true === $is_uuid(input.id) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".id",
+                            expected: "string (@format uuid)",
+                            value: input.id,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".id",
                         expected: "string",
                         value: input.id,
                     })) &&
-                (("string" === typeof input.dolloar &&
-                    $is_custom("dollar", "string", "", input.dolloar)) ||
+                (("string" === typeof input.dollar &&
+                    ($is_custom("dollar", "string", "", input.dollar) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dollar",
+                            expected: "string (@dollar)",
+                            value: input.dollar,
+                        }))) ||
                     $guard(_exceptionable, {
-                        path: _path + ".dolloar",
+                        path: _path + ".dollar",
                         expected: "string",
-                        value: input.dolloar,
+                        value: input.dollar,
                     })) &&
                 (("string" === typeof input.postfix &&
-                    $is_custom("postfix", "string", "abcd", input.postfix)) ||
+                    ($is_custom("postfix", "string", "abcd", input.postfix) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".postfix",
+                            expected: "string (@postfix abcd)",
+                            value: input.postfix,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".postfix",
                         expected: "string",
@@ -42,7 +57,12 @@ export const test_createAssert_TagCustom = _test_assert(
                     })) &&
                 (("number" === typeof input.log &&
                     Number.isFinite(input.log) &&
-                    $is_custom("powerOf", "number", "10", input.log)) ||
+                    ($is_custom("powerOf", "number", "10", input.log) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".log",
+                            expected: "number (@powerOf 10)",
+                            value: input.log,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".log",
                         expected: "number",

--- a/test/generated/output/createAssert/test_createAssert_TagFormat.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagFormat.ts
@@ -25,63 +25,108 @@ export const test_createAssert_TagFormat = _test_assert(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.uuid &&
-                    true === $is_uuid(input.uuid)) ||
+                    (true === $is_uuid(input.uuid) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uuid",
+                            expected: "string (@format uuid)",
+                            value: input.uuid,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uuid",
                         expected: "string",
                         value: input.uuid,
                     })) &&
                 (("string" === typeof input.email &&
-                    true === $is_email(input.email)) ||
+                    (true === $is_email(input.email) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".email",
+                            expected: "string (@format email)",
+                            value: input.email,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".email",
                         expected: "string",
                         value: input.email,
                     })) &&
                 (("string" === typeof input.url &&
-                    true === $is_url(input.url)) ||
+                    (true === $is_url(input.url) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".url",
+                            expected: "string (@format url)",
+                            value: input.url,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".url",
                         expected: "string",
                         value: input.url,
                     })) &&
                 (("string" === typeof input.ipv4 &&
-                    true === $is_ipv4(input.ipv4)) ||
+                    (true === $is_ipv4(input.ipv4) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv4",
+                            expected: "string (@format ipv4)",
+                            value: input.ipv4,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv4",
                         expected: "string",
                         value: input.ipv4,
                     })) &&
                 (("string" === typeof input.ipv6 &&
-                    true === $is_ipv6(input.ipv6)) ||
+                    (true === $is_ipv6(input.ipv6) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv6",
+                            expected: "string (@format ipv6)",
+                            value: input.ipv6,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv6",
                         expected: "string",
                         value: input.ipv6,
                     })) &&
                 (("string" === typeof input.date &&
-                    true === $is_date(input.date)) ||
+                    (true === $is_date(input.date) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".date",
+                            expected: "string (@format date)",
+                            value: input.date,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".date",
                         expected: "string",
                         value: input.date,
                     })) &&
                 (("string" === typeof input.date_time &&
-                    true === $is_datetime(input.date_time)) ||
+                    (true === $is_datetime(input.date_time) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".date_time",
+                            expected: "string (@format datetime)",
+                            value: input.date_time,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".date_time",
                         expected: "string",
                         value: input.date_time,
                     })) &&
                 (("string" === typeof input.datetime &&
-                    true === $is_datetime(input.datetime)) ||
+                    (true === $is_datetime(input.datetime) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".datetime",
+                            expected: "string (@format datetime)",
+                            value: input.datetime,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".datetime",
                         expected: "string",
                         value: input.datetime,
                     })) &&
                 (("string" === typeof input.dateTime &&
-                    true === $is_datetime(input.dateTime)) ||
+                    (true === $is_datetime(input.dateTime) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dateTime",
+                            expected: "string (@format datetime)",
+                            value: input.dateTime,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".dateTime",
                         expected: "string",

--- a/test/generated/output/createAssert/test_createAssert_TagInfinite.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagInfinite.ts
@@ -25,8 +25,18 @@ export const test_createAssert_TagInfinite = _test_assert(
                         value: input.value,
                     })) &&
                 (("number" === typeof input.ranged &&
-                    0 <= input.ranged &&
-                    100 >= input.ranged) ||
+                    (0 <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100 >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "number",
@@ -34,7 +44,12 @@ export const test_createAssert_TagInfinite = _test_assert(
                     })) &&
                 (("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
-                    0 <= input.minimum) ||
+                    (0 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
@@ -42,14 +57,24 @@ export const test_createAssert_TagInfinite = _test_assert(
                     })) &&
                 (("number" === typeof input.maximum &&
                     Number.isFinite(input.maximum) &&
-                    100 >= input.maximum) ||
+                    (100 >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "number (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "number",
                         value: input.maximum,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 3) ||
+                    (0 === input.multipleOf % 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",
@@ -57,7 +82,12 @@ export const test_createAssert_TagInfinite = _test_assert(
                     })) &&
                 (("number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
-                    parseInt(input.typed) === input.typed) ||
+                    (parseInt(input.typed) === input.typed ||
+                        $guard(_exceptionable, {
+                            path: _path + ".typed",
+                            expected: "number (@type int)",
+                            value: input.typed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".typed",
                         expected: "number",

--- a/test/generated/output/createAssert/test_createAssert_TagLength.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagLength.ts
@@ -18,29 +18,54 @@ export const test_createAssert_TagLength = _test_assert(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.fixed &&
-                    5 === input.fixed.length) ||
+                    (5 === input.fixed.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".fixed",
+                            expected: "string (@length 5)",
+                            value: input.fixed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".fixed",
                         expected: "string",
                         value: input.fixed,
                     })) &&
                 (("string" === typeof input.minimum &&
-                    3 <= input.minimum.length) ||
+                    (3 <= input.minimum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "string (@minLength 3)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "string",
                         value: input.minimum,
                     })) &&
                 (("string" === typeof input.maximum &&
-                    7 >= input.maximum.length) ||
+                    (7 >= input.maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "string (@maxLength 7)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "string",
                         value: input.maximum,
                     })) &&
                 (("string" === typeof input.minimum_and_maximum &&
-                    3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length) ||
+                    (3 <= input.minimum_and_maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum_and_maximum",
+                            expected: "string (@minLength 3)",
+                            value: input.minimum_and_maximum,
+                        })) &&
+                    (7 >= input.minimum_and_maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum_and_maximum",
+                            expected: "string (@maxLength 7)",
+                            value: input.minimum_and_maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum_and_maximum",
                         expected: "string",

--- a/test/generated/output/createAssert/test_createAssert_TagMatrix.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagMatrix.ts
@@ -18,7 +18,13 @@ export const test_createAssert_TagMatrix = _test_assert(
                 _path: string,
                 _exceptionable: boolean = true,
             ): boolean =>
-                ((Array.isArray(input.matrix) && 3 === input.matrix.length) ||
+                ((Array.isArray(input.matrix) &&
+                    (3 === input.matrix.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".matrix",
+                            expected: "Array.length (@items 3)",
+                            value: input.matrix,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".matrix",
                         expected: "Array<Array<string>>",
@@ -26,7 +32,13 @@ export const test_createAssert_TagMatrix = _test_assert(
                     })) &&
                 input.matrix.every(
                     (elem: any, _index1: number) =>
-                        ((Array.isArray(elem) && 3 === elem.length) ||
+                        ((Array.isArray(elem) &&
+                            (3 === elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".matrix[" + _index1 + "]",
+                                    expected: "Array.length (@items 3)",
+                                    value: elem,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".matrix[" + _index1 + "]",
                                 expected: "Array<string>",
@@ -35,7 +47,18 @@ export const test_createAssert_TagMatrix = _test_assert(
                         elem.every(
                             (elem: any, _index2: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".matrix[" +
+                                                _index1 +
+                                                "][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path:
                                         _path +

--- a/test/generated/output/createAssert/test_createAssert_TagNaN.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagNaN.ts
@@ -25,8 +25,18 @@ export const test_createAssert_TagNaN = _test_assert(
                         value: input.value,
                     })) &&
                 (("number" === typeof input.ranged &&
-                    0 <= input.ranged &&
-                    100 >= input.ranged) ||
+                    (0 <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100 >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "number",
@@ -34,7 +44,12 @@ export const test_createAssert_TagNaN = _test_assert(
                     })) &&
                 (("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
-                    0 <= input.minimum) ||
+                    (0 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
@@ -42,14 +57,24 @@ export const test_createAssert_TagNaN = _test_assert(
                     })) &&
                 (("number" === typeof input.maximum &&
                     Number.isFinite(input.maximum) &&
-                    100 >= input.maximum) ||
+                    (100 >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "number (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "number",
                         value: input.maximum,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 3) ||
+                    (0 === input.multipleOf % 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",
@@ -57,7 +82,12 @@ export const test_createAssert_TagNaN = _test_assert(
                     })) &&
                 (("number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
-                    parseInt(input.typed) === input.typed) ||
+                    (parseInt(input.typed) === input.typed ||
+                        $guard(_exceptionable, {
+                            path: _path + ".typed",
+                            expected: "number (@type int)",
+                            value: input.typed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".typed",
                         expected: "number",

--- a/test/generated/output/createAssert/test_createAssert_TagObjectUnion.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagObjectUnion.ts
@@ -19,7 +19,12 @@ export const test_createAssert_TagObjectUnion = _test_assert(
             ): boolean =>
                 ("number" === typeof input.value &&
                     Number.isFinite(input.value) &&
-                    3 <= input.value) ||
+                    (3 <= input.value ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "number (@minimum 3)",
+                            value: input.value,
+                        }))) ||
                 $guard(_exceptionable, {
                     path: _path + ".value",
                     expected: "number",
@@ -31,8 +36,18 @@ export const test_createAssert_TagObjectUnion = _test_assert(
                 _exceptionable: boolean = true,
             ): boolean =>
                 ("string" === typeof input.value &&
-                    3 <= input.value.length &&
-                    7 >= input.value.length) ||
+                    (3 <= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@minLength 3)",
+                            value: input.value,
+                        })) &&
+                    (7 >= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@maxLength 7)",
+                            value: input.value,
+                        }))) ||
                 $guard(_exceptionable, {
                     path: _path + ".value",
                     expected: "string",

--- a/test/generated/output/createAssert/test_createAssert_TagPattern.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagPattern.ts
@@ -18,40 +18,64 @@ export const test_createAssert_TagPattern = _test_assert(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.uuid &&
-                    true ===
+                    (true ===
                         RegExp(
                             /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                        ).test(input.uuid)) ||
+                        ).test(input.uuid) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uuid",
+                            expected:
+                                "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                            value: input.uuid,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uuid",
                         expected: "string",
                         value: input.uuid,
                     })) &&
                 (("string" === typeof input.email &&
-                    true ===
+                    (true ===
                         RegExp(
                             /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                        ).test(input.email)) ||
+                        ).test(input.email) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".email",
+                            expected:
+                                'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                            value: input.email,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".email",
                         expected: "string",
                         value: input.email,
                     })) &&
                 (("string" === typeof input.ipv4 &&
-                    true ===
+                    (true ===
                         RegExp(
                             /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                        ).test(input.ipv4)) ||
+                        ).test(input.ipv4) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv4",
+                            expected:
+                                "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                            value: input.ipv4,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv4",
                         expected: "string",
                         value: input.ipv4,
                     })) &&
                 (("string" === typeof input.ipv6 &&
-                    true ===
+                    (true ===
                         RegExp(
                             /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                        ).test(input.ipv6)) ||
+                        ).test(input.ipv6) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv6",
+                            expected:
+                                "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                            value: input.ipv6,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv6",
                         expected: "string",

--- a/test/generated/output/createAssert/test_createAssert_TagRange.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagRange.ts
@@ -19,7 +19,12 @@ export const test_createAssert_TagRange = _test_assert(
             ): boolean =>
                 (("number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
-                    3 < input.greater) ||
+                    (3 < input.greater ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater",
                         expected: "number",
@@ -27,7 +32,12 @@ export const test_createAssert_TagRange = _test_assert(
                     })) &&
                 (("number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
-                    3 <= input.greater_equal) ||
+                    (3 <= input.greater_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal",
                         expected: "number",
@@ -35,7 +45,12 @@ export const test_createAssert_TagRange = _test_assert(
                     })) &&
                 (("number" === typeof input.less &&
                     Number.isFinite(input.less) &&
-                    7 > input.less) ||
+                    (7 > input.less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".less",
                         expected: "number",
@@ -43,39 +58,84 @@ export const test_createAssert_TagRange = _test_assert(
                     })) &&
                 (("number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
-                    7 >= input.less_equal) ||
+                    (7 >= input.less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".less_equal",
                         expected: "number",
                         value: input.less_equal,
                     })) &&
                 (("number" === typeof input.greater_less &&
-                    3 < input.greater_less &&
-                    7 > input.greater_less) ||
+                    (3 < input.greater_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater_less,
+                        })) &&
+                    (7 > input.greater_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.greater_less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_less",
                         expected: "number",
                         value: input.greater_less,
                     })) &&
                 (("number" === typeof input.greater_equal_less &&
-                    3 <= input.greater_equal_less &&
-                    7 > input.greater_equal_less) ||
+                    (3 <= input.greater_equal_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal_less,
+                        })) &&
+                    (7 > input.greater_equal_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.greater_equal_less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal_less",
                         expected: "number",
                         value: input.greater_equal_less,
                     })) &&
                 (("number" === typeof input.greater_less_equal &&
-                    3 < input.greater_less_equal &&
-                    7 >= input.greater_less_equal) ||
+                    (3 < input.greater_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less_equal",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater_less_equal,
+                        })) &&
+                    (7 >= input.greater_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.greater_less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_less_equal",
                         expected: "number",
                         value: input.greater_less_equal,
                     })) &&
                 (("number" === typeof input.greater_equal_less_equal &&
-                    3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal) ||
+                    (3 <= input.greater_equal_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less_equal",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal_less_equal,
+                        })) &&
+                    (7 >= input.greater_equal_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.greater_equal_less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal_less_equal",
                         expected: "number",

--- a/test/generated/output/createAssert/test_createAssert_TagStep.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagStep.ts
@@ -18,34 +18,84 @@ export const test_createAssert_TagStep = _test_assert(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("number" === typeof input.exclusiveMinimum &&
-                    0 === (input.exclusiveMinimum % 5) - 3 &&
-                    3 < input.exclusiveMinimum) ||
+                    (0 === (input.exclusiveMinimum % 5) - 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "number (@step 5)",
+                            value: input.exclusiveMinimum,
+                        })) &&
+                    (3 < input.exclusiveMinimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.exclusiveMinimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".exclusiveMinimum",
                         expected: "number",
                         value: input.exclusiveMinimum,
                     })) &&
                 (("number" === typeof input.minimum &&
-                    0 === (input.minimum % 5) - 3 &&
-                    3 <= input.minimum) ||
+                    (0 === (input.minimum % 5) - 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@step 5)",
+                            value: input.minimum,
+                        })) &&
+                    (3 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 3)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
                         value: input.minimum,
                     })) &&
                 (("number" === typeof input.range &&
-                    0 === (input.range % 5) - 0 &&
-                    0 < input.range &&
-                    100 > input.range) ||
+                    (0 === (input.range % 5) - 0 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@step 5)",
+                            value: input.range,
+                        })) &&
+                    (0 < input.range ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@exclusiveMinimum 0)",
+                            value: input.range,
+                        })) &&
+                    (100 > input.range ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@exclusiveMaximum 100)",
+                            value: input.range,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".range",
                         expected: "number",
                         value: input.range,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 5 &&
-                    3 <= input.multipleOf &&
-                    99 >= input.multipleOf) ||
+                    (0 === input.multipleOf % 5 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 5)",
+                            value: input.multipleOf,
+                        })) &&
+                    (3 <= input.multipleOf ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@minimum 3)",
+                            value: input.multipleOf,
+                        })) &&
+                    (99 >= input.multipleOf ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@maximum 99)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",

--- a/test/generated/output/createAssert/test_createAssert_TagTuple.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagTuple.ts
@@ -32,24 +32,54 @@ export const test_createAssert_TagTuple = _test_assert(
                         value: input.tuple,
                     })) &&
                 (("string" === typeof input.tuple[0] &&
-                    3 <= input.tuple[0].length &&
-                    7 >= input.tuple[0].length) ||
+                    (3 <= input.tuple[0].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[0]",
+                            expected: "string (@minLength 3)",
+                            value: input.tuple[0],
+                        })) &&
+                    (7 >= input.tuple[0].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[0]",
+                            expected: "string (@maxLength 7)",
+                            value: input.tuple[0],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[0]",
                         expected: "string",
                         value: input.tuple[0],
                     })) &&
                 (("number" === typeof input.tuple[1] &&
-                    3 <= input.tuple[1] &&
-                    7 >= input.tuple[1]) ||
+                    (3 <= input.tuple[1] ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[1]",
+                            expected: "number (@minimum 3)",
+                            value: input.tuple[1],
+                        })) &&
+                    (7 >= input.tuple[1] ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[1]",
+                            expected: "number (@maximum 7)",
+                            value: input.tuple[1],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[1]",
                         expected: "number",
                         value: input.tuple[1],
                     })) &&
                 ((Array.isArray(input.tuple[2]) &&
-                    3 <= input.tuple[2].length &&
-                    7 >= input.tuple[2].length) ||
+                    (3 <= input.tuple[2].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[2]",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.tuple[2],
+                        })) &&
+                    (7 >= input.tuple[2].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[2]",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.tuple[2],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[2]",
                         expected: "Array<string>",
@@ -58,8 +88,18 @@ export const test_createAssert_TagTuple = _test_assert(
                 input.tuple[2].every(
                     (elem: any, _index1: number) =>
                         ("string" === typeof elem &&
-                            3 <= elem.length &&
-                            7 >= elem.length) ||
+                            (3 <= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2][" + _index1 + "]",
+                                    expected: "string (@minLength 3)",
+                                    value: elem,
+                                })) &&
+                            (7 >= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2][" + _index1 + "]",
+                                    expected: "string (@maxLength 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[2][" + _index1 + "]",
                             expected: "string",
@@ -67,8 +107,18 @@ export const test_createAssert_TagTuple = _test_assert(
                         }),
                 ) &&
                 ((Array.isArray(input.tuple[3]) &&
-                    3 <= input.tuple[3].length &&
-                    7 >= input.tuple[3].length) ||
+                    (3 <= input.tuple[3].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[3]",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.tuple[3],
+                        })) &&
+                    (7 >= input.tuple[3].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[3]",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.tuple[3],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[3]",
                         expected: "Array<number>",
@@ -76,7 +126,19 @@ export const test_createAssert_TagTuple = _test_assert(
                     })) &&
                 input.tuple[3].every(
                     (elem: any, _index2: number) =>
-                        ("number" === typeof elem && 3 <= elem && 7 >= elem) ||
+                        ("number" === typeof elem &&
+                            (3 <= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3][" + _index2 + "]",
+                                    expected: "number (@minimum 3)",
+                                    value: elem,
+                                })) &&
+                            (7 >= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3][" + _index2 + "]",
+                                    expected: "number (@maximum 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[3][" + _index2 + "]",
                             expected: "number",

--- a/test/generated/output/createAssert/test_createAssert_TagType.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagType.ts
@@ -19,7 +19,12 @@ export const test_createAssert_TagType = _test_assert(
             ): boolean =>
                 (("number" === typeof input.int &&
                     Number.isFinite(input.int) &&
-                    parseInt(input.int) === input.int) ||
+                    (parseInt(input.int) === input.int ||
+                        $guard(_exceptionable, {
+                            path: _path + ".int",
+                            expected: "number (@type int)",
+                            value: input.int,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".int",
                         expected: "number",
@@ -27,8 +32,18 @@ export const test_createAssert_TagType = _test_assert(
                     })) &&
                 (("number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
-                    parseInt(input.uint) === input.uint &&
-                    0 <= input.uint) ||
+                    (parseInt(input.uint) === input.uint ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uint",
+                            expected: "number (@type uint)",
+                            value: input.uint,
+                        })) &&
+                    (0 <= input.uint ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uint",
+                            expected: "number (@type uint)",
+                            value: input.uint,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uint",
                         expected: "number",

--- a/test/generated/output/createAssert/test_createAssert_UltimateUnion.ts
+++ b/test/generated/output/createAssert/test_createAssert_UltimateUnion.ts
@@ -919,7 +919,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        parseInt(input.minimum) === input.minimum) ||
+                        (parseInt(input.minimum) === input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@type int)",
+                                value: input.minimum,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "(number | undefined)",
@@ -928,7 +933,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        parseInt(input.maximum) === input.maximum) ||
+                        (parseInt(input.maximum) === input.maximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@type int)",
+                                value: input.maximum,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "(number | undefined)",
@@ -951,7 +961,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        parseInt(input.multipleOf) === input.multipleOf) ||
+                        (parseInt(input.multipleOf) === input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@type int)",
+                                value: input.multipleOf,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "(number | undefined)",
@@ -1236,8 +1251,18 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
-                        parseInt(input.minLength) === input.minLength &&
-                        0 <= input.minLength) ||
+                        (parseInt(input.minLength) === input.minLength ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minLength",
+                                expected: "number (@type uint)",
+                                value: input.minLength,
+                            })) &&
+                        (0 <= input.minLength ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minLength",
+                                expected: "number (@type uint)",
+                                value: input.minLength,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minLength",
                         expected: "(number | undefined)",
@@ -1246,8 +1271,18 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
-                        parseInt(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength) ||
+                        (parseInt(input.maxLength) === input.maxLength ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxLength",
+                                expected: "number (@type uint)",
+                                value: input.maxLength,
+                            })) &&
+                        (0 <= input.maxLength ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxLength",
+                                expected: "number (@type uint)",
+                                value: input.maxLength,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maxLength",
                         expected: "(number | undefined)",
@@ -1398,8 +1433,18 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
-                        parseInt(input.minItems) === input.minItems &&
-                        0 <= input.minItems) ||
+                        (parseInt(input.minItems) === input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            })) &&
+                        (0 <= input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minItems",
                         expected: "(number | undefined)",
@@ -1408,8 +1453,18 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
-                        parseInt(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems) ||
+                        (parseInt(input.maxItems) === input.maxItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "number (@type uint)",
+                                value: input.maxItems,
+                            })) &&
+                        (0 <= input.maxItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "number (@type uint)",
+                                value: input.maxItems,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maxItems",
                         expected: "(number | undefined)",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagArray.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagArray.ts
@@ -19,7 +19,13 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ((Array.isArray(input.items) && 3 === input.items.length) ||
+                    ((Array.isArray(input.items) &&
+                        (3 === input.items.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected: "Array.length (@items 3)",
+                                value: input.items,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected: "Array<string>",
@@ -28,7 +34,12 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                     input.items.every(
                         (elem: any, _index2: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".items[" + _index2 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items[" + _index2 + "]",
                                 expected: "string",
@@ -36,7 +47,12 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                             }),
                     ) &&
                     ((Array.isArray(input.minItems) &&
-                        3 <= input.minItems.length) ||
+                        (3 <= input.minItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.minItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "Array<number>",
@@ -46,7 +62,16 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                         (elem: any, _index3: number) =>
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                3 <= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".minItems[" +
+                                            _index3 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems[" + _index3 + "]",
                                 expected: "number",
@@ -54,7 +79,12 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                             }),
                     ) &&
                     ((Array.isArray(input.maxItems) &&
-                        7 >= input.maxItems.length) ||
+                        (7 >= input.maxItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.maxItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "Array<(number | string)>",
@@ -62,10 +92,29 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                         })) &&
                     input.maxItems.every(
                         (elem: any, _index4: number) =>
-                            ("string" === typeof elem && 7 >= elem.length) ||
+                            ("string" === typeof elem &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                7 >= elem) ||
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems[" + _index4 + "]",
                                 expected: "(number | string)",
@@ -73,8 +122,18 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                             }),
                     ) &&
                     ((Array.isArray(input.both) &&
-                        3 <= input.both.length &&
-                        7 >= input.both.length) ||
+                        (3 <= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.both,
+                            })) &&
+                        (7 >= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.both,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".both",
                             expected: "Array<string>",
@@ -83,7 +142,12 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                     input.both.every(
                         (elem: any, _index5: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".both[" + _index5 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".both[" + _index5 + "]",
                                 expected: "string",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagAtomicUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagAtomicUnion.ts
@@ -19,11 +19,26 @@ export const test_createAssertClone_TagAtomicUnion = _test_assertClone(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "(number | string)",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagCustom.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagCustom.ts
@@ -21,26 +21,41 @@ export const test_createAssertClone_TagCustom = _test_assertClone(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.id &&
-                        true === $is_uuid(input.id)) ||
+                        (true === $is_uuid(input.id) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string (@format uuid)",
+                                value: input.id,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".id",
                             expected: "string",
                             value: input.id,
                         })) &&
-                    (("string" === typeof input.dolloar &&
-                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                    (("string" === typeof input.dollar &&
+                        ($is_custom("dollar", "string", "", input.dollar) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dollar",
+                                expected: "string (@dollar)",
+                                value: input.dollar,
+                            }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".dolloar",
+                            path: _path + ".dollar",
                             expected: "string",
-                            value: input.dolloar,
+                            value: input.dollar,
                         })) &&
                     (("string" === typeof input.postfix &&
-                        $is_custom(
+                        ($is_custom(
                             "postfix",
                             "string",
                             "abcd",
                             input.postfix,
-                        )) ||
+                        ) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string (@postfix abcd)",
+                                value: input.postfix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".postfix",
                             expected: "string",
@@ -48,7 +63,12 @@ export const test_createAssertClone_TagCustom = _test_assertClone(
                         })) &&
                     (("number" === typeof input.log &&
                         Number.isFinite(input.log) &&
-                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        ($is_custom("powerOf", "number", "10", input.log) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number (@powerOf 10)",
+                                value: input.log,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".log",
                             expected: "number",
@@ -71,7 +91,7 @@ export const test_createAssertClone_TagCustom = _test_assertClone(
             const $is_custom = (typia.createAssertClone as any).is_custom;
             const $co0 = (input: any): any => ({
                 id: input.id as any,
-                dolloar: input.dolloar as any,
+                dollar: input.dollar as any,
                 postfix: input.postfix as any,
                 log: input.log as any,
             });

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagFormat.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagFormat.ts
@@ -26,63 +26,108 @@ export const test_createAssertClone_TagFormat = _test_assertClone(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true === $is_uuid(input.uuid)) ||
+                        (true === $is_uuid(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected: "string (@format uuid)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true === $is_email(input.email)) ||
+                        (true === $is_email(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected: "string (@format email)",
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.url &&
-                        true === $is_url(input.url)) ||
+                        (true === $is_url(input.url) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".url",
+                                expected: "string (@format url)",
+                                value: input.url,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".url",
                             expected: "string",
                             value: input.url,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true === $is_ipv4(input.ipv4)) ||
+                        (true === $is_ipv4(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected: "string (@format ipv4)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true === $is_ipv6(input.ipv6)) ||
+                        (true === $is_ipv6(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected: "string (@format ipv6)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",
                             value: input.ipv6,
                         })) &&
                     (("string" === typeof input.date &&
-                        true === $is_date(input.date)) ||
+                        (true === $is_date(input.date) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date",
+                                expected: "string (@format date)",
+                                value: input.date,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date",
                             expected: "string",
                             value: input.date,
                         })) &&
                     (("string" === typeof input.date_time &&
-                        true === $is_datetime(input.date_time)) ||
+                        (true === $is_datetime(input.date_time) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date_time",
+                                expected: "string (@format datetime)",
+                                value: input.date_time,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date_time",
                             expected: "string",
                             value: input.date_time,
                         })) &&
                     (("string" === typeof input.datetime &&
-                        true === $is_datetime(input.datetime)) ||
+                        (true === $is_datetime(input.datetime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".datetime",
+                                expected: "string (@format datetime)",
+                                value: input.datetime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".datetime",
                             expected: "string",
                             value: input.datetime,
                         })) &&
                     (("string" === typeof input.dateTime &&
-                        true === $is_datetime(input.dateTime)) ||
+                        (true === $is_datetime(input.dateTime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dateTime",
+                                expected: "string (@format datetime)",
+                                value: input.dateTime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".dateTime",
                             expected: "string",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagLength.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagLength.ts
@@ -19,29 +19,54 @@ export const test_createAssertClone_TagLength = _test_assertClone(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.fixed &&
-                        5 === input.fixed.length) ||
+                        (5 === input.fixed.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".fixed",
+                                expected: "string (@length 5)",
+                                value: input.fixed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".fixed",
                             expected: "string",
                             value: input.fixed,
                         })) &&
                     (("string" === typeof input.minimum &&
-                        3 <= input.minimum.length) ||
+                        (3 <= input.minimum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "string",
                             value: input.minimum,
                         })) &&
                     (("string" === typeof input.maximum &&
-                        7 >= input.maximum.length) ||
+                        (7 >= input.maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "string",
                             value: input.maximum,
                         })) &&
                     (("string" === typeof input.minimum_and_maximum &&
-                        3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length) ||
+                        (3 <= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum_and_maximum,
+                            })) &&
+                        (7 >= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.minimum_and_maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum_and_maximum",
                             expected: "string",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagMatrix.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagMatrix.ts
@@ -20,7 +20,12 @@ export const test_createAssertClone_TagMatrix = _test_assertClone(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ((Array.isArray(input.matrix) &&
-                        3 === input.matrix.length) ||
+                        (3 === input.matrix.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".matrix",
+                                expected: "Array.length (@items 3)",
+                                value: input.matrix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".matrix",
                             expected: "Array<Array<string>>",
@@ -28,7 +33,14 @@ export const test_createAssertClone_TagMatrix = _test_assertClone(
                         })) &&
                     input.matrix.every(
                         (elem: any, _index1: number) =>
-                            ((Array.isArray(elem) && 3 === elem.length) ||
+                            ((Array.isArray(elem) &&
+                                (3 === elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".matrix[" + _index1 + "]",
+                                        expected: "Array.length (@items 3)",
+                                        value: elem,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".matrix[" + _index1 + "]",
                                     expected: "Array<string>",
@@ -37,7 +49,19 @@ export const test_createAssertClone_TagMatrix = _test_assertClone(
                             elem.every(
                                 (elem: any, _index2: number) =>
                                     ("string" === typeof elem &&
-                                        true === $is_uuid(elem)) ||
+                                        (true === $is_uuid(elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".matrix[" +
+                                                    _index1 +
+                                                    "][" +
+                                                    _index2 +
+                                                    "]",
+                                                expected:
+                                                    "string (@format uuid)",
+                                                value: elem,
+                                            }))) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagObjectUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagObjectUnion.ts
@@ -20,7 +20,12 @@ export const test_createAssertClone_TagObjectUnion = _test_assertClone(
                 ): boolean =>
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "number",
@@ -32,8 +37,18 @@ export const test_createAssertClone_TagObjectUnion = _test_assertClone(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "string",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagPattern.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagPattern.ts
@@ -19,40 +19,64 @@ export const test_createAssertClone_TagPattern = _test_assertClone(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                            ).test(input.uuid)) ||
+                            ).test(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected:
+                                    "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                            ).test(input.email)) ||
+                            ).test(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected:
+                                    'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                            ).test(input.ipv4)) ||
+                            ).test(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected:
+                                    "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                            ).test(input.ipv6)) ||
+                            ).test(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected:
+                                    "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagRange.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagRange.ts
@@ -20,7 +20,12 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                 ): boolean =>
                     (("number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
-                        3 < input.greater) ||
+                        (3 < input.greater ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater",
                             expected: "number",
@@ -28,7 +33,12 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                         })) &&
                     (("number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
-                        3 <= input.greater_equal) ||
+                        (3 <= input.greater_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal",
                             expected: "number",
@@ -36,7 +46,12 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                         })) &&
                     (("number" === typeof input.less &&
                         Number.isFinite(input.less) &&
-                        7 > input.less) ||
+                        (7 > input.less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less",
                             expected: "number",
@@ -44,39 +59,84 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                         })) &&
                     (("number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
-                        7 >= input.less_equal) ||
+                        (7 >= input.less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less_equal",
                             expected: "number",
                             value: input.less_equal,
                         })) &&
                     (("number" === typeof input.greater_less &&
-                        3 < input.greater_less &&
-                        7 > input.greater_less) ||
+                        (3 < input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less,
+                            })) &&
+                        (7 > input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less",
                             expected: "number",
                             value: input.greater_less,
                         })) &&
                     (("number" === typeof input.greater_equal_less &&
-                        3 <= input.greater_equal_less &&
-                        7 > input.greater_equal_less) ||
+                        (3 <= input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less,
+                            })) &&
+                        (7 > input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_equal_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less",
                             expected: "number",
                             value: input.greater_equal_less,
                         })) &&
                     (("number" === typeof input.greater_less_equal &&
-                        3 < input.greater_less_equal &&
-                        7 >= input.greater_less_equal) ||
+                        (3 < input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        (7 >= input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less_equal",
                             expected: "number",
                             value: input.greater_less_equal,
                         })) &&
                     (("number" === typeof input.greater_equal_less_equal &&
-                        3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal) ||
+                        (3 <= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
+                        (7 >= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_equal_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagStep.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagStep.ts
@@ -19,34 +19,84 @@ export const test_createAssertClone_TagStep = _test_assertClone(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("number" === typeof input.exclusiveMinimum &&
-                        0 === (input.exclusiveMinimum % 5) - 3 &&
-                        3 < input.exclusiveMinimum) ||
+                        (0 === (input.exclusiveMinimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@step 5)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (3 < input.exclusiveMinimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.exclusiveMinimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".exclusiveMinimum",
                             expected: "number",
                             value: input.exclusiveMinimum,
                         })) &&
                     (("number" === typeof input.minimum &&
-                        0 === (input.minimum % 5) - 3 &&
-                        3 <= input.minimum) ||
+                        (0 === (input.minimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@step 5)",
+                                value: input.minimum,
+                            })) &&
+                        (3 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
                             value: input.minimum,
                         })) &&
                     (("number" === typeof input.range &&
-                        0 === (input.range % 5) - 0 &&
-                        0 < input.range &&
-                        100 > input.range) ||
+                        (0 === (input.range % 5) - 0 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@step 5)",
+                                value: input.range,
+                            })) &&
+                        (0 < input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMinimum 0)",
+                                value: input.range,
+                            })) &&
+                        (100 > input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMaximum 100)",
+                                value: input.range,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".range",
                             expected: "number",
                             value: input.range,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 5 &&
-                        3 <= input.multipleOf &&
-                        99 >= input.multipleOf) ||
+                        (0 === input.multipleOf % 5 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 5)",
+                                value: input.multipleOf,
+                            })) &&
+                        (3 <= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@minimum 3)",
+                                value: input.multipleOf,
+                            })) &&
+                        (99 >= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@maximum 99)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagTuple.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagTuple.ts
@@ -33,24 +33,54 @@ export const test_createAssertClone_TagTuple = _test_assertClone(
                             value: input.tuple,
                         })) &&
                     (("string" === typeof input.tuple[0] &&
-                        3 <= input.tuple[0].length &&
-                        7 >= input.tuple[0].length) ||
+                        (3 <= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@minLength 3)",
+                                value: input.tuple[0],
+                            })) &&
+                        (7 >= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@maxLength 7)",
+                                value: input.tuple[0],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[0]",
                             expected: "string",
                             value: input.tuple[0],
                         })) &&
                     (("number" === typeof input.tuple[1] &&
-                        3 <= input.tuple[1] &&
-                        7 >= input.tuple[1]) ||
+                        (3 <= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@minimum 3)",
+                                value: input.tuple[1],
+                            })) &&
+                        (7 >= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@maximum 7)",
+                                value: input.tuple[1],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[1]",
                             expected: "number",
                             value: input.tuple[1],
                         })) &&
                     ((Array.isArray(input.tuple[2]) &&
-                        3 <= input.tuple[2].length &&
-                        7 >= input.tuple[2].length) ||
+                        (3 <= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[2],
+                            })) &&
+                        (7 >= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[2],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[2]",
                             expected: "Array<string>",
@@ -59,8 +89,26 @@ export const test_createAssertClone_TagTuple = _test_assertClone(
                     input.tuple[2].every(
                         (elem: any, _index1: number) =>
                             ("string" === typeof elem &&
-                                3 <= elem.length &&
-                                7 >= elem.length) ||
+                                (3 <= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@minLength 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[2][" + _index1 + "]",
                                 expected: "string",
@@ -68,8 +116,18 @@ export const test_createAssertClone_TagTuple = _test_assertClone(
                             }),
                     ) &&
                     ((Array.isArray(input.tuple[3]) &&
-                        3 <= input.tuple[3].length &&
-                        7 >= input.tuple[3].length) ||
+                        (3 <= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[3],
+                            })) &&
+                        (7 >= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[3],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[3]",
                             expected: "Array<number>",
@@ -78,8 +136,26 @@ export const test_createAssertClone_TagTuple = _test_assertClone(
                     input.tuple[3].every(
                         (elem: any, _index2: number) =>
                             ("number" === typeof elem &&
-                                3 <= elem &&
-                                7 >= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[3][" + _index2 + "]",
                                 expected: "number",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagType.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagType.ts
@@ -20,7 +20,12 @@ export const test_createAssertClone_TagType = _test_assertClone(
                 ): boolean =>
                     (("number" === typeof input.int &&
                         Number.isFinite(input.int) &&
-                        parseInt(input.int) === input.int) ||
+                        (parseInt(input.int) === input.int ||
+                            $guard(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".int",
                             expected: "number",
@@ -28,8 +33,18 @@ export const test_createAssertClone_TagType = _test_assertClone(
                         })) &&
                     (("number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
-                        parseInt(input.uint) === input.uint &&
-                        0 <= input.uint) ||
+                        (parseInt(input.uint) === input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (0 <= input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uint",
                             expected: "number",

--- a/test/generated/output/createAssertClone/test_createAssertClone_UltimateUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_UltimateUnion.ts
@@ -934,7 +934,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            parseInt(input.minimum) === input.minimum) ||
+                            (parseInt(input.minimum) === input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "(number | undefined)",
@@ -943,7 +948,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            parseInt(input.maximum) === input.maximum) ||
+                            (parseInt(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "(number | undefined)",
@@ -966,7 +976,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            parseInt(input.multipleOf) === input.multipleOf) ||
+                            (parseInt(input.multipleOf) === input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "(number | undefined)",
@@ -1255,8 +1270,18 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
-                            parseInt(input.minLength) === input.minLength &&
-                            0 <= input.minLength) ||
+                            (parseInt(input.minLength) === input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                })) &&
+                            (0 <= input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minLength",
                             expected: "(number | undefined)",
@@ -1265,8 +1290,18 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
-                            parseInt(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength) ||
+                            (parseInt(input.maxLength) === input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxLength",
                             expected: "(number | undefined)",
@@ -1423,8 +1458,18 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
-                            parseInt(input.minItems) === input.minItems &&
-                            0 <= input.minItems) ||
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "(number | undefined)",
@@ -1433,8 +1478,18 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
-                            parseInt(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems) ||
+                            (parseInt(input.maxItems) === input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "(number | undefined)",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagArray.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagArray.ts
@@ -19,7 +19,13 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
                 _path: string,
                 _exceptionable: boolean = true,
             ): boolean =>
-                ((Array.isArray(input.items) && 3 === input.items.length) ||
+                ((Array.isArray(input.items) &&
+                    (3 === input.items.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".items",
+                            expected: "Array.length (@items 3)",
+                            value: input.items,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".items",
                         expected: "Array<string>",
@@ -27,7 +33,13 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
                     })) &&
                 input.items.every(
                     (elem: any, _index2: number) =>
-                        ("string" === typeof elem && true === $is_uuid(elem)) ||
+                        ("string" === typeof elem &&
+                            (true === $is_uuid(elem) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items[" + _index2 + "]",
+                                    expected: "string (@format uuid)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".items[" + _index2 + "]",
                             expected: "string",
@@ -35,7 +47,12 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
                         }),
                 ) &&
                 ((Array.isArray(input.minItems) &&
-                    3 <= input.minItems.length) ||
+                    (3 <= input.minItems.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minItems",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.minItems,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minItems",
                         expected: "Array<number>",
@@ -45,7 +62,12 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
                     (elem: any, _index3: number) =>
                         ("number" === typeof elem &&
                             Number.isFinite(elem) &&
-                            3 <= elem) ||
+                            (3 <= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems[" + _index3 + "]",
+                                    expected: "number (@minimum 3)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems[" + _index3 + "]",
                             expected: "number",
@@ -53,7 +75,12 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
                         }),
                 ) &&
                 ((Array.isArray(input.maxItems) &&
-                    7 >= input.maxItems.length) ||
+                    (7 >= input.maxItems.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maxItems",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.maxItems,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maxItems",
                         expected: "Array<(number | string)>",
@@ -61,10 +88,21 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
                     })) &&
                 input.maxItems.every(
                     (elem: any, _index4: number) =>
-                        ("string" === typeof elem && 7 >= elem.length) ||
+                        ("string" === typeof elem &&
+                            (7 >= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems[" + _index4 + "]",
+                                    expected: "string (@maxLength 7)",
+                                    value: elem,
+                                }))) ||
                         ("number" === typeof elem &&
                             Number.isFinite(elem) &&
-                            7 >= elem) ||
+                            (7 >= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems[" + _index4 + "]",
+                                    expected: "number (@maximum 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems[" + _index4 + "]",
                             expected: "(number | string)",
@@ -72,8 +110,18 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
                         }),
                 ) &&
                 ((Array.isArray(input.both) &&
-                    3 <= input.both.length &&
-                    7 >= input.both.length) ||
+                    (3 <= input.both.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".both",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.both,
+                        })) &&
+                    (7 >= input.both.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".both",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.both,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".both",
                         expected: "Array<string>",
@@ -81,7 +129,13 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
                     })) &&
                 input.both.every(
                     (elem: any, _index5: number) =>
-                        ("string" === typeof elem && true === $is_uuid(elem)) ||
+                        ("string" === typeof elem &&
+                            (true === $is_uuid(elem) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both[" + _index5 + "]",
+                                    expected: "string (@format uuid)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".both[" + _index5 + "]",
                             expected: "string",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagAtomicUnion.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagAtomicUnion.ts
@@ -19,11 +19,26 @@ export const test_createAssertEquals_TagAtomicUnion = _test_assertEquals(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.value &&
-                    3 <= input.value.length &&
-                    7 >= input.value.length) ||
+                    (3 <= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@minLength 3)",
+                            value: input.value,
+                        })) &&
+                    (7 >= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@maxLength 7)",
+                            value: input.value,
+                        }))) ||
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "(number | string)",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagBigInt.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagBigInt.ts
@@ -25,27 +25,54 @@ export const test_createAssertEquals_TagBigInt = _test_assertEquals(
                         value: input.value,
                     })) &&
                 (("bigint" === typeof input.ranged &&
-                    0n <= input.ranged &&
-                    100n >= input.ranged) ||
+                    (0n <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "bigint (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100n >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "bigint (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "bigint",
                         value: input.ranged,
                     })) &&
-                (("bigint" === typeof input.minimum && 0n <= input.minimum) ||
+                (("bigint" === typeof input.minimum &&
+                    (0n <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "bigint (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "bigint",
                         value: input.minimum,
                     })) &&
-                (("bigint" === typeof input.maximum && 100n >= input.maximum) ||
+                (("bigint" === typeof input.maximum &&
+                    (100n >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "bigint (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "bigint",
                         value: input.maximum,
                     })) &&
                 (("bigint" === typeof input.multipleOf &&
-                    0n === input.multipleOf % 3n) ||
+                    (0n === input.multipleOf % 3n ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "bigint (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "bigint",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagCustom.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagCustom.ts
@@ -21,21 +21,36 @@ export const test_createAssertEquals_TagCustom = _test_assertEquals(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.id &&
-                    true === $is_uuid(input.id)) ||
+                    (true === $is_uuid(input.id) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".id",
+                            expected: "string (@format uuid)",
+                            value: input.id,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".id",
                         expected: "string",
                         value: input.id,
                     })) &&
-                (("string" === typeof input.dolloar &&
-                    $is_custom("dollar", "string", "", input.dolloar)) ||
+                (("string" === typeof input.dollar &&
+                    ($is_custom("dollar", "string", "", input.dollar) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dollar",
+                            expected: "string (@dollar)",
+                            value: input.dollar,
+                        }))) ||
                     $guard(_exceptionable, {
-                        path: _path + ".dolloar",
+                        path: _path + ".dollar",
                         expected: "string",
-                        value: input.dolloar,
+                        value: input.dollar,
                     })) &&
                 (("string" === typeof input.postfix &&
-                    $is_custom("postfix", "string", "abcd", input.postfix)) ||
+                    ($is_custom("postfix", "string", "abcd", input.postfix) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".postfix",
+                            expected: "string (@postfix abcd)",
+                            value: input.postfix,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".postfix",
                         expected: "string",
@@ -43,7 +58,12 @@ export const test_createAssertEquals_TagCustom = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.log &&
                     Number.isFinite(input.log) &&
-                    $is_custom("powerOf", "number", "10", input.log)) ||
+                    ($is_custom("powerOf", "number", "10", input.log) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".log",
+                            expected: "number (@powerOf 10)",
+                            value: input.log,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".log",
                         expected: "number",
@@ -53,7 +73,7 @@ export const test_createAssertEquals_TagCustom = _test_assertEquals(
                     false === _exceptionable ||
                     Object.keys(input).every((key) => {
                         if (
-                            ["id", "dolloar", "postfix", "log"].some(
+                            ["id", "dollar", "postfix", "log"].some(
                                 (prop) => key === prop,
                             )
                         )

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagFormat.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagFormat.ts
@@ -26,63 +26,108 @@ export const test_createAssertEquals_TagFormat = _test_assertEquals(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.uuid &&
-                    true === $is_uuid(input.uuid)) ||
+                    (true === $is_uuid(input.uuid) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uuid",
+                            expected: "string (@format uuid)",
+                            value: input.uuid,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uuid",
                         expected: "string",
                         value: input.uuid,
                     })) &&
                 (("string" === typeof input.email &&
-                    true === $is_email(input.email)) ||
+                    (true === $is_email(input.email) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".email",
+                            expected: "string (@format email)",
+                            value: input.email,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".email",
                         expected: "string",
                         value: input.email,
                     })) &&
                 (("string" === typeof input.url &&
-                    true === $is_url(input.url)) ||
+                    (true === $is_url(input.url) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".url",
+                            expected: "string (@format url)",
+                            value: input.url,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".url",
                         expected: "string",
                         value: input.url,
                     })) &&
                 (("string" === typeof input.ipv4 &&
-                    true === $is_ipv4(input.ipv4)) ||
+                    (true === $is_ipv4(input.ipv4) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv4",
+                            expected: "string (@format ipv4)",
+                            value: input.ipv4,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv4",
                         expected: "string",
                         value: input.ipv4,
                     })) &&
                 (("string" === typeof input.ipv6 &&
-                    true === $is_ipv6(input.ipv6)) ||
+                    (true === $is_ipv6(input.ipv6) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv6",
+                            expected: "string (@format ipv6)",
+                            value: input.ipv6,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv6",
                         expected: "string",
                         value: input.ipv6,
                     })) &&
                 (("string" === typeof input.date &&
-                    true === $is_date(input.date)) ||
+                    (true === $is_date(input.date) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".date",
+                            expected: "string (@format date)",
+                            value: input.date,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".date",
                         expected: "string",
                         value: input.date,
                     })) &&
                 (("string" === typeof input.date_time &&
-                    true === $is_datetime(input.date_time)) ||
+                    (true === $is_datetime(input.date_time) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".date_time",
+                            expected: "string (@format datetime)",
+                            value: input.date_time,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".date_time",
                         expected: "string",
                         value: input.date_time,
                     })) &&
                 (("string" === typeof input.datetime &&
-                    true === $is_datetime(input.datetime)) ||
+                    (true === $is_datetime(input.datetime) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".datetime",
+                            expected: "string (@format datetime)",
+                            value: input.datetime,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".datetime",
                         expected: "string",
                         value: input.datetime,
                     })) &&
                 (("string" === typeof input.dateTime &&
-                    true === $is_datetime(input.dateTime)) ||
+                    (true === $is_datetime(input.dateTime) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dateTime",
+                            expected: "string (@format datetime)",
+                            value: input.dateTime,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".dateTime",
                         expected: "string",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagInfinite.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagInfinite.ts
@@ -26,8 +26,18 @@ export const test_createAssertEquals_TagInfinite = _test_assertEquals(
                         value: input.value,
                     })) &&
                 (("number" === typeof input.ranged &&
-                    0 <= input.ranged &&
-                    100 >= input.ranged) ||
+                    (0 <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100 >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "number",
@@ -35,7 +45,12 @@ export const test_createAssertEquals_TagInfinite = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
-                    0 <= input.minimum) ||
+                    (0 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
@@ -43,14 +58,24 @@ export const test_createAssertEquals_TagInfinite = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.maximum &&
                     Number.isFinite(input.maximum) &&
-                    100 >= input.maximum) ||
+                    (100 >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "number (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "number",
                         value: input.maximum,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 3) ||
+                    (0 === input.multipleOf % 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",
@@ -58,7 +83,12 @@ export const test_createAssertEquals_TagInfinite = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
-                    parseInt(input.typed) === input.typed) ||
+                    (parseInt(input.typed) === input.typed ||
+                        $guard(_exceptionable, {
+                            path: _path + ".typed",
+                            expected: "number (@type int)",
+                            value: input.typed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".typed",
                         expected: "number",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagLength.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagLength.ts
@@ -19,29 +19,54 @@ export const test_createAssertEquals_TagLength = _test_assertEquals(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.fixed &&
-                    5 === input.fixed.length) ||
+                    (5 === input.fixed.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".fixed",
+                            expected: "string (@length 5)",
+                            value: input.fixed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".fixed",
                         expected: "string",
                         value: input.fixed,
                     })) &&
                 (("string" === typeof input.minimum &&
-                    3 <= input.minimum.length) ||
+                    (3 <= input.minimum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "string (@minLength 3)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "string",
                         value: input.minimum,
                     })) &&
                 (("string" === typeof input.maximum &&
-                    7 >= input.maximum.length) ||
+                    (7 >= input.maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "string (@maxLength 7)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "string",
                         value: input.maximum,
                     })) &&
                 (("string" === typeof input.minimum_and_maximum &&
-                    3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length) ||
+                    (3 <= input.minimum_and_maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum_and_maximum",
+                            expected: "string (@minLength 3)",
+                            value: input.minimum_and_maximum,
+                        })) &&
+                    (7 >= input.minimum_and_maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum_and_maximum",
+                            expected: "string (@maxLength 7)",
+                            value: input.minimum_and_maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum_and_maximum",
                         expected: "string",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagMatrix.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagMatrix.ts
@@ -19,7 +19,13 @@ export const test_createAssertEquals_TagMatrix = _test_assertEquals(
                 _path: string,
                 _exceptionable: boolean = true,
             ): boolean =>
-                ((Array.isArray(input.matrix) && 3 === input.matrix.length) ||
+                ((Array.isArray(input.matrix) &&
+                    (3 === input.matrix.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".matrix",
+                            expected: "Array.length (@items 3)",
+                            value: input.matrix,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".matrix",
                         expected: "Array<Array<string>>",
@@ -27,7 +33,13 @@ export const test_createAssertEquals_TagMatrix = _test_assertEquals(
                     })) &&
                 input.matrix.every(
                     (elem: any, _index1: number) =>
-                        ((Array.isArray(elem) && 3 === elem.length) ||
+                        ((Array.isArray(elem) &&
+                            (3 === elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".matrix[" + _index1 + "]",
+                                    expected: "Array.length (@items 3)",
+                                    value: elem,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".matrix[" + _index1 + "]",
                                 expected: "Array<string>",
@@ -36,7 +48,18 @@ export const test_createAssertEquals_TagMatrix = _test_assertEquals(
                         elem.every(
                             (elem: any, _index2: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".matrix[" +
+                                                _index1 +
+                                                "][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path:
                                         _path +

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagNaN.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagNaN.ts
@@ -26,8 +26,18 @@ export const test_createAssertEquals_TagNaN = _test_assertEquals(
                         value: input.value,
                     })) &&
                 (("number" === typeof input.ranged &&
-                    0 <= input.ranged &&
-                    100 >= input.ranged) ||
+                    (0 <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100 >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "number",
@@ -35,7 +45,12 @@ export const test_createAssertEquals_TagNaN = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
-                    0 <= input.minimum) ||
+                    (0 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
@@ -43,14 +58,24 @@ export const test_createAssertEquals_TagNaN = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.maximum &&
                     Number.isFinite(input.maximum) &&
-                    100 >= input.maximum) ||
+                    (100 >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "number (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "number",
                         value: input.maximum,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 3) ||
+                    (0 === input.multipleOf % 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",
@@ -58,7 +83,12 @@ export const test_createAssertEquals_TagNaN = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
-                    parseInt(input.typed) === input.typed) ||
+                    (parseInt(input.typed) === input.typed ||
+                        $guard(_exceptionable, {
+                            path: _path + ".typed",
+                            expected: "number (@type int)",
+                            value: input.typed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".typed",
                         expected: "number",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagObjectUnion.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagObjectUnion.ts
@@ -20,7 +20,12 @@ export const test_createAssertEquals_TagObjectUnion = _test_assertEquals(
             ): boolean =>
                 (("number" === typeof input.value &&
                     Number.isFinite(input.value) &&
-                    3 <= input.value) ||
+                    (3 <= input.value ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "number (@minimum 3)",
+                            value: input.value,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "number",
@@ -44,8 +49,18 @@ export const test_createAssertEquals_TagObjectUnion = _test_assertEquals(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.value &&
-                    3 <= input.value.length &&
-                    7 >= input.value.length) ||
+                    (3 <= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@minLength 3)",
+                            value: input.value,
+                        })) &&
+                    (7 >= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@maxLength 7)",
+                            value: input.value,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "string",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagPattern.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagPattern.ts
@@ -19,40 +19,64 @@ export const test_createAssertEquals_TagPattern = _test_assertEquals(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.uuid &&
-                    true ===
+                    (true ===
                         RegExp(
                             /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                        ).test(input.uuid)) ||
+                        ).test(input.uuid) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uuid",
+                            expected:
+                                "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                            value: input.uuid,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uuid",
                         expected: "string",
                         value: input.uuid,
                     })) &&
                 (("string" === typeof input.email &&
-                    true ===
+                    (true ===
                         RegExp(
                             /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                        ).test(input.email)) ||
+                        ).test(input.email) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".email",
+                            expected:
+                                'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                            value: input.email,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".email",
                         expected: "string",
                         value: input.email,
                     })) &&
                 (("string" === typeof input.ipv4 &&
-                    true ===
+                    (true ===
                         RegExp(
                             /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                        ).test(input.ipv4)) ||
+                        ).test(input.ipv4) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv4",
+                            expected:
+                                "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                            value: input.ipv4,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv4",
                         expected: "string",
                         value: input.ipv4,
                     })) &&
                 (("string" === typeof input.ipv6 &&
-                    true ===
+                    (true ===
                         RegExp(
                             /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                        ).test(input.ipv6)) ||
+                        ).test(input.ipv6) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv6",
+                            expected:
+                                "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                            value: input.ipv6,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv6",
                         expected: "string",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagRange.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagRange.ts
@@ -20,7 +20,12 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
             ): boolean =>
                 (("number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
-                    3 < input.greater) ||
+                    (3 < input.greater ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater",
                         expected: "number",
@@ -28,7 +33,12 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
-                    3 <= input.greater_equal) ||
+                    (3 <= input.greater_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal",
                         expected: "number",
@@ -36,7 +46,12 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.less &&
                     Number.isFinite(input.less) &&
-                    7 > input.less) ||
+                    (7 > input.less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".less",
                         expected: "number",
@@ -44,39 +59,84 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
-                    7 >= input.less_equal) ||
+                    (7 >= input.less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".less_equal",
                         expected: "number",
                         value: input.less_equal,
                     })) &&
                 (("number" === typeof input.greater_less &&
-                    3 < input.greater_less &&
-                    7 > input.greater_less) ||
+                    (3 < input.greater_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater_less,
+                        })) &&
+                    (7 > input.greater_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.greater_less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_less",
                         expected: "number",
                         value: input.greater_less,
                     })) &&
                 (("number" === typeof input.greater_equal_less &&
-                    3 <= input.greater_equal_less &&
-                    7 > input.greater_equal_less) ||
+                    (3 <= input.greater_equal_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal_less,
+                        })) &&
+                    (7 > input.greater_equal_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.greater_equal_less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal_less",
                         expected: "number",
                         value: input.greater_equal_less,
                     })) &&
                 (("number" === typeof input.greater_less_equal &&
-                    3 < input.greater_less_equal &&
-                    7 >= input.greater_less_equal) ||
+                    (3 < input.greater_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less_equal",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater_less_equal,
+                        })) &&
+                    (7 >= input.greater_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.greater_less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_less_equal",
                         expected: "number",
                         value: input.greater_less_equal,
                     })) &&
                 (("number" === typeof input.greater_equal_less_equal &&
-                    3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal) ||
+                    (3 <= input.greater_equal_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less_equal",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal_less_equal,
+                        })) &&
+                    (7 >= input.greater_equal_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.greater_equal_less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal_less_equal",
                         expected: "number",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagStep.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagStep.ts
@@ -19,34 +19,84 @@ export const test_createAssertEquals_TagStep = _test_assertEquals(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("number" === typeof input.exclusiveMinimum &&
-                    0 === (input.exclusiveMinimum % 5) - 3 &&
-                    3 < input.exclusiveMinimum) ||
+                    (0 === (input.exclusiveMinimum % 5) - 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "number (@step 5)",
+                            value: input.exclusiveMinimum,
+                        })) &&
+                    (3 < input.exclusiveMinimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.exclusiveMinimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".exclusiveMinimum",
                         expected: "number",
                         value: input.exclusiveMinimum,
                     })) &&
                 (("number" === typeof input.minimum &&
-                    0 === (input.minimum % 5) - 3 &&
-                    3 <= input.minimum) ||
+                    (0 === (input.minimum % 5) - 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@step 5)",
+                            value: input.minimum,
+                        })) &&
+                    (3 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 3)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
                         value: input.minimum,
                     })) &&
                 (("number" === typeof input.range &&
-                    0 === (input.range % 5) - 0 &&
-                    0 < input.range &&
-                    100 > input.range) ||
+                    (0 === (input.range % 5) - 0 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@step 5)",
+                            value: input.range,
+                        })) &&
+                    (0 < input.range ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@exclusiveMinimum 0)",
+                            value: input.range,
+                        })) &&
+                    (100 > input.range ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@exclusiveMaximum 100)",
+                            value: input.range,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".range",
                         expected: "number",
                         value: input.range,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 5 &&
-                    3 <= input.multipleOf &&
-                    99 >= input.multipleOf) ||
+                    (0 === input.multipleOf % 5 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 5)",
+                            value: input.multipleOf,
+                        })) &&
+                    (3 <= input.multipleOf ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@minimum 3)",
+                            value: input.multipleOf,
+                        })) &&
+                    (99 >= input.multipleOf ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@maximum 99)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagTuple.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagTuple.ts
@@ -33,24 +33,54 @@ export const test_createAssertEquals_TagTuple = _test_assertEquals(
                         value: input.tuple,
                     })) &&
                 (("string" === typeof input.tuple[0] &&
-                    3 <= input.tuple[0].length &&
-                    7 >= input.tuple[0].length) ||
+                    (3 <= input.tuple[0].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[0]",
+                            expected: "string (@minLength 3)",
+                            value: input.tuple[0],
+                        })) &&
+                    (7 >= input.tuple[0].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[0]",
+                            expected: "string (@maxLength 7)",
+                            value: input.tuple[0],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[0]",
                         expected: "string",
                         value: input.tuple[0],
                     })) &&
                 (("number" === typeof input.tuple[1] &&
-                    3 <= input.tuple[1] &&
-                    7 >= input.tuple[1]) ||
+                    (3 <= input.tuple[1] ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[1]",
+                            expected: "number (@minimum 3)",
+                            value: input.tuple[1],
+                        })) &&
+                    (7 >= input.tuple[1] ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[1]",
+                            expected: "number (@maximum 7)",
+                            value: input.tuple[1],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[1]",
                         expected: "number",
                         value: input.tuple[1],
                     })) &&
                 ((Array.isArray(input.tuple[2]) &&
-                    3 <= input.tuple[2].length &&
-                    7 >= input.tuple[2].length) ||
+                    (3 <= input.tuple[2].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[2]",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.tuple[2],
+                        })) &&
+                    (7 >= input.tuple[2].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[2]",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.tuple[2],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[2]",
                         expected: "Array<string>",
@@ -59,8 +89,18 @@ export const test_createAssertEquals_TagTuple = _test_assertEquals(
                 input.tuple[2].every(
                     (elem: any, _index1: number) =>
                         ("string" === typeof elem &&
-                            3 <= elem.length &&
-                            7 >= elem.length) ||
+                            (3 <= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2][" + _index1 + "]",
+                                    expected: "string (@minLength 3)",
+                                    value: elem,
+                                })) &&
+                            (7 >= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2][" + _index1 + "]",
+                                    expected: "string (@maxLength 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[2][" + _index1 + "]",
                             expected: "string",
@@ -68,8 +108,18 @@ export const test_createAssertEquals_TagTuple = _test_assertEquals(
                         }),
                 ) &&
                 ((Array.isArray(input.tuple[3]) &&
-                    3 <= input.tuple[3].length &&
-                    7 >= input.tuple[3].length) ||
+                    (3 <= input.tuple[3].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[3]",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.tuple[3],
+                        })) &&
+                    (7 >= input.tuple[3].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[3]",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.tuple[3],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[3]",
                         expected: "Array<number>",
@@ -77,7 +127,19 @@ export const test_createAssertEquals_TagTuple = _test_assertEquals(
                     })) &&
                 input.tuple[3].every(
                     (elem: any, _index2: number) =>
-                        ("number" === typeof elem && 3 <= elem && 7 >= elem) ||
+                        ("number" === typeof elem &&
+                            (3 <= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3][" + _index2 + "]",
+                                    expected: "number (@minimum 3)",
+                                    value: elem,
+                                })) &&
+                            (7 >= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3][" + _index2 + "]",
+                                    expected: "number (@maximum 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[3][" + _index2 + "]",
                             expected: "number",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagType.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagType.ts
@@ -20,7 +20,12 @@ export const test_createAssertEquals_TagType = _test_assertEquals(
             ): boolean =>
                 (("number" === typeof input.int &&
                     Number.isFinite(input.int) &&
-                    parseInt(input.int) === input.int) ||
+                    (parseInt(input.int) === input.int ||
+                        $guard(_exceptionable, {
+                            path: _path + ".int",
+                            expected: "number (@type int)",
+                            value: input.int,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".int",
                         expected: "number",
@@ -28,8 +33,18 @@ export const test_createAssertEquals_TagType = _test_assertEquals(
                     })) &&
                 (("number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
-                    parseInt(input.uint) === input.uint &&
-                    0 <= input.uint) ||
+                    (parseInt(input.uint) === input.uint ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uint",
+                            expected: "number (@type uint)",
+                            value: input.uint,
+                        })) &&
+                    (0 <= input.uint ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uint",
+                            expected: "number (@type uint)",
+                            value: input.uint,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uint",
                         expected: "number",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagArray.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagArray.ts
@@ -19,7 +19,13 @@ export const test_createAssertParse_TagArray = _test_assertParse(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ((Array.isArray(input.items) && 3 === input.items.length) ||
+                    ((Array.isArray(input.items) &&
+                        (3 === input.items.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected: "Array.length (@items 3)",
+                                value: input.items,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected: "Array<string>",
@@ -28,7 +34,12 @@ export const test_createAssertParse_TagArray = _test_assertParse(
                     input.items.every(
                         (elem: any, _index2: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".items[" + _index2 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items[" + _index2 + "]",
                                 expected: "string",
@@ -36,7 +47,12 @@ export const test_createAssertParse_TagArray = _test_assertParse(
                             }),
                     ) &&
                     ((Array.isArray(input.minItems) &&
-                        3 <= input.minItems.length) ||
+                        (3 <= input.minItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.minItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "Array<number>",
@@ -46,7 +62,16 @@ export const test_createAssertParse_TagArray = _test_assertParse(
                         (elem: any, _index3: number) =>
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                3 <= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".minItems[" +
+                                            _index3 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems[" + _index3 + "]",
                                 expected: "number",
@@ -54,7 +79,12 @@ export const test_createAssertParse_TagArray = _test_assertParse(
                             }),
                     ) &&
                     ((Array.isArray(input.maxItems) &&
-                        7 >= input.maxItems.length) ||
+                        (7 >= input.maxItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.maxItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "Array<(number | string)>",
@@ -62,10 +92,29 @@ export const test_createAssertParse_TagArray = _test_assertParse(
                         })) &&
                     input.maxItems.every(
                         (elem: any, _index4: number) =>
-                            ("string" === typeof elem && 7 >= elem.length) ||
+                            ("string" === typeof elem &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                7 >= elem) ||
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems[" + _index4 + "]",
                                 expected: "(number | string)",
@@ -73,8 +122,18 @@ export const test_createAssertParse_TagArray = _test_assertParse(
                             }),
                     ) &&
                     ((Array.isArray(input.both) &&
-                        3 <= input.both.length &&
-                        7 >= input.both.length) ||
+                        (3 <= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.both,
+                            })) &&
+                        (7 >= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.both,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".both",
                             expected: "Array<string>",
@@ -83,7 +142,12 @@ export const test_createAssertParse_TagArray = _test_assertParse(
                     input.both.every(
                         (elem: any, _index5: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".both[" + _index5 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".both[" + _index5 + "]",
                                 expected: "string",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagAtomicUnion.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagAtomicUnion.ts
@@ -19,11 +19,26 @@ export const test_createAssertParse_TagAtomicUnion = _test_assertParse(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "(number | string)",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagCustom.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagCustom.ts
@@ -21,26 +21,41 @@ export const test_createAssertParse_TagCustom = _test_assertParse(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.id &&
-                        true === $is_uuid(input.id)) ||
+                        (true === $is_uuid(input.id) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string (@format uuid)",
+                                value: input.id,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".id",
                             expected: "string",
                             value: input.id,
                         })) &&
-                    (("string" === typeof input.dolloar &&
-                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                    (("string" === typeof input.dollar &&
+                        ($is_custom("dollar", "string", "", input.dollar) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dollar",
+                                expected: "string (@dollar)",
+                                value: input.dollar,
+                            }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".dolloar",
+                            path: _path + ".dollar",
                             expected: "string",
-                            value: input.dolloar,
+                            value: input.dollar,
                         })) &&
                     (("string" === typeof input.postfix &&
-                        $is_custom(
+                        ($is_custom(
                             "postfix",
                             "string",
                             "abcd",
                             input.postfix,
-                        )) ||
+                        ) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string (@postfix abcd)",
+                                value: input.postfix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".postfix",
                             expected: "string",
@@ -48,7 +63,12 @@ export const test_createAssertParse_TagCustom = _test_assertParse(
                         })) &&
                     (("number" === typeof input.log &&
                         Number.isFinite(input.log) &&
-                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        ($is_custom("powerOf", "number", "10", input.log) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number (@powerOf 10)",
+                                value: input.log,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".log",
                             expected: "number",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagFormat.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagFormat.ts
@@ -26,63 +26,108 @@ export const test_createAssertParse_TagFormat = _test_assertParse(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true === $is_uuid(input.uuid)) ||
+                        (true === $is_uuid(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected: "string (@format uuid)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true === $is_email(input.email)) ||
+                        (true === $is_email(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected: "string (@format email)",
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.url &&
-                        true === $is_url(input.url)) ||
+                        (true === $is_url(input.url) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".url",
+                                expected: "string (@format url)",
+                                value: input.url,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".url",
                             expected: "string",
                             value: input.url,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true === $is_ipv4(input.ipv4)) ||
+                        (true === $is_ipv4(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected: "string (@format ipv4)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true === $is_ipv6(input.ipv6)) ||
+                        (true === $is_ipv6(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected: "string (@format ipv6)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",
                             value: input.ipv6,
                         })) &&
                     (("string" === typeof input.date &&
-                        true === $is_date(input.date)) ||
+                        (true === $is_date(input.date) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date",
+                                expected: "string (@format date)",
+                                value: input.date,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date",
                             expected: "string",
                             value: input.date,
                         })) &&
                     (("string" === typeof input.date_time &&
-                        true === $is_datetime(input.date_time)) ||
+                        (true === $is_datetime(input.date_time) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date_time",
+                                expected: "string (@format datetime)",
+                                value: input.date_time,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date_time",
                             expected: "string",
                             value: input.date_time,
                         })) &&
                     (("string" === typeof input.datetime &&
-                        true === $is_datetime(input.datetime)) ||
+                        (true === $is_datetime(input.datetime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".datetime",
+                                expected: "string (@format datetime)",
+                                value: input.datetime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".datetime",
                             expected: "string",
                             value: input.datetime,
                         })) &&
                     (("string" === typeof input.dateTime &&
-                        true === $is_datetime(input.dateTime)) ||
+                        (true === $is_datetime(input.dateTime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dateTime",
+                                expected: "string (@format datetime)",
+                                value: input.dateTime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".dateTime",
                             expected: "string",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagLength.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagLength.ts
@@ -19,29 +19,54 @@ export const test_createAssertParse_TagLength = _test_assertParse(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.fixed &&
-                        5 === input.fixed.length) ||
+                        (5 === input.fixed.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".fixed",
+                                expected: "string (@length 5)",
+                                value: input.fixed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".fixed",
                             expected: "string",
                             value: input.fixed,
                         })) &&
                     (("string" === typeof input.minimum &&
-                        3 <= input.minimum.length) ||
+                        (3 <= input.minimum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "string",
                             value: input.minimum,
                         })) &&
                     (("string" === typeof input.maximum &&
-                        7 >= input.maximum.length) ||
+                        (7 >= input.maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "string",
                             value: input.maximum,
                         })) &&
                     (("string" === typeof input.minimum_and_maximum &&
-                        3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length) ||
+                        (3 <= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum_and_maximum,
+                            })) &&
+                        (7 >= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.minimum_and_maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum_and_maximum",
                             expected: "string",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagMatrix.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagMatrix.ts
@@ -20,7 +20,12 @@ export const test_createAssertParse_TagMatrix = _test_assertParse(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ((Array.isArray(input.matrix) &&
-                        3 === input.matrix.length) ||
+                        (3 === input.matrix.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".matrix",
+                                expected: "Array.length (@items 3)",
+                                value: input.matrix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".matrix",
                             expected: "Array<Array<string>>",
@@ -28,7 +33,14 @@ export const test_createAssertParse_TagMatrix = _test_assertParse(
                         })) &&
                     input.matrix.every(
                         (elem: any, _index1: number) =>
-                            ((Array.isArray(elem) && 3 === elem.length) ||
+                            ((Array.isArray(elem) &&
+                                (3 === elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".matrix[" + _index1 + "]",
+                                        expected: "Array.length (@items 3)",
+                                        value: elem,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".matrix[" + _index1 + "]",
                                     expected: "Array<string>",
@@ -37,7 +49,19 @@ export const test_createAssertParse_TagMatrix = _test_assertParse(
                             elem.every(
                                 (elem: any, _index2: number) =>
                                     ("string" === typeof elem &&
-                                        true === $is_uuid(elem)) ||
+                                        (true === $is_uuid(elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".matrix[" +
+                                                    _index1 +
+                                                    "][" +
+                                                    _index2 +
+                                                    "]",
+                                                expected:
+                                                    "string (@format uuid)",
+                                                value: elem,
+                                            }))) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagObjectUnion.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagObjectUnion.ts
@@ -20,7 +20,12 @@ export const test_createAssertParse_TagObjectUnion = _test_assertParse(
                 ): boolean =>
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "number",
@@ -32,8 +37,18 @@ export const test_createAssertParse_TagObjectUnion = _test_assertParse(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "string",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagPattern.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagPattern.ts
@@ -19,40 +19,64 @@ export const test_createAssertParse_TagPattern = _test_assertParse(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                            ).test(input.uuid)) ||
+                            ).test(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected:
+                                    "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                            ).test(input.email)) ||
+                            ).test(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected:
+                                    'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                            ).test(input.ipv4)) ||
+                            ).test(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected:
+                                    "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                            ).test(input.ipv6)) ||
+                            ).test(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected:
+                                    "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagRange.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagRange.ts
@@ -20,7 +20,12 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                 ): boolean =>
                     (("number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
-                        3 < input.greater) ||
+                        (3 < input.greater ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater",
                             expected: "number",
@@ -28,7 +33,12 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                         })) &&
                     (("number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
-                        3 <= input.greater_equal) ||
+                        (3 <= input.greater_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal",
                             expected: "number",
@@ -36,7 +46,12 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                         })) &&
                     (("number" === typeof input.less &&
                         Number.isFinite(input.less) &&
-                        7 > input.less) ||
+                        (7 > input.less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less",
                             expected: "number",
@@ -44,39 +59,84 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                         })) &&
                     (("number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
-                        7 >= input.less_equal) ||
+                        (7 >= input.less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less_equal",
                             expected: "number",
                             value: input.less_equal,
                         })) &&
                     (("number" === typeof input.greater_less &&
-                        3 < input.greater_less &&
-                        7 > input.greater_less) ||
+                        (3 < input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less,
+                            })) &&
+                        (7 > input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less",
                             expected: "number",
                             value: input.greater_less,
                         })) &&
                     (("number" === typeof input.greater_equal_less &&
-                        3 <= input.greater_equal_less &&
-                        7 > input.greater_equal_less) ||
+                        (3 <= input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less,
+                            })) &&
+                        (7 > input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_equal_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less",
                             expected: "number",
                             value: input.greater_equal_less,
                         })) &&
                     (("number" === typeof input.greater_less_equal &&
-                        3 < input.greater_less_equal &&
-                        7 >= input.greater_less_equal) ||
+                        (3 < input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        (7 >= input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less_equal",
                             expected: "number",
                             value: input.greater_less_equal,
                         })) &&
                     (("number" === typeof input.greater_equal_less_equal &&
-                        3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal) ||
+                        (3 <= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
+                        (7 >= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_equal_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagStep.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagStep.ts
@@ -19,34 +19,84 @@ export const test_createAssertParse_TagStep = _test_assertParse(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("number" === typeof input.exclusiveMinimum &&
-                        0 === (input.exclusiveMinimum % 5) - 3 &&
-                        3 < input.exclusiveMinimum) ||
+                        (0 === (input.exclusiveMinimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@step 5)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (3 < input.exclusiveMinimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.exclusiveMinimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".exclusiveMinimum",
                             expected: "number",
                             value: input.exclusiveMinimum,
                         })) &&
                     (("number" === typeof input.minimum &&
-                        0 === (input.minimum % 5) - 3 &&
-                        3 <= input.minimum) ||
+                        (0 === (input.minimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@step 5)",
+                                value: input.minimum,
+                            })) &&
+                        (3 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
                             value: input.minimum,
                         })) &&
                     (("number" === typeof input.range &&
-                        0 === (input.range % 5) - 0 &&
-                        0 < input.range &&
-                        100 > input.range) ||
+                        (0 === (input.range % 5) - 0 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@step 5)",
+                                value: input.range,
+                            })) &&
+                        (0 < input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMinimum 0)",
+                                value: input.range,
+                            })) &&
+                        (100 > input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMaximum 100)",
+                                value: input.range,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".range",
                             expected: "number",
                             value: input.range,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 5 &&
-                        3 <= input.multipleOf &&
-                        99 >= input.multipleOf) ||
+                        (0 === input.multipleOf % 5 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 5)",
+                                value: input.multipleOf,
+                            })) &&
+                        (3 <= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@minimum 3)",
+                                value: input.multipleOf,
+                            })) &&
+                        (99 >= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@maximum 99)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagTuple.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagTuple.ts
@@ -33,24 +33,54 @@ export const test_createAssertParse_TagTuple = _test_assertParse(
                             value: input.tuple,
                         })) &&
                     (("string" === typeof input.tuple[0] &&
-                        3 <= input.tuple[0].length &&
-                        7 >= input.tuple[0].length) ||
+                        (3 <= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@minLength 3)",
+                                value: input.tuple[0],
+                            })) &&
+                        (7 >= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@maxLength 7)",
+                                value: input.tuple[0],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[0]",
                             expected: "string",
                             value: input.tuple[0],
                         })) &&
                     (("number" === typeof input.tuple[1] &&
-                        3 <= input.tuple[1] &&
-                        7 >= input.tuple[1]) ||
+                        (3 <= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@minimum 3)",
+                                value: input.tuple[1],
+                            })) &&
+                        (7 >= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@maximum 7)",
+                                value: input.tuple[1],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[1]",
                             expected: "number",
                             value: input.tuple[1],
                         })) &&
                     ((Array.isArray(input.tuple[2]) &&
-                        3 <= input.tuple[2].length &&
-                        7 >= input.tuple[2].length) ||
+                        (3 <= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[2],
+                            })) &&
+                        (7 >= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[2],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[2]",
                             expected: "Array<string>",
@@ -59,8 +89,26 @@ export const test_createAssertParse_TagTuple = _test_assertParse(
                     input.tuple[2].every(
                         (elem: any, _index1: number) =>
                             ("string" === typeof elem &&
-                                3 <= elem.length &&
-                                7 >= elem.length) ||
+                                (3 <= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@minLength 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[2][" + _index1 + "]",
                                 expected: "string",
@@ -68,8 +116,18 @@ export const test_createAssertParse_TagTuple = _test_assertParse(
                             }),
                     ) &&
                     ((Array.isArray(input.tuple[3]) &&
-                        3 <= input.tuple[3].length &&
-                        7 >= input.tuple[3].length) ||
+                        (3 <= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[3],
+                            })) &&
+                        (7 >= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[3],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[3]",
                             expected: "Array<number>",
@@ -78,8 +136,26 @@ export const test_createAssertParse_TagTuple = _test_assertParse(
                     input.tuple[3].every(
                         (elem: any, _index2: number) =>
                             ("number" === typeof elem &&
-                                3 <= elem &&
-                                7 >= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[3][" + _index2 + "]",
                                 expected: "number",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagType.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagType.ts
@@ -20,7 +20,12 @@ export const test_createAssertParse_TagType = _test_assertParse(
                 ): boolean =>
                     (("number" === typeof input.int &&
                         Number.isFinite(input.int) &&
-                        parseInt(input.int) === input.int) ||
+                        (parseInt(input.int) === input.int ||
+                            $guard(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".int",
                             expected: "number",
@@ -28,8 +33,18 @@ export const test_createAssertParse_TagType = _test_assertParse(
                         })) &&
                     (("number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
-                        parseInt(input.uint) === input.uint &&
-                        0 <= input.uint) ||
+                        (parseInt(input.uint) === input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (0 <= input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uint",
                             expected: "number",

--- a/test/generated/output/createAssertParse/test_createAssertParse_UltimateUnion.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_UltimateUnion.ts
@@ -934,7 +934,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            parseInt(input.minimum) === input.minimum) ||
+                            (parseInt(input.minimum) === input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "(number | undefined)",
@@ -943,7 +948,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            parseInt(input.maximum) === input.maximum) ||
+                            (parseInt(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "(number | undefined)",
@@ -966,7 +976,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            parseInt(input.multipleOf) === input.multipleOf) ||
+                            (parseInt(input.multipleOf) === input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "(number | undefined)",
@@ -1255,8 +1270,18 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
-                            parseInt(input.minLength) === input.minLength &&
-                            0 <= input.minLength) ||
+                            (parseInt(input.minLength) === input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                })) &&
+                            (0 <= input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minLength",
                             expected: "(number | undefined)",
@@ -1265,8 +1290,18 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
-                            parseInt(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength) ||
+                            (parseInt(input.maxLength) === input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxLength",
                             expected: "(number | undefined)",
@@ -1423,8 +1458,18 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
-                            parseInt(input.minItems) === input.minItems &&
-                            0 <= input.minItems) ||
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "(number | undefined)",
@@ -1433,8 +1478,18 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
-                            parseInt(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems) ||
+                            (parseInt(input.maxItems) === input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "(number | undefined)",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagArray.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagArray.ts
@@ -19,7 +19,13 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ((Array.isArray(input.items) && 3 === input.items.length) ||
+                    ((Array.isArray(input.items) &&
+                        (3 === input.items.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected: "Array.length (@items 3)",
+                                value: input.items,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected: "Array<string>",
@@ -28,7 +34,12 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                     input.items.every(
                         (elem: any, _index2: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".items[" + _index2 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items[" + _index2 + "]",
                                 expected: "string",
@@ -36,7 +47,12 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                             }),
                     ) &&
                     ((Array.isArray(input.minItems) &&
-                        3 <= input.minItems.length) ||
+                        (3 <= input.minItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.minItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "Array<number>",
@@ -46,7 +62,16 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                         (elem: any, _index3: number) =>
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                3 <= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".minItems[" +
+                                            _index3 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems[" + _index3 + "]",
                                 expected: "number",
@@ -54,7 +79,12 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                             }),
                     ) &&
                     ((Array.isArray(input.maxItems) &&
-                        7 >= input.maxItems.length) ||
+                        (7 >= input.maxItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.maxItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "Array<(number | string)>",
@@ -62,10 +92,29 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                         })) &&
                     input.maxItems.every(
                         (elem: any, _index4: number) =>
-                            ("string" === typeof elem && 7 >= elem.length) ||
+                            ("string" === typeof elem &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                7 >= elem) ||
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems[" + _index4 + "]",
                                 expected: "(number | string)",
@@ -73,8 +122,18 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                             }),
                     ) &&
                     ((Array.isArray(input.both) &&
-                        3 <= input.both.length &&
-                        7 >= input.both.length) ||
+                        (3 <= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.both,
+                            })) &&
+                        (7 >= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.both,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".both",
                             expected: "Array<string>",
@@ -83,7 +142,12 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                     input.both.every(
                         (elem: any, _index5: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".both[" + _index5 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".both[" + _index5 + "]",
                                 expected: "string",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagAtomicUnion.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagAtomicUnion.ts
@@ -19,11 +19,26 @@ export const test_createAssertPrune_TagAtomicUnion = _test_assertPrune(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "(number | string)",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagBigInt.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagBigInt.ts
@@ -25,29 +25,54 @@ export const test_createAssertPrune_TagBigInt = _test_assertPrune(
                             value: input.value,
                         })) &&
                     (("bigint" === typeof input.ranged &&
-                        0n <= input.ranged &&
-                        100n >= input.ranged) ||
+                        (0n <= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "bigint (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100n >= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "bigint (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "bigint",
                             value: input.ranged,
                         })) &&
                     (("bigint" === typeof input.minimum &&
-                        0n <= input.minimum) ||
+                        (0n <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "bigint (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "bigint",
                             value: input.minimum,
                         })) &&
                     (("bigint" === typeof input.maximum &&
-                        100n >= input.maximum) ||
+                        (100n >= input.maximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "bigint (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "bigint",
                             value: input.maximum,
                         })) &&
                     (("bigint" === typeof input.multipleOf &&
-                        0n === input.multipleOf % 3n) ||
+                        (0n === input.multipleOf % 3n ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "bigint (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "bigint",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagCustom.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagCustom.ts
@@ -21,26 +21,41 @@ export const test_createAssertPrune_TagCustom = _test_assertPrune(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.id &&
-                        true === $is_uuid(input.id)) ||
+                        (true === $is_uuid(input.id) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string (@format uuid)",
+                                value: input.id,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".id",
                             expected: "string",
                             value: input.id,
                         })) &&
-                    (("string" === typeof input.dolloar &&
-                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                    (("string" === typeof input.dollar &&
+                        ($is_custom("dollar", "string", "", input.dollar) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dollar",
+                                expected: "string (@dollar)",
+                                value: input.dollar,
+                            }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".dolloar",
+                            path: _path + ".dollar",
                             expected: "string",
-                            value: input.dolloar,
+                            value: input.dollar,
                         })) &&
                     (("string" === typeof input.postfix &&
-                        $is_custom(
+                        ($is_custom(
                             "postfix",
                             "string",
                             "abcd",
                             input.postfix,
-                        )) ||
+                        ) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string (@postfix abcd)",
+                                value: input.postfix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".postfix",
                             expected: "string",
@@ -48,7 +63,12 @@ export const test_createAssertPrune_TagCustom = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.log &&
                         Number.isFinite(input.log) &&
-                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        ($is_custom("powerOf", "number", "10", input.log) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number (@powerOf 10)",
+                                value: input.log,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".log",
                             expected: "number",
@@ -73,7 +93,7 @@ export const test_createAssertPrune_TagCustom = _test_assertPrune(
                 for (const key of Object.keys(input)) {
                     if (
                         "id" === key ||
-                        "dolloar" === key ||
+                        "dollar" === key ||
                         "postfix" === key ||
                         "log" === key
                     )

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagFormat.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagFormat.ts
@@ -26,63 +26,108 @@ export const test_createAssertPrune_TagFormat = _test_assertPrune(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true === $is_uuid(input.uuid)) ||
+                        (true === $is_uuid(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected: "string (@format uuid)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true === $is_email(input.email)) ||
+                        (true === $is_email(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected: "string (@format email)",
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.url &&
-                        true === $is_url(input.url)) ||
+                        (true === $is_url(input.url) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".url",
+                                expected: "string (@format url)",
+                                value: input.url,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".url",
                             expected: "string",
                             value: input.url,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true === $is_ipv4(input.ipv4)) ||
+                        (true === $is_ipv4(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected: "string (@format ipv4)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true === $is_ipv6(input.ipv6)) ||
+                        (true === $is_ipv6(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected: "string (@format ipv6)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",
                             value: input.ipv6,
                         })) &&
                     (("string" === typeof input.date &&
-                        true === $is_date(input.date)) ||
+                        (true === $is_date(input.date) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date",
+                                expected: "string (@format date)",
+                                value: input.date,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date",
                             expected: "string",
                             value: input.date,
                         })) &&
                     (("string" === typeof input.date_time &&
-                        true === $is_datetime(input.date_time)) ||
+                        (true === $is_datetime(input.date_time) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date_time",
+                                expected: "string (@format datetime)",
+                                value: input.date_time,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date_time",
                             expected: "string",
                             value: input.date_time,
                         })) &&
                     (("string" === typeof input.datetime &&
-                        true === $is_datetime(input.datetime)) ||
+                        (true === $is_datetime(input.datetime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".datetime",
+                                expected: "string (@format datetime)",
+                                value: input.datetime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".datetime",
                             expected: "string",
                             value: input.datetime,
                         })) &&
                     (("string" === typeof input.dateTime &&
-                        true === $is_datetime(input.dateTime)) ||
+                        (true === $is_datetime(input.dateTime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dateTime",
+                                expected: "string (@format datetime)",
+                                value: input.dateTime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".dateTime",
                             expected: "string",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagInfinite.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagInfinite.ts
@@ -26,8 +26,18 @@ export const test_createAssertPrune_TagInfinite = _test_assertPrune(
                             value: input.value,
                         })) &&
                     (("number" === typeof input.ranged &&
-                        0 <= input.ranged &&
-                        100 >= input.ranged) ||
+                        (0 <= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100 >= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "number",
@@ -35,7 +45,12 @@ export const test_createAssertPrune_TagInfinite = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        0 <= input.minimum) ||
+                        (0 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
@@ -43,14 +58,24 @@ export const test_createAssertPrune_TagInfinite = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        100 >= input.maximum) ||
+                        (100 >= input.maximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "number",
                             value: input.maximum,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 3) ||
+                        (0 === input.multipleOf % 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",
@@ -58,7 +83,12 @@ export const test_createAssertPrune_TagInfinite = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
-                        parseInt(input.typed) === input.typed) ||
+                        (parseInt(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".typed",
                             expected: "number",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagLength.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagLength.ts
@@ -19,29 +19,54 @@ export const test_createAssertPrune_TagLength = _test_assertPrune(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.fixed &&
-                        5 === input.fixed.length) ||
+                        (5 === input.fixed.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".fixed",
+                                expected: "string (@length 5)",
+                                value: input.fixed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".fixed",
                             expected: "string",
                             value: input.fixed,
                         })) &&
                     (("string" === typeof input.minimum &&
-                        3 <= input.minimum.length) ||
+                        (3 <= input.minimum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "string",
                             value: input.minimum,
                         })) &&
                     (("string" === typeof input.maximum &&
-                        7 >= input.maximum.length) ||
+                        (7 >= input.maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "string",
                             value: input.maximum,
                         })) &&
                     (("string" === typeof input.minimum_and_maximum &&
-                        3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length) ||
+                        (3 <= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum_and_maximum,
+                            })) &&
+                        (7 >= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.minimum_and_maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum_and_maximum",
                             expected: "string",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagMatrix.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagMatrix.ts
@@ -20,7 +20,12 @@ export const test_createAssertPrune_TagMatrix = _test_assertPrune(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ((Array.isArray(input.matrix) &&
-                        3 === input.matrix.length) ||
+                        (3 === input.matrix.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".matrix",
+                                expected: "Array.length (@items 3)",
+                                value: input.matrix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".matrix",
                             expected: "Array<Array<string>>",
@@ -28,7 +33,14 @@ export const test_createAssertPrune_TagMatrix = _test_assertPrune(
                         })) &&
                     input.matrix.every(
                         (elem: any, _index1: number) =>
-                            ((Array.isArray(elem) && 3 === elem.length) ||
+                            ((Array.isArray(elem) &&
+                                (3 === elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".matrix[" + _index1 + "]",
+                                        expected: "Array.length (@items 3)",
+                                        value: elem,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".matrix[" + _index1 + "]",
                                     expected: "Array<string>",
@@ -37,7 +49,19 @@ export const test_createAssertPrune_TagMatrix = _test_assertPrune(
                             elem.every(
                                 (elem: any, _index2: number) =>
                                     ("string" === typeof elem &&
-                                        true === $is_uuid(elem)) ||
+                                        (true === $is_uuid(elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".matrix[" +
+                                                    _index1 +
+                                                    "][" +
+                                                    _index2 +
+                                                    "]",
+                                                expected:
+                                                    "string (@format uuid)",
+                                                value: elem,
+                                            }))) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagNaN.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagNaN.ts
@@ -26,8 +26,18 @@ export const test_createAssertPrune_TagNaN = _test_assertPrune(
                             value: input.value,
                         })) &&
                     (("number" === typeof input.ranged &&
-                        0 <= input.ranged &&
-                        100 >= input.ranged) ||
+                        (0 <= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100 >= input.ranged ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "number",
@@ -35,7 +45,12 @@ export const test_createAssertPrune_TagNaN = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        0 <= input.minimum) ||
+                        (0 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
@@ -43,14 +58,24 @@ export const test_createAssertPrune_TagNaN = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        100 >= input.maximum) ||
+                        (100 >= input.maximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "number",
                             value: input.maximum,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 3) ||
+                        (0 === input.multipleOf % 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",
@@ -58,7 +83,12 @@ export const test_createAssertPrune_TagNaN = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
-                        parseInt(input.typed) === input.typed) ||
+                        (parseInt(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".typed",
                             expected: "number",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagObjectUnion.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagObjectUnion.ts
@@ -20,7 +20,12 @@ export const test_createAssertPrune_TagObjectUnion = _test_assertPrune(
                 ): boolean =>
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "number",
@@ -32,8 +37,18 @@ export const test_createAssertPrune_TagObjectUnion = _test_assertPrune(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "string",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagPattern.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagPattern.ts
@@ -19,40 +19,64 @@ export const test_createAssertPrune_TagPattern = _test_assertPrune(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                            ).test(input.uuid)) ||
+                            ).test(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected:
+                                    "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                            ).test(input.email)) ||
+                            ).test(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected:
+                                    'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                            ).test(input.ipv4)) ||
+                            ).test(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected:
+                                    "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                            ).test(input.ipv6)) ||
+                            ).test(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected:
+                                    "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagRange.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagRange.ts
@@ -20,7 +20,12 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                 ): boolean =>
                     (("number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
-                        3 < input.greater) ||
+                        (3 < input.greater ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater",
                             expected: "number",
@@ -28,7 +33,12 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
-                        3 <= input.greater_equal) ||
+                        (3 <= input.greater_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal",
                             expected: "number",
@@ -36,7 +46,12 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.less &&
                         Number.isFinite(input.less) &&
-                        7 > input.less) ||
+                        (7 > input.less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less",
                             expected: "number",
@@ -44,39 +59,84 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
-                        7 >= input.less_equal) ||
+                        (7 >= input.less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less_equal",
                             expected: "number",
                             value: input.less_equal,
                         })) &&
                     (("number" === typeof input.greater_less &&
-                        3 < input.greater_less &&
-                        7 > input.greater_less) ||
+                        (3 < input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less,
+                            })) &&
+                        (7 > input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less",
                             expected: "number",
                             value: input.greater_less,
                         })) &&
                     (("number" === typeof input.greater_equal_less &&
-                        3 <= input.greater_equal_less &&
-                        7 > input.greater_equal_less) ||
+                        (3 <= input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less,
+                            })) &&
+                        (7 > input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_equal_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less",
                             expected: "number",
                             value: input.greater_equal_less,
                         })) &&
                     (("number" === typeof input.greater_less_equal &&
-                        3 < input.greater_less_equal &&
-                        7 >= input.greater_less_equal) ||
+                        (3 < input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        (7 >= input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less_equal",
                             expected: "number",
                             value: input.greater_less_equal,
                         })) &&
                     (("number" === typeof input.greater_equal_less_equal &&
-                        3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal) ||
+                        (3 <= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
+                        (7 >= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_equal_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagStep.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagStep.ts
@@ -19,34 +19,84 @@ export const test_createAssertPrune_TagStep = _test_assertPrune(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("number" === typeof input.exclusiveMinimum &&
-                        0 === (input.exclusiveMinimum % 5) - 3 &&
-                        3 < input.exclusiveMinimum) ||
+                        (0 === (input.exclusiveMinimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@step 5)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (3 < input.exclusiveMinimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.exclusiveMinimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".exclusiveMinimum",
                             expected: "number",
                             value: input.exclusiveMinimum,
                         })) &&
                     (("number" === typeof input.minimum &&
-                        0 === (input.minimum % 5) - 3 &&
-                        3 <= input.minimum) ||
+                        (0 === (input.minimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@step 5)",
+                                value: input.minimum,
+                            })) &&
+                        (3 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
                             value: input.minimum,
                         })) &&
                     (("number" === typeof input.range &&
-                        0 === (input.range % 5) - 0 &&
-                        0 < input.range &&
-                        100 > input.range) ||
+                        (0 === (input.range % 5) - 0 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@step 5)",
+                                value: input.range,
+                            })) &&
+                        (0 < input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMinimum 0)",
+                                value: input.range,
+                            })) &&
+                        (100 > input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMaximum 100)",
+                                value: input.range,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".range",
                             expected: "number",
                             value: input.range,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 5 &&
-                        3 <= input.multipleOf &&
-                        99 >= input.multipleOf) ||
+                        (0 === input.multipleOf % 5 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 5)",
+                                value: input.multipleOf,
+                            })) &&
+                        (3 <= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@minimum 3)",
+                                value: input.multipleOf,
+                            })) &&
+                        (99 >= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@maximum 99)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagTuple.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagTuple.ts
@@ -33,24 +33,54 @@ export const test_createAssertPrune_TagTuple = _test_assertPrune(
                             value: input.tuple,
                         })) &&
                     (("string" === typeof input.tuple[0] &&
-                        3 <= input.tuple[0].length &&
-                        7 >= input.tuple[0].length) ||
+                        (3 <= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@minLength 3)",
+                                value: input.tuple[0],
+                            })) &&
+                        (7 >= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@maxLength 7)",
+                                value: input.tuple[0],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[0]",
                             expected: "string",
                             value: input.tuple[0],
                         })) &&
                     (("number" === typeof input.tuple[1] &&
-                        3 <= input.tuple[1] &&
-                        7 >= input.tuple[1]) ||
+                        (3 <= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@minimum 3)",
+                                value: input.tuple[1],
+                            })) &&
+                        (7 >= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@maximum 7)",
+                                value: input.tuple[1],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[1]",
                             expected: "number",
                             value: input.tuple[1],
                         })) &&
                     ((Array.isArray(input.tuple[2]) &&
-                        3 <= input.tuple[2].length &&
-                        7 >= input.tuple[2].length) ||
+                        (3 <= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[2],
+                            })) &&
+                        (7 >= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[2],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[2]",
                             expected: "Array<string>",
@@ -59,8 +89,26 @@ export const test_createAssertPrune_TagTuple = _test_assertPrune(
                     input.tuple[2].every(
                         (elem: any, _index1: number) =>
                             ("string" === typeof elem &&
-                                3 <= elem.length &&
-                                7 >= elem.length) ||
+                                (3 <= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@minLength 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[2][" + _index1 + "]",
                                 expected: "string",
@@ -68,8 +116,18 @@ export const test_createAssertPrune_TagTuple = _test_assertPrune(
                             }),
                     ) &&
                     ((Array.isArray(input.tuple[3]) &&
-                        3 <= input.tuple[3].length &&
-                        7 >= input.tuple[3].length) ||
+                        (3 <= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[3],
+                            })) &&
+                        (7 >= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[3],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[3]",
                             expected: "Array<number>",
@@ -78,8 +136,26 @@ export const test_createAssertPrune_TagTuple = _test_assertPrune(
                     input.tuple[3].every(
                         (elem: any, _index2: number) =>
                             ("number" === typeof elem &&
-                                3 <= elem &&
-                                7 >= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[3][" + _index2 + "]",
                                 expected: "number",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagType.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagType.ts
@@ -20,7 +20,12 @@ export const test_createAssertPrune_TagType = _test_assertPrune(
                 ): boolean =>
                     (("number" === typeof input.int &&
                         Number.isFinite(input.int) &&
-                        parseInt(input.int) === input.int) ||
+                        (parseInt(input.int) === input.int ||
+                            $guard(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".int",
                             expected: "number",
@@ -28,8 +33,18 @@ export const test_createAssertPrune_TagType = _test_assertPrune(
                         })) &&
                     (("number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
-                        parseInt(input.uint) === input.uint &&
-                        0 <= input.uint) ||
+                        (parseInt(input.uint) === input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (0 <= input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uint",
                             expected: "number",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagArray.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagArray.ts
@@ -19,7 +19,13 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ((Array.isArray(input.items) && 3 === input.items.length) ||
+                    ((Array.isArray(input.items) &&
+                        (3 === input.items.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected: "Array.length (@items 3)",
+                                value: input.items,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected: "Array<string>",
@@ -28,7 +34,12 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                     input.items.every(
                         (elem: any, _index2: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".items[" + _index2 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items[" + _index2 + "]",
                                 expected: "string",
@@ -36,7 +47,12 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                             }),
                     ) &&
                     ((Array.isArray(input.minItems) &&
-                        3 <= input.minItems.length) ||
+                        (3 <= input.minItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.minItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "Array<number>",
@@ -46,7 +62,16 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                         (elem: any, _index3: number) =>
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                3 <= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".minItems[" +
+                                            _index3 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems[" + _index3 + "]",
                                 expected: "number",
@@ -54,7 +79,12 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                             }),
                     ) &&
                     ((Array.isArray(input.maxItems) &&
-                        7 >= input.maxItems.length) ||
+                        (7 >= input.maxItems.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.maxItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "Array<(number | string)>",
@@ -62,10 +92,29 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                         })) &&
                     input.maxItems.every(
                         (elem: any, _index4: number) =>
-                            ("string" === typeof elem && 7 >= elem.length) ||
+                            ("string" === typeof elem &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             ("number" === typeof elem &&
                                 Number.isFinite(elem) &&
-                                7 >= elem) ||
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".maxItems[" +
+                                            _index4 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maxItems[" + _index4 + "]",
                                 expected: "(number | string)",
@@ -73,8 +122,18 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                             }),
                     ) &&
                     ((Array.isArray(input.both) &&
-                        3 <= input.both.length &&
-                        7 >= input.both.length) ||
+                        (3 <= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.both,
+                            })) &&
+                        (7 >= input.both.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.both,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".both",
                             expected: "Array<string>",
@@ -83,7 +142,12 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                     input.both.every(
                         (elem: any, _index5: number) =>
                             ("string" === typeof elem &&
-                                true === $is_uuid(elem)) ||
+                                (true === $is_uuid(elem) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".both[" + _index5 + "]",
+                                        expected: "string (@format uuid)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".both[" + _index5 + "]",
                                 expected: "string",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagAtomicUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagAtomicUnion.ts
@@ -19,11 +19,26 @@ export const test_createAssertStringify_TagAtomicUnion = _test_assertStringify(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "(number | string)",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagCustom.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagCustom.ts
@@ -21,26 +21,41 @@ export const test_createAssertStringify_TagCustom = _test_assertStringify(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.id &&
-                        true === $is_uuid(input.id)) ||
+                        (true === $is_uuid(input.id) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string (@format uuid)",
+                                value: input.id,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".id",
                             expected: "string",
                             value: input.id,
                         })) &&
-                    (("string" === typeof input.dolloar &&
-                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                    (("string" === typeof input.dollar &&
+                        ($is_custom("dollar", "string", "", input.dollar) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dollar",
+                                expected: "string (@dollar)",
+                                value: input.dollar,
+                            }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".dolloar",
+                            path: _path + ".dollar",
                             expected: "string",
-                            value: input.dolloar,
+                            value: input.dollar,
                         })) &&
                     (("string" === typeof input.postfix &&
-                        $is_custom(
+                        ($is_custom(
                             "postfix",
                             "string",
                             "abcd",
                             input.postfix,
-                        )) ||
+                        ) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string (@postfix abcd)",
+                                value: input.postfix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".postfix",
                             expected: "string",
@@ -48,7 +63,12 @@ export const test_createAssertStringify_TagCustom = _test_assertStringify(
                         })) &&
                     (("number" === typeof input.log &&
                         Number.isFinite(input.log) &&
-                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        ($is_custom("powerOf", "number", "10", input.log) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number (@powerOf 10)",
+                                value: input.log,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".log",
                             expected: "number",
@@ -72,8 +92,8 @@ export const test_createAssertStringify_TagCustom = _test_assertStringify(
             const $is_uuid = (typia.createAssertStringify as any).is_uuid;
             const $is_custom = (typia.createAssertStringify as any).is_custom;
             const $so0 = (input: any): any =>
-                `{"id":${'"' + input.id + '"'},"dolloar":${$string(
-                    input.dolloar,
+                `{"id":${'"' + input.id + '"'},"dollar":${$string(
+                    input.dollar,
                 )},"postfix":${$string(input.postfix)},"log":${$number(
                     input.log,
                 )}}`;

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagFormat.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagFormat.ts
@@ -27,63 +27,108 @@ export const test_createAssertStringify_TagFormat = _test_assertStringify(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true === $is_uuid(input.uuid)) ||
+                        (true === $is_uuid(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected: "string (@format uuid)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true === $is_email(input.email)) ||
+                        (true === $is_email(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected: "string (@format email)",
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.url &&
-                        true === $is_url(input.url)) ||
+                        (true === $is_url(input.url) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".url",
+                                expected: "string (@format url)",
+                                value: input.url,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".url",
                             expected: "string",
                             value: input.url,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true === $is_ipv4(input.ipv4)) ||
+                        (true === $is_ipv4(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected: "string (@format ipv4)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true === $is_ipv6(input.ipv6)) ||
+                        (true === $is_ipv6(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected: "string (@format ipv6)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",
                             value: input.ipv6,
                         })) &&
                     (("string" === typeof input.date &&
-                        true === $is_date(input.date)) ||
+                        (true === $is_date(input.date) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date",
+                                expected: "string (@format date)",
+                                value: input.date,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date",
                             expected: "string",
                             value: input.date,
                         })) &&
                     (("string" === typeof input.date_time &&
-                        true === $is_datetime(input.date_time)) ||
+                        (true === $is_datetime(input.date_time) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".date_time",
+                                expected: "string (@format datetime)",
+                                value: input.date_time,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".date_time",
                             expected: "string",
                             value: input.date_time,
                         })) &&
                     (("string" === typeof input.datetime &&
-                        true === $is_datetime(input.datetime)) ||
+                        (true === $is_datetime(input.datetime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".datetime",
+                                expected: "string (@format datetime)",
+                                value: input.datetime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".datetime",
                             expected: "string",
                             value: input.datetime,
                         })) &&
                     (("string" === typeof input.dateTime &&
-                        true === $is_datetime(input.dateTime)) ||
+                        (true === $is_datetime(input.dateTime) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".dateTime",
+                                expected: "string (@format datetime)",
+                                value: input.dateTime,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".dateTime",
                             expected: "string",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagLength.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagLength.ts
@@ -19,29 +19,54 @@ export const test_createAssertStringify_TagLength = _test_assertStringify(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.fixed &&
-                        5 === input.fixed.length) ||
+                        (5 === input.fixed.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".fixed",
+                                expected: "string (@length 5)",
+                                value: input.fixed,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".fixed",
                             expected: "string",
                             value: input.fixed,
                         })) &&
                     (("string" === typeof input.minimum &&
-                        3 <= input.minimum.length) ||
+                        (3 <= input.minimum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "string",
                             value: input.minimum,
                         })) &&
                     (("string" === typeof input.maximum &&
-                        7 >= input.maximum.length) ||
+                        (7 >= input.maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "string",
                             value: input.maximum,
                         })) &&
                     (("string" === typeof input.minimum_and_maximum &&
-                        3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length) ||
+                        (3 <= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum_and_maximum,
+                            })) &&
+                        (7 >= input.minimum_and_maximum.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.minimum_and_maximum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum_and_maximum",
                             expected: "string",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagMatrix.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagMatrix.ts
@@ -20,7 +20,12 @@ export const test_createAssertStringify_TagMatrix = _test_assertStringify(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ((Array.isArray(input.matrix) &&
-                        3 === input.matrix.length) ||
+                        (3 === input.matrix.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".matrix",
+                                expected: "Array.length (@items 3)",
+                                value: input.matrix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".matrix",
                             expected: "Array<Array<string>>",
@@ -28,7 +33,14 @@ export const test_createAssertStringify_TagMatrix = _test_assertStringify(
                         })) &&
                     input.matrix.every(
                         (elem: any, _index1: number) =>
-                            ((Array.isArray(elem) && 3 === elem.length) ||
+                            ((Array.isArray(elem) &&
+                                (3 === elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".matrix[" + _index1 + "]",
+                                        expected: "Array.length (@items 3)",
+                                        value: elem,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".matrix[" + _index1 + "]",
                                     expected: "Array<string>",
@@ -37,7 +49,19 @@ export const test_createAssertStringify_TagMatrix = _test_assertStringify(
                             elem.every(
                                 (elem: any, _index2: number) =>
                                     ("string" === typeof elem &&
-                                        true === $is_uuid(elem)) ||
+                                        (true === $is_uuid(elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".matrix[" +
+                                                    _index1 +
+                                                    "][" +
+                                                    _index2 +
+                                                    "]",
+                                                expected:
+                                                    "string (@format uuid)",
+                                                value: elem,
+                                            }))) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagObjectUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagObjectUnion.ts
@@ -20,7 +20,12 @@ export const test_createAssertStringify_TagObjectUnion = _test_assertStringify(
                 ): boolean =>
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "number",
@@ -32,8 +37,18 @@ export const test_createAssertStringify_TagObjectUnion = _test_assertStringify(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".value",
                         expected: "string",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagPattern.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagPattern.ts
@@ -19,40 +19,64 @@ export const test_createAssertStringify_TagPattern = _test_assertStringify(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("string" === typeof input.uuid &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                            ).test(input.uuid)) ||
+                            ).test(input.uuid) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected:
+                                    "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                value: input.uuid,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         })) &&
                     (("string" === typeof input.email &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                            ).test(input.email)) ||
+                            ).test(input.email) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".email",
+                                expected:
+                                    'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                value: input.email,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         })) &&
                     (("string" === typeof input.ipv4 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                            ).test(input.ipv4)) ||
+                            ).test(input.ipv4) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected:
+                                    "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                value: input.ipv4,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         })) &&
                     (("string" === typeof input.ipv6 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                            ).test(input.ipv6)) ||
+                            ).test(input.ipv6) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected:
+                                    "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                value: input.ipv6,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagRange.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagRange.ts
@@ -20,7 +20,12 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                 ): boolean =>
                     (("number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
-                        3 < input.greater) ||
+                        (3 < input.greater ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater",
                             expected: "number",
@@ -28,7 +33,12 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                         })) &&
                     (("number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
-                        3 <= input.greater_equal) ||
+                        (3 <= input.greater_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal",
                             expected: "number",
@@ -36,7 +46,12 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                         })) &&
                     (("number" === typeof input.less &&
                         Number.isFinite(input.less) &&
-                        7 > input.less) ||
+                        (7 > input.less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less",
                             expected: "number",
@@ -44,39 +59,84 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                         })) &&
                     (("number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
-                        7 >= input.less_equal) ||
+                        (7 >= input.less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".less_equal",
                             expected: "number",
                             value: input.less_equal,
                         })) &&
                     (("number" === typeof input.greater_less &&
-                        3 < input.greater_less &&
-                        7 > input.greater_less) ||
+                        (3 < input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less,
+                            })) &&
+                        (7 > input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less",
                             expected: "number",
                             value: input.greater_less,
                         })) &&
                     (("number" === typeof input.greater_equal_less &&
-                        3 <= input.greater_equal_less &&
-                        7 > input.greater_equal_less) ||
+                        (3 <= input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less,
+                            })) &&
+                        (7 > input.greater_equal_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_equal_less,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less",
                             expected: "number",
                             value: input.greater_equal_less,
                         })) &&
                     (("number" === typeof input.greater_less_equal &&
-                        3 < input.greater_less_equal &&
-                        7 >= input.greater_less_equal) ||
+                        (3 < input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        (7 >= input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_less_equal",
                             expected: "number",
                             value: input.greater_less_equal,
                         })) &&
                     (("number" === typeof input.greater_equal_less_equal &&
-                        3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal) ||
+                        (3 <= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
+                        (7 >= input.greater_equal_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_equal_less_equal,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagStep.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagStep.ts
@@ -19,34 +19,84 @@ export const test_createAssertStringify_TagStep = _test_assertStringify(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     (("number" === typeof input.exclusiveMinimum &&
-                        0 === (input.exclusiveMinimum % 5) - 3 &&
-                        3 < input.exclusiveMinimum) ||
+                        (0 === (input.exclusiveMinimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@step 5)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (3 < input.exclusiveMinimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.exclusiveMinimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".exclusiveMinimum",
                             expected: "number",
                             value: input.exclusiveMinimum,
                         })) &&
                     (("number" === typeof input.minimum &&
-                        0 === (input.minimum % 5) - 3 &&
-                        3 <= input.minimum) ||
+                        (0 === (input.minimum % 5) - 3 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@step 5)",
+                                value: input.minimum,
+                            })) &&
+                        (3 <= input.minimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 3)",
+                                value: input.minimum,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
                             value: input.minimum,
                         })) &&
                     (("number" === typeof input.range &&
-                        0 === (input.range % 5) - 0 &&
-                        0 < input.range &&
-                        100 > input.range) ||
+                        (0 === (input.range % 5) - 0 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@step 5)",
+                                value: input.range,
+                            })) &&
+                        (0 < input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMinimum 0)",
+                                value: input.range,
+                            })) &&
+                        (100 > input.range ||
+                            $guard(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMaximum 100)",
+                                value: input.range,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".range",
                             expected: "number",
                             value: input.range,
                         })) &&
                     (("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 5 &&
-                        3 <= input.multipleOf &&
-                        99 >= input.multipleOf) ||
+                        (0 === input.multipleOf % 5 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 5)",
+                                value: input.multipleOf,
+                            })) &&
+                        (3 <= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@minimum 3)",
+                                value: input.multipleOf,
+                            })) &&
+                        (99 >= input.multipleOf ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@maximum 99)",
+                                value: input.multipleOf,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagTuple.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagTuple.ts
@@ -33,24 +33,54 @@ export const test_createAssertStringify_TagTuple = _test_assertStringify(
                             value: input.tuple,
                         })) &&
                     (("string" === typeof input.tuple[0] &&
-                        3 <= input.tuple[0].length &&
-                        7 >= input.tuple[0].length) ||
+                        (3 <= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@minLength 3)",
+                                value: input.tuple[0],
+                            })) &&
+                        (7 >= input.tuple[0].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[0]",
+                                expected: "string (@maxLength 7)",
+                                value: input.tuple[0],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[0]",
                             expected: "string",
                             value: input.tuple[0],
                         })) &&
                     (("number" === typeof input.tuple[1] &&
-                        3 <= input.tuple[1] &&
-                        7 >= input.tuple[1]) ||
+                        (3 <= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@minimum 3)",
+                                value: input.tuple[1],
+                            })) &&
+                        (7 >= input.tuple[1] ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[1]",
+                                expected: "number (@maximum 7)",
+                                value: input.tuple[1],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[1]",
                             expected: "number",
                             value: input.tuple[1],
                         })) &&
                     ((Array.isArray(input.tuple[2]) &&
-                        3 <= input.tuple[2].length &&
-                        7 >= input.tuple[2].length) ||
+                        (3 <= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[2],
+                            })) &&
+                        (7 >= input.tuple[2].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[2]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[2],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[2]",
                             expected: "Array<string>",
@@ -59,8 +89,26 @@ export const test_createAssertStringify_TagTuple = _test_assertStringify(
                     input.tuple[2].every(
                         (elem: any, _index1: number) =>
                             ("string" === typeof elem &&
-                                3 <= elem.length &&
-                                7 >= elem.length) ||
+                                (3 <= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@minLength 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem.length ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[2][" +
+                                            _index1 +
+                                            "]",
+                                        expected: "string (@maxLength 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[2][" + _index1 + "]",
                                 expected: "string",
@@ -68,8 +116,18 @@ export const test_createAssertStringify_TagTuple = _test_assertStringify(
                             }),
                     ) &&
                     ((Array.isArray(input.tuple[3]) &&
-                        3 <= input.tuple[3].length &&
-                        7 >= input.tuple[3].length) ||
+                        (3 <= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.tuple[3],
+                            })) &&
+                        (7 >= input.tuple[3].length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".tuple[3]",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.tuple[3],
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[3]",
                             expected: "Array<number>",
@@ -78,8 +136,26 @@ export const test_createAssertStringify_TagTuple = _test_assertStringify(
                     input.tuple[3].every(
                         (elem: any, _index2: number) =>
                             ("number" === typeof elem &&
-                                3 <= elem &&
-                                7 >= elem) ||
+                                (3 <= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@minimum 3)",
+                                        value: elem,
+                                    })) &&
+                                (7 >= elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".tuple[3][" +
+                                            _index2 +
+                                            "]",
+                                        expected: "number (@maximum 7)",
+                                        value: elem,
+                                    }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".tuple[3][" + _index2 + "]",
                                 expected: "number",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagType.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagType.ts
@@ -20,7 +20,12 @@ export const test_createAssertStringify_TagType = _test_assertStringify(
                 ): boolean =>
                     (("number" === typeof input.int &&
                         Number.isFinite(input.int) &&
-                        parseInt(input.int) === input.int) ||
+                        (parseInt(input.int) === input.int ||
+                            $guard(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".int",
                             expected: "number",
@@ -28,8 +33,18 @@ export const test_createAssertStringify_TagType = _test_assertStringify(
                         })) &&
                     (("number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
-                        parseInt(input.uint) === input.uint &&
-                        0 <= input.uint) ||
+                        (parseInt(input.uint) === input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (0 <= input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".uint",
                             expected: "number",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_UltimateUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_UltimateUnion.ts
@@ -934,7 +934,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            parseInt(input.minimum) === input.minimum) ||
+                            (parseInt(input.minimum) === input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "(number | undefined)",
@@ -943,7 +948,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            parseInt(input.maximum) === input.maximum) ||
+                            (parseInt(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "(number | undefined)",
@@ -966,7 +976,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            parseInt(input.multipleOf) === input.multipleOf) ||
+                            (parseInt(input.multipleOf) === input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "(number | undefined)",
@@ -1255,8 +1270,18 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
-                            parseInt(input.minLength) === input.minLength &&
-                            0 <= input.minLength) ||
+                            (parseInt(input.minLength) === input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                })) &&
+                            (0 <= input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minLength",
                             expected: "(number | undefined)",
@@ -1265,8 +1290,18 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
-                            parseInt(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength) ||
+                            (parseInt(input.maxLength) === input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxLength",
                             expected: "(number | undefined)",
@@ -1423,8 +1458,18 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
-                            parseInt(input.minItems) === input.minItems &&
-                            0 <= input.minItems) ||
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "(number | undefined)",
@@ -1433,8 +1478,18 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
-                            parseInt(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems) ||
+                            (parseInt(input.maxItems) === input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "(number | undefined)",

--- a/test/generated/output/createClone/test_createClone_TagCustom.ts
+++ b/test/generated/output/createClone/test_createClone_TagCustom.ts
@@ -10,7 +10,7 @@ export const test_createClone_TagCustom = _test_clone(
         const $is_custom = (typia.createClone as any).is_custom;
         const $co0 = (input: any): any => ({
             id: input.id as any,
-            dolloar: input.dolloar as any,
+            dollar: input.dollar as any,
             postfix: input.postfix as any,
             log: input.log as any,
         });

--- a/test/generated/output/createEquals/test_createEquals_TagCustom.ts
+++ b/test/generated/output/createEquals/test_createEquals_TagCustom.ts
@@ -11,8 +11,8 @@ export const test_createEquals_TagCustom = _test_equals(
         const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
             "string" === typeof input.id &&
             true === $is_uuid(input.id) &&
-            "string" === typeof input.dolloar &&
-            $is_custom("dollar", "string", "", input.dolloar) &&
+            "string" === typeof input.dollar &&
+            $is_custom("dollar", "string", "", input.dollar) &&
             "string" === typeof input.postfix &&
             $is_custom("postfix", "string", "abcd", input.postfix) &&
             "number" === typeof input.log &&
@@ -21,7 +21,7 @@ export const test_createEquals_TagCustom = _test_equals(
             (4 === Object.keys(input).length ||
                 Object.keys(input).every((key) => {
                     if (
-                        ["id", "dolloar", "postfix", "log"].some(
+                        ["id", "dollar", "postfix", "log"].some(
                             (prop) => key === prop,
                         )
                     )

--- a/test/generated/output/createIs/test_createIs_TagCustom.ts
+++ b/test/generated/output/createIs/test_createIs_TagCustom.ts
@@ -11,8 +11,8 @@ export const test_createIs_TagCustom = _test_is(
         const $io0 = (input: any): boolean =>
             "string" === typeof input.id &&
             true === $is_uuid(input.id) &&
-            "string" === typeof input.dolloar &&
-            $is_custom("dollar", "string", "", input.dolloar) &&
+            "string" === typeof input.dollar &&
+            $is_custom("dollar", "string", "", input.dollar) &&
             "string" === typeof input.postfix &&
             $is_custom("postfix", "string", "abcd", input.postfix) &&
             "number" === typeof input.log &&

--- a/test/generated/output/createIsClone/test_createIsClone_TagCustom.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_TagCustom.ts
@@ -12,8 +12,8 @@ export const test_createIsClone_TagCustom = _test_isClone(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 true === $is_uuid(input.id) &&
-                "string" === typeof input.dolloar &&
-                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.dollar &&
+                $is_custom("dollar", "string", "", input.dollar) &&
                 "string" === typeof input.postfix &&
                 $is_custom("postfix", "string", "abcd", input.postfix) &&
                 "number" === typeof input.log &&
@@ -26,7 +26,7 @@ export const test_createIsClone_TagCustom = _test_isClone(
             const $is_custom = (typia.createIsClone as any).is_custom;
             const $co0 = (input: any): any => ({
                 id: input.id as any,
-                dolloar: input.dolloar as any,
+                dollar: input.dollar as any,
                 postfix: input.postfix as any,
                 log: input.log as any,
             });

--- a/test/generated/output/createIsParse/test_createIsParse_TagCustom.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_TagCustom.ts
@@ -12,8 +12,8 @@ export const test_createIsParse_TagCustom = _test_isParse(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 true === $is_uuid(input.id) &&
-                "string" === typeof input.dolloar &&
-                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.dollar &&
+                $is_custom("dollar", "string", "", input.dollar) &&
                 "string" === typeof input.postfix &&
                 $is_custom("postfix", "string", "abcd", input.postfix) &&
                 "number" === typeof input.log &&

--- a/test/generated/output/createIsPrune/test_createIsPrune_TagCustom.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TagCustom.ts
@@ -12,8 +12,8 @@ export const test_createIsPrune_TagCustom = _test_isPrune(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 true === $is_uuid(input.id) &&
-                "string" === typeof input.dolloar &&
-                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.dollar &&
+                $is_custom("dollar", "string", "", input.dollar) &&
                 "string" === typeof input.postfix &&
                 $is_custom("postfix", "string", "abcd", input.postfix) &&
                 "number" === typeof input.log &&
@@ -28,7 +28,7 @@ export const test_createIsPrune_TagCustom = _test_isPrune(
                 for (const key of Object.keys(input)) {
                     if (
                         "id" === key ||
-                        "dolloar" === key ||
+                        "dollar" === key ||
                         "postfix" === key ||
                         "log" === key
                     )

--- a/test/generated/output/createIsStringify/test_createIsStringify_TagCustom.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_TagCustom.ts
@@ -12,8 +12,8 @@ export const test_createIsStringify_TagCustom = _test_isStringify(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 true === $is_uuid(input.id) &&
-                "string" === typeof input.dolloar &&
-                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.dollar &&
+                $is_custom("dollar", "string", "", input.dollar) &&
                 "string" === typeof input.postfix &&
                 $is_custom("postfix", "string", "abcd", input.postfix) &&
                 "number" === typeof input.log &&
@@ -27,8 +27,8 @@ export const test_createIsStringify_TagCustom = _test_isStringify(
             const $is_uuid = (typia.createIsStringify as any).is_uuid;
             const $is_custom = (typia.createIsStringify as any).is_custom;
             const $so0 = (input: any): any =>
-                `{"id":${'"' + input.id + '"'},"dolloar":${$string(
-                    input.dolloar,
+                `{"id":${'"' + input.id + '"'},"dollar":${$string(
+                    input.dollar,
                 )},"postfix":${$string(input.postfix)},"log":${$number(
                     input.log,
                 )}}`;

--- a/test/generated/output/createPrune/test_createPrune_TagCustom.ts
+++ b/test/generated/output/createPrune/test_createPrune_TagCustom.ts
@@ -12,7 +12,7 @@ export const test_createPrune_TagCustom = _test_prune(
             for (const key of Object.keys(input)) {
                 if (
                     "id" === key ||
-                    "dolloar" === key ||
+                    "dollar" === key ||
                     "postfix" === key ||
                     "log" === key
                 )

--- a/test/generated/output/createRandom/test_createRandom_TagArray.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagArray.ts
@@ -53,7 +53,13 @@ export const test_createRandom_TagArray = _test_random(
                 _path: string,
                 _exceptionable: boolean = true,
             ): boolean =>
-                ((Array.isArray(input.items) && 3 === input.items.length) ||
+                ((Array.isArray(input.items) &&
+                    (3 === input.items.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".items",
+                            expected: "Array.length (@items 3)",
+                            value: input.items,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".items",
                         expected: "Array<string>",
@@ -61,7 +67,13 @@ export const test_createRandom_TagArray = _test_random(
                     })) &&
                 input.items.every(
                     (elem: any, _index2: number) =>
-                        ("string" === typeof elem && true === $is_uuid(elem)) ||
+                        ("string" === typeof elem &&
+                            (true === $is_uuid(elem) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items[" + _index2 + "]",
+                                    expected: "string (@format uuid)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".items[" + _index2 + "]",
                             expected: "string",
@@ -69,7 +81,12 @@ export const test_createRandom_TagArray = _test_random(
                         }),
                 ) &&
                 ((Array.isArray(input.minItems) &&
-                    3 <= input.minItems.length) ||
+                    (3 <= input.minItems.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minItems",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.minItems,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minItems",
                         expected: "Array<number>",
@@ -79,7 +96,12 @@ export const test_createRandom_TagArray = _test_random(
                     (elem: any, _index3: number) =>
                         ("number" === typeof elem &&
                             Number.isFinite(elem) &&
-                            3 <= elem) ||
+                            (3 <= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems[" + _index3 + "]",
+                                    expected: "number (@minimum 3)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems[" + _index3 + "]",
                             expected: "number",
@@ -87,7 +109,12 @@ export const test_createRandom_TagArray = _test_random(
                         }),
                 ) &&
                 ((Array.isArray(input.maxItems) &&
-                    7 >= input.maxItems.length) ||
+                    (7 >= input.maxItems.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maxItems",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.maxItems,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maxItems",
                         expected: "Array<(number | string)>",
@@ -95,10 +122,21 @@ export const test_createRandom_TagArray = _test_random(
                     })) &&
                 input.maxItems.every(
                     (elem: any, _index4: number) =>
-                        ("string" === typeof elem && 7 >= elem.length) ||
+                        ("string" === typeof elem &&
+                            (7 >= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems[" + _index4 + "]",
+                                    expected: "string (@maxLength 7)",
+                                    value: elem,
+                                }))) ||
                         ("number" === typeof elem &&
                             Number.isFinite(elem) &&
-                            7 >= elem) ||
+                            (7 >= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems[" + _index4 + "]",
+                                    expected: "number (@maximum 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems[" + _index4 + "]",
                             expected: "(number | string)",
@@ -106,8 +144,18 @@ export const test_createRandom_TagArray = _test_random(
                         }),
                 ) &&
                 ((Array.isArray(input.both) &&
-                    3 <= input.both.length &&
-                    7 >= input.both.length) ||
+                    (3 <= input.both.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".both",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.both,
+                        })) &&
+                    (7 >= input.both.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".both",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.both,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".both",
                         expected: "Array<string>",
@@ -115,7 +163,13 @@ export const test_createRandom_TagArray = _test_random(
                     })) &&
                 input.both.every(
                     (elem: any, _index5: number) =>
-                        ("string" === typeof elem && true === $is_uuid(elem)) ||
+                        ("string" === typeof elem &&
+                            (true === $is_uuid(elem) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both[" + _index5 + "]",
+                                    expected: "string (@format uuid)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".both[" + _index5 + "]",
                             expected: "string",

--- a/test/generated/output/createRandom/test_createRandom_TagAtomicUnion.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagAtomicUnion.ts
@@ -37,11 +37,26 @@ export const test_createRandom_TagAtomicUnion = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 ("string" === typeof input.value &&
-                    3 <= input.value.length &&
-                    7 >= input.value.length) ||
+                    (3 <= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@minLength 3)",
+                            value: input.value,
+                        })) &&
+                    (7 >= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@maxLength 7)",
+                            value: input.value,
+                        }))) ||
                 ("number" === typeof input.value &&
                     Number.isFinite(input.value) &&
-                    3 <= input.value) ||
+                    (3 <= input.value ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "number (@minimum 3)",
+                            value: input.value,
+                        }))) ||
                 $guard(_exceptionable, {
                     path: _path + ".value",
                     expected: "(number | string)",

--- a/test/generated/output/createRandom/test_createRandom_TagBigInt.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagBigInt.ts
@@ -57,27 +57,54 @@ export const test_createRandom_TagBigInt = _test_random(
                         value: input.value,
                     })) &&
                 (("bigint" === typeof input.ranged &&
-                    0n <= input.ranged &&
-                    100n >= input.ranged) ||
+                    (0n <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "bigint (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100n >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "bigint (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "bigint",
                         value: input.ranged,
                     })) &&
-                (("bigint" === typeof input.minimum && 0n <= input.minimum) ||
+                (("bigint" === typeof input.minimum &&
+                    (0n <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "bigint (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "bigint",
                         value: input.minimum,
                     })) &&
-                (("bigint" === typeof input.maximum && 100n >= input.maximum) ||
+                (("bigint" === typeof input.maximum &&
+                    (100n >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "bigint (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "bigint",
                         value: input.maximum,
                     })) &&
                 (("bigint" === typeof input.multipleOf &&
-                    0n === input.multipleOf % 3n) ||
+                    (0n === input.multipleOf % 3n ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "bigint (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "bigint",

--- a/test/generated/output/createRandom/test_createRandom_TagFormat.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagFormat.ts
@@ -46,63 +46,108 @@ export const test_createRandom_TagFormat = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.uuid &&
-                    true === $is_uuid(input.uuid)) ||
+                    (true === $is_uuid(input.uuid) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uuid",
+                            expected: "string (@format uuid)",
+                            value: input.uuid,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uuid",
                         expected: "string",
                         value: input.uuid,
                     })) &&
                 (("string" === typeof input.email &&
-                    true === $is_email(input.email)) ||
+                    (true === $is_email(input.email) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".email",
+                            expected: "string (@format email)",
+                            value: input.email,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".email",
                         expected: "string",
                         value: input.email,
                     })) &&
                 (("string" === typeof input.url &&
-                    true === $is_url(input.url)) ||
+                    (true === $is_url(input.url) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".url",
+                            expected: "string (@format url)",
+                            value: input.url,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".url",
                         expected: "string",
                         value: input.url,
                     })) &&
                 (("string" === typeof input.ipv4 &&
-                    true === $is_ipv4(input.ipv4)) ||
+                    (true === $is_ipv4(input.ipv4) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv4",
+                            expected: "string (@format ipv4)",
+                            value: input.ipv4,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv4",
                         expected: "string",
                         value: input.ipv4,
                     })) &&
                 (("string" === typeof input.ipv6 &&
-                    true === $is_ipv6(input.ipv6)) ||
+                    (true === $is_ipv6(input.ipv6) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv6",
+                            expected: "string (@format ipv6)",
+                            value: input.ipv6,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv6",
                         expected: "string",
                         value: input.ipv6,
                     })) &&
                 (("string" === typeof input.date &&
-                    true === $is_date(input.date)) ||
+                    (true === $is_date(input.date) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".date",
+                            expected: "string (@format date)",
+                            value: input.date,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".date",
                         expected: "string",
                         value: input.date,
                     })) &&
                 (("string" === typeof input.date_time &&
-                    true === $is_datetime(input.date_time)) ||
+                    (true === $is_datetime(input.date_time) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".date_time",
+                            expected: "string (@format datetime)",
+                            value: input.date_time,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".date_time",
                         expected: "string",
                         value: input.date_time,
                     })) &&
                 (("string" === typeof input.datetime &&
-                    true === $is_datetime(input.datetime)) ||
+                    (true === $is_datetime(input.datetime) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".datetime",
+                            expected: "string (@format datetime)",
+                            value: input.datetime,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".datetime",
                         expected: "string",
                         value: input.datetime,
                     })) &&
                 (("string" === typeof input.dateTime &&
-                    true === $is_datetime(input.dateTime)) ||
+                    (true === $is_datetime(input.dateTime) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dateTime",
+                            expected: "string (@format datetime)",
+                            value: input.dateTime,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".dateTime",
                         expected: "string",

--- a/test/generated/output/createRandom/test_createRandom_TagInfinite.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagInfinite.ts
@@ -42,8 +42,18 @@ export const test_createRandom_TagInfinite = _test_random(
                         value: input.value,
                     })) &&
                 (("number" === typeof input.ranged &&
-                    0 <= input.ranged &&
-                    100 >= input.ranged) ||
+                    (0 <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100 >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "number",
@@ -51,7 +61,12 @@ export const test_createRandom_TagInfinite = _test_random(
                     })) &&
                 (("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
-                    0 <= input.minimum) ||
+                    (0 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
@@ -59,14 +74,24 @@ export const test_createRandom_TagInfinite = _test_random(
                     })) &&
                 (("number" === typeof input.maximum &&
                     Number.isFinite(input.maximum) &&
-                    100 >= input.maximum) ||
+                    (100 >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "number (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "number",
                         value: input.maximum,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 3) ||
+                    (0 === input.multipleOf % 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",
@@ -74,7 +99,12 @@ export const test_createRandom_TagInfinite = _test_random(
                     })) &&
                 (("number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
-                    parseInt(input.typed) === input.typed) ||
+                    (parseInt(input.typed) === input.typed ||
+                        $guard(_exceptionable, {
+                            path: _path + ".typed",
+                            expected: "number (@type int)",
+                            value: input.typed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".typed",
                         expected: "number",

--- a/test/generated/output/createRandom/test_createRandom_TagLength.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagLength.ts
@@ -39,29 +39,54 @@ export const test_createRandom_TagLength = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.fixed &&
-                    5 === input.fixed.length) ||
+                    (5 === input.fixed.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".fixed",
+                            expected: "string (@length 5)",
+                            value: input.fixed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".fixed",
                         expected: "string",
                         value: input.fixed,
                     })) &&
                 (("string" === typeof input.minimum &&
-                    3 <= input.minimum.length) ||
+                    (3 <= input.minimum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "string (@minLength 3)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "string",
                         value: input.minimum,
                     })) &&
                 (("string" === typeof input.maximum &&
-                    7 >= input.maximum.length) ||
+                    (7 >= input.maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "string (@maxLength 7)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "string",
                         value: input.maximum,
                     })) &&
                 (("string" === typeof input.minimum_and_maximum &&
-                    3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length) ||
+                    (3 <= input.minimum_and_maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum_and_maximum",
+                            expected: "string (@minLength 3)",
+                            value: input.minimum_and_maximum,
+                        })) &&
+                    (7 >= input.minimum_and_maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum_and_maximum",
+                            expected: "string (@maxLength 7)",
+                            value: input.minimum_and_maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum_and_maximum",
                         expected: "string",

--- a/test/generated/output/createRandom/test_createRandom_TagMatrix.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagMatrix.ts
@@ -37,7 +37,13 @@ export const test_createRandom_TagMatrix = _test_random(
                 _path: string,
                 _exceptionable: boolean = true,
             ): boolean =>
-                ((Array.isArray(input.matrix) && 3 === input.matrix.length) ||
+                ((Array.isArray(input.matrix) &&
+                    (3 === input.matrix.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".matrix",
+                            expected: "Array.length (@items 3)",
+                            value: input.matrix,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".matrix",
                         expected: "Array<Array<string>>",
@@ -45,7 +51,13 @@ export const test_createRandom_TagMatrix = _test_random(
                     })) &&
                 input.matrix.every(
                     (elem: any, _index1: number) =>
-                        ((Array.isArray(elem) && 3 === elem.length) ||
+                        ((Array.isArray(elem) &&
+                            (3 === elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".matrix[" + _index1 + "]",
+                                    expected: "Array.length (@items 3)",
+                                    value: elem,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".matrix[" + _index1 + "]",
                                 expected: "Array<string>",
@@ -54,7 +66,18 @@ export const test_createRandom_TagMatrix = _test_random(
                         elem.every(
                             (elem: any, _index2: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".matrix[" +
+                                                _index1 +
+                                                "][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path:
                                         _path +

--- a/test/generated/output/createRandom/test_createRandom_TagNaN.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagNaN.ts
@@ -42,8 +42,18 @@ export const test_createRandom_TagNaN = _test_random(
                         value: input.value,
                     })) &&
                 (("number" === typeof input.ranged &&
-                    0 <= input.ranged &&
-                    100 >= input.ranged) ||
+                    (0 <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100 >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "number",
@@ -51,7 +61,12 @@ export const test_createRandom_TagNaN = _test_random(
                     })) &&
                 (("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
-                    0 <= input.minimum) ||
+                    (0 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
@@ -59,14 +74,24 @@ export const test_createRandom_TagNaN = _test_random(
                     })) &&
                 (("number" === typeof input.maximum &&
                     Number.isFinite(input.maximum) &&
-                    100 >= input.maximum) ||
+                    (100 >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "number (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "number",
                         value: input.maximum,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 3) ||
+                    (0 === input.multipleOf % 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",
@@ -74,7 +99,12 @@ export const test_createRandom_TagNaN = _test_random(
                     })) &&
                 (("number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
-                    parseInt(input.typed) === input.typed) ||
+                    (parseInt(input.typed) === input.typed ||
+                        $guard(_exceptionable, {
+                            path: _path + ".typed",
+                            expected: "number (@type int)",
+                            value: input.typed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".typed",
                         expected: "number",

--- a/test/generated/output/createRandom/test_createRandom_TagObjectUnion.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagObjectUnion.ts
@@ -42,7 +42,12 @@ export const test_createRandom_TagObjectUnion = _test_random(
             ): boolean =>
                 ("number" === typeof input.value &&
                     Number.isFinite(input.value) &&
-                    3 <= input.value) ||
+                    (3 <= input.value ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "number (@minimum 3)",
+                            value: input.value,
+                        }))) ||
                 $guard(_exceptionable, {
                     path: _path + ".value",
                     expected: "number",
@@ -54,8 +59,18 @@ export const test_createRandom_TagObjectUnion = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 ("string" === typeof input.value &&
-                    3 <= input.value.length &&
-                    7 >= input.value.length) ||
+                    (3 <= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@minLength 3)",
+                            value: input.value,
+                        })) &&
+                    (7 >= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@maxLength 7)",
+                            value: input.value,
+                        }))) ||
                 $guard(_exceptionable, {
                     path: _path + ".value",
                     expected: "string",

--- a/test/generated/output/createRandom/test_createRandom_TagPattern.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagPattern.ts
@@ -41,40 +41,64 @@ export const test_createRandom_TagPattern = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.uuid &&
-                    true ===
+                    (true ===
                         RegExp(
                             /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                        ).test(input.uuid)) ||
+                        ).test(input.uuid) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uuid",
+                            expected:
+                                "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                            value: input.uuid,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uuid",
                         expected: "string",
                         value: input.uuid,
                     })) &&
                 (("string" === typeof input.email &&
-                    true ===
+                    (true ===
                         RegExp(
                             /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                        ).test(input.email)) ||
+                        ).test(input.email) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".email",
+                            expected:
+                                'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                            value: input.email,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".email",
                         expected: "string",
                         value: input.email,
                     })) &&
                 (("string" === typeof input.ipv4 &&
-                    true ===
+                    (true ===
                         RegExp(
                             /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                        ).test(input.ipv4)) ||
+                        ).test(input.ipv4) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv4",
+                            expected:
+                                "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                            value: input.ipv4,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv4",
                         expected: "string",
                         value: input.ipv4,
                     })) &&
                 (("string" === typeof input.ipv6 &&
-                    true ===
+                    (true ===
                         RegExp(
                             /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                        ).test(input.ipv6)) ||
+                        ).test(input.ipv6) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv6",
+                            expected:
+                                "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                            value: input.ipv6,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv6",
                         expected: "string",

--- a/test/generated/output/createRandom/test_createRandom_TagRange.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagRange.ts
@@ -41,7 +41,12 @@ export const test_createRandom_TagRange = _test_random(
             ): boolean =>
                 (("number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
-                    3 < input.greater) ||
+                    (3 < input.greater ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater",
                         expected: "number",
@@ -49,7 +54,12 @@ export const test_createRandom_TagRange = _test_random(
                     })) &&
                 (("number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
-                    3 <= input.greater_equal) ||
+                    (3 <= input.greater_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal",
                         expected: "number",
@@ -57,7 +67,12 @@ export const test_createRandom_TagRange = _test_random(
                     })) &&
                 (("number" === typeof input.less &&
                     Number.isFinite(input.less) &&
-                    7 > input.less) ||
+                    (7 > input.less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".less",
                         expected: "number",
@@ -65,39 +80,84 @@ export const test_createRandom_TagRange = _test_random(
                     })) &&
                 (("number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
-                    7 >= input.less_equal) ||
+                    (7 >= input.less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".less_equal",
                         expected: "number",
                         value: input.less_equal,
                     })) &&
                 (("number" === typeof input.greater_less &&
-                    3 < input.greater_less &&
-                    7 > input.greater_less) ||
+                    (3 < input.greater_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater_less,
+                        })) &&
+                    (7 > input.greater_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.greater_less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_less",
                         expected: "number",
                         value: input.greater_less,
                     })) &&
                 (("number" === typeof input.greater_equal_less &&
-                    3 <= input.greater_equal_less &&
-                    7 > input.greater_equal_less) ||
+                    (3 <= input.greater_equal_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal_less,
+                        })) &&
+                    (7 > input.greater_equal_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.greater_equal_less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal_less",
                         expected: "number",
                         value: input.greater_equal_less,
                     })) &&
                 (("number" === typeof input.greater_less_equal &&
-                    3 < input.greater_less_equal &&
-                    7 >= input.greater_less_equal) ||
+                    (3 < input.greater_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less_equal",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater_less_equal,
+                        })) &&
+                    (7 >= input.greater_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.greater_less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_less_equal",
                         expected: "number",
                         value: input.greater_less_equal,
                     })) &&
                 (("number" === typeof input.greater_equal_less_equal &&
-                    3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal) ||
+                    (3 <= input.greater_equal_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less_equal",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal_less_equal,
+                        })) &&
+                    (7 >= input.greater_equal_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.greater_equal_less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal_less_equal",
                         expected: "number",

--- a/test/generated/output/createRandom/test_createRandom_TagStep.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagStep.ts
@@ -34,34 +34,84 @@ export const test_createRandom_TagStep = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("number" === typeof input.exclusiveMinimum &&
-                    0 === (input.exclusiveMinimum % 5) - 3 &&
-                    3 < input.exclusiveMinimum) ||
+                    (0 === (input.exclusiveMinimum % 5) - 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "number (@step 5)",
+                            value: input.exclusiveMinimum,
+                        })) &&
+                    (3 < input.exclusiveMinimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.exclusiveMinimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".exclusiveMinimum",
                         expected: "number",
                         value: input.exclusiveMinimum,
                     })) &&
                 (("number" === typeof input.minimum &&
-                    0 === (input.minimum % 5) - 3 &&
-                    3 <= input.minimum) ||
+                    (0 === (input.minimum % 5) - 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@step 5)",
+                            value: input.minimum,
+                        })) &&
+                    (3 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 3)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
                         value: input.minimum,
                     })) &&
                 (("number" === typeof input.range &&
-                    0 === (input.range % 5) - 0 &&
-                    0 < input.range &&
-                    100 > input.range) ||
+                    (0 === (input.range % 5) - 0 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@step 5)",
+                            value: input.range,
+                        })) &&
+                    (0 < input.range ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@exclusiveMinimum 0)",
+                            value: input.range,
+                        })) &&
+                    (100 > input.range ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@exclusiveMaximum 100)",
+                            value: input.range,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".range",
                         expected: "number",
                         value: input.range,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 5 &&
-                    3 <= input.multipleOf &&
-                    99 >= input.multipleOf) ||
+                    (0 === input.multipleOf % 5 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 5)",
+                            value: input.multipleOf,
+                        })) &&
+                    (3 <= input.multipleOf ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@minimum 3)",
+                            value: input.multipleOf,
+                        })) &&
+                    (99 >= input.multipleOf ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@maximum 99)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",

--- a/test/generated/output/createRandom/test_createRandom_TagTuple.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagTuple.ts
@@ -60,24 +60,54 @@ export const test_createRandom_TagTuple = _test_random(
                         value: input.tuple,
                     })) &&
                 (("string" === typeof input.tuple[0] &&
-                    3 <= input.tuple[0].length &&
-                    7 >= input.tuple[0].length) ||
+                    (3 <= input.tuple[0].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[0]",
+                            expected: "string (@minLength 3)",
+                            value: input.tuple[0],
+                        })) &&
+                    (7 >= input.tuple[0].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[0]",
+                            expected: "string (@maxLength 7)",
+                            value: input.tuple[0],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[0]",
                         expected: "string",
                         value: input.tuple[0],
                     })) &&
                 (("number" === typeof input.tuple[1] &&
-                    3 <= input.tuple[1] &&
-                    7 >= input.tuple[1]) ||
+                    (3 <= input.tuple[1] ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[1]",
+                            expected: "number (@minimum 3)",
+                            value: input.tuple[1],
+                        })) &&
+                    (7 >= input.tuple[1] ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[1]",
+                            expected: "number (@maximum 7)",
+                            value: input.tuple[1],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[1]",
                         expected: "number",
                         value: input.tuple[1],
                     })) &&
                 ((Array.isArray(input.tuple[2]) &&
-                    3 <= input.tuple[2].length &&
-                    7 >= input.tuple[2].length) ||
+                    (3 <= input.tuple[2].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[2]",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.tuple[2],
+                        })) &&
+                    (7 >= input.tuple[2].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[2]",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.tuple[2],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[2]",
                         expected: "Array<string>",
@@ -86,8 +116,18 @@ export const test_createRandom_TagTuple = _test_random(
                 input.tuple[2].every(
                     (elem: any, _index1: number) =>
                         ("string" === typeof elem &&
-                            3 <= elem.length &&
-                            7 >= elem.length) ||
+                            (3 <= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2][" + _index1 + "]",
+                                    expected: "string (@minLength 3)",
+                                    value: elem,
+                                })) &&
+                            (7 >= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2][" + _index1 + "]",
+                                    expected: "string (@maxLength 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[2][" + _index1 + "]",
                             expected: "string",
@@ -95,8 +135,18 @@ export const test_createRandom_TagTuple = _test_random(
                         }),
                 ) &&
                 ((Array.isArray(input.tuple[3]) &&
-                    3 <= input.tuple[3].length &&
-                    7 >= input.tuple[3].length) ||
+                    (3 <= input.tuple[3].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[3]",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.tuple[3],
+                        })) &&
+                    (7 >= input.tuple[3].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[3]",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.tuple[3],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[3]",
                         expected: "Array<number>",
@@ -104,7 +154,19 @@ export const test_createRandom_TagTuple = _test_random(
                     })) &&
                 input.tuple[3].every(
                     (elem: any, _index2: number) =>
-                        ("number" === typeof elem && 3 <= elem && 7 >= elem) ||
+                        ("number" === typeof elem &&
+                            (3 <= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3][" + _index2 + "]",
+                                    expected: "number (@minimum 3)",
+                                    value: elem,
+                                })) &&
+                            (7 >= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3][" + _index2 + "]",
+                                    expected: "number (@maximum 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[3][" + _index2 + "]",
                             expected: "number",

--- a/test/generated/output/createRandom/test_createRandom_TagType.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagType.ts
@@ -32,7 +32,12 @@ export const test_createRandom_TagType = _test_random(
             ): boolean =>
                 (("number" === typeof input.int &&
                     Number.isFinite(input.int) &&
-                    parseInt(input.int) === input.int) ||
+                    (parseInt(input.int) === input.int ||
+                        $guard(_exceptionable, {
+                            path: _path + ".int",
+                            expected: "number (@type int)",
+                            value: input.int,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".int",
                         expected: "number",
@@ -40,8 +45,18 @@ export const test_createRandom_TagType = _test_random(
                     })) &&
                 (("number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
-                    parseInt(input.uint) === input.uint &&
-                    0 <= input.uint) ||
+                    (parseInt(input.uint) === input.uint ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uint",
+                            expected: "number (@type uint)",
+                            value: input.uint,
+                        })) &&
+                    (0 <= input.uint ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uint",
+                            expected: "number (@type uint)",
+                            value: input.uint,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uint",
                         expected: "number",

--- a/test/generated/output/createStringify/test_createStringify_TagCustom.ts
+++ b/test/generated/output/createStringify/test_createStringify_TagCustom.ts
@@ -11,8 +11,8 @@ export const test_createStringify_TagCustom = _test_stringify(
         const $is_uuid = (typia.createStringify as any).is_uuid;
         const $is_custom = (typia.createStringify as any).is_custom;
         const $so0 = (input: any): any =>
-            `{"id":${'"' + input.id + '"'},"dolloar":${$string(
-                input.dolloar,
+            `{"id":${'"' + input.id + '"'},"dollar":${$string(
+                input.dollar,
             )},"postfix":${$string(input.postfix)},"log":${$number(
                 input.log,
             )}}`;

--- a/test/generated/output/createValidate/test_createValidate_TagArray.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagArray.ts
@@ -21,7 +21,12 @@ export const test_createValidate_TagArray = _test_validate(
             ): boolean =>
                 [
                     (((Array.isArray(input.items) &&
-                        3 === input.items.length) ||
+                        (3 === input.items.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".items",
+                                expected: "Array.length (@items 3)",
+                                value: input.items,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".items",
                             expected: "Array<string>",
@@ -31,7 +36,17 @@ export const test_createValidate_TagArray = _test_validate(
                             .map(
                                 (elem: any, _index2: number) =>
                                     ("string" === typeof elem &&
-                                        true === $is_uuid(elem)) ||
+                                        (true === $is_uuid(elem) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".items[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected:
+                                                    "string (@format uuid)",
+                                                value: elem,
+                                            }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".items[" + _index2 + "]",
                                         expected: "string",
@@ -45,7 +60,12 @@ export const test_createValidate_TagArray = _test_validate(
                             value: input.items,
                         }),
                     (((Array.isArray(input.minItems) &&
-                        3 <= input.minItems.length) ||
+                        (3 <= input.minItems.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.minItems,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "Array<number>",
@@ -56,7 +76,16 @@ export const test_createValidate_TagArray = _test_validate(
                                 (elem: any, _index3: number) =>
                                     ("number" === typeof elem &&
                                         Number.isFinite(elem) &&
-                                        3 <= elem) ||
+                                        (3 <= elem ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".minItems[" +
+                                                    _index3 +
+                                                    "]",
+                                                expected: "number (@minimum 3)",
+                                                value: elem,
+                                            }))) ||
                                     $report(_exceptionable, {
                                         path:
                                             _path +
@@ -74,7 +103,12 @@ export const test_createValidate_TagArray = _test_validate(
                             value: input.minItems,
                         }),
                     (((Array.isArray(input.maxItems) &&
-                        7 >= input.maxItems.length) ||
+                        (7 >= input.maxItems.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.maxItems,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "Array<(number | string)>",
@@ -84,10 +118,29 @@ export const test_createValidate_TagArray = _test_validate(
                             .map(
                                 (elem: any, _index4: number) =>
                                     ("string" === typeof elem &&
-                                        7 >= elem.length) ||
+                                        (7 >= elem.length ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".maxItems[" +
+                                                    _index4 +
+                                                    "]",
+                                                expected:
+                                                    "string (@maxLength 7)",
+                                                value: elem,
+                                            }))) ||
                                     ("number" === typeof elem &&
                                         Number.isFinite(elem) &&
-                                        7 >= elem) ||
+                                        (7 >= elem ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".maxItems[" +
+                                                    _index4 +
+                                                    "]",
+                                                expected: "number (@maximum 7)",
+                                                value: elem,
+                                            }))) ||
                                     $report(_exceptionable, {
                                         path:
                                             _path +
@@ -105,8 +158,18 @@ export const test_createValidate_TagArray = _test_validate(
                             value: input.maxItems,
                         }),
                     (((Array.isArray(input.both) &&
-                        3 <= input.both.length &&
-                        7 >= input.both.length) ||
+                        (3 <= input.both.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.both,
+                            })) &&
+                        (7 >= input.both.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.both,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".both",
                             expected: "Array<string>",
@@ -116,7 +179,17 @@ export const test_createValidate_TagArray = _test_validate(
                             .map(
                                 (elem: any, _index5: number) =>
                                     ("string" === typeof elem &&
-                                        true === $is_uuid(elem)) ||
+                                        (true === $is_uuid(elem) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".both[" +
+                                                    _index5 +
+                                                    "]",
+                                                expected:
+                                                    "string (@format uuid)",
+                                                value: elem,
+                                            }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".both[" + _index5 + "]",
                                         expected: "string",

--- a/test/generated/output/createValidate/test_createValidate_TagAtomicUnion.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagAtomicUnion.ts
@@ -20,11 +20,26 @@ export const test_createValidate_TagAtomicUnion = _test_validate(
             ): boolean =>
                 [
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $report(_exceptionable, {
                             path: _path + ".value",
                             expected: "(number | string)",

--- a/test/generated/output/createValidate/test_createValidate_TagBigInt.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagBigInt.ts
@@ -26,29 +26,54 @@ export const test_createValidate_TagBigInt = _test_validate(
                             value: input.value,
                         }),
                     ("bigint" === typeof input.ranged &&
-                        0n <= input.ranged &&
-                        100n >= input.ranged) ||
+                        (0n <= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "bigint (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100n >= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "bigint (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "bigint",
                             value: input.ranged,
                         }),
                     ("bigint" === typeof input.minimum &&
-                        0n <= input.minimum) ||
+                        (0n <= input.minimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "bigint (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "bigint",
                             value: input.minimum,
                         }),
                     ("bigint" === typeof input.maximum &&
-                        100n >= input.maximum) ||
+                        (100n >= input.maximum ||
+                            $report(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "bigint (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "bigint",
                             value: input.maximum,
                         }),
                     ("bigint" === typeof input.multipleOf &&
-                        0n === input.multipleOf % 3n) ||
+                        (0n === input.multipleOf % 3n ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "bigint (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "bigint",

--- a/test/generated/output/createValidate/test_createValidate_TagCustom.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagCustom.ts
@@ -22,26 +22,41 @@ export const test_createValidate_TagCustom = _test_validate(
             ): boolean =>
                 [
                     ("string" === typeof input.id &&
-                        true === $is_uuid(input.id)) ||
+                        (true === $is_uuid(input.id) ||
+                            $report(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string (@format uuid)",
+                                value: input.id,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".id",
                             expected: "string",
                             value: input.id,
                         }),
-                    ("string" === typeof input.dolloar &&
-                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                    ("string" === typeof input.dollar &&
+                        ($is_custom("dollar", "string", "", input.dollar) ||
+                            $report(_exceptionable, {
+                                path: _path + ".dollar",
+                                expected: "string (@dollar)",
+                                value: input.dollar,
+                            }))) ||
                         $report(_exceptionable, {
-                            path: _path + ".dolloar",
+                            path: _path + ".dollar",
                             expected: "string",
-                            value: input.dolloar,
+                            value: input.dollar,
                         }),
                     ("string" === typeof input.postfix &&
-                        $is_custom(
+                        ($is_custom(
                             "postfix",
                             "string",
                             "abcd",
                             input.postfix,
-                        )) ||
+                        ) ||
+                            $report(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string (@postfix abcd)",
+                                value: input.postfix,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".postfix",
                             expected: "string",
@@ -49,7 +64,12 @@ export const test_createValidate_TagCustom = _test_validate(
                         }),
                     ("number" === typeof input.log &&
                         Number.isFinite(input.log) &&
-                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        ($is_custom("powerOf", "number", "10", input.log) ||
+                            $report(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number (@powerOf 10)",
+                                value: input.log,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".log",
                             expected: "number",

--- a/test/generated/output/createValidate/test_createValidate_TagFormat.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagFormat.ts
@@ -27,63 +27,108 @@ export const test_createValidate_TagFormat = _test_validate(
             ): boolean =>
                 [
                     ("string" === typeof input.uuid &&
-                        true === $is_uuid(input.uuid)) ||
+                        (true === $is_uuid(input.uuid) ||
+                            $report(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected: "string (@format uuid)",
+                                value: input.uuid,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         }),
                     ("string" === typeof input.email &&
-                        true === $is_email(input.email)) ||
+                        (true === $is_email(input.email) ||
+                            $report(_exceptionable, {
+                                path: _path + ".email",
+                                expected: "string (@format email)",
+                                value: input.email,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         }),
                     ("string" === typeof input.url &&
-                        true === $is_url(input.url)) ||
+                        (true === $is_url(input.url) ||
+                            $report(_exceptionable, {
+                                path: _path + ".url",
+                                expected: "string (@format url)",
+                                value: input.url,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".url",
                             expected: "string",
                             value: input.url,
                         }),
                     ("string" === typeof input.ipv4 &&
-                        true === $is_ipv4(input.ipv4)) ||
+                        (true === $is_ipv4(input.ipv4) ||
+                            $report(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected: "string (@format ipv4)",
+                                value: input.ipv4,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         }),
                     ("string" === typeof input.ipv6 &&
-                        true === $is_ipv6(input.ipv6)) ||
+                        (true === $is_ipv6(input.ipv6) ||
+                            $report(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected: "string (@format ipv6)",
+                                value: input.ipv6,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",
                             value: input.ipv6,
                         }),
                     ("string" === typeof input.date &&
-                        true === $is_date(input.date)) ||
+                        (true === $is_date(input.date) ||
+                            $report(_exceptionable, {
+                                path: _path + ".date",
+                                expected: "string (@format date)",
+                                value: input.date,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".date",
                             expected: "string",
                             value: input.date,
                         }),
                     ("string" === typeof input.date_time &&
-                        true === $is_datetime(input.date_time)) ||
+                        (true === $is_datetime(input.date_time) ||
+                            $report(_exceptionable, {
+                                path: _path + ".date_time",
+                                expected: "string (@format datetime)",
+                                value: input.date_time,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".date_time",
                             expected: "string",
                             value: input.date_time,
                         }),
                     ("string" === typeof input.datetime &&
-                        true === $is_datetime(input.datetime)) ||
+                        (true === $is_datetime(input.datetime) ||
+                            $report(_exceptionable, {
+                                path: _path + ".datetime",
+                                expected: "string (@format datetime)",
+                                value: input.datetime,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".datetime",
                             expected: "string",
                             value: input.datetime,
                         }),
                     ("string" === typeof input.dateTime &&
-                        true === $is_datetime(input.dateTime)) ||
+                        (true === $is_datetime(input.dateTime) ||
+                            $report(_exceptionable, {
+                                path: _path + ".dateTime",
+                                expected: "string (@format datetime)",
+                                value: input.dateTime,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".dateTime",
                             expected: "string",

--- a/test/generated/output/createValidate/test_createValidate_TagInfinite.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagInfinite.ts
@@ -27,8 +27,18 @@ export const test_createValidate_TagInfinite = _test_validate(
                             value: input.value,
                         }),
                     ("number" === typeof input.ranged &&
-                        0 <= input.ranged &&
-                        100 >= input.ranged) ||
+                        (0 <= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100 >= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "number",
@@ -36,7 +46,12 @@ export const test_createValidate_TagInfinite = _test_validate(
                         }),
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        0 <= input.minimum) ||
+                        (0 <= input.minimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
@@ -44,14 +59,24 @@ export const test_createValidate_TagInfinite = _test_validate(
                         }),
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        100 >= input.maximum) ||
+                        (100 >= input.maximum ||
+                            $report(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "number",
                             value: input.maximum,
                         }),
                     ("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 3) ||
+                        (0 === input.multipleOf % 3 ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",
@@ -59,7 +84,12 @@ export const test_createValidate_TagInfinite = _test_validate(
                         }),
                     ("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
-                        parseInt(input.typed) === input.typed) ||
+                        (parseInt(input.typed) === input.typed ||
+                            $report(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".typed",
                             expected: "number",

--- a/test/generated/output/createValidate/test_createValidate_TagLength.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagLength.ts
@@ -20,29 +20,54 @@ export const test_createValidate_TagLength = _test_validate(
             ): boolean =>
                 [
                     ("string" === typeof input.fixed &&
-                        5 === input.fixed.length) ||
+                        (5 === input.fixed.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".fixed",
+                                expected: "string (@length 5)",
+                                value: input.fixed,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".fixed",
                             expected: "string",
                             value: input.fixed,
                         }),
                     ("string" === typeof input.minimum &&
-                        3 <= input.minimum.length) ||
+                        (3 <= input.minimum.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "string",
                             value: input.minimum,
                         }),
                     ("string" === typeof input.maximum &&
-                        7 >= input.maximum.length) ||
+                        (7 >= input.maximum.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.maximum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "string",
                             value: input.maximum,
                         }),
                     ("string" === typeof input.minimum_and_maximum &&
-                        3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length) ||
+                        (3 <= input.minimum_and_maximum.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum_and_maximum,
+                            })) &&
+                        (7 >= input.minimum_and_maximum.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.minimum_and_maximum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum_and_maximum",
                             expected: "string",

--- a/test/generated/output/createValidate/test_createValidate_TagMatrix.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagMatrix.ts
@@ -21,7 +21,12 @@ export const test_createValidate_TagMatrix = _test_validate(
             ): boolean =>
                 [
                     (((Array.isArray(input.matrix) &&
-                        3 === input.matrix.length) ||
+                        (3 === input.matrix.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".matrix",
+                                expected: "Array.length (@items 3)",
+                                value: input.matrix,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".matrix",
                             expected: "Array<Array<string>>",
@@ -31,7 +36,17 @@ export const test_createValidate_TagMatrix = _test_validate(
                             .map(
                                 (elem: any, _index1: number) =>
                                     (((Array.isArray(elem) &&
-                                        3 === elem.length) ||
+                                        (3 === elem.length ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".matrix[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected:
+                                                    "Array.length (@items 3)",
+                                                value: elem,
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -45,8 +60,23 @@ export const test_createValidate_TagMatrix = _test_validate(
                                             .map(
                                                 (elem: any, _index2: number) =>
                                                     ("string" === typeof elem &&
-                                                        true ===
-                                                            $is_uuid(elem)) ||
+                                                        (true ===
+                                                            $is_uuid(elem) ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".matrix[" +
+                                                                        _index1 +
+                                                                        "][" +
+                                                                        _index2 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "string (@format uuid)",
+                                                                    value: elem,
+                                                                },
+                                                            ))) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +

--- a/test/generated/output/createValidate/test_createValidate_TagNaN.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagNaN.ts
@@ -27,8 +27,18 @@ export const test_createValidate_TagNaN = _test_validate(
                             value: input.value,
                         }),
                     ("number" === typeof input.ranged &&
-                        0 <= input.ranged &&
-                        100 >= input.ranged) ||
+                        (0 <= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100 >= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "number",
@@ -36,7 +46,12 @@ export const test_createValidate_TagNaN = _test_validate(
                         }),
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        0 <= input.minimum) ||
+                        (0 <= input.minimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
@@ -44,14 +59,24 @@ export const test_createValidate_TagNaN = _test_validate(
                         }),
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        100 >= input.maximum) ||
+                        (100 >= input.maximum ||
+                            $report(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "number",
                             value: input.maximum,
                         }),
                     ("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 3) ||
+                        (0 === input.multipleOf % 3 ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",
@@ -59,7 +84,12 @@ export const test_createValidate_TagNaN = _test_validate(
                         }),
                     ("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
-                        parseInt(input.typed) === input.typed) ||
+                        (parseInt(input.typed) === input.typed ||
+                            $report(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".typed",
                             expected: "number",

--- a/test/generated/output/createValidate/test_createValidate_TagObjectUnion.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagObjectUnion.ts
@@ -21,7 +21,12 @@ export const test_createValidate_TagObjectUnion = _test_validate(
                 [
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $report(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".value",
                             expected: "number",
@@ -35,8 +40,18 @@ export const test_createValidate_TagObjectUnion = _test_validate(
             ): boolean =>
                 [
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".value",
                             expected: "string",

--- a/test/generated/output/createValidate/test_createValidate_TagPattern.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagPattern.ts
@@ -20,40 +20,64 @@ export const test_createValidate_TagPattern = _test_validate(
             ): boolean =>
                 [
                     ("string" === typeof input.uuid &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                            ).test(input.uuid)) ||
+                            ).test(input.uuid) ||
+                            $report(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected:
+                                    "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                value: input.uuid,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         }),
                     ("string" === typeof input.email &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                            ).test(input.email)) ||
+                            ).test(input.email) ||
+                            $report(_exceptionable, {
+                                path: _path + ".email",
+                                expected:
+                                    'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                value: input.email,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         }),
                     ("string" === typeof input.ipv4 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                            ).test(input.ipv4)) ||
+                            ).test(input.ipv4) ||
+                            $report(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected:
+                                    "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                value: input.ipv4,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         }),
                     ("string" === typeof input.ipv6 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                            ).test(input.ipv6)) ||
+                            ).test(input.ipv6) ||
+                            $report(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected:
+                                    "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                value: input.ipv6,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",

--- a/test/generated/output/createValidate/test_createValidate_TagRange.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagRange.ts
@@ -21,7 +21,12 @@ export const test_createValidate_TagRange = _test_validate(
                 [
                     ("number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
-                        3 < input.greater) ||
+                        (3 < input.greater ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater",
                             expected: "number",
@@ -29,7 +34,12 @@ export const test_createValidate_TagRange = _test_validate(
                         }),
                     ("number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
-                        3 <= input.greater_equal) ||
+                        (3 <= input.greater_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater_equal",
                             expected: "number",
@@ -37,7 +47,12 @@ export const test_createValidate_TagRange = _test_validate(
                         }),
                     ("number" === typeof input.less &&
                         Number.isFinite(input.less) &&
-                        7 > input.less) ||
+                        (7 > input.less ||
+                            $report(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.less,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".less",
                             expected: "number",
@@ -45,39 +60,84 @@ export const test_createValidate_TagRange = _test_validate(
                         }),
                     ("number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
-                        7 >= input.less_equal) ||
+                        (7 >= input.less_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.less_equal,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".less_equal",
                             expected: "number",
                             value: input.less_equal,
                         }),
                     ("number" === typeof input.greater_less &&
-                        3 < input.greater_less &&
-                        7 > input.greater_less) ||
+                        (3 < input.greater_less ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less,
+                            })) &&
+                        (7 > input.greater_less ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_less,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater_less",
                             expected: "number",
                             value: input.greater_less,
                         }),
                     ("number" === typeof input.greater_equal_less &&
-                        3 <= input.greater_equal_less &&
-                        7 > input.greater_equal_less) ||
+                        (3 <= input.greater_equal_less ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less,
+                            })) &&
+                        (7 > input.greater_equal_less ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_equal_less,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater_equal_less",
                             expected: "number",
                             value: input.greater_equal_less,
                         }),
                     ("number" === typeof input.greater_less_equal &&
-                        3 < input.greater_less_equal &&
-                        7 >= input.greater_less_equal) ||
+                        (3 < input.greater_less_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        (7 >= input.greater_less_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_less_equal,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater_less_equal",
                             expected: "number",
                             value: input.greater_less_equal,
                         }),
                     ("number" === typeof input.greater_equal_less_equal &&
-                        3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal) ||
+                        (3 <= input.greater_equal_less_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
+                        (7 >= input.greater_equal_less_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_equal_less_equal,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",

--- a/test/generated/output/createValidate/test_createValidate_TagStep.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagStep.ts
@@ -20,34 +20,84 @@ export const test_createValidate_TagStep = _test_validate(
             ): boolean =>
                 [
                     ("number" === typeof input.exclusiveMinimum &&
-                        0 === (input.exclusiveMinimum % 5) - 3 &&
-                        3 < input.exclusiveMinimum) ||
+                        (0 === (input.exclusiveMinimum % 5) - 3 ||
+                            $report(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@step 5)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (3 < input.exclusiveMinimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.exclusiveMinimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".exclusiveMinimum",
                             expected: "number",
                             value: input.exclusiveMinimum,
                         }),
                     ("number" === typeof input.minimum &&
-                        0 === (input.minimum % 5) - 3 &&
-                        3 <= input.minimum) ||
+                        (0 === (input.minimum % 5) - 3 ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@step 5)",
+                                value: input.minimum,
+                            })) &&
+                        (3 <= input.minimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 3)",
+                                value: input.minimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
                             value: input.minimum,
                         }),
                     ("number" === typeof input.range &&
-                        0 === (input.range % 5) - 0 &&
-                        0 < input.range &&
-                        100 > input.range) ||
+                        (0 === (input.range % 5) - 0 ||
+                            $report(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@step 5)",
+                                value: input.range,
+                            })) &&
+                        (0 < input.range ||
+                            $report(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMinimum 0)",
+                                value: input.range,
+                            })) &&
+                        (100 > input.range ||
+                            $report(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMaximum 100)",
+                                value: input.range,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".range",
                             expected: "number",
                             value: input.range,
                         }),
                     ("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 5 &&
-                        3 <= input.multipleOf &&
-                        99 >= input.multipleOf) ||
+                        (0 === input.multipleOf % 5 ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 5)",
+                                value: input.multipleOf,
+                            })) &&
+                        (3 <= input.multipleOf ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@minimum 3)",
+                                value: input.multipleOf,
+                            })) &&
+                        (99 >= input.multipleOf ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@maximum 99)",
+                                value: input.multipleOf,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",

--- a/test/generated/output/createValidate/test_createValidate_TagTuple.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagTuple.ts
@@ -35,24 +35,54 @@ export const test_createValidate_TagTuple = _test_validate(
                             })) &&
                         [
                             ("string" === typeof input.tuple[0] &&
-                                3 <= input.tuple[0].length &&
-                                7 >= input.tuple[0].length) ||
+                                (3 <= input.tuple[0].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[0]",
+                                        expected: "string (@minLength 3)",
+                                        value: input.tuple[0],
+                                    })) &&
+                                (7 >= input.tuple[0].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[0]",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.tuple[0],
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".tuple[0]",
                                     expected: "string",
                                     value: input.tuple[0],
                                 }),
                             ("number" === typeof input.tuple[1] &&
-                                3 <= input.tuple[1] &&
-                                7 >= input.tuple[1]) ||
+                                (3 <= input.tuple[1] ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[1]",
+                                        expected: "number (@minimum 3)",
+                                        value: input.tuple[1],
+                                    })) &&
+                                (7 >= input.tuple[1] ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[1]",
+                                        expected: "number (@maximum 7)",
+                                        value: input.tuple[1],
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".tuple[1]",
                                     expected: "number",
                                     value: input.tuple[1],
                                 }),
                             (((Array.isArray(input.tuple[2]) &&
-                                3 <= input.tuple[2].length &&
-                                7 >= input.tuple[2].length) ||
+                                (3 <= input.tuple[2].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[2]",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.tuple[2],
+                                    })) &&
+                                (7 >= input.tuple[2].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[2]",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.tuple[2],
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".tuple[2]",
                                     expected: "Array<string>",
@@ -62,8 +92,28 @@ export const test_createValidate_TagTuple = _test_validate(
                                     .map(
                                         (elem: any, _index1: number) =>
                                             ("string" === typeof elem &&
-                                                3 <= elem.length &&
-                                                7 >= elem.length) ||
+                                                (3 <= elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".tuple[2][" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@minLength 3)",
+                                                        value: elem,
+                                                    })) &&
+                                                (7 >= elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".tuple[2][" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@maxLength 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -81,8 +131,18 @@ export const test_createValidate_TagTuple = _test_validate(
                                     value: input.tuple[2],
                                 }),
                             (((Array.isArray(input.tuple[3]) &&
-                                3 <= input.tuple[3].length &&
-                                7 >= input.tuple[3].length) ||
+                                (3 <= input.tuple[3].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[3]",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.tuple[3],
+                                    })) &&
+                                (7 >= input.tuple[3].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[3]",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.tuple[3],
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".tuple[3]",
                                     expected: "Array<number>",
@@ -92,8 +152,28 @@ export const test_createValidate_TagTuple = _test_validate(
                                     .map(
                                         (elem: any, _index2: number) =>
                                             ("number" === typeof elem &&
-                                                3 <= elem &&
-                                                7 >= elem) ||
+                                                (3 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".tuple[3][" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 3)",
+                                                        value: elem,
+                                                    })) &&
+                                                (7 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".tuple[3][" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +

--- a/test/generated/output/createValidate/test_createValidate_TagType.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagType.ts
@@ -21,7 +21,12 @@ export const test_createValidate_TagType = _test_validate(
                 [
                     ("number" === typeof input.int &&
                         Number.isFinite(input.int) &&
-                        parseInt(input.int) === input.int) ||
+                        (parseInt(input.int) === input.int ||
+                            $report(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".int",
                             expected: "number",
@@ -29,8 +34,18 @@ export const test_createValidate_TagType = _test_validate(
                         }),
                     ("number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
-                        parseInt(input.uint) === input.uint &&
-                        0 <= input.uint) ||
+                        (parseInt(input.uint) === input.uint ||
+                            $report(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (0 <= input.uint ||
+                            $report(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".uint",
                             expected: "number",

--- a/test/generated/output/createValidate/test_createValidate_UltimateUnion.ts
+++ b/test/generated/output/createValidate/test_createValidate_UltimateUnion.ts
@@ -1195,7 +1195,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            parseInt(input.minimum) === input.minimum) ||
+                            (parseInt(input.minimum) === input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
+                                }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "(number | undefined)",
@@ -1204,7 +1209,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            parseInt(input.maximum) === input.maximum) ||
+                            (parseInt(input.maximum) === input.maximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "(number | undefined)",
@@ -1227,7 +1237,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            parseInt(input.multipleOf) === input.multipleOf) ||
+                            (parseInt(input.multipleOf) === input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                }))) ||
                         $report(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "(number | undefined)",
@@ -1592,8 +1607,18 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
-                            parseInt(input.minLength) === input.minLength &&
-                            0 <= input.minLength) ||
+                            (parseInt(input.minLength) === input.minLength ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                })) &&
+                            (0 <= input.minLength ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minLength",
                             expected: "(number | undefined)",
@@ -1602,8 +1627,18 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
-                            parseInt(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength) ||
+                            (parseInt(input.maxLength) === input.maxLength ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (0 <= input.maxLength ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maxLength",
                             expected: "(number | undefined)",
@@ -1804,8 +1839,18 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
-                            parseInt(input.minItems) === input.minItems &&
-                            0 <= input.minItems) ||
+                            (parseInt(input.minItems) === input.minItems ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "(number | undefined)",
@@ -1814,8 +1859,18 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
-                            parseInt(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems) ||
+                            (parseInt(input.maxItems) === input.maxItems ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (0 <= input.maxItems ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "(number | undefined)",

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagArray.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagArray.ts
@@ -22,7 +22,12 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                 ): boolean =>
                     [
                         (((Array.isArray(input.items) &&
-                            3 === input.items.length) ||
+                            (3 === input.items.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.items,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".items",
                                 expected: "Array<string>",
@@ -32,7 +37,17 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                                 .map(
                                     (elem: any, _index2: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -50,7 +65,12 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                                 value: input.items,
                             }),
                         (((Array.isArray(input.minItems) &&
-                            3 <= input.minItems.length) ||
+                            (3 <= input.minItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.minItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "Array<number>",
@@ -61,7 +81,17 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                                     (elem: any, _index3: number) =>
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            3 <= elem) ||
+                                            (3 <= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".minItems[" +
+                                                        _index3 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 3)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -79,7 +109,12 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                                 value: input.minItems,
                             }),
                         (((Array.isArray(input.maxItems) &&
-                            7 >= input.maxItems.length) ||
+                            (7 >= input.maxItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.maxItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "Array<(number | string)>",
@@ -89,10 +124,30 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                                 .map(
                                     (elem: any, _index4: number) =>
                                         ("string" === typeof elem &&
-                                            7 >= elem.length) ||
+                                            (7 >= elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@maxLength 7)",
+                                                    value: elem,
+                                                }))) ||
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            7 >= elem) ||
+                                            (7 >= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 7)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -110,8 +165,18 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                                 value: input.maxItems,
                             }),
                         (((Array.isArray(input.both) &&
-                            3 <= input.both.length &&
-                            7 >= input.both.length) ||
+                            (3 <= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.both,
+                                })) &&
+                            (7 >= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.both,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".both",
                                 expected: "Array<string>",
@@ -121,7 +186,17 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                                 .map(
                                     (elem: any, _index5: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".both[" +
+                                                        _index5 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagAtomicUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagAtomicUnion.ts
@@ -21,11 +21,26 @@ export const test_createValidateClone_TagAtomicUnion = _test_validateClone(
                 ): boolean =>
                     [
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                             ("number" === typeof input.value &&
                                 Number.isFinite(input.value) &&
-                                3 <= input.value) ||
+                                (3 <= input.value ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "number (@minimum 3)",
+                                        value: input.value,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "(number | string)",

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagCustom.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagCustom.ts
@@ -23,31 +23,41 @@ export const test_createValidateClone_TagCustom = _test_validateClone(
                 ): boolean =>
                     [
                         ("string" === typeof input.id &&
-                            true === $is_uuid(input.id)) ||
+                            (true === $is_uuid(input.id) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string (@format uuid)",
+                                    value: input.id,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".id",
                                 expected: "string",
                                 value: input.id,
                             }),
-                        ("string" === typeof input.dolloar &&
-                            $is_custom(
-                                "dollar",
-                                "string",
-                                "",
-                                input.dolloar,
-                            )) ||
+                        ("string" === typeof input.dollar &&
+                            ($is_custom("dollar", "string", "", input.dollar) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dollar",
+                                    expected: "string (@dollar)",
+                                    value: input.dollar,
+                                }))) ||
                             $report(_exceptionable, {
-                                path: _path + ".dolloar",
+                                path: _path + ".dollar",
                                 expected: "string",
-                                value: input.dolloar,
+                                value: input.dollar,
                             }),
                         ("string" === typeof input.postfix &&
-                            $is_custom(
+                            ($is_custom(
                                 "postfix",
                                 "string",
                                 "abcd",
                                 input.postfix,
-                            )) ||
+                            ) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string (@postfix abcd)",
+                                    value: input.postfix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected: "string",
@@ -55,7 +65,12 @@ export const test_createValidateClone_TagCustom = _test_validateClone(
                             }),
                         ("number" === typeof input.log &&
                             Number.isFinite(input.log) &&
-                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            ($is_custom("powerOf", "number", "10", input.log) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number (@powerOf 10)",
+                                    value: input.log,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".log",
                                 expected: "number",
@@ -89,7 +104,7 @@ export const test_createValidateClone_TagCustom = _test_validateClone(
             const $is_custom = (typia.createValidateClone as any).is_custom;
             const $co0 = (input: any): any => ({
                 id: input.id as any,
-                dolloar: input.dolloar as any,
+                dollar: input.dollar as any,
                 postfix: input.postfix as any,
                 log: input.log as any,
             });

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagFormat.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagFormat.ts
@@ -28,63 +28,108 @@ export const test_createValidateClone_TagFormat = _test_validateClone(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true === $is_uuid(input.uuid)) ||
+                            (true === $is_uuid(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected: "string (@format uuid)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true === $is_email(input.email)) ||
+                            (true === $is_email(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected: "string (@format email)",
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.url &&
-                            true === $is_url(input.url)) ||
+                            (true === $is_url(input.url) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".url",
+                                    expected: "string (@format url)",
+                                    value: input.url,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".url",
                                 expected: "string",
                                 value: input.url,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true === $is_ipv4(input.ipv4)) ||
+                            (true === $is_ipv4(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected: "string (@format ipv4)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true === $is_ipv6(input.ipv6)) ||
+                            (true === $is_ipv6(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected: "string (@format ipv6)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",
                                 value: input.ipv6,
                             }),
                         ("string" === typeof input.date &&
-                            true === $is_date(input.date)) ||
+                            (true === $is_date(input.date) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date",
+                                    expected: "string (@format date)",
+                                    value: input.date,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date",
                                 expected: "string",
                                 value: input.date,
                             }),
                         ("string" === typeof input.date_time &&
-                            true === $is_datetime(input.date_time)) ||
+                            (true === $is_datetime(input.date_time) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date_time",
+                                    expected: "string (@format datetime)",
+                                    value: input.date_time,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date_time",
                                 expected: "string",
                                 value: input.date_time,
                             }),
                         ("string" === typeof input.datetime &&
-                            true === $is_datetime(input.datetime)) ||
+                            (true === $is_datetime(input.datetime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".datetime",
+                                    expected: "string (@format datetime)",
+                                    value: input.datetime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".datetime",
                                 expected: "string",
                                 value: input.datetime,
                             }),
                         ("string" === typeof input.dateTime &&
-                            true === $is_datetime(input.dateTime)) ||
+                            (true === $is_datetime(input.dateTime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dateTime",
+                                    expected: "string (@format datetime)",
+                                    value: input.dateTime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".dateTime",
                                 expected: "string",

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagLength.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagLength.ts
@@ -21,29 +21,54 @@ export const test_createValidateClone_TagLength = _test_validateClone(
                 ): boolean =>
                     [
                         ("string" === typeof input.fixed &&
-                            5 === input.fixed.length) ||
+                            (5 === input.fixed.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".fixed",
+                                    expected: "string (@length 5)",
+                                    value: input.fixed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".fixed",
                                 expected: "string",
                                 value: input.fixed,
                             }),
                         ("string" === typeof input.minimum &&
-                            3 <= input.minimum.length) ||
+                            (3 <= input.minimum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "string",
                                 value: input.minimum,
                             }),
                         ("string" === typeof input.maximum &&
-                            7 >= input.maximum.length) ||
+                            (7 >= input.maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "string",
                                 value: input.maximum,
                             }),
                         ("string" === typeof input.minimum_and_maximum &&
-                            3 <= input.minimum_and_maximum.length &&
-                            7 >= input.minimum_and_maximum.length) ||
+                            (3 <= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum_and_maximum,
+                                })) &&
+                            (7 >= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.minimum_and_maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagMatrix.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagMatrix.ts
@@ -22,7 +22,12 @@ export const test_createValidateClone_TagMatrix = _test_validateClone(
                 ): boolean =>
                     [
                         (((Array.isArray(input.matrix) &&
-                            3 === input.matrix.length) ||
+                            (3 === input.matrix.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".matrix",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.matrix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".matrix",
                                 expected: "Array<Array<string>>",
@@ -32,7 +37,17 @@ export const test_createValidateClone_TagMatrix = _test_validateClone(
                                 .map(
                                     (elem: any, _index1: number) =>
                                         (((Array.isArray(elem) &&
-                                            3 === elem.length) ||
+                                            (3 === elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".matrix[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected:
+                                                        "Array.length (@items 3)",
+                                                    value: elem,
+                                                }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -50,10 +65,25 @@ export const test_createValidateClone_TagMatrix = _test_validateClone(
                                                     ) =>
                                                         ("string" ===
                                                             typeof elem &&
-                                                            true ===
+                                                            (true ===
                                                                 $is_uuid(
                                                                     elem,
-                                                                )) ||
+                                                                ) ||
+                                                                $report(
+                                                                    _exceptionable,
+                                                                    {
+                                                                        path:
+                                                                            _path +
+                                                                            ".matrix[" +
+                                                                            _index1 +
+                                                                            "][" +
+                                                                            _index2 +
+                                                                            "]",
+                                                                        expected:
+                                                                            "string (@format uuid)",
+                                                                        value: elem,
+                                                                    },
+                                                                ))) ||
                                                         $report(
                                                             _exceptionable,
                                                             {

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagObjectUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagObjectUnion.ts
@@ -22,7 +22,12 @@ export const test_createValidateClone_TagObjectUnion = _test_validateClone(
                     [
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "number",
@@ -36,8 +41,18 @@ export const test_createValidateClone_TagObjectUnion = _test_validateClone(
                 ): boolean =>
                     [
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "string",

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagPattern.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagPattern.ts
@@ -21,40 +21,64 @@ export const test_createValidateClone_TagPattern = _test_validateClone(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                ).test(input.uuid)) ||
+                                ).test(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected:
+                                        "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                ).test(input.email)) ||
+                                ).test(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected:
+                                        'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                ).test(input.ipv4)) ||
+                                ).test(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected:
+                                        "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                ).test(input.ipv6)) ||
+                                ).test(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected:
+                                        "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagRange.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagRange.ts
@@ -22,7 +22,12 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                     [
                         ("number" === typeof input.greater &&
                             Number.isFinite(input.greater) &&
-                            3 < input.greater) ||
+                            (3 < input.greater ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater",
                                 expected: "number",
@@ -30,7 +35,12 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                             }),
                         ("number" === typeof input.greater_equal &&
                             Number.isFinite(input.greater_equal) &&
-                            3 <= input.greater_equal) ||
+                            (3 <= input.greater_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number",
@@ -38,7 +48,12 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                             }),
                         ("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
-                            7 > input.less) ||
+                            (7 > input.less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less",
                                 expected: "number",
@@ -46,39 +61,84 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                             }),
                         ("number" === typeof input.less_equal &&
                             Number.isFinite(input.less_equal) &&
-                            7 >= input.less_equal) ||
+                            (7 >= input.less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less_equal",
                                 expected: "number",
                                 value: input.less_equal,
                             }),
                         ("number" === typeof input.greater_less &&
-                            3 < input.greater_less &&
-                            7 > input.greater_less) ||
+                            (3 < input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less,
+                                })) &&
+                            (7 > input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number",
                                 value: input.greater_less,
                             }),
                         ("number" === typeof input.greater_equal_less &&
-                            3 <= input.greater_equal_less &&
-                            7 > input.greater_equal_less) ||
+                            (3 <= input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less,
+                                })) &&
+                            (7 > input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_equal_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less",
                                 expected: "number",
                                 value: input.greater_equal_less,
                             }),
                         ("number" === typeof input.greater_less_equal &&
-                            3 < input.greater_less_equal &&
-                            7 >= input.greater_less_equal) ||
+                            (3 < input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            (7 >= input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number",
                                 value: input.greater_less_equal,
                             }),
                         ("number" === typeof input.greater_equal_less_equal &&
-                            3 <= input.greater_equal_less_equal &&
-                            7 >= input.greater_equal_less_equal) ||
+                            (3 <= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
+                            (7 >= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_equal_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagStep.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagStep.ts
@@ -21,34 +21,84 @@ export const test_createValidateClone_TagStep = _test_validateClone(
                 ): boolean =>
                     [
                         ("number" === typeof input.exclusiveMinimum &&
-                            0 === (input.exclusiveMinimum % 5) - 3 &&
-                            3 < input.exclusiveMinimum) ||
+                            (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@step 5)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (3 < input.exclusiveMinimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.exclusiveMinimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".exclusiveMinimum",
                                 expected: "number",
                                 value: input.exclusiveMinimum,
                             }),
                         ("number" === typeof input.minimum &&
-                            0 === (input.minimum % 5) - 3 &&
-                            3 <= input.minimum) ||
+                            (0 === (input.minimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@step 5)",
+                                    value: input.minimum,
+                                })) &&
+                            (3 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
                                 value: input.minimum,
                             }),
                         ("number" === typeof input.range &&
-                            0 === (input.range % 5) - 0 &&
-                            0 < input.range &&
-                            100 > input.range) ||
+                            (0 === (input.range % 5) - 0 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@step 5)",
+                                    value: input.range,
+                                })) &&
+                            (0 < input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMinimum 0)",
+                                    value: input.range,
+                                })) &&
+                            (100 > input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMaximum 100)",
+                                    value: input.range,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".range",
                                 expected: "number",
                                 value: input.range,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 5 &&
-                            3 <= input.multipleOf &&
-                            99 >= input.multipleOf) ||
+                            (0 === input.multipleOf % 5 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 5)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (3 <= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@minimum 3)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (99 >= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@maximum 99)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagTuple.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagTuple.ts
@@ -36,24 +36,56 @@ export const test_createValidateClone_TagTuple = _test_validateClone(
                                 })) &&
                             [
                                 ("string" === typeof input.tuple[0] &&
-                                    3 <= input.tuple[0].length &&
-                                    7 >= input.tuple[0].length) ||
+                                    (3 <= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@minLength 3)",
+                                            value: input.tuple[0],
+                                        })) &&
+                                    (7 >= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@maxLength 7)",
+                                            value: input.tuple[0],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[0]",
                                         expected: "string",
                                         value: input.tuple[0],
                                     }),
                                 ("number" === typeof input.tuple[1] &&
-                                    3 <= input.tuple[1] &&
-                                    7 >= input.tuple[1]) ||
+                                    (3 <= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@minimum 3)",
+                                            value: input.tuple[1],
+                                        })) &&
+                                    (7 >= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@maximum 7)",
+                                            value: input.tuple[1],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[1]",
                                         expected: "number",
                                         value: input.tuple[1],
                                     }),
                                 (((Array.isArray(input.tuple[2]) &&
-                                    3 <= input.tuple[2].length &&
-                                    7 >= input.tuple[2].length) ||
+                                    (3 <= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[2],
+                                        })) &&
+                                    (7 >= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[2],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[2]",
                                         expected: "Array<string>",
@@ -63,8 +95,34 @@ export const test_createValidateClone_TagTuple = _test_validateClone(
                                         .map(
                                             (elem: any, _index1: number) =>
                                                 ("string" === typeof elem &&
-                                                    3 <= elem.length &&
-                                                    7 >= elem.length) ||
+                                                    (3 <= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@minLength 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@maxLength 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
@@ -82,8 +140,20 @@ export const test_createValidateClone_TagTuple = _test_validateClone(
                                         value: input.tuple[2],
                                     }),
                                 (((Array.isArray(input.tuple[3]) &&
-                                    3 <= input.tuple[3].length &&
-                                    7 >= input.tuple[3].length) ||
+                                    (3 <= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[3],
+                                        })) &&
+                                    (7 >= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[3],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[3]",
                                         expected: "Array<number>",
@@ -93,8 +163,34 @@ export const test_createValidateClone_TagTuple = _test_validateClone(
                                         .map(
                                             (elem: any, _index2: number) =>
                                                 ("number" === typeof elem &&
-                                                    3 <= elem &&
-                                                    7 >= elem) ||
+                                                    (3 <= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@minimum 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@maximum 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagType.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagType.ts
@@ -22,7 +22,12 @@ export const test_createValidateClone_TagType = _test_validateClone(
                     [
                         ("number" === typeof input.int &&
                             Number.isFinite(input.int) &&
-                            parseInt(input.int) === input.int) ||
+                            (parseInt(input.int) === input.int ||
+                                $report(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".int",
                                 expected: "number",
@@ -30,8 +35,18 @@ export const test_createValidateClone_TagType = _test_validateClone(
                             }),
                         ("number" === typeof input.uint &&
                             Number.isFinite(input.uint) &&
-                            parseInt(input.uint) === input.uint &&
-                            0 <= input.uint) ||
+                            (parseInt(input.uint) === input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (0 <= input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number",

--- a/test/generated/output/createValidateClone/test_createValidateClone_UltimateUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_UltimateUnion.ts
@@ -1212,7 +1212,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                parseInt(input.minimum) === input.minimum) ||
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -1221,7 +1226,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                parseInt(input.maximum) === input.maximum) ||
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -1244,8 +1254,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
-                                parseInt(input.multipleOf) ===
-                                    input.multipleOf) ||
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -1612,8 +1627,19 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
-                                parseInt(input.minLength) === input.minLength &&
-                                0 <= input.minLength) ||
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minLength",
                                 expected: "(number | undefined)",
@@ -1622,8 +1648,19 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
-                                parseInt(input.maxLength) === input.maxLength &&
-                                0 <= input.maxLength) ||
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxLength",
                                 expected: "(number | undefined)",
@@ -1825,8 +1862,18 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         undefined === input.minItems ||
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
-                                parseInt(input.minItems) === input.minItems &&
-                                0 <= input.minItems) ||
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "(number | undefined)",
@@ -1835,8 +1882,18 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
-                                parseInt(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems) ||
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagArray.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagArray.ts
@@ -22,7 +22,12 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
             ): boolean =>
                 [
                     (((Array.isArray(input.items) &&
-                        3 === input.items.length) ||
+                        (3 === input.items.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".items",
+                                expected: "Array.length (@items 3)",
+                                value: input.items,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".items",
                             expected: "Array<string>",
@@ -32,7 +37,17 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
                             .map(
                                 (elem: any, _index2: number) =>
                                     ("string" === typeof elem &&
-                                        true === $is_uuid(elem)) ||
+                                        (true === $is_uuid(elem) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".items[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected:
+                                                    "string (@format uuid)",
+                                                value: elem,
+                                            }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".items[" + _index2 + "]",
                                         expected: "string",
@@ -46,7 +61,12 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
                             value: input.items,
                         }),
                     (((Array.isArray(input.minItems) &&
-                        3 <= input.minItems.length) ||
+                        (3 <= input.minItems.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.minItems,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minItems",
                             expected: "Array<number>",
@@ -57,7 +77,16 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
                                 (elem: any, _index3: number) =>
                                     ("number" === typeof elem &&
                                         Number.isFinite(elem) &&
-                                        3 <= elem) ||
+                                        (3 <= elem ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".minItems[" +
+                                                    _index3 +
+                                                    "]",
+                                                expected: "number (@minimum 3)",
+                                                value: elem,
+                                            }))) ||
                                     $report(_exceptionable, {
                                         path:
                                             _path +
@@ -75,7 +104,12 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
                             value: input.minItems,
                         }),
                     (((Array.isArray(input.maxItems) &&
-                        7 >= input.maxItems.length) ||
+                        (7 >= input.maxItems.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.maxItems,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maxItems",
                             expected: "Array<(number | string)>",
@@ -85,10 +119,29 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
                             .map(
                                 (elem: any, _index4: number) =>
                                     ("string" === typeof elem &&
-                                        7 >= elem.length) ||
+                                        (7 >= elem.length ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".maxItems[" +
+                                                    _index4 +
+                                                    "]",
+                                                expected:
+                                                    "string (@maxLength 7)",
+                                                value: elem,
+                                            }))) ||
                                     ("number" === typeof elem &&
                                         Number.isFinite(elem) &&
-                                        7 >= elem) ||
+                                        (7 >= elem ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".maxItems[" +
+                                                    _index4 +
+                                                    "]",
+                                                expected: "number (@maximum 7)",
+                                                value: elem,
+                                            }))) ||
                                     $report(_exceptionable, {
                                         path:
                                             _path +
@@ -106,8 +159,18 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
                             value: input.maxItems,
                         }),
                     (((Array.isArray(input.both) &&
-                        3 <= input.both.length &&
-                        7 >= input.both.length) ||
+                        (3 <= input.both.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@minItems 3)",
+                                value: input.both,
+                            })) &&
+                        (7 >= input.both.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".both",
+                                expected: "Array.length (@maxItems 7)",
+                                value: input.both,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".both",
                             expected: "Array<string>",
@@ -117,7 +180,17 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
                             .map(
                                 (elem: any, _index5: number) =>
                                     ("string" === typeof elem &&
-                                        true === $is_uuid(elem)) ||
+                                        (true === $is_uuid(elem) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".both[" +
+                                                    _index5 +
+                                                    "]",
+                                                expected:
+                                                    "string (@format uuid)",
+                                                value: elem,
+                                            }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".both[" + _index5 + "]",
                                         expected: "string",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagAtomicUnion.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagAtomicUnion.ts
@@ -21,11 +21,26 @@ export const test_createValidateEquals_TagAtomicUnion = _test_validateEquals(
             ): boolean =>
                 [
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                         $report(_exceptionable, {
                             path: _path + ".value",
                             expected: "(number | string)",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagBigInt.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagBigInt.ts
@@ -27,29 +27,54 @@ export const test_createValidateEquals_TagBigInt = _test_validateEquals(
                             value: input.value,
                         }),
                     ("bigint" === typeof input.ranged &&
-                        0n <= input.ranged &&
-                        100n >= input.ranged) ||
+                        (0n <= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "bigint (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100n >= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "bigint (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "bigint",
                             value: input.ranged,
                         }),
                     ("bigint" === typeof input.minimum &&
-                        0n <= input.minimum) ||
+                        (0n <= input.minimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "bigint (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "bigint",
                             value: input.minimum,
                         }),
                     ("bigint" === typeof input.maximum &&
-                        100n >= input.maximum) ||
+                        (100n >= input.maximum ||
+                            $report(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "bigint (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "bigint",
                             value: input.maximum,
                         }),
                     ("bigint" === typeof input.multipleOf &&
-                        0n === input.multipleOf % 3n) ||
+                        (0n === input.multipleOf % 3n ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "bigint (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "bigint",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagCustom.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagCustom.ts
@@ -23,26 +23,41 @@ export const test_createValidateEquals_TagCustom = _test_validateEquals(
             ): boolean =>
                 [
                     ("string" === typeof input.id &&
-                        true === $is_uuid(input.id)) ||
+                        (true === $is_uuid(input.id) ||
+                            $report(_exceptionable, {
+                                path: _path + ".id",
+                                expected: "string (@format uuid)",
+                                value: input.id,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".id",
                             expected: "string",
                             value: input.id,
                         }),
-                    ("string" === typeof input.dolloar &&
-                        $is_custom("dollar", "string", "", input.dolloar)) ||
+                    ("string" === typeof input.dollar &&
+                        ($is_custom("dollar", "string", "", input.dollar) ||
+                            $report(_exceptionable, {
+                                path: _path + ".dollar",
+                                expected: "string (@dollar)",
+                                value: input.dollar,
+                            }))) ||
                         $report(_exceptionable, {
-                            path: _path + ".dolloar",
+                            path: _path + ".dollar",
                             expected: "string",
-                            value: input.dolloar,
+                            value: input.dollar,
                         }),
                     ("string" === typeof input.postfix &&
-                        $is_custom(
+                        ($is_custom(
                             "postfix",
                             "string",
                             "abcd",
                             input.postfix,
-                        )) ||
+                        ) ||
+                            $report(_exceptionable, {
+                                path: _path + ".postfix",
+                                expected: "string (@postfix abcd)",
+                                value: input.postfix,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".postfix",
                             expected: "string",
@@ -50,7 +65,12 @@ export const test_createValidateEquals_TagCustom = _test_validateEquals(
                         }),
                     ("number" === typeof input.log &&
                         Number.isFinite(input.log) &&
-                        $is_custom("powerOf", "number", "10", input.log)) ||
+                        ($is_custom("powerOf", "number", "10", input.log) ||
+                            $report(_exceptionable, {
+                                path: _path + ".log",
+                                expected: "number (@powerOf 10)",
+                                value: input.log,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".log",
                             expected: "number",
@@ -61,7 +81,7 @@ export const test_createValidateEquals_TagCustom = _test_validateEquals(
                         Object.keys(input)
                             .map((key) => {
                                 if (
-                                    ["id", "dolloar", "postfix", "log"].some(
+                                    ["id", "dollar", "postfix", "log"].some(
                                         (prop) => key === prop,
                                     )
                                 )

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagFormat.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagFormat.ts
@@ -28,63 +28,108 @@ export const test_createValidateEquals_TagFormat = _test_validateEquals(
             ): boolean =>
                 [
                     ("string" === typeof input.uuid &&
-                        true === $is_uuid(input.uuid)) ||
+                        (true === $is_uuid(input.uuid) ||
+                            $report(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected: "string (@format uuid)",
+                                value: input.uuid,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         }),
                     ("string" === typeof input.email &&
-                        true === $is_email(input.email)) ||
+                        (true === $is_email(input.email) ||
+                            $report(_exceptionable, {
+                                path: _path + ".email",
+                                expected: "string (@format email)",
+                                value: input.email,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         }),
                     ("string" === typeof input.url &&
-                        true === $is_url(input.url)) ||
+                        (true === $is_url(input.url) ||
+                            $report(_exceptionable, {
+                                path: _path + ".url",
+                                expected: "string (@format url)",
+                                value: input.url,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".url",
                             expected: "string",
                             value: input.url,
                         }),
                     ("string" === typeof input.ipv4 &&
-                        true === $is_ipv4(input.ipv4)) ||
+                        (true === $is_ipv4(input.ipv4) ||
+                            $report(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected: "string (@format ipv4)",
+                                value: input.ipv4,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         }),
                     ("string" === typeof input.ipv6 &&
-                        true === $is_ipv6(input.ipv6)) ||
+                        (true === $is_ipv6(input.ipv6) ||
+                            $report(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected: "string (@format ipv6)",
+                                value: input.ipv6,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",
                             value: input.ipv6,
                         }),
                     ("string" === typeof input.date &&
-                        true === $is_date(input.date)) ||
+                        (true === $is_date(input.date) ||
+                            $report(_exceptionable, {
+                                path: _path + ".date",
+                                expected: "string (@format date)",
+                                value: input.date,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".date",
                             expected: "string",
                             value: input.date,
                         }),
                     ("string" === typeof input.date_time &&
-                        true === $is_datetime(input.date_time)) ||
+                        (true === $is_datetime(input.date_time) ||
+                            $report(_exceptionable, {
+                                path: _path + ".date_time",
+                                expected: "string (@format datetime)",
+                                value: input.date_time,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".date_time",
                             expected: "string",
                             value: input.date_time,
                         }),
                     ("string" === typeof input.datetime &&
-                        true === $is_datetime(input.datetime)) ||
+                        (true === $is_datetime(input.datetime) ||
+                            $report(_exceptionable, {
+                                path: _path + ".datetime",
+                                expected: "string (@format datetime)",
+                                value: input.datetime,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".datetime",
                             expected: "string",
                             value: input.datetime,
                         }),
                     ("string" === typeof input.dateTime &&
-                        true === $is_datetime(input.dateTime)) ||
+                        (true === $is_datetime(input.dateTime) ||
+                            $report(_exceptionable, {
+                                path: _path + ".dateTime",
+                                expected: "string (@format datetime)",
+                                value: input.dateTime,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".dateTime",
                             expected: "string",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagInfinite.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagInfinite.ts
@@ -28,8 +28,18 @@ export const test_createValidateEquals_TagInfinite = _test_validateEquals(
                             value: input.value,
                         }),
                     ("number" === typeof input.ranged &&
-                        0 <= input.ranged &&
-                        100 >= input.ranged) ||
+                        (0 <= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100 >= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "number",
@@ -37,7 +47,12 @@ export const test_createValidateEquals_TagInfinite = _test_validateEquals(
                         }),
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        0 <= input.minimum) ||
+                        (0 <= input.minimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
@@ -45,14 +60,24 @@ export const test_createValidateEquals_TagInfinite = _test_validateEquals(
                         }),
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        100 >= input.maximum) ||
+                        (100 >= input.maximum ||
+                            $report(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "number",
                             value: input.maximum,
                         }),
                     ("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 3) ||
+                        (0 === input.multipleOf % 3 ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",
@@ -60,7 +85,12 @@ export const test_createValidateEquals_TagInfinite = _test_validateEquals(
                         }),
                     ("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
-                        parseInt(input.typed) === input.typed) ||
+                        (parseInt(input.typed) === input.typed ||
+                            $report(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".typed",
                             expected: "number",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagLength.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagLength.ts
@@ -21,29 +21,54 @@ export const test_createValidateEquals_TagLength = _test_validateEquals(
             ): boolean =>
                 [
                     ("string" === typeof input.fixed &&
-                        5 === input.fixed.length) ||
+                        (5 === input.fixed.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".fixed",
+                                expected: "string (@length 5)",
+                                value: input.fixed,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".fixed",
                             expected: "string",
                             value: input.fixed,
                         }),
                     ("string" === typeof input.minimum &&
-                        3 <= input.minimum.length) ||
+                        (3 <= input.minimum.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "string",
                             value: input.minimum,
                         }),
                     ("string" === typeof input.maximum &&
-                        7 >= input.maximum.length) ||
+                        (7 >= input.maximum.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.maximum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "string",
                             value: input.maximum,
                         }),
                     ("string" === typeof input.minimum_and_maximum &&
-                        3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length) ||
+                        (3 <= input.minimum_and_maximum.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@minLength 3)",
+                                value: input.minimum_and_maximum,
+                            })) &&
+                        (7 >= input.minimum_and_maximum.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum_and_maximum",
+                                expected: "string (@maxLength 7)",
+                                value: input.minimum_and_maximum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum_and_maximum",
                             expected: "string",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagMatrix.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagMatrix.ts
@@ -22,7 +22,12 @@ export const test_createValidateEquals_TagMatrix = _test_validateEquals(
             ): boolean =>
                 [
                     (((Array.isArray(input.matrix) &&
-                        3 === input.matrix.length) ||
+                        (3 === input.matrix.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".matrix",
+                                expected: "Array.length (@items 3)",
+                                value: input.matrix,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".matrix",
                             expected: "Array<Array<string>>",
@@ -32,7 +37,17 @@ export const test_createValidateEquals_TagMatrix = _test_validateEquals(
                             .map(
                                 (elem: any, _index1: number) =>
                                     (((Array.isArray(elem) &&
-                                        3 === elem.length) ||
+                                        (3 === elem.length ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".matrix[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected:
+                                                    "Array.length (@items 3)",
+                                                value: elem,
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -46,8 +61,23 @@ export const test_createValidateEquals_TagMatrix = _test_validateEquals(
                                             .map(
                                                 (elem: any, _index2: number) =>
                                                     ("string" === typeof elem &&
-                                                        true ===
-                                                            $is_uuid(elem)) ||
+                                                        (true ===
+                                                            $is_uuid(elem) ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".matrix[" +
+                                                                        _index1 +
+                                                                        "][" +
+                                                                        _index2 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "string (@format uuid)",
+                                                                    value: elem,
+                                                                },
+                                                            ))) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagNaN.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagNaN.ts
@@ -28,8 +28,18 @@ export const test_createValidateEquals_TagNaN = _test_validateEquals(
                             value: input.value,
                         }),
                     ("number" === typeof input.ranged &&
-                        0 <= input.ranged &&
-                        100 >= input.ranged) ||
+                        (0 <= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@minimum 0)",
+                                value: input.ranged,
+                            })) &&
+                        (100 >= input.ranged ||
+                            $report(_exceptionable, {
+                                path: _path + ".ranged",
+                                expected: "number (@maximum 100)",
+                                value: input.ranged,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ranged",
                             expected: "number",
@@ -37,7 +47,12 @@ export const test_createValidateEquals_TagNaN = _test_validateEquals(
                         }),
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        0 <= input.minimum) ||
+                        (0 <= input.minimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 0)",
+                                value: input.minimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
@@ -45,14 +60,24 @@ export const test_createValidateEquals_TagNaN = _test_validateEquals(
                         }),
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        100 >= input.maximum) ||
+                        (100 >= input.maximum ||
+                            $report(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "number (@maximum 100)",
+                                value: input.maximum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "number",
                             value: input.maximum,
                         }),
                     ("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 3) ||
+                        (0 === input.multipleOf % 3 ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 3)",
+                                value: input.multipleOf,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",
@@ -60,7 +85,12 @@ export const test_createValidateEquals_TagNaN = _test_validateEquals(
                         }),
                     ("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
-                        parseInt(input.typed) === input.typed) ||
+                        (parseInt(input.typed) === input.typed ||
+                            $report(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".typed",
                             expected: "number",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagObjectUnion.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagObjectUnion.ts
@@ -22,7 +22,12 @@ export const test_createValidateEquals_TagObjectUnion = _test_validateEquals(
                 [
                     ("number" === typeof input.value &&
                         Number.isFinite(input.value) &&
-                        3 <= input.value) ||
+                        (3 <= input.value ||
+                            $report(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "number (@minimum 3)",
+                                value: input.value,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".value",
                             expected: "number",
@@ -51,8 +56,18 @@ export const test_createValidateEquals_TagObjectUnion = _test_validateEquals(
             ): boolean =>
                 [
                     ("string" === typeof input.value &&
-                        3 <= input.value.length &&
-                        7 >= input.value.length) ||
+                        (3 <= input.value.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@minLength 3)",
+                                value: input.value,
+                            })) &&
+                        (7 >= input.value.length ||
+                            $report(_exceptionable, {
+                                path: _path + ".value",
+                                expected: "string (@maxLength 7)",
+                                value: input.value,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".value",
                             expected: "string",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagPattern.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagPattern.ts
@@ -21,40 +21,64 @@ export const test_createValidateEquals_TagPattern = _test_validateEquals(
             ): boolean =>
                 [
                     ("string" === typeof input.uuid &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                            ).test(input.uuid)) ||
+                            ).test(input.uuid) ||
+                            $report(_exceptionable, {
+                                path: _path + ".uuid",
+                                expected:
+                                    "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                value: input.uuid,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".uuid",
                             expected: "string",
                             value: input.uuid,
                         }),
                     ("string" === typeof input.email &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                            ).test(input.email)) ||
+                            ).test(input.email) ||
+                            $report(_exceptionable, {
+                                path: _path + ".email",
+                                expected:
+                                    'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                value: input.email,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".email",
                             expected: "string",
                             value: input.email,
                         }),
                     ("string" === typeof input.ipv4 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                            ).test(input.ipv4)) ||
+                            ).test(input.ipv4) ||
+                            $report(_exceptionable, {
+                                path: _path + ".ipv4",
+                                expected:
+                                    "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                value: input.ipv4,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ipv4",
                             expected: "string",
                             value: input.ipv4,
                         }),
                     ("string" === typeof input.ipv6 &&
-                        true ===
+                        (true ===
                             RegExp(
                                 /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                            ).test(input.ipv6)) ||
+                            ).test(input.ipv6) ||
+                            $report(_exceptionable, {
+                                path: _path + ".ipv6",
+                                expected:
+                                    "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                value: input.ipv6,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".ipv6",
                             expected: "string",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagRange.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagRange.ts
@@ -22,7 +22,12 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                 [
                     ("number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
-                        3 < input.greater) ||
+                        (3 < input.greater ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater",
                             expected: "number",
@@ -30,7 +35,12 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                         }),
                     ("number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
-                        3 <= input.greater_equal) ||
+                        (3 <= input.greater_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater_equal",
                             expected: "number",
@@ -38,7 +48,12 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                         }),
                     ("number" === typeof input.less &&
                         Number.isFinite(input.less) &&
-                        7 > input.less) ||
+                        (7 > input.less ||
+                            $report(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.less,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".less",
                             expected: "number",
@@ -46,39 +61,84 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                         }),
                     ("number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
-                        7 >= input.less_equal) ||
+                        (7 >= input.less_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.less_equal,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".less_equal",
                             expected: "number",
                             value: input.less_equal,
                         }),
                     ("number" === typeof input.greater_less &&
-                        3 < input.greater_less &&
-                        7 > input.greater_less) ||
+                        (3 < input.greater_less ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less,
+                            })) &&
+                        (7 > input.greater_less ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_less,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater_less",
                             expected: "number",
                             value: input.greater_less,
                         }),
                     ("number" === typeof input.greater_equal_less &&
-                        3 <= input.greater_equal_less &&
-                        7 > input.greater_equal_less) ||
+                        (3 <= input.greater_equal_less ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less,
+                            })) &&
+                        (7 > input.greater_equal_less ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@exclusiveMaximum 7)",
+                                value: input.greater_equal_less,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater_equal_less",
                             expected: "number",
                             value: input.greater_equal_less,
                         }),
                     ("number" === typeof input.greater_less_equal &&
-                        3 < input.greater_less_equal &&
-                        7 >= input.greater_less_equal) ||
+                        (3 < input.greater_less_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        (7 >= input.greater_less_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_less_equal,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater_less_equal",
                             expected: "number",
                             value: input.greater_less_equal,
                         }),
                     ("number" === typeof input.greater_equal_less_equal &&
-                        3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal) ||
+                        (3 <= input.greater_equal_less_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@minimum 3)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
+                        (7 >= input.greater_equal_less_equal ||
+                            $report(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@maximum 7)",
+                                value: input.greater_equal_less_equal,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagStep.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagStep.ts
@@ -21,34 +21,84 @@ export const test_createValidateEquals_TagStep = _test_validateEquals(
             ): boolean =>
                 [
                     ("number" === typeof input.exclusiveMinimum &&
-                        0 === (input.exclusiveMinimum % 5) - 3 &&
-                        3 < input.exclusiveMinimum) ||
+                        (0 === (input.exclusiveMinimum % 5) - 3 ||
+                            $report(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@step 5)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (3 < input.exclusiveMinimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "number (@exclusiveMinimum 3)",
+                                value: input.exclusiveMinimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".exclusiveMinimum",
                             expected: "number",
                             value: input.exclusiveMinimum,
                         }),
                     ("number" === typeof input.minimum &&
-                        0 === (input.minimum % 5) - 3 &&
-                        3 <= input.minimum) ||
+                        (0 === (input.minimum % 5) - 3 ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@step 5)",
+                                value: input.minimum,
+                            })) &&
+                        (3 <= input.minimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "number (@minimum 3)",
+                                value: input.minimum,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "number",
                             value: input.minimum,
                         }),
                     ("number" === typeof input.range &&
-                        0 === (input.range % 5) - 0 &&
-                        0 < input.range &&
-                        100 > input.range) ||
+                        (0 === (input.range % 5) - 0 ||
+                            $report(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@step 5)",
+                                value: input.range,
+                            })) &&
+                        (0 < input.range ||
+                            $report(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMinimum 0)",
+                                value: input.range,
+                            })) &&
+                        (100 > input.range ||
+                            $report(_exceptionable, {
+                                path: _path + ".range",
+                                expected: "number (@exclusiveMaximum 100)",
+                                value: input.range,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".range",
                             expected: "number",
                             value: input.range,
                         }),
                     ("number" === typeof input.multipleOf &&
-                        0 === input.multipleOf % 5 &&
-                        3 <= input.multipleOf &&
-                        99 >= input.multipleOf) ||
+                        (0 === input.multipleOf % 5 ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@multipleOf 5)",
+                                value: input.multipleOf,
+                            })) &&
+                        (3 <= input.multipleOf ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@minimum 3)",
+                                value: input.multipleOf,
+                            })) &&
+                        (99 >= input.multipleOf ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "number (@maximum 99)",
+                                value: input.multipleOf,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "number",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagTuple.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagTuple.ts
@@ -36,24 +36,54 @@ export const test_createValidateEquals_TagTuple = _test_validateEquals(
                             })) &&
                         [
                             ("string" === typeof input.tuple[0] &&
-                                3 <= input.tuple[0].length &&
-                                7 >= input.tuple[0].length) ||
+                                (3 <= input.tuple[0].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[0]",
+                                        expected: "string (@minLength 3)",
+                                        value: input.tuple[0],
+                                    })) &&
+                                (7 >= input.tuple[0].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[0]",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.tuple[0],
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".tuple[0]",
                                     expected: "string",
                                     value: input.tuple[0],
                                 }),
                             ("number" === typeof input.tuple[1] &&
-                                3 <= input.tuple[1] &&
-                                7 >= input.tuple[1]) ||
+                                (3 <= input.tuple[1] ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[1]",
+                                        expected: "number (@minimum 3)",
+                                        value: input.tuple[1],
+                                    })) &&
+                                (7 >= input.tuple[1] ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[1]",
+                                        expected: "number (@maximum 7)",
+                                        value: input.tuple[1],
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".tuple[1]",
                                     expected: "number",
                                     value: input.tuple[1],
                                 }),
                             (((Array.isArray(input.tuple[2]) &&
-                                3 <= input.tuple[2].length &&
-                                7 >= input.tuple[2].length) ||
+                                (3 <= input.tuple[2].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[2]",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.tuple[2],
+                                    })) &&
+                                (7 >= input.tuple[2].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[2]",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.tuple[2],
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".tuple[2]",
                                     expected: "Array<string>",
@@ -63,8 +93,28 @@ export const test_createValidateEquals_TagTuple = _test_validateEquals(
                                     .map(
                                         (elem: any, _index1: number) =>
                                             ("string" === typeof elem &&
-                                                3 <= elem.length &&
-                                                7 >= elem.length) ||
+                                                (3 <= elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".tuple[2][" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@minLength 3)",
+                                                        value: elem,
+                                                    })) &&
+                                                (7 >= elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".tuple[2][" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@maxLength 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -82,8 +132,18 @@ export const test_createValidateEquals_TagTuple = _test_validateEquals(
                                     value: input.tuple[2],
                                 }),
                             (((Array.isArray(input.tuple[3]) &&
-                                3 <= input.tuple[3].length &&
-                                7 >= input.tuple[3].length) ||
+                                (3 <= input.tuple[3].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[3]",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.tuple[3],
+                                    })) &&
+                                (7 >= input.tuple[3].length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".tuple[3]",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.tuple[3],
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".tuple[3]",
                                     expected: "Array<number>",
@@ -93,8 +153,28 @@ export const test_createValidateEquals_TagTuple = _test_validateEquals(
                                     .map(
                                         (elem: any, _index2: number) =>
                                             ("number" === typeof elem &&
-                                                3 <= elem &&
-                                                7 >= elem) ||
+                                                (3 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".tuple[3][" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 3)",
+                                                        value: elem,
+                                                    })) &&
+                                                (7 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".tuple[3][" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagType.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagType.ts
@@ -22,7 +22,12 @@ export const test_createValidateEquals_TagType = _test_validateEquals(
                 [
                     ("number" === typeof input.int &&
                         Number.isFinite(input.int) &&
-                        parseInt(input.int) === input.int) ||
+                        (parseInt(input.int) === input.int ||
+                            $report(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".int",
                             expected: "number",
@@ -30,8 +35,18 @@ export const test_createValidateEquals_TagType = _test_validateEquals(
                         }),
                     ("number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
-                        parseInt(input.uint) === input.uint &&
-                        0 <= input.uint) ||
+                        (parseInt(input.uint) === input.uint ||
+                            $report(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (0 <= input.uint ||
+                            $report(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            }))) ||
                         $report(_exceptionable, {
                             path: _path + ".uint",
                             expected: "number",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagArray.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagArray.ts
@@ -22,7 +22,12 @@ export const test_createValidateParse_TagArray = _test_validateParse(
                 ): boolean =>
                     [
                         (((Array.isArray(input.items) &&
-                            3 === input.items.length) ||
+                            (3 === input.items.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.items,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".items",
                                 expected: "Array<string>",
@@ -32,7 +37,17 @@ export const test_createValidateParse_TagArray = _test_validateParse(
                                 .map(
                                     (elem: any, _index2: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -50,7 +65,12 @@ export const test_createValidateParse_TagArray = _test_validateParse(
                                 value: input.items,
                             }),
                         (((Array.isArray(input.minItems) &&
-                            3 <= input.minItems.length) ||
+                            (3 <= input.minItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.minItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "Array<number>",
@@ -61,7 +81,17 @@ export const test_createValidateParse_TagArray = _test_validateParse(
                                     (elem: any, _index3: number) =>
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            3 <= elem) ||
+                                            (3 <= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".minItems[" +
+                                                        _index3 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 3)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -79,7 +109,12 @@ export const test_createValidateParse_TagArray = _test_validateParse(
                                 value: input.minItems,
                             }),
                         (((Array.isArray(input.maxItems) &&
-                            7 >= input.maxItems.length) ||
+                            (7 >= input.maxItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.maxItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "Array<(number | string)>",
@@ -89,10 +124,30 @@ export const test_createValidateParse_TagArray = _test_validateParse(
                                 .map(
                                     (elem: any, _index4: number) =>
                                         ("string" === typeof elem &&
-                                            7 >= elem.length) ||
+                                            (7 >= elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@maxLength 7)",
+                                                    value: elem,
+                                                }))) ||
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            7 >= elem) ||
+                                            (7 >= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 7)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -110,8 +165,18 @@ export const test_createValidateParse_TagArray = _test_validateParse(
                                 value: input.maxItems,
                             }),
                         (((Array.isArray(input.both) &&
-                            3 <= input.both.length &&
-                            7 >= input.both.length) ||
+                            (3 <= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.both,
+                                })) &&
+                            (7 >= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.both,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".both",
                                 expected: "Array<string>",
@@ -121,7 +186,17 @@ export const test_createValidateParse_TagArray = _test_validateParse(
                                 .map(
                                     (elem: any, _index5: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".both[" +
+                                                        _index5 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagAtomicUnion.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagAtomicUnion.ts
@@ -21,11 +21,26 @@ export const test_createValidateParse_TagAtomicUnion = _test_validateParse(
                 ): boolean =>
                     [
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                             ("number" === typeof input.value &&
                                 Number.isFinite(input.value) &&
-                                3 <= input.value) ||
+                                (3 <= input.value ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "number (@minimum 3)",
+                                        value: input.value,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "(number | string)",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagCustom.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagCustom.ts
@@ -23,31 +23,41 @@ export const test_createValidateParse_TagCustom = _test_validateParse(
                 ): boolean =>
                     [
                         ("string" === typeof input.id &&
-                            true === $is_uuid(input.id)) ||
+                            (true === $is_uuid(input.id) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string (@format uuid)",
+                                    value: input.id,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".id",
                                 expected: "string",
                                 value: input.id,
                             }),
-                        ("string" === typeof input.dolloar &&
-                            $is_custom(
-                                "dollar",
-                                "string",
-                                "",
-                                input.dolloar,
-                            )) ||
+                        ("string" === typeof input.dollar &&
+                            ($is_custom("dollar", "string", "", input.dollar) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dollar",
+                                    expected: "string (@dollar)",
+                                    value: input.dollar,
+                                }))) ||
                             $report(_exceptionable, {
-                                path: _path + ".dolloar",
+                                path: _path + ".dollar",
                                 expected: "string",
-                                value: input.dolloar,
+                                value: input.dollar,
                             }),
                         ("string" === typeof input.postfix &&
-                            $is_custom(
+                            ($is_custom(
                                 "postfix",
                                 "string",
                                 "abcd",
                                 input.postfix,
-                            )) ||
+                            ) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string (@postfix abcd)",
+                                    value: input.postfix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected: "string",
@@ -55,7 +65,12 @@ export const test_createValidateParse_TagCustom = _test_validateParse(
                             }),
                         ("number" === typeof input.log &&
                             Number.isFinite(input.log) &&
-                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            ($is_custom("powerOf", "number", "10", input.log) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number (@powerOf 10)",
+                                    value: input.log,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".log",
                                 expected: "number",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagFormat.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagFormat.ts
@@ -28,63 +28,108 @@ export const test_createValidateParse_TagFormat = _test_validateParse(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true === $is_uuid(input.uuid)) ||
+                            (true === $is_uuid(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected: "string (@format uuid)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true === $is_email(input.email)) ||
+                            (true === $is_email(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected: "string (@format email)",
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.url &&
-                            true === $is_url(input.url)) ||
+                            (true === $is_url(input.url) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".url",
+                                    expected: "string (@format url)",
+                                    value: input.url,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".url",
                                 expected: "string",
                                 value: input.url,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true === $is_ipv4(input.ipv4)) ||
+                            (true === $is_ipv4(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected: "string (@format ipv4)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true === $is_ipv6(input.ipv6)) ||
+                            (true === $is_ipv6(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected: "string (@format ipv6)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",
                                 value: input.ipv6,
                             }),
                         ("string" === typeof input.date &&
-                            true === $is_date(input.date)) ||
+                            (true === $is_date(input.date) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date",
+                                    expected: "string (@format date)",
+                                    value: input.date,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date",
                                 expected: "string",
                                 value: input.date,
                             }),
                         ("string" === typeof input.date_time &&
-                            true === $is_datetime(input.date_time)) ||
+                            (true === $is_datetime(input.date_time) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date_time",
+                                    expected: "string (@format datetime)",
+                                    value: input.date_time,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date_time",
                                 expected: "string",
                                 value: input.date_time,
                             }),
                         ("string" === typeof input.datetime &&
-                            true === $is_datetime(input.datetime)) ||
+                            (true === $is_datetime(input.datetime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".datetime",
+                                    expected: "string (@format datetime)",
+                                    value: input.datetime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".datetime",
                                 expected: "string",
                                 value: input.datetime,
                             }),
                         ("string" === typeof input.dateTime &&
-                            true === $is_datetime(input.dateTime)) ||
+                            (true === $is_datetime(input.dateTime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dateTime",
+                                    expected: "string (@format datetime)",
+                                    value: input.dateTime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".dateTime",
                                 expected: "string",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagLength.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagLength.ts
@@ -21,29 +21,54 @@ export const test_createValidateParse_TagLength = _test_validateParse(
                 ): boolean =>
                     [
                         ("string" === typeof input.fixed &&
-                            5 === input.fixed.length) ||
+                            (5 === input.fixed.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".fixed",
+                                    expected: "string (@length 5)",
+                                    value: input.fixed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".fixed",
                                 expected: "string",
                                 value: input.fixed,
                             }),
                         ("string" === typeof input.minimum &&
-                            3 <= input.minimum.length) ||
+                            (3 <= input.minimum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "string",
                                 value: input.minimum,
                             }),
                         ("string" === typeof input.maximum &&
-                            7 >= input.maximum.length) ||
+                            (7 >= input.maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "string",
                                 value: input.maximum,
                             }),
                         ("string" === typeof input.minimum_and_maximum &&
-                            3 <= input.minimum_and_maximum.length &&
-                            7 >= input.minimum_and_maximum.length) ||
+                            (3 <= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum_and_maximum,
+                                })) &&
+                            (7 >= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.minimum_and_maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagMatrix.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagMatrix.ts
@@ -22,7 +22,12 @@ export const test_createValidateParse_TagMatrix = _test_validateParse(
                 ): boolean =>
                     [
                         (((Array.isArray(input.matrix) &&
-                            3 === input.matrix.length) ||
+                            (3 === input.matrix.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".matrix",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.matrix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".matrix",
                                 expected: "Array<Array<string>>",
@@ -32,7 +37,17 @@ export const test_createValidateParse_TagMatrix = _test_validateParse(
                                 .map(
                                     (elem: any, _index1: number) =>
                                         (((Array.isArray(elem) &&
-                                            3 === elem.length) ||
+                                            (3 === elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".matrix[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected:
+                                                        "Array.length (@items 3)",
+                                                    value: elem,
+                                                }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -50,10 +65,25 @@ export const test_createValidateParse_TagMatrix = _test_validateParse(
                                                     ) =>
                                                         ("string" ===
                                                             typeof elem &&
-                                                            true ===
+                                                            (true ===
                                                                 $is_uuid(
                                                                     elem,
-                                                                )) ||
+                                                                ) ||
+                                                                $report(
+                                                                    _exceptionable,
+                                                                    {
+                                                                        path:
+                                                                            _path +
+                                                                            ".matrix[" +
+                                                                            _index1 +
+                                                                            "][" +
+                                                                            _index2 +
+                                                                            "]",
+                                                                        expected:
+                                                                            "string (@format uuid)",
+                                                                        value: elem,
+                                                                    },
+                                                                ))) ||
                                                         $report(
                                                             _exceptionable,
                                                             {

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagObjectUnion.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagObjectUnion.ts
@@ -22,7 +22,12 @@ export const test_createValidateParse_TagObjectUnion = _test_validateParse(
                     [
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "number",
@@ -36,8 +41,18 @@ export const test_createValidateParse_TagObjectUnion = _test_validateParse(
                 ): boolean =>
                     [
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "string",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagPattern.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagPattern.ts
@@ -21,40 +21,64 @@ export const test_createValidateParse_TagPattern = _test_validateParse(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                ).test(input.uuid)) ||
+                                ).test(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected:
+                                        "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                ).test(input.email)) ||
+                                ).test(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected:
+                                        'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                ).test(input.ipv4)) ||
+                                ).test(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected:
+                                        "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                ).test(input.ipv6)) ||
+                                ).test(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected:
+                                        "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagRange.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagRange.ts
@@ -22,7 +22,12 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                     [
                         ("number" === typeof input.greater &&
                             Number.isFinite(input.greater) &&
-                            3 < input.greater) ||
+                            (3 < input.greater ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater",
                                 expected: "number",
@@ -30,7 +35,12 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                             }),
                         ("number" === typeof input.greater_equal &&
                             Number.isFinite(input.greater_equal) &&
-                            3 <= input.greater_equal) ||
+                            (3 <= input.greater_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number",
@@ -38,7 +48,12 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                             }),
                         ("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
-                            7 > input.less) ||
+                            (7 > input.less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less",
                                 expected: "number",
@@ -46,39 +61,84 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                             }),
                         ("number" === typeof input.less_equal &&
                             Number.isFinite(input.less_equal) &&
-                            7 >= input.less_equal) ||
+                            (7 >= input.less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less_equal",
                                 expected: "number",
                                 value: input.less_equal,
                             }),
                         ("number" === typeof input.greater_less &&
-                            3 < input.greater_less &&
-                            7 > input.greater_less) ||
+                            (3 < input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less,
+                                })) &&
+                            (7 > input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number",
                                 value: input.greater_less,
                             }),
                         ("number" === typeof input.greater_equal_less &&
-                            3 <= input.greater_equal_less &&
-                            7 > input.greater_equal_less) ||
+                            (3 <= input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less,
+                                })) &&
+                            (7 > input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_equal_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less",
                                 expected: "number",
                                 value: input.greater_equal_less,
                             }),
                         ("number" === typeof input.greater_less_equal &&
-                            3 < input.greater_less_equal &&
-                            7 >= input.greater_less_equal) ||
+                            (3 < input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            (7 >= input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number",
                                 value: input.greater_less_equal,
                             }),
                         ("number" === typeof input.greater_equal_less_equal &&
-                            3 <= input.greater_equal_less_equal &&
-                            7 >= input.greater_equal_less_equal) ||
+                            (3 <= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
+                            (7 >= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_equal_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagStep.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagStep.ts
@@ -21,34 +21,84 @@ export const test_createValidateParse_TagStep = _test_validateParse(
                 ): boolean =>
                     [
                         ("number" === typeof input.exclusiveMinimum &&
-                            0 === (input.exclusiveMinimum % 5) - 3 &&
-                            3 < input.exclusiveMinimum) ||
+                            (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@step 5)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (3 < input.exclusiveMinimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.exclusiveMinimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".exclusiveMinimum",
                                 expected: "number",
                                 value: input.exclusiveMinimum,
                             }),
                         ("number" === typeof input.minimum &&
-                            0 === (input.minimum % 5) - 3 &&
-                            3 <= input.minimum) ||
+                            (0 === (input.minimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@step 5)",
+                                    value: input.minimum,
+                                })) &&
+                            (3 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
                                 value: input.minimum,
                             }),
                         ("number" === typeof input.range &&
-                            0 === (input.range % 5) - 0 &&
-                            0 < input.range &&
-                            100 > input.range) ||
+                            (0 === (input.range % 5) - 0 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@step 5)",
+                                    value: input.range,
+                                })) &&
+                            (0 < input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMinimum 0)",
+                                    value: input.range,
+                                })) &&
+                            (100 > input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMaximum 100)",
+                                    value: input.range,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".range",
                                 expected: "number",
                                 value: input.range,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 5 &&
-                            3 <= input.multipleOf &&
-                            99 >= input.multipleOf) ||
+                            (0 === input.multipleOf % 5 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 5)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (3 <= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@minimum 3)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (99 >= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@maximum 99)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagTuple.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagTuple.ts
@@ -36,24 +36,56 @@ export const test_createValidateParse_TagTuple = _test_validateParse(
                                 })) &&
                             [
                                 ("string" === typeof input.tuple[0] &&
-                                    3 <= input.tuple[0].length &&
-                                    7 >= input.tuple[0].length) ||
+                                    (3 <= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@minLength 3)",
+                                            value: input.tuple[0],
+                                        })) &&
+                                    (7 >= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@maxLength 7)",
+                                            value: input.tuple[0],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[0]",
                                         expected: "string",
                                         value: input.tuple[0],
                                     }),
                                 ("number" === typeof input.tuple[1] &&
-                                    3 <= input.tuple[1] &&
-                                    7 >= input.tuple[1]) ||
+                                    (3 <= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@minimum 3)",
+                                            value: input.tuple[1],
+                                        })) &&
+                                    (7 >= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@maximum 7)",
+                                            value: input.tuple[1],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[1]",
                                         expected: "number",
                                         value: input.tuple[1],
                                     }),
                                 (((Array.isArray(input.tuple[2]) &&
-                                    3 <= input.tuple[2].length &&
-                                    7 >= input.tuple[2].length) ||
+                                    (3 <= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[2],
+                                        })) &&
+                                    (7 >= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[2],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[2]",
                                         expected: "Array<string>",
@@ -63,8 +95,34 @@ export const test_createValidateParse_TagTuple = _test_validateParse(
                                         .map(
                                             (elem: any, _index1: number) =>
                                                 ("string" === typeof elem &&
-                                                    3 <= elem.length &&
-                                                    7 >= elem.length) ||
+                                                    (3 <= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@minLength 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@maxLength 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
@@ -82,8 +140,20 @@ export const test_createValidateParse_TagTuple = _test_validateParse(
                                         value: input.tuple[2],
                                     }),
                                 (((Array.isArray(input.tuple[3]) &&
-                                    3 <= input.tuple[3].length &&
-                                    7 >= input.tuple[3].length) ||
+                                    (3 <= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[3],
+                                        })) &&
+                                    (7 >= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[3],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[3]",
                                         expected: "Array<number>",
@@ -93,8 +163,34 @@ export const test_createValidateParse_TagTuple = _test_validateParse(
                                         .map(
                                             (elem: any, _index2: number) =>
                                                 ("number" === typeof elem &&
-                                                    3 <= elem &&
-                                                    7 >= elem) ||
+                                                    (3 <= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@minimum 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@maximum 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagType.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagType.ts
@@ -22,7 +22,12 @@ export const test_createValidateParse_TagType = _test_validateParse(
                     [
                         ("number" === typeof input.int &&
                             Number.isFinite(input.int) &&
-                            parseInt(input.int) === input.int) ||
+                            (parseInt(input.int) === input.int ||
+                                $report(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".int",
                                 expected: "number",
@@ -30,8 +35,18 @@ export const test_createValidateParse_TagType = _test_validateParse(
                             }),
                         ("number" === typeof input.uint &&
                             Number.isFinite(input.uint) &&
-                            parseInt(input.uint) === input.uint &&
-                            0 <= input.uint) ||
+                            (parseInt(input.uint) === input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (0 <= input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number",

--- a/test/generated/output/createValidateParse/test_createValidateParse_UltimateUnion.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_UltimateUnion.ts
@@ -1212,7 +1212,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                parseInt(input.minimum) === input.minimum) ||
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -1221,7 +1226,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                parseInt(input.maximum) === input.maximum) ||
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -1244,8 +1254,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
-                                parseInt(input.multipleOf) ===
-                                    input.multipleOf) ||
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -1612,8 +1627,19 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
-                                parseInt(input.minLength) === input.minLength &&
-                                0 <= input.minLength) ||
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minLength",
                                 expected: "(number | undefined)",
@@ -1622,8 +1648,19 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
-                                parseInt(input.maxLength) === input.maxLength &&
-                                0 <= input.maxLength) ||
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxLength",
                                 expected: "(number | undefined)",
@@ -1825,8 +1862,18 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         undefined === input.minItems ||
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
-                                parseInt(input.minItems) === input.minItems &&
-                                0 <= input.minItems) ||
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "(number | undefined)",
@@ -1835,8 +1882,18 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
-                                parseInt(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems) ||
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagArray.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagArray.ts
@@ -22,7 +22,12 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                 ): boolean =>
                     [
                         (((Array.isArray(input.items) &&
-                            3 === input.items.length) ||
+                            (3 === input.items.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.items,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".items",
                                 expected: "Array<string>",
@@ -32,7 +37,17 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                                 .map(
                                     (elem: any, _index2: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -50,7 +65,12 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                                 value: input.items,
                             }),
                         (((Array.isArray(input.minItems) &&
-                            3 <= input.minItems.length) ||
+                            (3 <= input.minItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.minItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "Array<number>",
@@ -61,7 +81,17 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                                     (elem: any, _index3: number) =>
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            3 <= elem) ||
+                                            (3 <= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".minItems[" +
+                                                        _index3 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 3)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -79,7 +109,12 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                                 value: input.minItems,
                             }),
                         (((Array.isArray(input.maxItems) &&
-                            7 >= input.maxItems.length) ||
+                            (7 >= input.maxItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.maxItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "Array<(number | string)>",
@@ -89,10 +124,30 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                                 .map(
                                     (elem: any, _index4: number) =>
                                         ("string" === typeof elem &&
-                                            7 >= elem.length) ||
+                                            (7 >= elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@maxLength 7)",
+                                                    value: elem,
+                                                }))) ||
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            7 >= elem) ||
+                                            (7 >= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 7)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -110,8 +165,18 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                                 value: input.maxItems,
                             }),
                         (((Array.isArray(input.both) &&
-                            3 <= input.both.length &&
-                            7 >= input.both.length) ||
+                            (3 <= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.both,
+                                })) &&
+                            (7 >= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.both,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".both",
                                 expected: "Array<string>",
@@ -121,7 +186,17 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                                 .map(
                                     (elem: any, _index5: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".both[" +
+                                                        _index5 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagAtomicUnion.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagAtomicUnion.ts
@@ -21,11 +21,26 @@ export const test_createValidatePrune_TagAtomicUnion = _test_validatePrune(
                 ): boolean =>
                     [
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                             ("number" === typeof input.value &&
                                 Number.isFinite(input.value) &&
-                                3 <= input.value) ||
+                                (3 <= input.value ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "number (@minimum 3)",
+                                        value: input.value,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "(number | string)",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagBigInt.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagBigInt.ts
@@ -27,29 +27,54 @@ export const test_createValidatePrune_TagBigInt = _test_validatePrune(
                                 value: input.value,
                             }),
                         ("bigint" === typeof input.ranged &&
-                            0n <= input.ranged &&
-                            100n >= input.ranged) ||
+                            (0n <= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "bigint (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100n >= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "bigint (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "bigint",
                                 value: input.ranged,
                             }),
                         ("bigint" === typeof input.minimum &&
-                            0n <= input.minimum) ||
+                            (0n <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "bigint (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "bigint",
                                 value: input.minimum,
                             }),
                         ("bigint" === typeof input.maximum &&
-                            100n >= input.maximum) ||
+                            (100n >= input.maximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "bigint (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "bigint",
                                 value: input.maximum,
                             }),
                         ("bigint" === typeof input.multipleOf &&
-                            0n === input.multipleOf % 3n) ||
+                            (0n === input.multipleOf % 3n ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "bigint (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "bigint",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagCustom.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagCustom.ts
@@ -23,31 +23,41 @@ export const test_createValidatePrune_TagCustom = _test_validatePrune(
                 ): boolean =>
                     [
                         ("string" === typeof input.id &&
-                            true === $is_uuid(input.id)) ||
+                            (true === $is_uuid(input.id) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string (@format uuid)",
+                                    value: input.id,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".id",
                                 expected: "string",
                                 value: input.id,
                             }),
-                        ("string" === typeof input.dolloar &&
-                            $is_custom(
-                                "dollar",
-                                "string",
-                                "",
-                                input.dolloar,
-                            )) ||
+                        ("string" === typeof input.dollar &&
+                            ($is_custom("dollar", "string", "", input.dollar) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dollar",
+                                    expected: "string (@dollar)",
+                                    value: input.dollar,
+                                }))) ||
                             $report(_exceptionable, {
-                                path: _path + ".dolloar",
+                                path: _path + ".dollar",
                                 expected: "string",
-                                value: input.dolloar,
+                                value: input.dollar,
                             }),
                         ("string" === typeof input.postfix &&
-                            $is_custom(
+                            ($is_custom(
                                 "postfix",
                                 "string",
                                 "abcd",
                                 input.postfix,
-                            )) ||
+                            ) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string (@postfix abcd)",
+                                    value: input.postfix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected: "string",
@@ -55,7 +65,12 @@ export const test_createValidatePrune_TagCustom = _test_validatePrune(
                             }),
                         ("number" === typeof input.log &&
                             Number.isFinite(input.log) &&
-                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            ($is_custom("powerOf", "number", "10", input.log) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number (@powerOf 10)",
+                                    value: input.log,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".log",
                                 expected: "number",
@@ -91,7 +106,7 @@ export const test_createValidatePrune_TagCustom = _test_validatePrune(
                 for (const key of Object.keys(input)) {
                     if (
                         "id" === key ||
-                        "dolloar" === key ||
+                        "dollar" === key ||
                         "postfix" === key ||
                         "log" === key
                     )

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagFormat.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagFormat.ts
@@ -28,63 +28,108 @@ export const test_createValidatePrune_TagFormat = _test_validatePrune(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true === $is_uuid(input.uuid)) ||
+                            (true === $is_uuid(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected: "string (@format uuid)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true === $is_email(input.email)) ||
+                            (true === $is_email(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected: "string (@format email)",
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.url &&
-                            true === $is_url(input.url)) ||
+                            (true === $is_url(input.url) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".url",
+                                    expected: "string (@format url)",
+                                    value: input.url,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".url",
                                 expected: "string",
                                 value: input.url,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true === $is_ipv4(input.ipv4)) ||
+                            (true === $is_ipv4(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected: "string (@format ipv4)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true === $is_ipv6(input.ipv6)) ||
+                            (true === $is_ipv6(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected: "string (@format ipv6)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",
                                 value: input.ipv6,
                             }),
                         ("string" === typeof input.date &&
-                            true === $is_date(input.date)) ||
+                            (true === $is_date(input.date) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date",
+                                    expected: "string (@format date)",
+                                    value: input.date,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date",
                                 expected: "string",
                                 value: input.date,
                             }),
                         ("string" === typeof input.date_time &&
-                            true === $is_datetime(input.date_time)) ||
+                            (true === $is_datetime(input.date_time) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date_time",
+                                    expected: "string (@format datetime)",
+                                    value: input.date_time,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date_time",
                                 expected: "string",
                                 value: input.date_time,
                             }),
                         ("string" === typeof input.datetime &&
-                            true === $is_datetime(input.datetime)) ||
+                            (true === $is_datetime(input.datetime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".datetime",
+                                    expected: "string (@format datetime)",
+                                    value: input.datetime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".datetime",
                                 expected: "string",
                                 value: input.datetime,
                             }),
                         ("string" === typeof input.dateTime &&
-                            true === $is_datetime(input.dateTime)) ||
+                            (true === $is_datetime(input.dateTime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dateTime",
+                                    expected: "string (@format datetime)",
+                                    value: input.dateTime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".dateTime",
                                 expected: "string",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagInfinite.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagInfinite.ts
@@ -28,8 +28,18 @@ export const test_createValidatePrune_TagInfinite = _test_validatePrune(
                                 value: input.value,
                             }),
                         ("number" === typeof input.ranged &&
-                            0 <= input.ranged &&
-                            100 >= input.ranged) ||
+                            (0 <= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100 >= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "number",
@@ -37,7 +47,12 @@ export const test_createValidatePrune_TagInfinite = _test_validatePrune(
                             }),
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            0 <= input.minimum) ||
+                            (0 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
@@ -45,14 +60,24 @@ export const test_createValidatePrune_TagInfinite = _test_validatePrune(
                             }),
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            100 >= input.maximum) ||
+                            (100 >= input.maximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "number",
                                 value: input.maximum,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 3) ||
+                            (0 === input.multipleOf % 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",
@@ -60,7 +85,12 @@ export const test_createValidatePrune_TagInfinite = _test_validatePrune(
                             }),
                         ("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
-                            parseInt(input.typed) === input.typed) ||
+                            (parseInt(input.typed) === input.typed ||
+                                $report(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagLength.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagLength.ts
@@ -21,29 +21,54 @@ export const test_createValidatePrune_TagLength = _test_validatePrune(
                 ): boolean =>
                     [
                         ("string" === typeof input.fixed &&
-                            5 === input.fixed.length) ||
+                            (5 === input.fixed.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".fixed",
+                                    expected: "string (@length 5)",
+                                    value: input.fixed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".fixed",
                                 expected: "string",
                                 value: input.fixed,
                             }),
                         ("string" === typeof input.minimum &&
-                            3 <= input.minimum.length) ||
+                            (3 <= input.minimum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "string",
                                 value: input.minimum,
                             }),
                         ("string" === typeof input.maximum &&
-                            7 >= input.maximum.length) ||
+                            (7 >= input.maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "string",
                                 value: input.maximum,
                             }),
                         ("string" === typeof input.minimum_and_maximum &&
-                            3 <= input.minimum_and_maximum.length &&
-                            7 >= input.minimum_and_maximum.length) ||
+                            (3 <= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum_and_maximum,
+                                })) &&
+                            (7 >= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.minimum_and_maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagMatrix.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagMatrix.ts
@@ -22,7 +22,12 @@ export const test_createValidatePrune_TagMatrix = _test_validatePrune(
                 ): boolean =>
                     [
                         (((Array.isArray(input.matrix) &&
-                            3 === input.matrix.length) ||
+                            (3 === input.matrix.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".matrix",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.matrix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".matrix",
                                 expected: "Array<Array<string>>",
@@ -32,7 +37,17 @@ export const test_createValidatePrune_TagMatrix = _test_validatePrune(
                                 .map(
                                     (elem: any, _index1: number) =>
                                         (((Array.isArray(elem) &&
-                                            3 === elem.length) ||
+                                            (3 === elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".matrix[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected:
+                                                        "Array.length (@items 3)",
+                                                    value: elem,
+                                                }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -50,10 +65,25 @@ export const test_createValidatePrune_TagMatrix = _test_validatePrune(
                                                     ) =>
                                                         ("string" ===
                                                             typeof elem &&
-                                                            true ===
+                                                            (true ===
                                                                 $is_uuid(
                                                                     elem,
-                                                                )) ||
+                                                                ) ||
+                                                                $report(
+                                                                    _exceptionable,
+                                                                    {
+                                                                        path:
+                                                                            _path +
+                                                                            ".matrix[" +
+                                                                            _index1 +
+                                                                            "][" +
+                                                                            _index2 +
+                                                                            "]",
+                                                                        expected:
+                                                                            "string (@format uuid)",
+                                                                        value: elem,
+                                                                    },
+                                                                ))) ||
                                                         $report(
                                                             _exceptionable,
                                                             {

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagNaN.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagNaN.ts
@@ -28,8 +28,18 @@ export const test_createValidatePrune_TagNaN = _test_validatePrune(
                                 value: input.value,
                             }),
                         ("number" === typeof input.ranged &&
-                            0 <= input.ranged &&
-                            100 >= input.ranged) ||
+                            (0 <= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100 >= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "number",
@@ -37,7 +47,12 @@ export const test_createValidatePrune_TagNaN = _test_validatePrune(
                             }),
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            0 <= input.minimum) ||
+                            (0 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
@@ -45,14 +60,24 @@ export const test_createValidatePrune_TagNaN = _test_validatePrune(
                             }),
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            100 >= input.maximum) ||
+                            (100 >= input.maximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "number",
                                 value: input.maximum,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 3) ||
+                            (0 === input.multipleOf % 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",
@@ -60,7 +85,12 @@ export const test_createValidatePrune_TagNaN = _test_validatePrune(
                             }),
                         ("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
-                            parseInt(input.typed) === input.typed) ||
+                            (parseInt(input.typed) === input.typed ||
+                                $report(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagObjectUnion.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagObjectUnion.ts
@@ -22,7 +22,12 @@ export const test_createValidatePrune_TagObjectUnion = _test_validatePrune(
                     [
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "number",
@@ -36,8 +41,18 @@ export const test_createValidatePrune_TagObjectUnion = _test_validatePrune(
                 ): boolean =>
                     [
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "string",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagPattern.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagPattern.ts
@@ -21,40 +21,64 @@ export const test_createValidatePrune_TagPattern = _test_validatePrune(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                ).test(input.uuid)) ||
+                                ).test(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected:
+                                        "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                ).test(input.email)) ||
+                                ).test(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected:
+                                        'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                ).test(input.ipv4)) ||
+                                ).test(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected:
+                                        "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                ).test(input.ipv6)) ||
+                                ).test(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected:
+                                        "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagRange.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagRange.ts
@@ -22,7 +22,12 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                     [
                         ("number" === typeof input.greater &&
                             Number.isFinite(input.greater) &&
-                            3 < input.greater) ||
+                            (3 < input.greater ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater",
                                 expected: "number",
@@ -30,7 +35,12 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                             }),
                         ("number" === typeof input.greater_equal &&
                             Number.isFinite(input.greater_equal) &&
-                            3 <= input.greater_equal) ||
+                            (3 <= input.greater_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number",
@@ -38,7 +48,12 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                             }),
                         ("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
-                            7 > input.less) ||
+                            (7 > input.less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less",
                                 expected: "number",
@@ -46,39 +61,84 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                             }),
                         ("number" === typeof input.less_equal &&
                             Number.isFinite(input.less_equal) &&
-                            7 >= input.less_equal) ||
+                            (7 >= input.less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less_equal",
                                 expected: "number",
                                 value: input.less_equal,
                             }),
                         ("number" === typeof input.greater_less &&
-                            3 < input.greater_less &&
-                            7 > input.greater_less) ||
+                            (3 < input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less,
+                                })) &&
+                            (7 > input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number",
                                 value: input.greater_less,
                             }),
                         ("number" === typeof input.greater_equal_less &&
-                            3 <= input.greater_equal_less &&
-                            7 > input.greater_equal_less) ||
+                            (3 <= input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less,
+                                })) &&
+                            (7 > input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_equal_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less",
                                 expected: "number",
                                 value: input.greater_equal_less,
                             }),
                         ("number" === typeof input.greater_less_equal &&
-                            3 < input.greater_less_equal &&
-                            7 >= input.greater_less_equal) ||
+                            (3 < input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            (7 >= input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number",
                                 value: input.greater_less_equal,
                             }),
                         ("number" === typeof input.greater_equal_less_equal &&
-                            3 <= input.greater_equal_less_equal &&
-                            7 >= input.greater_equal_less_equal) ||
+                            (3 <= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
+                            (7 >= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_equal_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagStep.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagStep.ts
@@ -21,34 +21,84 @@ export const test_createValidatePrune_TagStep = _test_validatePrune(
                 ): boolean =>
                     [
                         ("number" === typeof input.exclusiveMinimum &&
-                            0 === (input.exclusiveMinimum % 5) - 3 &&
-                            3 < input.exclusiveMinimum) ||
+                            (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@step 5)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (3 < input.exclusiveMinimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.exclusiveMinimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".exclusiveMinimum",
                                 expected: "number",
                                 value: input.exclusiveMinimum,
                             }),
                         ("number" === typeof input.minimum &&
-                            0 === (input.minimum % 5) - 3 &&
-                            3 <= input.minimum) ||
+                            (0 === (input.minimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@step 5)",
+                                    value: input.minimum,
+                                })) &&
+                            (3 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
                                 value: input.minimum,
                             }),
                         ("number" === typeof input.range &&
-                            0 === (input.range % 5) - 0 &&
-                            0 < input.range &&
-                            100 > input.range) ||
+                            (0 === (input.range % 5) - 0 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@step 5)",
+                                    value: input.range,
+                                })) &&
+                            (0 < input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMinimum 0)",
+                                    value: input.range,
+                                })) &&
+                            (100 > input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMaximum 100)",
+                                    value: input.range,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".range",
                                 expected: "number",
                                 value: input.range,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 5 &&
-                            3 <= input.multipleOf &&
-                            99 >= input.multipleOf) ||
+                            (0 === input.multipleOf % 5 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 5)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (3 <= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@minimum 3)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (99 >= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@maximum 99)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagTuple.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagTuple.ts
@@ -36,24 +36,56 @@ export const test_createValidatePrune_TagTuple = _test_validatePrune(
                                 })) &&
                             [
                                 ("string" === typeof input.tuple[0] &&
-                                    3 <= input.tuple[0].length &&
-                                    7 >= input.tuple[0].length) ||
+                                    (3 <= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@minLength 3)",
+                                            value: input.tuple[0],
+                                        })) &&
+                                    (7 >= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@maxLength 7)",
+                                            value: input.tuple[0],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[0]",
                                         expected: "string",
                                         value: input.tuple[0],
                                     }),
                                 ("number" === typeof input.tuple[1] &&
-                                    3 <= input.tuple[1] &&
-                                    7 >= input.tuple[1]) ||
+                                    (3 <= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@minimum 3)",
+                                            value: input.tuple[1],
+                                        })) &&
+                                    (7 >= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@maximum 7)",
+                                            value: input.tuple[1],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[1]",
                                         expected: "number",
                                         value: input.tuple[1],
                                     }),
                                 (((Array.isArray(input.tuple[2]) &&
-                                    3 <= input.tuple[2].length &&
-                                    7 >= input.tuple[2].length) ||
+                                    (3 <= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[2],
+                                        })) &&
+                                    (7 >= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[2],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[2]",
                                         expected: "Array<string>",
@@ -63,8 +95,34 @@ export const test_createValidatePrune_TagTuple = _test_validatePrune(
                                         .map(
                                             (elem: any, _index1: number) =>
                                                 ("string" === typeof elem &&
-                                                    3 <= elem.length &&
-                                                    7 >= elem.length) ||
+                                                    (3 <= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@minLength 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@maxLength 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
@@ -82,8 +140,20 @@ export const test_createValidatePrune_TagTuple = _test_validatePrune(
                                         value: input.tuple[2],
                                     }),
                                 (((Array.isArray(input.tuple[3]) &&
-                                    3 <= input.tuple[3].length &&
-                                    7 >= input.tuple[3].length) ||
+                                    (3 <= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[3],
+                                        })) &&
+                                    (7 >= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[3],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[3]",
                                         expected: "Array<number>",
@@ -93,8 +163,34 @@ export const test_createValidatePrune_TagTuple = _test_validatePrune(
                                         .map(
                                             (elem: any, _index2: number) =>
                                                 ("number" === typeof elem &&
-                                                    3 <= elem &&
-                                                    7 >= elem) ||
+                                                    (3 <= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@minimum 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@maximum 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagType.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagType.ts
@@ -22,7 +22,12 @@ export const test_createValidatePrune_TagType = _test_validatePrune(
                     [
                         ("number" === typeof input.int &&
                             Number.isFinite(input.int) &&
-                            parseInt(input.int) === input.int) ||
+                            (parseInt(input.int) === input.int ||
+                                $report(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".int",
                                 expected: "number",
@@ -30,8 +35,18 @@ export const test_createValidatePrune_TagType = _test_validatePrune(
                             }),
                         ("number" === typeof input.uint &&
                             Number.isFinite(input.uint) &&
-                            parseInt(input.uint) === input.uint &&
-                            0 <= input.uint) ||
+                            (parseInt(input.uint) === input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (0 <= input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number",

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagArray.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagArray.ts
@@ -24,7 +24,12 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                 ): boolean =>
                     [
                         (((Array.isArray(input.items) &&
-                            3 === input.items.length) ||
+                            (3 === input.items.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.items,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".items",
                                 expected: "Array<string>",
@@ -34,7 +39,17 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                                 .map(
                                     (elem: any, _index2: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -52,7 +67,12 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                                 value: input.items,
                             }),
                         (((Array.isArray(input.minItems) &&
-                            3 <= input.minItems.length) ||
+                            (3 <= input.minItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.minItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "Array<number>",
@@ -63,7 +83,17 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                                     (elem: any, _index3: number) =>
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            3 <= elem) ||
+                                            (3 <= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".minItems[" +
+                                                        _index3 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 3)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -81,7 +111,12 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                                 value: input.minItems,
                             }),
                         (((Array.isArray(input.maxItems) &&
-                            7 >= input.maxItems.length) ||
+                            (7 >= input.maxItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.maxItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "Array<(number | string)>",
@@ -91,10 +126,30 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                                 .map(
                                     (elem: any, _index4: number) =>
                                         ("string" === typeof elem &&
-                                            7 >= elem.length) ||
+                                            (7 >= elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@maxLength 7)",
+                                                    value: elem,
+                                                }))) ||
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            7 >= elem) ||
+                                            (7 >= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 7)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -112,8 +167,18 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                                 value: input.maxItems,
                             }),
                         (((Array.isArray(input.both) &&
-                            3 <= input.both.length &&
-                            7 >= input.both.length) ||
+                            (3 <= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.both,
+                                })) &&
+                            (7 >= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.both,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".both",
                                 expected: "Array<string>",
@@ -123,7 +188,17 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                                 .map(
                                     (elem: any, _index5: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".both[" +
+                                                        _index5 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagAtomicUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagAtomicUnion.ts
@@ -26,11 +26,26 @@ export const test_createValidateStringify_TagAtomicUnion =
                     ): boolean =>
                         [
                             ("string" === typeof input.value &&
-                                3 <= input.value.length &&
-                                7 >= input.value.length) ||
+                                (3 <= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@minLength 3)",
+                                        value: input.value,
+                                    })) &&
+                                (7 >= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.value,
+                                    }))) ||
                                 ("number" === typeof input.value &&
                                     Number.isFinite(input.value) &&
-                                    3 <= input.value) ||
+                                    (3 <= input.value ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".value",
+                                            expected: "number (@minimum 3)",
+                                            value: input.value,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "(number | string)",

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagCustom.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagCustom.ts
@@ -25,31 +25,41 @@ export const test_createValidateStringify_TagCustom = _test_validateStringify(
                 ): boolean =>
                     [
                         ("string" === typeof input.id &&
-                            true === $is_uuid(input.id)) ||
+                            (true === $is_uuid(input.id) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string (@format uuid)",
+                                    value: input.id,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".id",
                                 expected: "string",
                                 value: input.id,
                             }),
-                        ("string" === typeof input.dolloar &&
-                            $is_custom(
-                                "dollar",
-                                "string",
-                                "",
-                                input.dolloar,
-                            )) ||
+                        ("string" === typeof input.dollar &&
+                            ($is_custom("dollar", "string", "", input.dollar) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dollar",
+                                    expected: "string (@dollar)",
+                                    value: input.dollar,
+                                }))) ||
                             $report(_exceptionable, {
-                                path: _path + ".dolloar",
+                                path: _path + ".dollar",
                                 expected: "string",
-                                value: input.dolloar,
+                                value: input.dollar,
                             }),
                         ("string" === typeof input.postfix &&
-                            $is_custom(
+                            ($is_custom(
                                 "postfix",
                                 "string",
                                 "abcd",
                                 input.postfix,
-                            )) ||
+                            ) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string (@postfix abcd)",
+                                    value: input.postfix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected: "string",
@@ -57,7 +67,12 @@ export const test_createValidateStringify_TagCustom = _test_validateStringify(
                             }),
                         ("number" === typeof input.log &&
                             Number.isFinite(input.log) &&
-                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            ($is_custom("powerOf", "number", "10", input.log) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number (@powerOf 10)",
+                                    value: input.log,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".log",
                                 expected: "number",
@@ -92,8 +107,8 @@ export const test_createValidateStringify_TagCustom = _test_validateStringify(
             const $is_uuid = (typia.createValidateStringify as any).is_uuid;
             const $is_custom = (typia.createValidateStringify as any).is_custom;
             const $so0 = (input: any): any =>
-                `{"id":${'"' + input.id + '"'},"dolloar":${$string(
-                    input.dolloar,
+                `{"id":${'"' + input.id + '"'},"dollar":${$string(
+                    input.dollar,
                 )},"postfix":${$string(input.postfix)},"log":${$number(
                     input.log,
                 )}}`;

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagFormat.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagFormat.ts
@@ -31,63 +31,108 @@ export const test_createValidateStringify_TagFormat = _test_validateStringify(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true === $is_uuid(input.uuid)) ||
+                            (true === $is_uuid(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected: "string (@format uuid)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true === $is_email(input.email)) ||
+                            (true === $is_email(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected: "string (@format email)",
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.url &&
-                            true === $is_url(input.url)) ||
+                            (true === $is_url(input.url) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".url",
+                                    expected: "string (@format url)",
+                                    value: input.url,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".url",
                                 expected: "string",
                                 value: input.url,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true === $is_ipv4(input.ipv4)) ||
+                            (true === $is_ipv4(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected: "string (@format ipv4)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true === $is_ipv6(input.ipv6)) ||
+                            (true === $is_ipv6(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected: "string (@format ipv6)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",
                                 value: input.ipv6,
                             }),
                         ("string" === typeof input.date &&
-                            true === $is_date(input.date)) ||
+                            (true === $is_date(input.date) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date",
+                                    expected: "string (@format date)",
+                                    value: input.date,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date",
                                 expected: "string",
                                 value: input.date,
                             }),
                         ("string" === typeof input.date_time &&
-                            true === $is_datetime(input.date_time)) ||
+                            (true === $is_datetime(input.date_time) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date_time",
+                                    expected: "string (@format datetime)",
+                                    value: input.date_time,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date_time",
                                 expected: "string",
                                 value: input.date_time,
                             }),
                         ("string" === typeof input.datetime &&
-                            true === $is_datetime(input.datetime)) ||
+                            (true === $is_datetime(input.datetime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".datetime",
+                                    expected: "string (@format datetime)",
+                                    value: input.datetime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".datetime",
                                 expected: "string",
                                 value: input.datetime,
                             }),
                         ("string" === typeof input.dateTime &&
-                            true === $is_datetime(input.dateTime)) ||
+                            (true === $is_datetime(input.dateTime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dateTime",
+                                    expected: "string (@format datetime)",
+                                    value: input.dateTime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".dateTime",
                                 expected: "string",

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagLength.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagLength.ts
@@ -23,29 +23,54 @@ export const test_createValidateStringify_TagLength = _test_validateStringify(
                 ): boolean =>
                     [
                         ("string" === typeof input.fixed &&
-                            5 === input.fixed.length) ||
+                            (5 === input.fixed.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".fixed",
+                                    expected: "string (@length 5)",
+                                    value: input.fixed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".fixed",
                                 expected: "string",
                                 value: input.fixed,
                             }),
                         ("string" === typeof input.minimum &&
-                            3 <= input.minimum.length) ||
+                            (3 <= input.minimum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "string",
                                 value: input.minimum,
                             }),
                         ("string" === typeof input.maximum &&
-                            7 >= input.maximum.length) ||
+                            (7 >= input.maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "string",
                                 value: input.maximum,
                             }),
                         ("string" === typeof input.minimum_and_maximum &&
-                            3 <= input.minimum_and_maximum.length &&
-                            7 >= input.minimum_and_maximum.length) ||
+                            (3 <= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum_and_maximum,
+                                })) &&
+                            (7 >= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.minimum_and_maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagMatrix.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagMatrix.ts
@@ -24,7 +24,12 @@ export const test_createValidateStringify_TagMatrix = _test_validateStringify(
                 ): boolean =>
                     [
                         (((Array.isArray(input.matrix) &&
-                            3 === input.matrix.length) ||
+                            (3 === input.matrix.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".matrix",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.matrix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".matrix",
                                 expected: "Array<Array<string>>",
@@ -34,7 +39,17 @@ export const test_createValidateStringify_TagMatrix = _test_validateStringify(
                                 .map(
                                     (elem: any, _index1: number) =>
                                         (((Array.isArray(elem) &&
-                                            3 === elem.length) ||
+                                            (3 === elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".matrix[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected:
+                                                        "Array.length (@items 3)",
+                                                    value: elem,
+                                                }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -52,10 +67,25 @@ export const test_createValidateStringify_TagMatrix = _test_validateStringify(
                                                     ) =>
                                                         ("string" ===
                                                             typeof elem &&
-                                                            true ===
+                                                            (true ===
                                                                 $is_uuid(
                                                                     elem,
-                                                                )) ||
+                                                                ) ||
+                                                                $report(
+                                                                    _exceptionable,
+                                                                    {
+                                                                        path:
+                                                                            _path +
+                                                                            ".matrix[" +
+                                                                            _index1 +
+                                                                            "][" +
+                                                                            _index2 +
+                                                                            "]",
+                                                                        expected:
+                                                                            "string (@format uuid)",
+                                                                        value: elem,
+                                                                    },
+                                                                ))) ||
                                                         $report(
                                                             _exceptionable,
                                                             {

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagObjectUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagObjectUnion.ts
@@ -27,7 +27,12 @@ export const test_createValidateStringify_TagObjectUnion =
                         [
                             ("number" === typeof input.value &&
                                 Number.isFinite(input.value) &&
-                                3 <= input.value) ||
+                                (3 <= input.value ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "number (@minimum 3)",
+                                        value: input.value,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "number",
@@ -41,8 +46,18 @@ export const test_createValidateStringify_TagObjectUnion =
                     ): boolean =>
                         [
                             ("string" === typeof input.value &&
-                                3 <= input.value.length &&
-                                7 >= input.value.length) ||
+                                (3 <= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@minLength 3)",
+                                        value: input.value,
+                                    })) &&
+                                (7 >= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.value,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "string",

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagPattern.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagPattern.ts
@@ -23,40 +23,64 @@ export const test_createValidateStringify_TagPattern = _test_validateStringify(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                ).test(input.uuid)) ||
+                                ).test(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected:
+                                        "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                ).test(input.email)) ||
+                                ).test(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected:
+                                        'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                ).test(input.ipv4)) ||
+                                ).test(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected:
+                                        "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                ).test(input.ipv6)) ||
+                                ).test(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected:
+                                        "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagRange.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagRange.ts
@@ -24,7 +24,12 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                     [
                         ("number" === typeof input.greater &&
                             Number.isFinite(input.greater) &&
-                            3 < input.greater) ||
+                            (3 < input.greater ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater",
                                 expected: "number",
@@ -32,7 +37,12 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                             }),
                         ("number" === typeof input.greater_equal &&
                             Number.isFinite(input.greater_equal) &&
-                            3 <= input.greater_equal) ||
+                            (3 <= input.greater_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number",
@@ -40,7 +50,12 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                             }),
                         ("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
-                            7 > input.less) ||
+                            (7 > input.less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less",
                                 expected: "number",
@@ -48,39 +63,84 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                             }),
                         ("number" === typeof input.less_equal &&
                             Number.isFinite(input.less_equal) &&
-                            7 >= input.less_equal) ||
+                            (7 >= input.less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less_equal",
                                 expected: "number",
                                 value: input.less_equal,
                             }),
                         ("number" === typeof input.greater_less &&
-                            3 < input.greater_less &&
-                            7 > input.greater_less) ||
+                            (3 < input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less,
+                                })) &&
+                            (7 > input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number",
                                 value: input.greater_less,
                             }),
                         ("number" === typeof input.greater_equal_less &&
-                            3 <= input.greater_equal_less &&
-                            7 > input.greater_equal_less) ||
+                            (3 <= input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less,
+                                })) &&
+                            (7 > input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_equal_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less",
                                 expected: "number",
                                 value: input.greater_equal_less,
                             }),
                         ("number" === typeof input.greater_less_equal &&
-                            3 < input.greater_less_equal &&
-                            7 >= input.greater_less_equal) ||
+                            (3 < input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            (7 >= input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number",
                                 value: input.greater_less_equal,
                             }),
                         ("number" === typeof input.greater_equal_less_equal &&
-                            3 <= input.greater_equal_less_equal &&
-                            7 >= input.greater_equal_less_equal) ||
+                            (3 <= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
+                            (7 >= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_equal_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagStep.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagStep.ts
@@ -23,34 +23,84 @@ export const test_createValidateStringify_TagStep = _test_validateStringify(
                 ): boolean =>
                     [
                         ("number" === typeof input.exclusiveMinimum &&
-                            0 === (input.exclusiveMinimum % 5) - 3 &&
-                            3 < input.exclusiveMinimum) ||
+                            (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@step 5)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (3 < input.exclusiveMinimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.exclusiveMinimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".exclusiveMinimum",
                                 expected: "number",
                                 value: input.exclusiveMinimum,
                             }),
                         ("number" === typeof input.minimum &&
-                            0 === (input.minimum % 5) - 3 &&
-                            3 <= input.minimum) ||
+                            (0 === (input.minimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@step 5)",
+                                    value: input.minimum,
+                                })) &&
+                            (3 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
                                 value: input.minimum,
                             }),
                         ("number" === typeof input.range &&
-                            0 === (input.range % 5) - 0 &&
-                            0 < input.range &&
-                            100 > input.range) ||
+                            (0 === (input.range % 5) - 0 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@step 5)",
+                                    value: input.range,
+                                })) &&
+                            (0 < input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMinimum 0)",
+                                    value: input.range,
+                                })) &&
+                            (100 > input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMaximum 100)",
+                                    value: input.range,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".range",
                                 expected: "number",
                                 value: input.range,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 5 &&
-                            3 <= input.multipleOf &&
-                            99 >= input.multipleOf) ||
+                            (0 === input.multipleOf % 5 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 5)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (3 <= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@minimum 3)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (99 >= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@maximum 99)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagTuple.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagTuple.ts
@@ -38,24 +38,56 @@ export const test_createValidateStringify_TagTuple = _test_validateStringify(
                                 })) &&
                             [
                                 ("string" === typeof input.tuple[0] &&
-                                    3 <= input.tuple[0].length &&
-                                    7 >= input.tuple[0].length) ||
+                                    (3 <= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@minLength 3)",
+                                            value: input.tuple[0],
+                                        })) &&
+                                    (7 >= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@maxLength 7)",
+                                            value: input.tuple[0],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[0]",
                                         expected: "string",
                                         value: input.tuple[0],
                                     }),
                                 ("number" === typeof input.tuple[1] &&
-                                    3 <= input.tuple[1] &&
-                                    7 >= input.tuple[1]) ||
+                                    (3 <= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@minimum 3)",
+                                            value: input.tuple[1],
+                                        })) &&
+                                    (7 >= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@maximum 7)",
+                                            value: input.tuple[1],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[1]",
                                         expected: "number",
                                         value: input.tuple[1],
                                     }),
                                 (((Array.isArray(input.tuple[2]) &&
-                                    3 <= input.tuple[2].length &&
-                                    7 >= input.tuple[2].length) ||
+                                    (3 <= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[2],
+                                        })) &&
+                                    (7 >= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[2],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[2]",
                                         expected: "Array<string>",
@@ -65,8 +97,34 @@ export const test_createValidateStringify_TagTuple = _test_validateStringify(
                                         .map(
                                             (elem: any, _index1: number) =>
                                                 ("string" === typeof elem &&
-                                                    3 <= elem.length &&
-                                                    7 >= elem.length) ||
+                                                    (3 <= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@minLength 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@maxLength 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
@@ -84,8 +142,20 @@ export const test_createValidateStringify_TagTuple = _test_validateStringify(
                                         value: input.tuple[2],
                                     }),
                                 (((Array.isArray(input.tuple[3]) &&
-                                    3 <= input.tuple[3].length &&
-                                    7 >= input.tuple[3].length) ||
+                                    (3 <= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[3],
+                                        })) &&
+                                    (7 >= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[3],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[3]",
                                         expected: "Array<number>",
@@ -95,8 +165,34 @@ export const test_createValidateStringify_TagTuple = _test_validateStringify(
                                         .map(
                                             (elem: any, _index2: number) =>
                                                 ("number" === typeof elem &&
-                                                    3 <= elem &&
-                                                    7 >= elem) ||
+                                                    (3 <= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@minimum 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@maximum 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagType.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagType.ts
@@ -24,7 +24,12 @@ export const test_createValidateStringify_TagType = _test_validateStringify(
                     [
                         ("number" === typeof input.int &&
                             Number.isFinite(input.int) &&
-                            parseInt(input.int) === input.int) ||
+                            (parseInt(input.int) === input.int ||
+                                $report(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".int",
                                 expected: "number",
@@ -32,8 +37,18 @@ export const test_createValidateStringify_TagType = _test_validateStringify(
                             }),
                         ("number" === typeof input.uint &&
                             Number.isFinite(input.uint) &&
-                            parseInt(input.uint) === input.uint &&
-                            0 <= input.uint) ||
+                            (parseInt(input.uint) === input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (0 <= input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number",

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_UltimateUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_UltimateUnion.ts
@@ -1220,8 +1220,13 @@ export const test_createValidateStringify_UltimateUnion =
                             undefined === input.minimum ||
                                 ("number" === typeof input.minimum &&
                                     Number.isFinite(input.minimum) &&
-                                    parseInt(input.minimum) ===
-                                        input.minimum) ||
+                                    (parseInt(input.minimum) ===
+                                        input.minimum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "(number | undefined)",
@@ -1230,8 +1235,13 @@ export const test_createValidateStringify_UltimateUnion =
                             undefined === input.maximum ||
                                 ("number" === typeof input.maximum &&
                                     Number.isFinite(input.maximum) &&
-                                    parseInt(input.maximum) ===
-                                        input.maximum) ||
+                                    (parseInt(input.maximum) ===
+                                        input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "(number | undefined)",
@@ -1254,8 +1264,13 @@ export const test_createValidateStringify_UltimateUnion =
                             undefined === input.multipleOf ||
                                 ("number" === typeof input.multipleOf &&
                                     Number.isFinite(input.multipleOf) &&
-                                    parseInt(input.multipleOf) ===
-                                        input.multipleOf) ||
+                                    (parseInt(input.multipleOf) ===
+                                        input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "(number | undefined)",
@@ -1624,9 +1639,19 @@ export const test_createValidateStringify_UltimateUnion =
                             undefined === input.minLength ||
                                 ("number" === typeof input.minLength &&
                                     Number.isFinite(input.minLength) &&
-                                    parseInt(input.minLength) ===
-                                        input.minLength &&
-                                    0 <= input.minLength) ||
+                                    (parseInt(input.minLength) ===
+                                        input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        })) &&
+                                    (0 <= input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minLength",
                                     expected: "(number | undefined)",
@@ -1635,9 +1660,19 @@ export const test_createValidateStringify_UltimateUnion =
                             undefined === input.maxLength ||
                                 ("number" === typeof input.maxLength &&
                                     Number.isFinite(input.maxLength) &&
-                                    parseInt(input.maxLength) ===
-                                        input.maxLength &&
-                                    0 <= input.maxLength) ||
+                                    (parseInt(input.maxLength) ===
+                                        input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxLength",
                                     expected: "(number | undefined)",
@@ -1840,9 +1875,19 @@ export const test_createValidateStringify_UltimateUnion =
                             undefined === input.minItems ||
                                 ("number" === typeof input.minItems &&
                                     Number.isFinite(input.minItems) &&
-                                    parseInt(input.minItems) ===
-                                        input.minItems &&
-                                    0 <= input.minItems) ||
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
                                     expected: "(number | undefined)",
@@ -1851,9 +1896,19 @@ export const test_createValidateStringify_UltimateUnion =
                             undefined === input.maxItems ||
                                 ("number" === typeof input.maxItems &&
                                     Number.isFinite(input.maxItems) &&
-                                    parseInt(input.maxItems) ===
-                                        input.maxItems &&
-                                    0 <= input.maxItems) ||
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "(number | undefined)",

--- a/test/generated/output/equals/test_equals_TagCustom.ts
+++ b/test/generated/output/equals/test_equals_TagCustom.ts
@@ -15,8 +15,8 @@ export const test_equals_TagCustom = _test_equals(
             ): boolean =>
                 "string" === typeof input.id &&
                 true === $is_uuid(input.id) &&
-                "string" === typeof input.dolloar &&
-                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.dollar &&
+                $is_custom("dollar", "string", "", input.dollar) &&
                 "string" === typeof input.postfix &&
                 $is_custom("postfix", "string", "abcd", input.postfix) &&
                 "number" === typeof input.log &&
@@ -25,7 +25,7 @@ export const test_equals_TagCustom = _test_equals(
                 (4 === Object.keys(input).length ||
                     Object.keys(input).every((key) => {
                         if (
-                            ["id", "dolloar", "postfix", "log"].some(
+                            ["id", "dollar", "postfix", "log"].some(
                                 (prop) => key === prop,
                             )
                         )

--- a/test/generated/output/is/test_is_TagCustom.ts
+++ b/test/generated/output/is/test_is_TagCustom.ts
@@ -12,8 +12,8 @@ export const test_is_TagCustom = _test_is(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 true === $is_uuid(input.id) &&
-                "string" === typeof input.dolloar &&
-                $is_custom("dollar", "string", "", input.dolloar) &&
+                "string" === typeof input.dollar &&
+                $is_custom("dollar", "string", "", input.dollar) &&
                 "string" === typeof input.postfix &&
                 $is_custom("postfix", "string", "abcd", input.postfix) &&
                 "number" === typeof input.log &&

--- a/test/generated/output/isClone/test_isClone_TagCustom.ts
+++ b/test/generated/output/isClone/test_isClone_TagCustom.ts
@@ -13,8 +13,8 @@ export const test_isClone_TagCustom = _test_isClone(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     true === $is_uuid(input.id) &&
-                    "string" === typeof input.dolloar &&
-                    $is_custom("dollar", "string", "", input.dolloar) &&
+                    "string" === typeof input.dollar &&
+                    $is_custom("dollar", "string", "", input.dollar) &&
                     "string" === typeof input.postfix &&
                     $is_custom("postfix", "string", "abcd", input.postfix) &&
                     "number" === typeof input.log &&
@@ -29,7 +29,7 @@ export const test_isClone_TagCustom = _test_isClone(
                 const $is_custom = (typia.isClone as any).is_custom;
                 const $co0 = (input: any): any => ({
                     id: input.id as any,
-                    dolloar: input.dolloar as any,
+                    dollar: input.dollar as any,
                     postfix: input.postfix as any,
                     log: input.log as any,
                 });

--- a/test/generated/output/isParse/test_isParse_TagCustom.ts
+++ b/test/generated/output/isParse/test_isParse_TagCustom.ts
@@ -13,8 +13,8 @@ export const test_isParse_TagCustom = _test_isParse(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     true === $is_uuid(input.id) &&
-                    "string" === typeof input.dolloar &&
-                    $is_custom("dollar", "string", "", input.dolloar) &&
+                    "string" === typeof input.dollar &&
+                    $is_custom("dollar", "string", "", input.dollar) &&
                     "string" === typeof input.postfix &&
                     $is_custom("postfix", "string", "abcd", input.postfix) &&
                     "number" === typeof input.log &&

--- a/test/generated/output/isPrune/test_isPrune_TagCustom.ts
+++ b/test/generated/output/isPrune/test_isPrune_TagCustom.ts
@@ -13,8 +13,8 @@ export const test_isPrune_TagCustom = _test_isPrune(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     true === $is_uuid(input.id) &&
-                    "string" === typeof input.dolloar &&
-                    $is_custom("dollar", "string", "", input.dolloar) &&
+                    "string" === typeof input.dollar &&
+                    $is_custom("dollar", "string", "", input.dollar) &&
                     "string" === typeof input.postfix &&
                     $is_custom("postfix", "string", "abcd", input.postfix) &&
                     "number" === typeof input.log &&
@@ -31,7 +31,7 @@ export const test_isPrune_TagCustom = _test_isPrune(
                     for (const key of Object.keys(input)) {
                         if (
                             "id" === key ||
-                            "dolloar" === key ||
+                            "dollar" === key ||
                             "postfix" === key ||
                             "log" === key
                         )

--- a/test/generated/output/isStringify/test_isStringify_TagCustom.ts
+++ b/test/generated/output/isStringify/test_isStringify_TagCustom.ts
@@ -13,8 +13,8 @@ export const test_isStringify_TagCustom = _test_isStringify(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     true === $is_uuid(input.id) &&
-                    "string" === typeof input.dolloar &&
-                    $is_custom("dollar", "string", "", input.dolloar) &&
+                    "string" === typeof input.dollar &&
+                    $is_custom("dollar", "string", "", input.dollar) &&
                     "string" === typeof input.postfix &&
                     $is_custom("postfix", "string", "abcd", input.postfix) &&
                     "number" === typeof input.log &&
@@ -30,8 +30,8 @@ export const test_isStringify_TagCustom = _test_isStringify(
                 const $is_uuid = (typia.isStringify as any).is_uuid;
                 const $is_custom = (typia.isStringify as any).is_custom;
                 const $so0 = (input: any): any =>
-                    `{"id":${'"' + input.id + '"'},"dolloar":${$string(
-                        input.dolloar,
+                    `{"id":${'"' + input.id + '"'},"dollar":${$string(
+                        input.dollar,
                     )},"postfix":${$string(input.postfix)},"log":${$number(
                         input.log,
                     )}}`;

--- a/test/generated/output/prune/test_prune_TagCustom.ts
+++ b/test/generated/output/prune/test_prune_TagCustom.ts
@@ -13,7 +13,7 @@ export const test_prune_TagCustom = _test_prune(
                 for (const key of Object.keys(input)) {
                     if (
                         "id" === key ||
-                        "dolloar" === key ||
+                        "dollar" === key ||
                         "postfix" === key ||
                         "log" === key
                     )

--- a/test/generated/output/random/test_random_TagArray.ts
+++ b/test/generated/output/random/test_random_TagArray.ts
@@ -58,7 +58,13 @@ export const test_random_TagArray = _test_random(
                 _path: string,
                 _exceptionable: boolean = true,
             ): boolean =>
-                ((Array.isArray(input.items) && 3 === input.items.length) ||
+                ((Array.isArray(input.items) &&
+                    (3 === input.items.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".items",
+                            expected: "Array.length (@items 3)",
+                            value: input.items,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".items",
                         expected: "Array<string>",
@@ -66,7 +72,13 @@ export const test_random_TagArray = _test_random(
                     })) &&
                 input.items.every(
                     (elem: any, _index2: number) =>
-                        ("string" === typeof elem && true === $is_uuid(elem)) ||
+                        ("string" === typeof elem &&
+                            (true === $is_uuid(elem) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items[" + _index2 + "]",
+                                    expected: "string (@format uuid)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".items[" + _index2 + "]",
                             expected: "string",
@@ -74,7 +86,12 @@ export const test_random_TagArray = _test_random(
                         }),
                 ) &&
                 ((Array.isArray(input.minItems) &&
-                    3 <= input.minItems.length) ||
+                    (3 <= input.minItems.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minItems",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.minItems,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minItems",
                         expected: "Array<number>",
@@ -84,7 +101,12 @@ export const test_random_TagArray = _test_random(
                     (elem: any, _index3: number) =>
                         ("number" === typeof elem &&
                             Number.isFinite(elem) &&
-                            3 <= elem) ||
+                            (3 <= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems[" + _index3 + "]",
+                                    expected: "number (@minimum 3)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems[" + _index3 + "]",
                             expected: "number",
@@ -92,7 +114,12 @@ export const test_random_TagArray = _test_random(
                         }),
                 ) &&
                 ((Array.isArray(input.maxItems) &&
-                    7 >= input.maxItems.length) ||
+                    (7 >= input.maxItems.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maxItems",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.maxItems,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maxItems",
                         expected: "Array<(number | string)>",
@@ -100,10 +127,21 @@ export const test_random_TagArray = _test_random(
                     })) &&
                 input.maxItems.every(
                     (elem: any, _index4: number) =>
-                        ("string" === typeof elem && 7 >= elem.length) ||
+                        ("string" === typeof elem &&
+                            (7 >= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems[" + _index4 + "]",
+                                    expected: "string (@maxLength 7)",
+                                    value: elem,
+                                }))) ||
                         ("number" === typeof elem &&
                             Number.isFinite(elem) &&
-                            7 >= elem) ||
+                            (7 >= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems[" + _index4 + "]",
+                                    expected: "number (@maximum 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".maxItems[" + _index4 + "]",
                             expected: "(number | string)",
@@ -111,8 +149,18 @@ export const test_random_TagArray = _test_random(
                         }),
                 ) &&
                 ((Array.isArray(input.both) &&
-                    3 <= input.both.length &&
-                    7 >= input.both.length) ||
+                    (3 <= input.both.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".both",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.both,
+                        })) &&
+                    (7 >= input.both.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".both",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.both,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".both",
                         expected: "Array<string>",
@@ -120,7 +168,13 @@ export const test_random_TagArray = _test_random(
                     })) &&
                 input.both.every(
                     (elem: any, _index5: number) =>
-                        ("string" === typeof elem && true === $is_uuid(elem)) ||
+                        ("string" === typeof elem &&
+                            (true === $is_uuid(elem) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".both[" + _index5 + "]",
+                                    expected: "string (@format uuid)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".both[" + _index5 + "]",
                             expected: "string",

--- a/test/generated/output/random/test_random_TagAtomicUnion.ts
+++ b/test/generated/output/random/test_random_TagAtomicUnion.ts
@@ -38,11 +38,26 @@ export const test_random_TagAtomicUnion = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 ("string" === typeof input.value &&
-                    3 <= input.value.length &&
-                    7 >= input.value.length) ||
+                    (3 <= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@minLength 3)",
+                            value: input.value,
+                        })) &&
+                    (7 >= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@maxLength 7)",
+                            value: input.value,
+                        }))) ||
                 ("number" === typeof input.value &&
                     Number.isFinite(input.value) &&
-                    3 <= input.value) ||
+                    (3 <= input.value ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "number (@minimum 3)",
+                            value: input.value,
+                        }))) ||
                 $guard(_exceptionable, {
                     path: _path + ".value",
                     expected: "(number | string)",

--- a/test/generated/output/random/test_random_TagBigInt.ts
+++ b/test/generated/output/random/test_random_TagBigInt.ts
@@ -58,27 +58,54 @@ export const test_random_TagBigInt = _test_random(
                         value: input.value,
                     })) &&
                 (("bigint" === typeof input.ranged &&
-                    0n <= input.ranged &&
-                    100n >= input.ranged) ||
+                    (0n <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "bigint (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100n >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "bigint (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "bigint",
                         value: input.ranged,
                     })) &&
-                (("bigint" === typeof input.minimum && 0n <= input.minimum) ||
+                (("bigint" === typeof input.minimum &&
+                    (0n <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "bigint (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "bigint",
                         value: input.minimum,
                     })) &&
-                (("bigint" === typeof input.maximum && 100n >= input.maximum) ||
+                (("bigint" === typeof input.maximum &&
+                    (100n >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "bigint (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "bigint",
                         value: input.maximum,
                     })) &&
                 (("bigint" === typeof input.multipleOf &&
-                    0n === input.multipleOf % 3n) ||
+                    (0n === input.multipleOf % 3n ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "bigint (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "bigint",

--- a/test/generated/output/random/test_random_TagFormat.ts
+++ b/test/generated/output/random/test_random_TagFormat.ts
@@ -47,63 +47,108 @@ export const test_random_TagFormat = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.uuid &&
-                    true === $is_uuid(input.uuid)) ||
+                    (true === $is_uuid(input.uuid) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uuid",
+                            expected: "string (@format uuid)",
+                            value: input.uuid,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uuid",
                         expected: "string",
                         value: input.uuid,
                     })) &&
                 (("string" === typeof input.email &&
-                    true === $is_email(input.email)) ||
+                    (true === $is_email(input.email) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".email",
+                            expected: "string (@format email)",
+                            value: input.email,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".email",
                         expected: "string",
                         value: input.email,
                     })) &&
                 (("string" === typeof input.url &&
-                    true === $is_url(input.url)) ||
+                    (true === $is_url(input.url) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".url",
+                            expected: "string (@format url)",
+                            value: input.url,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".url",
                         expected: "string",
                         value: input.url,
                     })) &&
                 (("string" === typeof input.ipv4 &&
-                    true === $is_ipv4(input.ipv4)) ||
+                    (true === $is_ipv4(input.ipv4) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv4",
+                            expected: "string (@format ipv4)",
+                            value: input.ipv4,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv4",
                         expected: "string",
                         value: input.ipv4,
                     })) &&
                 (("string" === typeof input.ipv6 &&
-                    true === $is_ipv6(input.ipv6)) ||
+                    (true === $is_ipv6(input.ipv6) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv6",
+                            expected: "string (@format ipv6)",
+                            value: input.ipv6,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv6",
                         expected: "string",
                         value: input.ipv6,
                     })) &&
                 (("string" === typeof input.date &&
-                    true === $is_date(input.date)) ||
+                    (true === $is_date(input.date) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".date",
+                            expected: "string (@format date)",
+                            value: input.date,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".date",
                         expected: "string",
                         value: input.date,
                     })) &&
                 (("string" === typeof input.date_time &&
-                    true === $is_datetime(input.date_time)) ||
+                    (true === $is_datetime(input.date_time) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".date_time",
+                            expected: "string (@format datetime)",
+                            value: input.date_time,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".date_time",
                         expected: "string",
                         value: input.date_time,
                     })) &&
                 (("string" === typeof input.datetime &&
-                    true === $is_datetime(input.datetime)) ||
+                    (true === $is_datetime(input.datetime) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".datetime",
+                            expected: "string (@format datetime)",
+                            value: input.datetime,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".datetime",
                         expected: "string",
                         value: input.datetime,
                     })) &&
                 (("string" === typeof input.dateTime &&
-                    true === $is_datetime(input.dateTime)) ||
+                    (true === $is_datetime(input.dateTime) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".dateTime",
+                            expected: "string (@format datetime)",
+                            value: input.dateTime,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".dateTime",
                         expected: "string",

--- a/test/generated/output/random/test_random_TagInfinite.ts
+++ b/test/generated/output/random/test_random_TagInfinite.ts
@@ -44,8 +44,18 @@ export const test_random_TagInfinite = _test_random(
                         value: input.value,
                     })) &&
                 (("number" === typeof input.ranged &&
-                    0 <= input.ranged &&
-                    100 >= input.ranged) ||
+                    (0 <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100 >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "number",
@@ -53,7 +63,12 @@ export const test_random_TagInfinite = _test_random(
                     })) &&
                 (("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
-                    0 <= input.minimum) ||
+                    (0 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
@@ -61,14 +76,24 @@ export const test_random_TagInfinite = _test_random(
                     })) &&
                 (("number" === typeof input.maximum &&
                     Number.isFinite(input.maximum) &&
-                    100 >= input.maximum) ||
+                    (100 >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "number (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "number",
                         value: input.maximum,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 3) ||
+                    (0 === input.multipleOf % 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",
@@ -76,7 +101,12 @@ export const test_random_TagInfinite = _test_random(
                     })) &&
                 (("number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
-                    parseInt(input.typed) === input.typed) ||
+                    (parseInt(input.typed) === input.typed ||
+                        $guard(_exceptionable, {
+                            path: _path + ".typed",
+                            expected: "number (@type int)",
+                            value: input.typed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".typed",
                         expected: "number",

--- a/test/generated/output/random/test_random_TagLength.ts
+++ b/test/generated/output/random/test_random_TagLength.ts
@@ -40,29 +40,54 @@ export const test_random_TagLength = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.fixed &&
-                    5 === input.fixed.length) ||
+                    (5 === input.fixed.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".fixed",
+                            expected: "string (@length 5)",
+                            value: input.fixed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".fixed",
                         expected: "string",
                         value: input.fixed,
                     })) &&
                 (("string" === typeof input.minimum &&
-                    3 <= input.minimum.length) ||
+                    (3 <= input.minimum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "string (@minLength 3)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "string",
                         value: input.minimum,
                     })) &&
                 (("string" === typeof input.maximum &&
-                    7 >= input.maximum.length) ||
+                    (7 >= input.maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "string (@maxLength 7)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "string",
                         value: input.maximum,
                     })) &&
                 (("string" === typeof input.minimum_and_maximum &&
-                    3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length) ||
+                    (3 <= input.minimum_and_maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum_and_maximum",
+                            expected: "string (@minLength 3)",
+                            value: input.minimum_and_maximum,
+                        })) &&
+                    (7 >= input.minimum_and_maximum.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum_and_maximum",
+                            expected: "string (@maxLength 7)",
+                            value: input.minimum_and_maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum_and_maximum",
                         expected: "string",

--- a/test/generated/output/random/test_random_TagMatrix.ts
+++ b/test/generated/output/random/test_random_TagMatrix.ts
@@ -38,7 +38,13 @@ export const test_random_TagMatrix = _test_random(
                 _path: string,
                 _exceptionable: boolean = true,
             ): boolean =>
-                ((Array.isArray(input.matrix) && 3 === input.matrix.length) ||
+                ((Array.isArray(input.matrix) &&
+                    (3 === input.matrix.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".matrix",
+                            expected: "Array.length (@items 3)",
+                            value: input.matrix,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".matrix",
                         expected: "Array<Array<string>>",
@@ -46,7 +52,13 @@ export const test_random_TagMatrix = _test_random(
                     })) &&
                 input.matrix.every(
                     (elem: any, _index1: number) =>
-                        ((Array.isArray(elem) && 3 === elem.length) ||
+                        ((Array.isArray(elem) &&
+                            (3 === elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".matrix[" + _index1 + "]",
+                                    expected: "Array.length (@items 3)",
+                                    value: elem,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".matrix[" + _index1 + "]",
                                 expected: "Array<string>",
@@ -55,7 +67,18 @@ export const test_random_TagMatrix = _test_random(
                         elem.every(
                             (elem: any, _index2: number) =>
                                 ("string" === typeof elem &&
-                                    true === $is_uuid(elem)) ||
+                                    (true === $is_uuid(elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".matrix[" +
+                                                _index1 +
+                                                "][" +
+                                                _index2 +
+                                                "]",
+                                            expected: "string (@format uuid)",
+                                            value: elem,
+                                        }))) ||
                                 $guard(_exceptionable, {
                                     path:
                                         _path +

--- a/test/generated/output/random/test_random_TagNaN.ts
+++ b/test/generated/output/random/test_random_TagNaN.ts
@@ -44,8 +44,18 @@ export const test_random_TagNaN = _test_random(
                         value: input.value,
                     })) &&
                 (("number" === typeof input.ranged &&
-                    0 <= input.ranged &&
-                    100 >= input.ranged) ||
+                    (0 <= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@minimum 0)",
+                            value: input.ranged,
+                        })) &&
+                    (100 >= input.ranged ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ranged",
+                            expected: "number (@maximum 100)",
+                            value: input.ranged,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ranged",
                         expected: "number",
@@ -53,7 +63,12 @@ export const test_random_TagNaN = _test_random(
                     })) &&
                 (("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
-                    0 <= input.minimum) ||
+                    (0 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 0)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
@@ -61,14 +76,24 @@ export const test_random_TagNaN = _test_random(
                     })) &&
                 (("number" === typeof input.maximum &&
                     Number.isFinite(input.maximum) &&
-                    100 >= input.maximum) ||
+                    (100 >= input.maximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "number (@maximum 100)",
+                            value: input.maximum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".maximum",
                         expected: "number",
                         value: input.maximum,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 3) ||
+                    (0 === input.multipleOf % 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 3)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",
@@ -76,7 +101,12 @@ export const test_random_TagNaN = _test_random(
                     })) &&
                 (("number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
-                    parseInt(input.typed) === input.typed) ||
+                    (parseInt(input.typed) === input.typed ||
+                        $guard(_exceptionable, {
+                            path: _path + ".typed",
+                            expected: "number (@type int)",
+                            value: input.typed,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".typed",
                         expected: "number",

--- a/test/generated/output/random/test_random_TagObjectUnion.ts
+++ b/test/generated/output/random/test_random_TagObjectUnion.ts
@@ -43,7 +43,12 @@ export const test_random_TagObjectUnion = _test_random(
             ): boolean =>
                 ("number" === typeof input.value &&
                     Number.isFinite(input.value) &&
-                    3 <= input.value) ||
+                    (3 <= input.value ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "number (@minimum 3)",
+                            value: input.value,
+                        }))) ||
                 $guard(_exceptionable, {
                     path: _path + ".value",
                     expected: "number",
@@ -55,8 +60,18 @@ export const test_random_TagObjectUnion = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 ("string" === typeof input.value &&
-                    3 <= input.value.length &&
-                    7 >= input.value.length) ||
+                    (3 <= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@minLength 3)",
+                            value: input.value,
+                        })) &&
+                    (7 >= input.value.length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".value",
+                            expected: "string (@maxLength 7)",
+                            value: input.value,
+                        }))) ||
                 $guard(_exceptionable, {
                     path: _path + ".value",
                     expected: "string",

--- a/test/generated/output/random/test_random_TagPattern.ts
+++ b/test/generated/output/random/test_random_TagPattern.ts
@@ -42,40 +42,64 @@ export const test_random_TagPattern = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("string" === typeof input.uuid &&
-                    true ===
+                    (true ===
                         RegExp(
                             /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                        ).test(input.uuid)) ||
+                        ).test(input.uuid) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uuid",
+                            expected:
+                                "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                            value: input.uuid,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uuid",
                         expected: "string",
                         value: input.uuid,
                     })) &&
                 (("string" === typeof input.email &&
-                    true ===
+                    (true ===
                         RegExp(
                             /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                        ).test(input.email)) ||
+                        ).test(input.email) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".email",
+                            expected:
+                                'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                            value: input.email,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".email",
                         expected: "string",
                         value: input.email,
                     })) &&
                 (("string" === typeof input.ipv4 &&
-                    true ===
+                    (true ===
                         RegExp(
                             /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                        ).test(input.ipv4)) ||
+                        ).test(input.ipv4) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv4",
+                            expected:
+                                "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                            value: input.ipv4,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv4",
                         expected: "string",
                         value: input.ipv4,
                     })) &&
                 (("string" === typeof input.ipv6 &&
-                    true ===
+                    (true ===
                         RegExp(
                             /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                        ).test(input.ipv6)) ||
+                        ).test(input.ipv6) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".ipv6",
+                            expected:
+                                "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                            value: input.ipv6,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".ipv6",
                         expected: "string",

--- a/test/generated/output/random/test_random_TagRange.ts
+++ b/test/generated/output/random/test_random_TagRange.ts
@@ -47,7 +47,12 @@ export const test_random_TagRange = _test_random(
             ): boolean =>
                 (("number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
-                    3 < input.greater) ||
+                    (3 < input.greater ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater",
                         expected: "number",
@@ -55,7 +60,12 @@ export const test_random_TagRange = _test_random(
                     })) &&
                 (("number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
-                    3 <= input.greater_equal) ||
+                    (3 <= input.greater_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal",
                         expected: "number",
@@ -63,7 +73,12 @@ export const test_random_TagRange = _test_random(
                     })) &&
                 (("number" === typeof input.less &&
                     Number.isFinite(input.less) &&
-                    7 > input.less) ||
+                    (7 > input.less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".less",
                         expected: "number",
@@ -71,39 +86,84 @@ export const test_random_TagRange = _test_random(
                     })) &&
                 (("number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
-                    7 >= input.less_equal) ||
+                    (7 >= input.less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".less_equal",
                         expected: "number",
                         value: input.less_equal,
                     })) &&
                 (("number" === typeof input.greater_less &&
-                    3 < input.greater_less &&
-                    7 > input.greater_less) ||
+                    (3 < input.greater_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater_less,
+                        })) &&
+                    (7 > input.greater_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.greater_less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_less",
                         expected: "number",
                         value: input.greater_less,
                     })) &&
                 (("number" === typeof input.greater_equal_less &&
-                    3 <= input.greater_equal_less &&
-                    7 > input.greater_equal_less) ||
+                    (3 <= input.greater_equal_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal_less,
+                        })) &&
+                    (7 > input.greater_equal_less ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less",
+                            expected: "number (@exclusiveMaximum 7)",
+                            value: input.greater_equal_less,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal_less",
                         expected: "number",
                         value: input.greater_equal_less,
                     })) &&
                 (("number" === typeof input.greater_less_equal &&
-                    3 < input.greater_less_equal &&
-                    7 >= input.greater_less_equal) ||
+                    (3 < input.greater_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less_equal",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.greater_less_equal,
+                        })) &&
+                    (7 >= input.greater_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.greater_less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_less_equal",
                         expected: "number",
                         value: input.greater_less_equal,
                     })) &&
                 (("number" === typeof input.greater_equal_less_equal &&
-                    3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal) ||
+                    (3 <= input.greater_equal_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less_equal",
+                            expected: "number (@minimum 3)",
+                            value: input.greater_equal_less_equal,
+                        })) &&
+                    (7 >= input.greater_equal_less_equal ||
+                        $guard(_exceptionable, {
+                            path: _path + ".greater_equal_less_equal",
+                            expected: "number (@maximum 7)",
+                            value: input.greater_equal_less_equal,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".greater_equal_less_equal",
                         expected: "number",

--- a/test/generated/output/random/test_random_TagStep.ts
+++ b/test/generated/output/random/test_random_TagStep.ts
@@ -37,34 +37,84 @@ export const test_random_TagStep = _test_random(
                 _exceptionable: boolean = true,
             ): boolean =>
                 (("number" === typeof input.exclusiveMinimum &&
-                    0 === (input.exclusiveMinimum % 5) - 3 &&
-                    3 < input.exclusiveMinimum) ||
+                    (0 === (input.exclusiveMinimum % 5) - 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "number (@step 5)",
+                            value: input.exclusiveMinimum,
+                        })) &&
+                    (3 < input.exclusiveMinimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "number (@exclusiveMinimum 3)",
+                            value: input.exclusiveMinimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".exclusiveMinimum",
                         expected: "number",
                         value: input.exclusiveMinimum,
                     })) &&
                 (("number" === typeof input.minimum &&
-                    0 === (input.minimum % 5) - 3 &&
-                    3 <= input.minimum) ||
+                    (0 === (input.minimum % 5) - 3 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@step 5)",
+                            value: input.minimum,
+                        })) &&
+                    (3 <= input.minimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "number (@minimum 3)",
+                            value: input.minimum,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".minimum",
                         expected: "number",
                         value: input.minimum,
                     })) &&
                 (("number" === typeof input.range &&
-                    0 === (input.range % 5) - 0 &&
-                    0 < input.range &&
-                    100 > input.range) ||
+                    (0 === (input.range % 5) - 0 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@step 5)",
+                            value: input.range,
+                        })) &&
+                    (0 < input.range ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@exclusiveMinimum 0)",
+                            value: input.range,
+                        })) &&
+                    (100 > input.range ||
+                        $guard(_exceptionable, {
+                            path: _path + ".range",
+                            expected: "number (@exclusiveMaximum 100)",
+                            value: input.range,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".range",
                         expected: "number",
                         value: input.range,
                     })) &&
                 (("number" === typeof input.multipleOf &&
-                    0 === input.multipleOf % 5 &&
-                    3 <= input.multipleOf &&
-                    99 >= input.multipleOf) ||
+                    (0 === input.multipleOf % 5 ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@multipleOf 5)",
+                            value: input.multipleOf,
+                        })) &&
+                    (3 <= input.multipleOf ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@minimum 3)",
+                            value: input.multipleOf,
+                        })) &&
+                    (99 >= input.multipleOf ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "number (@maximum 99)",
+                            value: input.multipleOf,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".multipleOf",
                         expected: "number",

--- a/test/generated/output/random/test_random_TagTuple.ts
+++ b/test/generated/output/random/test_random_TagTuple.ts
@@ -61,24 +61,54 @@ export const test_random_TagTuple = _test_random(
                         value: input.tuple,
                     })) &&
                 (("string" === typeof input.tuple[0] &&
-                    3 <= input.tuple[0].length &&
-                    7 >= input.tuple[0].length) ||
+                    (3 <= input.tuple[0].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[0]",
+                            expected: "string (@minLength 3)",
+                            value: input.tuple[0],
+                        })) &&
+                    (7 >= input.tuple[0].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[0]",
+                            expected: "string (@maxLength 7)",
+                            value: input.tuple[0],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[0]",
                         expected: "string",
                         value: input.tuple[0],
                     })) &&
                 (("number" === typeof input.tuple[1] &&
-                    3 <= input.tuple[1] &&
-                    7 >= input.tuple[1]) ||
+                    (3 <= input.tuple[1] ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[1]",
+                            expected: "number (@minimum 3)",
+                            value: input.tuple[1],
+                        })) &&
+                    (7 >= input.tuple[1] ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[1]",
+                            expected: "number (@maximum 7)",
+                            value: input.tuple[1],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[1]",
                         expected: "number",
                         value: input.tuple[1],
                     })) &&
                 ((Array.isArray(input.tuple[2]) &&
-                    3 <= input.tuple[2].length &&
-                    7 >= input.tuple[2].length) ||
+                    (3 <= input.tuple[2].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[2]",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.tuple[2],
+                        })) &&
+                    (7 >= input.tuple[2].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[2]",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.tuple[2],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[2]",
                         expected: "Array<string>",
@@ -87,8 +117,18 @@ export const test_random_TagTuple = _test_random(
                 input.tuple[2].every(
                     (elem: any, _index1: number) =>
                         ("string" === typeof elem &&
-                            3 <= elem.length &&
-                            7 >= elem.length) ||
+                            (3 <= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2][" + _index1 + "]",
+                                    expected: "string (@minLength 3)",
+                                    value: elem,
+                                })) &&
+                            (7 >= elem.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[2][" + _index1 + "]",
+                                    expected: "string (@maxLength 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[2][" + _index1 + "]",
                             expected: "string",
@@ -96,8 +136,18 @@ export const test_random_TagTuple = _test_random(
                         }),
                 ) &&
                 ((Array.isArray(input.tuple[3]) &&
-                    3 <= input.tuple[3].length &&
-                    7 >= input.tuple[3].length) ||
+                    (3 <= input.tuple[3].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[3]",
+                            expected: "Array.length (@minItems 3)",
+                            value: input.tuple[3],
+                        })) &&
+                    (7 >= input.tuple[3].length ||
+                        $guard(_exceptionable, {
+                            path: _path + ".tuple[3]",
+                            expected: "Array.length (@maxItems 7)",
+                            value: input.tuple[3],
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".tuple[3]",
                         expected: "Array<number>",
@@ -105,7 +155,19 @@ export const test_random_TagTuple = _test_random(
                     })) &&
                 input.tuple[3].every(
                     (elem: any, _index2: number) =>
-                        ("number" === typeof elem && 3 <= elem && 7 >= elem) ||
+                        ("number" === typeof elem &&
+                            (3 <= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3][" + _index2 + "]",
+                                    expected: "number (@minimum 3)",
+                                    value: elem,
+                                })) &&
+                            (7 >= elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".tuple[3][" + _index2 + "]",
+                                    expected: "number (@maximum 7)",
+                                    value: elem,
+                                }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".tuple[3][" + _index2 + "]",
                             expected: "number",

--- a/test/generated/output/random/test_random_TagType.ts
+++ b/test/generated/output/random/test_random_TagType.ts
@@ -33,7 +33,12 @@ export const test_random_TagType = _test_random(
             ): boolean =>
                 (("number" === typeof input.int &&
                     Number.isFinite(input.int) &&
-                    parseInt(input.int) === input.int) ||
+                    (parseInt(input.int) === input.int ||
+                        $guard(_exceptionable, {
+                            path: _path + ".int",
+                            expected: "number (@type int)",
+                            value: input.int,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".int",
                         expected: "number",
@@ -41,8 +46,18 @@ export const test_random_TagType = _test_random(
                     })) &&
                 (("number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
-                    parseInt(input.uint) === input.uint &&
-                    0 <= input.uint) ||
+                    (parseInt(input.uint) === input.uint ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uint",
+                            expected: "number (@type uint)",
+                            value: input.uint,
+                        })) &&
+                    (0 <= input.uint ||
+                        $guard(_exceptionable, {
+                            path: _path + ".uint",
+                            expected: "number (@type uint)",
+                            value: input.uint,
+                        }))) ||
                     $guard(_exceptionable, {
                         path: _path + ".uint",
                         expected: "number",

--- a/test/generated/output/stringify/test_stringify_TagCustom.ts
+++ b/test/generated/output/stringify/test_stringify_TagCustom.ts
@@ -12,8 +12,8 @@ export const test_stringify_TagCustom = _test_stringify(
             const $is_uuid = (typia.stringify as any).is_uuid;
             const $is_custom = (typia.stringify as any).is_custom;
             const $so0 = (input: any): any =>
-                `{"id":${'"' + input.id + '"'},"dolloar":${$string(
-                    input.dolloar,
+                `{"id":${'"' + input.id + '"'},"dollar":${$string(
+                    input.dollar,
                 )},"postfix":${$string(input.postfix)},"log":${$number(
                     input.log,
                 )}}`;

--- a/test/generated/output/validate/test_validate_TagArray.ts
+++ b/test/generated/output/validate/test_validate_TagArray.ts
@@ -22,7 +22,12 @@ export const test_validate_TagArray = _test_validate(
                 ): boolean =>
                     [
                         (((Array.isArray(input.items) &&
-                            3 === input.items.length) ||
+                            (3 === input.items.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.items,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".items",
                                 expected: "Array<string>",
@@ -32,7 +37,17 @@ export const test_validate_TagArray = _test_validate(
                                 .map(
                                     (elem: any, _index2: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -50,7 +65,12 @@ export const test_validate_TagArray = _test_validate(
                                 value: input.items,
                             }),
                         (((Array.isArray(input.minItems) &&
-                            3 <= input.minItems.length) ||
+                            (3 <= input.minItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.minItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "Array<number>",
@@ -61,7 +81,17 @@ export const test_validate_TagArray = _test_validate(
                                     (elem: any, _index3: number) =>
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            3 <= elem) ||
+                                            (3 <= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".minItems[" +
+                                                        _index3 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 3)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -79,7 +109,12 @@ export const test_validate_TagArray = _test_validate(
                                 value: input.minItems,
                             }),
                         (((Array.isArray(input.maxItems) &&
-                            7 >= input.maxItems.length) ||
+                            (7 >= input.maxItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.maxItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "Array<(number | string)>",
@@ -89,10 +124,30 @@ export const test_validate_TagArray = _test_validate(
                                 .map(
                                     (elem: any, _index4: number) =>
                                         ("string" === typeof elem &&
-                                            7 >= elem.length) ||
+                                            (7 >= elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@maxLength 7)",
+                                                    value: elem,
+                                                }))) ||
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            7 >= elem) ||
+                                            (7 >= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 7)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -110,8 +165,18 @@ export const test_validate_TagArray = _test_validate(
                                 value: input.maxItems,
                             }),
                         (((Array.isArray(input.both) &&
-                            3 <= input.both.length &&
-                            7 >= input.both.length) ||
+                            (3 <= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.both,
+                                })) &&
+                            (7 >= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.both,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".both",
                                 expected: "Array<string>",
@@ -121,7 +186,17 @@ export const test_validate_TagArray = _test_validate(
                                 .map(
                                     (elem: any, _index5: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".both[" +
+                                                        _index5 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +

--- a/test/generated/output/validate/test_validate_TagAtomicUnion.ts
+++ b/test/generated/output/validate/test_validate_TagAtomicUnion.ts
@@ -21,11 +21,26 @@ export const test_validate_TagAtomicUnion = _test_validate(
                 ): boolean =>
                     [
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                             ("number" === typeof input.value &&
                                 Number.isFinite(input.value) &&
-                                3 <= input.value) ||
+                                (3 <= input.value ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "number (@minimum 3)",
+                                        value: input.value,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "(number | string)",

--- a/test/generated/output/validate/test_validate_TagBigInt.ts
+++ b/test/generated/output/validate/test_validate_TagBigInt.ts
@@ -27,29 +27,54 @@ export const test_validate_TagBigInt = _test_validate(
                                 value: input.value,
                             }),
                         ("bigint" === typeof input.ranged &&
-                            0n <= input.ranged &&
-                            100n >= input.ranged) ||
+                            (0n <= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "bigint (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100n >= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "bigint (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "bigint",
                                 value: input.ranged,
                             }),
                         ("bigint" === typeof input.minimum &&
-                            0n <= input.minimum) ||
+                            (0n <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "bigint (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "bigint",
                                 value: input.minimum,
                             }),
                         ("bigint" === typeof input.maximum &&
-                            100n >= input.maximum) ||
+                            (100n >= input.maximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "bigint (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "bigint",
                                 value: input.maximum,
                             }),
                         ("bigint" === typeof input.multipleOf &&
-                            0n === input.multipleOf % 3n) ||
+                            (0n === input.multipleOf % 3n ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "bigint (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "bigint",

--- a/test/generated/output/validate/test_validate_TagCustom.ts
+++ b/test/generated/output/validate/test_validate_TagCustom.ts
@@ -23,31 +23,41 @@ export const test_validate_TagCustom = _test_validate(
                 ): boolean =>
                     [
                         ("string" === typeof input.id &&
-                            true === $is_uuid(input.id)) ||
+                            (true === $is_uuid(input.id) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string (@format uuid)",
+                                    value: input.id,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".id",
                                 expected: "string",
                                 value: input.id,
                             }),
-                        ("string" === typeof input.dolloar &&
-                            $is_custom(
-                                "dollar",
-                                "string",
-                                "",
-                                input.dolloar,
-                            )) ||
+                        ("string" === typeof input.dollar &&
+                            ($is_custom("dollar", "string", "", input.dollar) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dollar",
+                                    expected: "string (@dollar)",
+                                    value: input.dollar,
+                                }))) ||
                             $report(_exceptionable, {
-                                path: _path + ".dolloar",
+                                path: _path + ".dollar",
                                 expected: "string",
-                                value: input.dolloar,
+                                value: input.dollar,
                             }),
                         ("string" === typeof input.postfix &&
-                            $is_custom(
+                            ($is_custom(
                                 "postfix",
                                 "string",
                                 "abcd",
                                 input.postfix,
-                            )) ||
+                            ) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string (@postfix abcd)",
+                                    value: input.postfix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected: "string",
@@ -55,7 +65,12 @@ export const test_validate_TagCustom = _test_validate(
                             }),
                         ("number" === typeof input.log &&
                             Number.isFinite(input.log) &&
-                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            ($is_custom("powerOf", "number", "10", input.log) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number (@powerOf 10)",
+                                    value: input.log,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".log",
                                 expected: "number",

--- a/test/generated/output/validate/test_validate_TagFormat.ts
+++ b/test/generated/output/validate/test_validate_TagFormat.ts
@@ -28,63 +28,108 @@ export const test_validate_TagFormat = _test_validate(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true === $is_uuid(input.uuid)) ||
+                            (true === $is_uuid(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected: "string (@format uuid)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true === $is_email(input.email)) ||
+                            (true === $is_email(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected: "string (@format email)",
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.url &&
-                            true === $is_url(input.url)) ||
+                            (true === $is_url(input.url) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".url",
+                                    expected: "string (@format url)",
+                                    value: input.url,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".url",
                                 expected: "string",
                                 value: input.url,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true === $is_ipv4(input.ipv4)) ||
+                            (true === $is_ipv4(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected: "string (@format ipv4)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true === $is_ipv6(input.ipv6)) ||
+                            (true === $is_ipv6(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected: "string (@format ipv6)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",
                                 value: input.ipv6,
                             }),
                         ("string" === typeof input.date &&
-                            true === $is_date(input.date)) ||
+                            (true === $is_date(input.date) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date",
+                                    expected: "string (@format date)",
+                                    value: input.date,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date",
                                 expected: "string",
                                 value: input.date,
                             }),
                         ("string" === typeof input.date_time &&
-                            true === $is_datetime(input.date_time)) ||
+                            (true === $is_datetime(input.date_time) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date_time",
+                                    expected: "string (@format datetime)",
+                                    value: input.date_time,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date_time",
                                 expected: "string",
                                 value: input.date_time,
                             }),
                         ("string" === typeof input.datetime &&
-                            true === $is_datetime(input.datetime)) ||
+                            (true === $is_datetime(input.datetime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".datetime",
+                                    expected: "string (@format datetime)",
+                                    value: input.datetime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".datetime",
                                 expected: "string",
                                 value: input.datetime,
                             }),
                         ("string" === typeof input.dateTime &&
-                            true === $is_datetime(input.dateTime)) ||
+                            (true === $is_datetime(input.dateTime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dateTime",
+                                    expected: "string (@format datetime)",
+                                    value: input.dateTime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".dateTime",
                                 expected: "string",

--- a/test/generated/output/validate/test_validate_TagInfinite.ts
+++ b/test/generated/output/validate/test_validate_TagInfinite.ts
@@ -28,8 +28,18 @@ export const test_validate_TagInfinite = _test_validate(
                                 value: input.value,
                             }),
                         ("number" === typeof input.ranged &&
-                            0 <= input.ranged &&
-                            100 >= input.ranged) ||
+                            (0 <= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100 >= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "number",
@@ -37,7 +47,12 @@ export const test_validate_TagInfinite = _test_validate(
                             }),
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            0 <= input.minimum) ||
+                            (0 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
@@ -45,14 +60,24 @@ export const test_validate_TagInfinite = _test_validate(
                             }),
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            100 >= input.maximum) ||
+                            (100 >= input.maximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "number",
                                 value: input.maximum,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 3) ||
+                            (0 === input.multipleOf % 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",
@@ -60,7 +85,12 @@ export const test_validate_TagInfinite = _test_validate(
                             }),
                         ("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
-                            parseInt(input.typed) === input.typed) ||
+                            (parseInt(input.typed) === input.typed ||
+                                $report(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number",

--- a/test/generated/output/validate/test_validate_TagLength.ts
+++ b/test/generated/output/validate/test_validate_TagLength.ts
@@ -21,29 +21,54 @@ export const test_validate_TagLength = _test_validate(
                 ): boolean =>
                     [
                         ("string" === typeof input.fixed &&
-                            5 === input.fixed.length) ||
+                            (5 === input.fixed.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".fixed",
+                                    expected: "string (@length 5)",
+                                    value: input.fixed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".fixed",
                                 expected: "string",
                                 value: input.fixed,
                             }),
                         ("string" === typeof input.minimum &&
-                            3 <= input.minimum.length) ||
+                            (3 <= input.minimum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "string",
                                 value: input.minimum,
                             }),
                         ("string" === typeof input.maximum &&
-                            7 >= input.maximum.length) ||
+                            (7 >= input.maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "string",
                                 value: input.maximum,
                             }),
                         ("string" === typeof input.minimum_and_maximum &&
-                            3 <= input.minimum_and_maximum.length &&
-                            7 >= input.minimum_and_maximum.length) ||
+                            (3 <= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum_and_maximum,
+                                })) &&
+                            (7 >= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.minimum_and_maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",

--- a/test/generated/output/validate/test_validate_TagMatrix.ts
+++ b/test/generated/output/validate/test_validate_TagMatrix.ts
@@ -22,7 +22,12 @@ export const test_validate_TagMatrix = _test_validate(
                 ): boolean =>
                     [
                         (((Array.isArray(input.matrix) &&
-                            3 === input.matrix.length) ||
+                            (3 === input.matrix.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".matrix",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.matrix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".matrix",
                                 expected: "Array<Array<string>>",
@@ -32,7 +37,17 @@ export const test_validate_TagMatrix = _test_validate(
                                 .map(
                                     (elem: any, _index1: number) =>
                                         (((Array.isArray(elem) &&
-                                            3 === elem.length) ||
+                                            (3 === elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".matrix[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected:
+                                                        "Array.length (@items 3)",
+                                                    value: elem,
+                                                }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -50,10 +65,25 @@ export const test_validate_TagMatrix = _test_validate(
                                                     ) =>
                                                         ("string" ===
                                                             typeof elem &&
-                                                            true ===
+                                                            (true ===
                                                                 $is_uuid(
                                                                     elem,
-                                                                )) ||
+                                                                ) ||
+                                                                $report(
+                                                                    _exceptionable,
+                                                                    {
+                                                                        path:
+                                                                            _path +
+                                                                            ".matrix[" +
+                                                                            _index1 +
+                                                                            "][" +
+                                                                            _index2 +
+                                                                            "]",
+                                                                        expected:
+                                                                            "string (@format uuid)",
+                                                                        value: elem,
+                                                                    },
+                                                                ))) ||
                                                         $report(
                                                             _exceptionable,
                                                             {

--- a/test/generated/output/validate/test_validate_TagNaN.ts
+++ b/test/generated/output/validate/test_validate_TagNaN.ts
@@ -28,8 +28,18 @@ export const test_validate_TagNaN = _test_validate(
                                 value: input.value,
                             }),
                         ("number" === typeof input.ranged &&
-                            0 <= input.ranged &&
-                            100 >= input.ranged) ||
+                            (0 <= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100 >= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "number",
@@ -37,7 +47,12 @@ export const test_validate_TagNaN = _test_validate(
                             }),
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            0 <= input.minimum) ||
+                            (0 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
@@ -45,14 +60,24 @@ export const test_validate_TagNaN = _test_validate(
                             }),
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            100 >= input.maximum) ||
+                            (100 >= input.maximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "number",
                                 value: input.maximum,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 3) ||
+                            (0 === input.multipleOf % 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",
@@ -60,7 +85,12 @@ export const test_validate_TagNaN = _test_validate(
                             }),
                         ("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
-                            parseInt(input.typed) === input.typed) ||
+                            (parseInt(input.typed) === input.typed ||
+                                $report(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number",

--- a/test/generated/output/validate/test_validate_TagObjectUnion.ts
+++ b/test/generated/output/validate/test_validate_TagObjectUnion.ts
@@ -22,7 +22,12 @@ export const test_validate_TagObjectUnion = _test_validate(
                     [
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "number",
@@ -36,8 +41,18 @@ export const test_validate_TagObjectUnion = _test_validate(
                 ): boolean =>
                     [
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "string",

--- a/test/generated/output/validate/test_validate_TagPattern.ts
+++ b/test/generated/output/validate/test_validate_TagPattern.ts
@@ -21,40 +21,64 @@ export const test_validate_TagPattern = _test_validate(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                ).test(input.uuid)) ||
+                                ).test(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected:
+                                        "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                ).test(input.email)) ||
+                                ).test(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected:
+                                        'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                ).test(input.ipv4)) ||
+                                ).test(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected:
+                                        "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                ).test(input.ipv6)) ||
+                                ).test(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected:
+                                        "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",

--- a/test/generated/output/validate/test_validate_TagRange.ts
+++ b/test/generated/output/validate/test_validate_TagRange.ts
@@ -22,7 +22,12 @@ export const test_validate_TagRange = _test_validate(
                     [
                         ("number" === typeof input.greater &&
                             Number.isFinite(input.greater) &&
-                            3 < input.greater) ||
+                            (3 < input.greater ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater",
                                 expected: "number",
@@ -30,7 +35,12 @@ export const test_validate_TagRange = _test_validate(
                             }),
                         ("number" === typeof input.greater_equal &&
                             Number.isFinite(input.greater_equal) &&
-                            3 <= input.greater_equal) ||
+                            (3 <= input.greater_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number",
@@ -38,7 +48,12 @@ export const test_validate_TagRange = _test_validate(
                             }),
                         ("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
-                            7 > input.less) ||
+                            (7 > input.less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less",
                                 expected: "number",
@@ -46,39 +61,84 @@ export const test_validate_TagRange = _test_validate(
                             }),
                         ("number" === typeof input.less_equal &&
                             Number.isFinite(input.less_equal) &&
-                            7 >= input.less_equal) ||
+                            (7 >= input.less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less_equal",
                                 expected: "number",
                                 value: input.less_equal,
                             }),
                         ("number" === typeof input.greater_less &&
-                            3 < input.greater_less &&
-                            7 > input.greater_less) ||
+                            (3 < input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less,
+                                })) &&
+                            (7 > input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number",
                                 value: input.greater_less,
                             }),
                         ("number" === typeof input.greater_equal_less &&
-                            3 <= input.greater_equal_less &&
-                            7 > input.greater_equal_less) ||
+                            (3 <= input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less,
+                                })) &&
+                            (7 > input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_equal_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less",
                                 expected: "number",
                                 value: input.greater_equal_less,
                             }),
                         ("number" === typeof input.greater_less_equal &&
-                            3 < input.greater_less_equal &&
-                            7 >= input.greater_less_equal) ||
+                            (3 < input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            (7 >= input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number",
                                 value: input.greater_less_equal,
                             }),
                         ("number" === typeof input.greater_equal_less_equal &&
-                            3 <= input.greater_equal_less_equal &&
-                            7 >= input.greater_equal_less_equal) ||
+                            (3 <= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
+                            (7 >= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_equal_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",

--- a/test/generated/output/validate/test_validate_TagStep.ts
+++ b/test/generated/output/validate/test_validate_TagStep.ts
@@ -21,34 +21,84 @@ export const test_validate_TagStep = _test_validate(
                 ): boolean =>
                     [
                         ("number" === typeof input.exclusiveMinimum &&
-                            0 === (input.exclusiveMinimum % 5) - 3 &&
-                            3 < input.exclusiveMinimum) ||
+                            (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@step 5)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (3 < input.exclusiveMinimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.exclusiveMinimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".exclusiveMinimum",
                                 expected: "number",
                                 value: input.exclusiveMinimum,
                             }),
                         ("number" === typeof input.minimum &&
-                            0 === (input.minimum % 5) - 3 &&
-                            3 <= input.minimum) ||
+                            (0 === (input.minimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@step 5)",
+                                    value: input.minimum,
+                                })) &&
+                            (3 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
                                 value: input.minimum,
                             }),
                         ("number" === typeof input.range &&
-                            0 === (input.range % 5) - 0 &&
-                            0 < input.range &&
-                            100 > input.range) ||
+                            (0 === (input.range % 5) - 0 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@step 5)",
+                                    value: input.range,
+                                })) &&
+                            (0 < input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMinimum 0)",
+                                    value: input.range,
+                                })) &&
+                            (100 > input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMaximum 100)",
+                                    value: input.range,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".range",
                                 expected: "number",
                                 value: input.range,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 5 &&
-                            3 <= input.multipleOf &&
-                            99 >= input.multipleOf) ||
+                            (0 === input.multipleOf % 5 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 5)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (3 <= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@minimum 3)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (99 >= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@maximum 99)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",

--- a/test/generated/output/validate/test_validate_TagTuple.ts
+++ b/test/generated/output/validate/test_validate_TagTuple.ts
@@ -36,24 +36,56 @@ export const test_validate_TagTuple = _test_validate(
                                 })) &&
                             [
                                 ("string" === typeof input.tuple[0] &&
-                                    3 <= input.tuple[0].length &&
-                                    7 >= input.tuple[0].length) ||
+                                    (3 <= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@minLength 3)",
+                                            value: input.tuple[0],
+                                        })) &&
+                                    (7 >= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@maxLength 7)",
+                                            value: input.tuple[0],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[0]",
                                         expected: "string",
                                         value: input.tuple[0],
                                     }),
                                 ("number" === typeof input.tuple[1] &&
-                                    3 <= input.tuple[1] &&
-                                    7 >= input.tuple[1]) ||
+                                    (3 <= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@minimum 3)",
+                                            value: input.tuple[1],
+                                        })) &&
+                                    (7 >= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@maximum 7)",
+                                            value: input.tuple[1],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[1]",
                                         expected: "number",
                                         value: input.tuple[1],
                                     }),
                                 (((Array.isArray(input.tuple[2]) &&
-                                    3 <= input.tuple[2].length &&
-                                    7 >= input.tuple[2].length) ||
+                                    (3 <= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[2],
+                                        })) &&
+                                    (7 >= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[2],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[2]",
                                         expected: "Array<string>",
@@ -63,8 +95,34 @@ export const test_validate_TagTuple = _test_validate(
                                         .map(
                                             (elem: any, _index1: number) =>
                                                 ("string" === typeof elem &&
-                                                    3 <= elem.length &&
-                                                    7 >= elem.length) ||
+                                                    (3 <= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@minLength 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@maxLength 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
@@ -82,8 +140,20 @@ export const test_validate_TagTuple = _test_validate(
                                         value: input.tuple[2],
                                     }),
                                 (((Array.isArray(input.tuple[3]) &&
-                                    3 <= input.tuple[3].length &&
-                                    7 >= input.tuple[3].length) ||
+                                    (3 <= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[3],
+                                        })) &&
+                                    (7 >= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[3],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[3]",
                                         expected: "Array<number>",
@@ -93,8 +163,34 @@ export const test_validate_TagTuple = _test_validate(
                                         .map(
                                             (elem: any, _index2: number) =>
                                                 ("number" === typeof elem &&
-                                                    3 <= elem &&
-                                                    7 >= elem) ||
+                                                    (3 <= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@minimum 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@maximum 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +

--- a/test/generated/output/validate/test_validate_TagType.ts
+++ b/test/generated/output/validate/test_validate_TagType.ts
@@ -22,7 +22,12 @@ export const test_validate_TagType = _test_validate(
                     [
                         ("number" === typeof input.int &&
                             Number.isFinite(input.int) &&
-                            parseInt(input.int) === input.int) ||
+                            (parseInt(input.int) === input.int ||
+                                $report(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".int",
                                 expected: "number",
@@ -30,8 +35,18 @@ export const test_validate_TagType = _test_validate(
                             }),
                         ("number" === typeof input.uint &&
                             Number.isFinite(input.uint) &&
-                            parseInt(input.uint) === input.uint &&
-                            0 <= input.uint) ||
+                            (parseInt(input.uint) === input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (0 <= input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number",

--- a/test/generated/output/validate/test_validate_UltimateUnion.ts
+++ b/test/generated/output/validate/test_validate_UltimateUnion.ts
@@ -1212,7 +1212,12 @@ export const test_validate_UltimateUnion = _test_validate(
                         undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                parseInt(input.minimum) === input.minimum) ||
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -1221,7 +1226,12 @@ export const test_validate_UltimateUnion = _test_validate(
                         undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                parseInt(input.maximum) === input.maximum) ||
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -1244,8 +1254,13 @@ export const test_validate_UltimateUnion = _test_validate(
                         undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
-                                parseInt(input.multipleOf) ===
-                                    input.multipleOf) ||
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -1612,8 +1627,19 @@ export const test_validate_UltimateUnion = _test_validate(
                         undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
-                                parseInt(input.minLength) === input.minLength &&
-                                0 <= input.minLength) ||
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minLength",
                                 expected: "(number | undefined)",
@@ -1622,8 +1648,19 @@ export const test_validate_UltimateUnion = _test_validate(
                         undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
-                                parseInt(input.maxLength) === input.maxLength &&
-                                0 <= input.maxLength) ||
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxLength",
                                 expected: "(number | undefined)",
@@ -1825,8 +1862,18 @@ export const test_validate_UltimateUnion = _test_validate(
                         undefined === input.minItems ||
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
-                                parseInt(input.minItems) === input.minItems &&
-                                0 <= input.minItems) ||
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "(number | undefined)",
@@ -1835,8 +1882,18 @@ export const test_validate_UltimateUnion = _test_validate(
                         undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
-                                parseInt(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems) ||
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",

--- a/test/generated/output/validateClone/test_validateClone_TagArray.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagArray.ts
@@ -27,7 +27,12 @@ export const test_validateClone_TagArray = _test_validateClone(
                     ): boolean =>
                         [
                             (((Array.isArray(input.items) &&
-                                3 === input.items.length) ||
+                                (3 === input.items.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected: "Array.length (@items 3)",
+                                        value: input.items,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".items",
                                     expected: "Array<string>",
@@ -37,7 +42,17 @@ export const test_validateClone_TagArray = _test_validateClone(
                                     .map(
                                         (elem: any, _index2: number) =>
                                             ("string" === typeof elem &&
-                                                true === $is_uuid(elem)) ||
+                                                (true === $is_uuid(elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".items[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@format uuid)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -55,7 +70,12 @@ export const test_validateClone_TagArray = _test_validateClone(
                                     value: input.items,
                                 }),
                             (((Array.isArray(input.minItems) &&
-                                3 <= input.minItems.length) ||
+                                (3 <= input.minItems.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.minItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
                                     expected: "Array<number>",
@@ -66,7 +86,17 @@ export const test_validateClone_TagArray = _test_validateClone(
                                         (elem: any, _index3: number) =>
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem) &&
-                                                3 <= elem) ||
+                                                (3 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".minItems[" +
+                                                            _index3 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 3)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -84,7 +114,12 @@ export const test_validateClone_TagArray = _test_validateClone(
                                     value: input.minItems,
                                 }),
                             (((Array.isArray(input.maxItems) &&
-                                7 >= input.maxItems.length) ||
+                                (7 >= input.maxItems.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.maxItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "Array<(number | string)>",
@@ -94,10 +129,30 @@ export const test_validateClone_TagArray = _test_validateClone(
                                     .map(
                                         (elem: any, _index4: number) =>
                                             ("string" === typeof elem &&
-                                                7 >= elem.length) ||
+                                                (7 >= elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".maxItems[" +
+                                                            _index4 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@maxLength 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem) &&
-                                                7 >= elem) ||
+                                                (7 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".maxItems[" +
+                                                            _index4 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -115,8 +170,18 @@ export const test_validateClone_TagArray = _test_validateClone(
                                     value: input.maxItems,
                                 }),
                             (((Array.isArray(input.both) &&
-                                3 <= input.both.length &&
-                                7 >= input.both.length) ||
+                                (3 <= input.both.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".both",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.both,
+                                    })) &&
+                                (7 >= input.both.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".both",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.both,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".both",
                                     expected: "Array<string>",
@@ -126,7 +191,17 @@ export const test_validateClone_TagArray = _test_validateClone(
                                     .map(
                                         (elem: any, _index5: number) =>
                                             ("string" === typeof elem &&
-                                                true === $is_uuid(elem)) ||
+                                                (true === $is_uuid(elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".both[" +
+                                                            _index5 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@format uuid)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +

--- a/test/generated/output/validateClone/test_validateClone_TagAtomicUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagAtomicUnion.ts
@@ -26,11 +26,26 @@ export const test_validateClone_TagAtomicUnion = _test_validateClone(
                     ): boolean =>
                         [
                             ("string" === typeof input.value &&
-                                3 <= input.value.length &&
-                                7 >= input.value.length) ||
+                                (3 <= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@minLength 3)",
+                                        value: input.value,
+                                    })) &&
+                                (7 >= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.value,
+                                    }))) ||
                                 ("number" === typeof input.value &&
                                     Number.isFinite(input.value) &&
-                                    3 <= input.value) ||
+                                    (3 <= input.value ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".value",
+                                            expected: "number (@minimum 3)",
+                                            value: input.value,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "(number | string)",

--- a/test/generated/output/validateClone/test_validateClone_TagCustom.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagCustom.ts
@@ -24,31 +24,46 @@ export const test_validateClone_TagCustom = _test_validateClone(
                     ): boolean =>
                         [
                             ("string" === typeof input.id &&
-                                true === $is_uuid(input.id)) ||
+                                (true === $is_uuid(input.id) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".id",
+                                        expected: "string (@format uuid)",
+                                        value: input.id,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".id",
                                     expected: "string",
                                     value: input.id,
                                 }),
-                            ("string" === typeof input.dolloar &&
-                                $is_custom(
+                            ("string" === typeof input.dollar &&
+                                ($is_custom(
                                     "dollar",
                                     "string",
                                     "",
-                                    input.dolloar,
-                                )) ||
+                                    input.dollar,
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".dollar",
+                                        expected: "string (@dollar)",
+                                        value: input.dollar,
+                                    }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".dolloar",
+                                    path: _path + ".dollar",
                                     expected: "string",
-                                    value: input.dolloar,
+                                    value: input.dollar,
                                 }),
                             ("string" === typeof input.postfix &&
-                                $is_custom(
+                                ($is_custom(
                                     "postfix",
                                     "string",
                                     "abcd",
                                     input.postfix,
-                                )) ||
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".postfix",
+                                        expected: "string (@postfix abcd)",
+                                        value: input.postfix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".postfix",
                                     expected: "string",
@@ -56,12 +71,17 @@ export const test_validateClone_TagCustom = _test_validateClone(
                                 }),
                             ("number" === typeof input.log &&
                                 Number.isFinite(input.log) &&
-                                $is_custom(
+                                ($is_custom(
                                     "powerOf",
                                     "number",
                                     "10",
                                     input.log,
-                                )) ||
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".log",
+                                        expected: "number (@powerOf 10)",
+                                        value: input.log,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".log",
                                     expected: "number",
@@ -95,7 +115,7 @@ export const test_validateClone_TagCustom = _test_validateClone(
                 const $is_custom = (typia.validateClone as any).is_custom;
                 const $co0 = (input: any): any => ({
                     id: input.id as any,
-                    dolloar: input.dolloar as any,
+                    dollar: input.dollar as any,
                     postfix: input.postfix as any,
                     log: input.log as any,
                 });

--- a/test/generated/output/validateClone/test_validateClone_TagFormat.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagFormat.ts
@@ -29,63 +29,108 @@ export const test_validateClone_TagFormat = _test_validateClone(
                     ): boolean =>
                         [
                             ("string" === typeof input.uuid &&
-                                true === $is_uuid(input.uuid)) ||
+                                (true === $is_uuid(input.uuid) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uuid",
+                                        expected: "string (@format uuid)",
+                                        value: input.uuid,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uuid",
                                     expected: "string",
                                     value: input.uuid,
                                 }),
                             ("string" === typeof input.email &&
-                                true === $is_email(input.email)) ||
+                                (true === $is_email(input.email) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".email",
+                                        expected: "string (@format email)",
+                                        value: input.email,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".email",
                                     expected: "string",
                                     value: input.email,
                                 }),
                             ("string" === typeof input.url &&
-                                true === $is_url(input.url)) ||
+                                (true === $is_url(input.url) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".url",
+                                        expected: "string (@format url)",
+                                        value: input.url,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".url",
                                     expected: "string",
                                     value: input.url,
                                 }),
                             ("string" === typeof input.ipv4 &&
-                                true === $is_ipv4(input.ipv4)) ||
+                                (true === $is_ipv4(input.ipv4) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv4",
+                                        expected: "string (@format ipv4)",
+                                        value: input.ipv4,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",
                                     expected: "string",
                                     value: input.ipv4,
                                 }),
                             ("string" === typeof input.ipv6 &&
-                                true === $is_ipv6(input.ipv6)) ||
+                                (true === $is_ipv6(input.ipv6) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv6",
+                                        expected: "string (@format ipv6)",
+                                        value: input.ipv6,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv6",
                                     expected: "string",
                                     value: input.ipv6,
                                 }),
                             ("string" === typeof input.date &&
-                                true === $is_date(input.date)) ||
+                                (true === $is_date(input.date) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".date",
+                                        expected: "string (@format date)",
+                                        value: input.date,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".date",
                                     expected: "string",
                                     value: input.date,
                                 }),
                             ("string" === typeof input.date_time &&
-                                true === $is_datetime(input.date_time)) ||
+                                (true === $is_datetime(input.date_time) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".date_time",
+                                        expected: "string (@format datetime)",
+                                        value: input.date_time,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".date_time",
                                     expected: "string",
                                     value: input.date_time,
                                 }),
                             ("string" === typeof input.datetime &&
-                                true === $is_datetime(input.datetime)) ||
+                                (true === $is_datetime(input.datetime) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".datetime",
+                                        expected: "string (@format datetime)",
+                                        value: input.datetime,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".datetime",
                                     expected: "string",
                                     value: input.datetime,
                                 }),
                             ("string" === typeof input.dateTime &&
-                                true === $is_datetime(input.dateTime)) ||
+                                (true === $is_datetime(input.dateTime) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".dateTime",
+                                        expected: "string (@format datetime)",
+                                        value: input.dateTime,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".dateTime",
                                     expected: "string",

--- a/test/generated/output/validateClone/test_validateClone_TagLength.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagLength.ts
@@ -26,29 +26,54 @@ export const test_validateClone_TagLength = _test_validateClone(
                     ): boolean =>
                         [
                             ("string" === typeof input.fixed &&
-                                5 === input.fixed.length) ||
+                                (5 === input.fixed.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".fixed",
+                                        expected: "string (@length 5)",
+                                        value: input.fixed,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".fixed",
                                     expected: "string",
                                     value: input.fixed,
                                 }),
                             ("string" === typeof input.minimum &&
-                                3 <= input.minimum.length) ||
+                                (3 <= input.minimum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "string (@minLength 3)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "string",
                                     value: input.minimum,
                                 }),
                             ("string" === typeof input.maximum &&
-                                7 >= input.maximum.length) ||
+                                (7 >= input.maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "string",
                                     value: input.maximum,
                                 }),
                             ("string" === typeof input.minimum_and_maximum &&
-                                3 <= input.minimum_and_maximum.length &&
-                                7 >= input.minimum_and_maximum.length) ||
+                                (3 <= input.minimum_and_maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum_and_maximum",
+                                        expected: "string (@minLength 3)",
+                                        value: input.minimum_and_maximum,
+                                    })) &&
+                                (7 >= input.minimum_and_maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum_and_maximum",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.minimum_and_maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum_and_maximum",
                                     expected: "string",

--- a/test/generated/output/validateClone/test_validateClone_TagMatrix.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagMatrix.ts
@@ -23,7 +23,12 @@ export const test_validateClone_TagMatrix = _test_validateClone(
                     ): boolean =>
                         [
                             (((Array.isArray(input.matrix) &&
-                                3 === input.matrix.length) ||
+                                (3 === input.matrix.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".matrix",
+                                        expected: "Array.length (@items 3)",
+                                        value: input.matrix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".matrix",
                                     expected: "Array<Array<string>>",
@@ -33,7 +38,17 @@ export const test_validateClone_TagMatrix = _test_validateClone(
                                     .map(
                                         (elem: any, _index1: number) =>
                                             (((Array.isArray(elem) &&
-                                                3 === elem.length) ||
+                                                (3 === elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".matrix[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected:
+                                                            "Array.length (@items 3)",
+                                                        value: elem,
+                                                    }))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
@@ -51,10 +66,25 @@ export const test_validateClone_TagMatrix = _test_validateClone(
                                                         ) =>
                                                             ("string" ===
                                                                 typeof elem &&
-                                                                true ===
+                                                                (true ===
                                                                     $is_uuid(
                                                                         elem,
-                                                                    )) ||
+                                                                    ) ||
+                                                                    $report(
+                                                                        _exceptionable,
+                                                                        {
+                                                                            path:
+                                                                                _path +
+                                                                                ".matrix[" +
+                                                                                _index1 +
+                                                                                "][" +
+                                                                                _index2 +
+                                                                                "]",
+                                                                            expected:
+                                                                                "string (@format uuid)",
+                                                                            value: elem,
+                                                                        },
+                                                                    ))) ||
                                                             $report(
                                                                 _exceptionable,
                                                                 {

--- a/test/generated/output/validateClone/test_validateClone_TagObjectUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagObjectUnion.ts
@@ -27,7 +27,12 @@ export const test_validateClone_TagObjectUnion = _test_validateClone(
                         [
                             ("number" === typeof input.value &&
                                 Number.isFinite(input.value) &&
-                                3 <= input.value) ||
+                                (3 <= input.value ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "number (@minimum 3)",
+                                        value: input.value,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "number",
@@ -41,8 +46,18 @@ export const test_validateClone_TagObjectUnion = _test_validateClone(
                     ): boolean =>
                         [
                             ("string" === typeof input.value &&
-                                3 <= input.value.length &&
-                                7 >= input.value.length) ||
+                                (3 <= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@minLength 3)",
+                                        value: input.value,
+                                    })) &&
+                                (7 >= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.value,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "string",

--- a/test/generated/output/validateClone/test_validateClone_TagPattern.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagPattern.ts
@@ -22,40 +22,64 @@ export const test_validateClone_TagPattern = _test_validateClone(
                     ): boolean =>
                         [
                             ("string" === typeof input.uuid &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                    ).test(input.uuid)) ||
+                                    ).test(input.uuid) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uuid",
+                                        expected:
+                                            "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                        value: input.uuid,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uuid",
                                     expected: "string",
                                     value: input.uuid,
                                 }),
                             ("string" === typeof input.email &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                    ).test(input.email)) ||
+                                    ).test(input.email) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".email",
+                                        expected:
+                                            'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                        value: input.email,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".email",
                                     expected: "string",
                                     value: input.email,
                                 }),
                             ("string" === typeof input.ipv4 &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                    ).test(input.ipv4)) ||
+                                    ).test(input.ipv4) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv4",
+                                        expected:
+                                            "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                        value: input.ipv4,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",
                                     expected: "string",
                                     value: input.ipv4,
                                 }),
                             ("string" === typeof input.ipv6 &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                    ).test(input.ipv6)) ||
+                                    ).test(input.ipv6) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv6",
+                                        expected:
+                                            "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                        value: input.ipv6,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv6",
                                     expected: "string",

--- a/test/generated/output/validateClone/test_validateClone_TagRange.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagRange.ts
@@ -27,7 +27,13 @@ export const test_validateClone_TagRange = _test_validateClone(
                         [
                             ("number" === typeof input.greater &&
                                 Number.isFinite(input.greater) &&
-                                3 < input.greater) ||
+                                (3 < input.greater ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater",
                                     expected: "number",
@@ -35,7 +41,12 @@ export const test_validateClone_TagRange = _test_validateClone(
                                 }),
                             ("number" === typeof input.greater_equal &&
                                 Number.isFinite(input.greater_equal) &&
-                                3 <= input.greater_equal) ||
+                                (3 <= input.greater_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal",
                                     expected: "number",
@@ -43,7 +54,13 @@ export const test_validateClone_TagRange = _test_validateClone(
                                 }),
                             ("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
-                                7 > input.less) ||
+                                (7 > input.less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number",
@@ -51,31 +68,70 @@ export const test_validateClone_TagRange = _test_validateClone(
                                 }),
                             ("number" === typeof input.less_equal &&
                                 Number.isFinite(input.less_equal) &&
-                                7 >= input.less_equal) ||
+                                (7 >= input.less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".less_equal",
                                     expected: "number",
                                     value: input.less_equal,
                                 }),
                             ("number" === typeof input.greater_less &&
-                                3 < input.greater_less &&
-                                7 > input.greater_less) ||
+                                (3 < input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater_less,
+                                    })) &&
+                                (7 > input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.greater_less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number",
                                     value: input.greater_less,
                                 }),
                             ("number" === typeof input.greater_equal_less &&
-                                3 <= input.greater_equal_less &&
-                                7 > input.greater_equal_less) ||
+                                (3 <= input.greater_equal_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal_less,
+                                    })) &&
+                                (7 > input.greater_equal_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.greater_equal_less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less",
                                     expected: "number",
                                     value: input.greater_equal_less,
                                 }),
                             ("number" === typeof input.greater_less_equal &&
-                                3 < input.greater_less_equal &&
-                                7 >= input.greater_less_equal) ||
+                                (3 < input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                (7 >= input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.greater_less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number",
@@ -83,8 +139,20 @@ export const test_validateClone_TagRange = _test_validateClone(
                                 }),
                             ("number" ===
                                 typeof input.greater_equal_less_equal &&
-                                3 <= input.greater_equal_less_equal &&
-                                7 >= input.greater_equal_less_equal) ||
+                                (3 <= input.greater_equal_less_equal ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
+                                (7 >= input.greater_equal_less_equal ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.greater_equal_less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
                                     expected: "number",

--- a/test/generated/output/validateClone/test_validateClone_TagStep.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagStep.ts
@@ -26,34 +26,87 @@ export const test_validateClone_TagStep = _test_validateClone(
                     ): boolean =>
                         [
                             ("number" === typeof input.exclusiveMinimum &&
-                                0 === (input.exclusiveMinimum % 5) - 3 &&
-                                3 < input.exclusiveMinimum) ||
+                                (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected: "number (@step 5)",
+                                        value: input.exclusiveMinimum,
+                                    })) &&
+                                (3 < input.exclusiveMinimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.exclusiveMinimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".exclusiveMinimum",
                                     expected: "number",
                                     value: input.exclusiveMinimum,
                                 }),
                             ("number" === typeof input.minimum &&
-                                0 === (input.minimum % 5) - 3 &&
-                                3 <= input.minimum) ||
+                                (0 === (input.minimum % 5) - 3 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@step 5)",
+                                        value: input.minimum,
+                                    })) &&
+                                (3 <= input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@minimum 3)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "number",
                                     value: input.minimum,
                                 }),
                             ("number" === typeof input.range &&
-                                0 === (input.range % 5) - 0 &&
-                                0 < input.range &&
-                                100 > input.range) ||
+                                (0 === (input.range % 5) - 0 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected: "number (@step 5)",
+                                        value: input.range,
+                                    })) &&
+                                (0 < input.range ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected:
+                                            "number (@exclusiveMinimum 0)",
+                                        value: input.range,
+                                    })) &&
+                                (100 > input.range ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected:
+                                            "number (@exclusiveMaximum 100)",
+                                        value: input.range,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".range",
                                     expected: "number",
                                     value: input.range,
                                 }),
                             ("number" === typeof input.multipleOf &&
-                                0 === input.multipleOf % 5 &&
-                                3 <= input.multipleOf &&
-                                99 >= input.multipleOf) ||
+                                (0 === input.multipleOf % 5 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@multipleOf 5)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                (3 <= input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@minimum 3)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                (99 >= input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@maximum 99)",
+                                        value: input.multipleOf,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number",

--- a/test/generated/output/validateClone/test_validateClone_TagTuple.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagTuple.ts
@@ -37,24 +37,58 @@ export const test_validateClone_TagTuple = _test_validateClone(
                                     })) &&
                                 [
                                     ("string" === typeof input.tuple[0] &&
-                                        3 <= input.tuple[0].length &&
-                                        7 >= input.tuple[0].length) ||
+                                        (3 <= input.tuple[0].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[0]",
+                                                expected:
+                                                    "string (@minLength 3)",
+                                                value: input.tuple[0],
+                                            })) &&
+                                        (7 >= input.tuple[0].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[0]",
+                                                expected:
+                                                    "string (@maxLength 7)",
+                                                value: input.tuple[0],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[0]",
                                             expected: "string",
                                             value: input.tuple[0],
                                         }),
                                     ("number" === typeof input.tuple[1] &&
-                                        3 <= input.tuple[1] &&
-                                        7 >= input.tuple[1]) ||
+                                        (3 <= input.tuple[1] ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[1]",
+                                                expected: "number (@minimum 3)",
+                                                value: input.tuple[1],
+                                            })) &&
+                                        (7 >= input.tuple[1] ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[1]",
+                                                expected: "number (@maximum 7)",
+                                                value: input.tuple[1],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[1]",
                                             expected: "number",
                                             value: input.tuple[1],
                                         }),
                                     (((Array.isArray(input.tuple[2]) &&
-                                        3 <= input.tuple[2].length &&
-                                        7 >= input.tuple[2].length) ||
+                                        (3 <= input.tuple[2].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[2]",
+                                                expected:
+                                                    "Array.length (@minItems 3)",
+                                                value: input.tuple[2],
+                                            })) &&
+                                        (7 >= input.tuple[2].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[2]",
+                                                expected:
+                                                    "Array.length (@maxItems 7)",
+                                                value: input.tuple[2],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[2]",
                                             expected: "Array<string>",
@@ -64,8 +98,34 @@ export const test_validateClone_TagTuple = _test_validateClone(
                                             .map(
                                                 (elem: any, _index1: number) =>
                                                     ("string" === typeof elem &&
-                                                        3 <= elem.length &&
-                                                        7 >= elem.length) ||
+                                                        (3 <= elem.length ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[2][" +
+                                                                        _index1 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "string (@minLength 3)",
+                                                                    value: elem,
+                                                                },
+                                                            )) &&
+                                                        (7 >= elem.length ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[2][" +
+                                                                        _index1 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "string (@maxLength 7)",
+                                                                    value: elem,
+                                                                },
+                                                            ))) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
@@ -83,8 +143,20 @@ export const test_validateClone_TagTuple = _test_validateClone(
                                             value: input.tuple[2],
                                         }),
                                     (((Array.isArray(input.tuple[3]) &&
-                                        3 <= input.tuple[3].length &&
-                                        7 >= input.tuple[3].length) ||
+                                        (3 <= input.tuple[3].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[3]",
+                                                expected:
+                                                    "Array.length (@minItems 3)",
+                                                value: input.tuple[3],
+                                            })) &&
+                                        (7 >= input.tuple[3].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[3]",
+                                                expected:
+                                                    "Array.length (@maxItems 7)",
+                                                value: input.tuple[3],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[3]",
                                             expected: "Array<number>",
@@ -94,8 +166,34 @@ export const test_validateClone_TagTuple = _test_validateClone(
                                             .map(
                                                 (elem: any, _index2: number) =>
                                                     ("number" === typeof elem &&
-                                                        3 <= elem &&
-                                                        7 >= elem) ||
+                                                        (3 <= elem ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[3][" +
+                                                                        _index2 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "number (@minimum 3)",
+                                                                    value: elem,
+                                                                },
+                                                            )) &&
+                                                        (7 >= elem ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[3][" +
+                                                                        _index2 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "number (@maximum 7)",
+                                                                    value: elem,
+                                                                },
+                                                            ))) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +

--- a/test/generated/output/validateClone/test_validateClone_TagType.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagType.ts
@@ -27,7 +27,12 @@ export const test_validateClone_TagType = _test_validateClone(
                         [
                             ("number" === typeof input.int &&
                                 Number.isFinite(input.int) &&
-                                parseInt(input.int) === input.int) ||
+                                (parseInt(input.int) === input.int ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".int",
                                     expected: "number",
@@ -35,8 +40,18 @@ export const test_validateClone_TagType = _test_validateClone(
                                 }),
                             ("number" === typeof input.uint &&
                                 Number.isFinite(input.uint) &&
-                                parseInt(input.uint) === input.uint &&
-                                0 <= input.uint) ||
+                                (parseInt(input.uint) === input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (0 <= input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number",

--- a/test/generated/output/validateClone/test_validateClone_UltimateUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_UltimateUnion.ts
@@ -1224,8 +1224,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             undefined === input.minimum ||
                                 ("number" === typeof input.minimum &&
                                     Number.isFinite(input.minimum) &&
-                                    parseInt(input.minimum) ===
-                                        input.minimum) ||
+                                    (parseInt(input.minimum) ===
+                                        input.minimum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "(number | undefined)",
@@ -1234,8 +1239,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             undefined === input.maximum ||
                                 ("number" === typeof input.maximum &&
                                     Number.isFinite(input.maximum) &&
-                                    parseInt(input.maximum) ===
-                                        input.maximum) ||
+                                    (parseInt(input.maximum) ===
+                                        input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "(number | undefined)",
@@ -1258,8 +1268,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             undefined === input.multipleOf ||
                                 ("number" === typeof input.multipleOf &&
                                     Number.isFinite(input.multipleOf) &&
-                                    parseInt(input.multipleOf) ===
-                                        input.multipleOf) ||
+                                    (parseInt(input.multipleOf) ===
+                                        input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "(number | undefined)",
@@ -1628,9 +1643,19 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             undefined === input.minLength ||
                                 ("number" === typeof input.minLength &&
                                     Number.isFinite(input.minLength) &&
-                                    parseInt(input.minLength) ===
-                                        input.minLength &&
-                                    0 <= input.minLength) ||
+                                    (parseInt(input.minLength) ===
+                                        input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        })) &&
+                                    (0 <= input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minLength",
                                     expected: "(number | undefined)",
@@ -1639,9 +1664,19 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             undefined === input.maxLength ||
                                 ("number" === typeof input.maxLength &&
                                     Number.isFinite(input.maxLength) &&
-                                    parseInt(input.maxLength) ===
-                                        input.maxLength &&
-                                    0 <= input.maxLength) ||
+                                    (parseInt(input.maxLength) ===
+                                        input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxLength",
                                     expected: "(number | undefined)",
@@ -1844,9 +1879,19 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             undefined === input.minItems ||
                                 ("number" === typeof input.minItems &&
                                     Number.isFinite(input.minItems) &&
-                                    parseInt(input.minItems) ===
-                                        input.minItems &&
-                                    0 <= input.minItems) ||
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
                                     expected: "(number | undefined)",
@@ -1855,9 +1900,19 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             undefined === input.maxItems ||
                                 ("number" === typeof input.maxItems &&
                                     Number.isFinite(input.maxItems) &&
-                                    parseInt(input.maxItems) ===
-                                        input.maxItems &&
-                                    0 <= input.maxItems) ||
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "(number | undefined)",

--- a/test/generated/output/validateEquals/test_validateEquals_TagArray.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagArray.ts
@@ -23,7 +23,12 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                 ): boolean =>
                     [
                         (((Array.isArray(input.items) &&
-                            3 === input.items.length) ||
+                            (3 === input.items.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.items,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".items",
                                 expected: "Array<string>",
@@ -33,7 +38,17 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                                 .map(
                                     (elem: any, _index2: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -51,7 +66,12 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                                 value: input.items,
                             }),
                         (((Array.isArray(input.minItems) &&
-                            3 <= input.minItems.length) ||
+                            (3 <= input.minItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.minItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
                                 expected: "Array<number>",
@@ -62,7 +82,17 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                                     (elem: any, _index3: number) =>
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            3 <= elem) ||
+                                            (3 <= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".minItems[" +
+                                                        _index3 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 3)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -80,7 +110,12 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                                 value: input.minItems,
                             }),
                         (((Array.isArray(input.maxItems) &&
-                            7 >= input.maxItems.length) ||
+                            (7 >= input.maxItems.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.maxItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maxItems",
                                 expected: "Array<(number | string)>",
@@ -90,10 +125,30 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                                 .map(
                                     (elem: any, _index4: number) =>
                                         ("string" === typeof elem &&
-                                            7 >= elem.length) ||
+                                            (7 >= elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@maxLength 7)",
+                                                    value: elem,
+                                                }))) ||
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem) &&
-                                            7 >= elem) ||
+                                            (7 >= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".maxItems[" +
+                                                        _index4 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 7)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
@@ -111,8 +166,18 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                                 value: input.maxItems,
                             }),
                         (((Array.isArray(input.both) &&
-                            3 <= input.both.length &&
-                            7 >= input.both.length) ||
+                            (3 <= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@minItems 3)",
+                                    value: input.both,
+                                })) &&
+                            (7 >= input.both.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".both",
+                                    expected: "Array.length (@maxItems 7)",
+                                    value: input.both,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".both",
                                 expected: "Array<string>",
@@ -122,7 +187,17 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                                 .map(
                                     (elem: any, _index5: number) =>
                                         ("string" === typeof elem &&
-                                            true === $is_uuid(elem)) ||
+                                            (true === $is_uuid(elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".both[" +
+                                                        _index5 +
+                                                        "]",
+                                                    expected:
+                                                        "string (@format uuid)",
+                                                    value: elem,
+                                                }))) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +

--- a/test/generated/output/validateEquals/test_validateEquals_TagAtomicUnion.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagAtomicUnion.ts
@@ -22,11 +22,26 @@ export const test_validateEquals_TagAtomicUnion = _test_validateEquals(
                 ): boolean =>
                     [
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                             ("number" === typeof input.value &&
                                 Number.isFinite(input.value) &&
-                                3 <= input.value) ||
+                                (3 <= input.value ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "number (@minimum 3)",
+                                        value: input.value,
+                                    }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "(number | string)",

--- a/test/generated/output/validateEquals/test_validateEquals_TagBigInt.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagBigInt.ts
@@ -28,29 +28,54 @@ export const test_validateEquals_TagBigInt = _test_validateEquals(
                                 value: input.value,
                             }),
                         ("bigint" === typeof input.ranged &&
-                            0n <= input.ranged &&
-                            100n >= input.ranged) ||
+                            (0n <= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "bigint (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100n >= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "bigint (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "bigint",
                                 value: input.ranged,
                             }),
                         ("bigint" === typeof input.minimum &&
-                            0n <= input.minimum) ||
+                            (0n <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "bigint (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "bigint",
                                 value: input.minimum,
                             }),
                         ("bigint" === typeof input.maximum &&
-                            100n >= input.maximum) ||
+                            (100n >= input.maximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "bigint (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "bigint",
                                 value: input.maximum,
                             }),
                         ("bigint" === typeof input.multipleOf &&
-                            0n === input.multipleOf % 3n) ||
+                            (0n === input.multipleOf % 3n ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "bigint (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "bigint",

--- a/test/generated/output/validateEquals/test_validateEquals_TagCustom.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagCustom.ts
@@ -24,31 +24,41 @@ export const test_validateEquals_TagCustom = _test_validateEquals(
                 ): boolean =>
                     [
                         ("string" === typeof input.id &&
-                            true === $is_uuid(input.id)) ||
+                            (true === $is_uuid(input.id) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".id",
+                                    expected: "string (@format uuid)",
+                                    value: input.id,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".id",
                                 expected: "string",
                                 value: input.id,
                             }),
-                        ("string" === typeof input.dolloar &&
-                            $is_custom(
-                                "dollar",
-                                "string",
-                                "",
-                                input.dolloar,
-                            )) ||
+                        ("string" === typeof input.dollar &&
+                            ($is_custom("dollar", "string", "", input.dollar) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dollar",
+                                    expected: "string (@dollar)",
+                                    value: input.dollar,
+                                }))) ||
                             $report(_exceptionable, {
-                                path: _path + ".dolloar",
+                                path: _path + ".dollar",
                                 expected: "string",
-                                value: input.dolloar,
+                                value: input.dollar,
                             }),
                         ("string" === typeof input.postfix &&
-                            $is_custom(
+                            ($is_custom(
                                 "postfix",
                                 "string",
                                 "abcd",
                                 input.postfix,
-                            )) ||
+                            ) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".postfix",
+                                    expected: "string (@postfix abcd)",
+                                    value: input.postfix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected: "string",
@@ -56,7 +66,12 @@ export const test_validateEquals_TagCustom = _test_validateEquals(
                             }),
                         ("number" === typeof input.log &&
                             Number.isFinite(input.log) &&
-                            $is_custom("powerOf", "number", "10", input.log)) ||
+                            ($is_custom("powerOf", "number", "10", input.log) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".log",
+                                    expected: "number (@powerOf 10)",
+                                    value: input.log,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".log",
                                 expected: "number",
@@ -67,12 +82,9 @@ export const test_validateEquals_TagCustom = _test_validateEquals(
                             Object.keys(input)
                                 .map((key) => {
                                     if (
-                                        [
-                                            "id",
-                                            "dolloar",
-                                            "postfix",
-                                            "log",
-                                        ].some((prop) => key === prop)
+                                        ["id", "dollar", "postfix", "log"].some(
+                                            (prop) => key === prop,
+                                        )
                                     )
                                         return true;
                                     const value = input[key];

--- a/test/generated/output/validateEquals/test_validateEquals_TagFormat.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagFormat.ts
@@ -29,63 +29,108 @@ export const test_validateEquals_TagFormat = _test_validateEquals(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true === $is_uuid(input.uuid)) ||
+                            (true === $is_uuid(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected: "string (@format uuid)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true === $is_email(input.email)) ||
+                            (true === $is_email(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected: "string (@format email)",
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.url &&
-                            true === $is_url(input.url)) ||
+                            (true === $is_url(input.url) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".url",
+                                    expected: "string (@format url)",
+                                    value: input.url,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".url",
                                 expected: "string",
                                 value: input.url,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true === $is_ipv4(input.ipv4)) ||
+                            (true === $is_ipv4(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected: "string (@format ipv4)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true === $is_ipv6(input.ipv6)) ||
+                            (true === $is_ipv6(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected: "string (@format ipv6)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",
                                 value: input.ipv6,
                             }),
                         ("string" === typeof input.date &&
-                            true === $is_date(input.date)) ||
+                            (true === $is_date(input.date) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date",
+                                    expected: "string (@format date)",
+                                    value: input.date,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date",
                                 expected: "string",
                                 value: input.date,
                             }),
                         ("string" === typeof input.date_time &&
-                            true === $is_datetime(input.date_time)) ||
+                            (true === $is_datetime(input.date_time) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".date_time",
+                                    expected: "string (@format datetime)",
+                                    value: input.date_time,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".date_time",
                                 expected: "string",
                                 value: input.date_time,
                             }),
                         ("string" === typeof input.datetime &&
-                            true === $is_datetime(input.datetime)) ||
+                            (true === $is_datetime(input.datetime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".datetime",
+                                    expected: "string (@format datetime)",
+                                    value: input.datetime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".datetime",
                                 expected: "string",
                                 value: input.datetime,
                             }),
                         ("string" === typeof input.dateTime &&
-                            true === $is_datetime(input.dateTime)) ||
+                            (true === $is_datetime(input.dateTime) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".dateTime",
+                                    expected: "string (@format datetime)",
+                                    value: input.dateTime,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".dateTime",
                                 expected: "string",

--- a/test/generated/output/validateEquals/test_validateEquals_TagInfinite.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagInfinite.ts
@@ -29,8 +29,18 @@ export const test_validateEquals_TagInfinite = _test_validateEquals(
                                 value: input.value,
                             }),
                         ("number" === typeof input.ranged &&
-                            0 <= input.ranged &&
-                            100 >= input.ranged) ||
+                            (0 <= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100 >= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "number",
@@ -38,7 +48,12 @@ export const test_validateEquals_TagInfinite = _test_validateEquals(
                             }),
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            0 <= input.minimum) ||
+                            (0 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
@@ -46,14 +61,24 @@ export const test_validateEquals_TagInfinite = _test_validateEquals(
                             }),
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            100 >= input.maximum) ||
+                            (100 >= input.maximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "number",
                                 value: input.maximum,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 3) ||
+                            (0 === input.multipleOf % 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",
@@ -61,7 +86,12 @@ export const test_validateEquals_TagInfinite = _test_validateEquals(
                             }),
                         ("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
-                            parseInt(input.typed) === input.typed) ||
+                            (parseInt(input.typed) === input.typed ||
+                                $report(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number",

--- a/test/generated/output/validateEquals/test_validateEquals_TagLength.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagLength.ts
@@ -22,29 +22,54 @@ export const test_validateEquals_TagLength = _test_validateEquals(
                 ): boolean =>
                     [
                         ("string" === typeof input.fixed &&
-                            5 === input.fixed.length) ||
+                            (5 === input.fixed.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".fixed",
+                                    expected: "string (@length 5)",
+                                    value: input.fixed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".fixed",
                                 expected: "string",
                                 value: input.fixed,
                             }),
                         ("string" === typeof input.minimum &&
-                            3 <= input.minimum.length) ||
+                            (3 <= input.minimum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "string",
                                 value: input.minimum,
                             }),
                         ("string" === typeof input.maximum &&
-                            7 >= input.maximum.length) ||
+                            (7 >= input.maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "string",
                                 value: input.maximum,
                             }),
                         ("string" === typeof input.minimum_and_maximum &&
-                            3 <= input.minimum_and_maximum.length &&
-                            7 >= input.minimum_and_maximum.length) ||
+                            (3 <= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@minLength 3)",
+                                    value: input.minimum_and_maximum,
+                                })) &&
+                            (7 >= input.minimum_and_maximum.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum_and_maximum",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.minimum_and_maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",

--- a/test/generated/output/validateEquals/test_validateEquals_TagMatrix.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagMatrix.ts
@@ -23,7 +23,12 @@ export const test_validateEquals_TagMatrix = _test_validateEquals(
                 ): boolean =>
                     [
                         (((Array.isArray(input.matrix) &&
-                            3 === input.matrix.length) ||
+                            (3 === input.matrix.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".matrix",
+                                    expected: "Array.length (@items 3)",
+                                    value: input.matrix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".matrix",
                                 expected: "Array<Array<string>>",
@@ -33,7 +38,17 @@ export const test_validateEquals_TagMatrix = _test_validateEquals(
                                 .map(
                                     (elem: any, _index1: number) =>
                                         (((Array.isArray(elem) &&
-                                            3 === elem.length) ||
+                                            (3 === elem.length ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".matrix[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected:
+                                                        "Array.length (@items 3)",
+                                                    value: elem,
+                                                }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -51,10 +66,25 @@ export const test_validateEquals_TagMatrix = _test_validateEquals(
                                                     ) =>
                                                         ("string" ===
                                                             typeof elem &&
-                                                            true ===
+                                                            (true ===
                                                                 $is_uuid(
                                                                     elem,
-                                                                )) ||
+                                                                ) ||
+                                                                $report(
+                                                                    _exceptionable,
+                                                                    {
+                                                                        path:
+                                                                            _path +
+                                                                            ".matrix[" +
+                                                                            _index1 +
+                                                                            "][" +
+                                                                            _index2 +
+                                                                            "]",
+                                                                        expected:
+                                                                            "string (@format uuid)",
+                                                                        value: elem,
+                                                                    },
+                                                                ))) ||
                                                         $report(
                                                             _exceptionable,
                                                             {

--- a/test/generated/output/validateEquals/test_validateEquals_TagNaN.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagNaN.ts
@@ -29,8 +29,18 @@ export const test_validateEquals_TagNaN = _test_validateEquals(
                                 value: input.value,
                             }),
                         ("number" === typeof input.ranged &&
-                            0 <= input.ranged &&
-                            100 >= input.ranged) ||
+                            (0 <= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@minimum 0)",
+                                    value: input.ranged,
+                                })) &&
+                            (100 >= input.ranged ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ranged",
+                                    expected: "number (@maximum 100)",
+                                    value: input.ranged,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ranged",
                                 expected: "number",
@@ -38,7 +48,12 @@ export const test_validateEquals_TagNaN = _test_validateEquals(
                             }),
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            0 <= input.minimum) ||
+                            (0 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 0)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
@@ -46,14 +61,24 @@ export const test_validateEquals_TagNaN = _test_validateEquals(
                             }),
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            100 >= input.maximum) ||
+                            (100 >= input.maximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@maximum 100)",
+                                    value: input.maximum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "number",
                                 value: input.maximum,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 3) ||
+                            (0 === input.multipleOf % 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 3)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",
@@ -61,7 +86,12 @@ export const test_validateEquals_TagNaN = _test_validateEquals(
                             }),
                         ("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
-                            parseInt(input.typed) === input.typed) ||
+                            (parseInt(input.typed) === input.typed ||
+                                $report(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number",

--- a/test/generated/output/validateEquals/test_validateEquals_TagObjectUnion.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagObjectUnion.ts
@@ -23,7 +23,12 @@ export const test_validateEquals_TagObjectUnion = _test_validateEquals(
                     [
                         ("number" === typeof input.value &&
                             Number.isFinite(input.value) &&
-                            3 <= input.value) ||
+                            (3 <= input.value ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "number (@minimum 3)",
+                                    value: input.value,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "number",
@@ -52,8 +57,18 @@ export const test_validateEquals_TagObjectUnion = _test_validateEquals(
                 ): boolean =>
                     [
                         ("string" === typeof input.value &&
-                            3 <= input.value.length &&
-                            7 >= input.value.length) ||
+                            (3 <= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@minLength 3)",
+                                    value: input.value,
+                                })) &&
+                            (7 >= input.value.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".value",
+                                    expected: "string (@maxLength 7)",
+                                    value: input.value,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".value",
                                 expected: "string",

--- a/test/generated/output/validateEquals/test_validateEquals_TagPattern.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagPattern.ts
@@ -22,40 +22,64 @@ export const test_validateEquals_TagPattern = _test_validateEquals(
                 ): boolean =>
                     [
                         ("string" === typeof input.uuid &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                ).test(input.uuid)) ||
+                                ).test(input.uuid) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uuid",
+                                    expected:
+                                        "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                    value: input.uuid,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uuid",
                                 expected: "string",
                                 value: input.uuid,
                             }),
                         ("string" === typeof input.email &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                ).test(input.email)) ||
+                                ).test(input.email) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".email",
+                                    expected:
+                                        'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                    value: input.email,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".email",
                                 expected: "string",
                                 value: input.email,
                             }),
                         ("string" === typeof input.ipv4 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                ).test(input.ipv4)) ||
+                                ).test(input.ipv4) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv4",
+                                    expected:
+                                        "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                    value: input.ipv4,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",
                                 expected: "string",
                                 value: input.ipv4,
                             }),
                         ("string" === typeof input.ipv6 &&
-                            true ===
+                            (true ===
                                 RegExp(
                                     /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                ).test(input.ipv6)) ||
+                                ).test(input.ipv6) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".ipv6",
+                                    expected:
+                                        "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                    value: input.ipv6,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv6",
                                 expected: "string",

--- a/test/generated/output/validateEquals/test_validateEquals_TagRange.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagRange.ts
@@ -23,7 +23,12 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                     [
                         ("number" === typeof input.greater &&
                             Number.isFinite(input.greater) &&
-                            3 < input.greater) ||
+                            (3 < input.greater ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater",
                                 expected: "number",
@@ -31,7 +36,12 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                             }),
                         ("number" === typeof input.greater_equal &&
                             Number.isFinite(input.greater_equal) &&
-                            3 <= input.greater_equal) ||
+                            (3 <= input.greater_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number",
@@ -39,7 +49,12 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                             }),
                         ("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
-                            7 > input.less) ||
+                            (7 > input.less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less",
                                 expected: "number",
@@ -47,39 +62,84 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                             }),
                         ("number" === typeof input.less_equal &&
                             Number.isFinite(input.less_equal) &&
-                            7 >= input.less_equal) ||
+                            (7 >= input.less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".less_equal",
                                 expected: "number",
                                 value: input.less_equal,
                             }),
                         ("number" === typeof input.greater_less &&
-                            3 < input.greater_less &&
-                            7 > input.greater_less) ||
+                            (3 < input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less,
+                                })) &&
+                            (7 > input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number",
                                 value: input.greater_less,
                             }),
                         ("number" === typeof input.greater_equal_less &&
-                            3 <= input.greater_equal_less &&
-                            7 > input.greater_equal_less) ||
+                            (3 <= input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less,
+                                })) &&
+                            (7 > input.greater_equal_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@exclusiveMaximum 7)",
+                                    value: input.greater_equal_less,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less",
                                 expected: "number",
                                 value: input.greater_equal_less,
                             }),
                         ("number" === typeof input.greater_less_equal &&
-                            3 < input.greater_less_equal &&
-                            7 >= input.greater_less_equal) ||
+                            (3 < input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            (7 >= input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number",
                                 value: input.greater_less_equal,
                             }),
                         ("number" === typeof input.greater_equal_less_equal &&
-                            3 <= input.greater_equal_less_equal &&
-                            7 >= input.greater_equal_less_equal) ||
+                            (3 <= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@minimum 3)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
+                            (7 >= input.greater_equal_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@maximum 7)",
+                                    value: input.greater_equal_less_equal,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",

--- a/test/generated/output/validateEquals/test_validateEquals_TagStep.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagStep.ts
@@ -22,34 +22,84 @@ export const test_validateEquals_TagStep = _test_validateEquals(
                 ): boolean =>
                     [
                         ("number" === typeof input.exclusiveMinimum &&
-                            0 === (input.exclusiveMinimum % 5) - 3 &&
-                            3 < input.exclusiveMinimum) ||
+                            (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@step 5)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (3 < input.exclusiveMinimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "number (@exclusiveMinimum 3)",
+                                    value: input.exclusiveMinimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".exclusiveMinimum",
                                 expected: "number",
                                 value: input.exclusiveMinimum,
                             }),
                         ("number" === typeof input.minimum &&
-                            0 === (input.minimum % 5) - 3 &&
-                            3 <= input.minimum) ||
+                            (0 === (input.minimum % 5) - 3 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@step 5)",
+                                    value: input.minimum,
+                                })) &&
+                            (3 <= input.minimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@minimum 3)",
+                                    value: input.minimum,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "number",
                                 value: input.minimum,
                             }),
                         ("number" === typeof input.range &&
-                            0 === (input.range % 5) - 0 &&
-                            0 < input.range &&
-                            100 > input.range) ||
+                            (0 === (input.range % 5) - 0 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@step 5)",
+                                    value: input.range,
+                                })) &&
+                            (0 < input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMinimum 0)",
+                                    value: input.range,
+                                })) &&
+                            (100 > input.range ||
+                                $report(_exceptionable, {
+                                    path: _path + ".range",
+                                    expected: "number (@exclusiveMaximum 100)",
+                                    value: input.range,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".range",
                                 expected: "number",
                                 value: input.range,
                             }),
                         ("number" === typeof input.multipleOf &&
-                            0 === input.multipleOf % 5 &&
-                            3 <= input.multipleOf &&
-                            99 >= input.multipleOf) ||
+                            (0 === input.multipleOf % 5 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@multipleOf 5)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (3 <= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@minimum 3)",
+                                    value: input.multipleOf,
+                                })) &&
+                            (99 >= input.multipleOf ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@maximum 99)",
+                                    value: input.multipleOf,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "number",

--- a/test/generated/output/validateEquals/test_validateEquals_TagTuple.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagTuple.ts
@@ -37,24 +37,56 @@ export const test_validateEquals_TagTuple = _test_validateEquals(
                                 })) &&
                             [
                                 ("string" === typeof input.tuple[0] &&
-                                    3 <= input.tuple[0].length &&
-                                    7 >= input.tuple[0].length) ||
+                                    (3 <= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@minLength 3)",
+                                            value: input.tuple[0],
+                                        })) &&
+                                    (7 >= input.tuple[0].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[0]",
+                                            expected: "string (@maxLength 7)",
+                                            value: input.tuple[0],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[0]",
                                         expected: "string",
                                         value: input.tuple[0],
                                     }),
                                 ("number" === typeof input.tuple[1] &&
-                                    3 <= input.tuple[1] &&
-                                    7 >= input.tuple[1]) ||
+                                    (3 <= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@minimum 3)",
+                                            value: input.tuple[1],
+                                        })) &&
+                                    (7 >= input.tuple[1] ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[1]",
+                                            expected: "number (@maximum 7)",
+                                            value: input.tuple[1],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[1]",
                                         expected: "number",
                                         value: input.tuple[1],
                                     }),
                                 (((Array.isArray(input.tuple[2]) &&
-                                    3 <= input.tuple[2].length &&
-                                    7 >= input.tuple[2].length) ||
+                                    (3 <= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[2],
+                                        })) &&
+                                    (7 >= input.tuple[2].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[2]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[2],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[2]",
                                         expected: "Array<string>",
@@ -64,8 +96,34 @@ export const test_validateEquals_TagTuple = _test_validateEquals(
                                         .map(
                                             (elem: any, _index1: number) =>
                                                 ("string" === typeof elem &&
-                                                    3 <= elem.length &&
-                                                    7 >= elem.length) ||
+                                                    (3 <= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@minLength 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem.length ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[2][" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "string (@maxLength 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
@@ -83,8 +141,20 @@ export const test_validateEquals_TagTuple = _test_validateEquals(
                                         value: input.tuple[2],
                                     }),
                                 (((Array.isArray(input.tuple[3]) &&
-                                    3 <= input.tuple[3].length &&
-                                    7 >= input.tuple[3].length) ||
+                                    (3 <= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@minItems 3)",
+                                            value: input.tuple[3],
+                                        })) &&
+                                    (7 >= input.tuple[3].length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".tuple[3]",
+                                            expected:
+                                                "Array.length (@maxItems 7)",
+                                            value: input.tuple[3],
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".tuple[3]",
                                         expected: "Array<number>",
@@ -94,8 +164,34 @@ export const test_validateEquals_TagTuple = _test_validateEquals(
                                         .map(
                                             (elem: any, _index2: number) =>
                                                 ("number" === typeof elem &&
-                                                    3 <= elem &&
-                                                    7 >= elem) ||
+                                                    (3 <= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@minimum 3)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (7 >= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".tuple[3][" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@maximum 7)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +

--- a/test/generated/output/validateEquals/test_validateEquals_TagType.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagType.ts
@@ -23,7 +23,12 @@ export const test_validateEquals_TagType = _test_validateEquals(
                     [
                         ("number" === typeof input.int &&
                             Number.isFinite(input.int) &&
-                            parseInt(input.int) === input.int) ||
+                            (parseInt(input.int) === input.int ||
+                                $report(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".int",
                                 expected: "number",
@@ -31,8 +36,18 @@ export const test_validateEquals_TagType = _test_validateEquals(
                             }),
                         ("number" === typeof input.uint &&
                             Number.isFinite(input.uint) &&
-                            parseInt(input.uint) === input.uint &&
-                            0 <= input.uint) ||
+                            (parseInt(input.uint) === input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (0 <= input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number",

--- a/test/generated/output/validateParse/test_validateParse_TagArray.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagArray.ts
@@ -23,7 +23,12 @@ export const test_validateParse_TagArray = _test_validateParse(
                     ): boolean =>
                         [
                             (((Array.isArray(input.items) &&
-                                3 === input.items.length) ||
+                                (3 === input.items.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected: "Array.length (@items 3)",
+                                        value: input.items,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".items",
                                     expected: "Array<string>",
@@ -33,7 +38,17 @@ export const test_validateParse_TagArray = _test_validateParse(
                                     .map(
                                         (elem: any, _index2: number) =>
                                             ("string" === typeof elem &&
-                                                true === $is_uuid(elem)) ||
+                                                (true === $is_uuid(elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".items[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@format uuid)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -51,7 +66,12 @@ export const test_validateParse_TagArray = _test_validateParse(
                                     value: input.items,
                                 }),
                             (((Array.isArray(input.minItems) &&
-                                3 <= input.minItems.length) ||
+                                (3 <= input.minItems.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.minItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
                                     expected: "Array<number>",
@@ -62,7 +82,17 @@ export const test_validateParse_TagArray = _test_validateParse(
                                         (elem: any, _index3: number) =>
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem) &&
-                                                3 <= elem) ||
+                                                (3 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".minItems[" +
+                                                            _index3 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 3)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -80,7 +110,12 @@ export const test_validateParse_TagArray = _test_validateParse(
                                     value: input.minItems,
                                 }),
                             (((Array.isArray(input.maxItems) &&
-                                7 >= input.maxItems.length) ||
+                                (7 >= input.maxItems.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.maxItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "Array<(number | string)>",
@@ -90,10 +125,30 @@ export const test_validateParse_TagArray = _test_validateParse(
                                     .map(
                                         (elem: any, _index4: number) =>
                                             ("string" === typeof elem &&
-                                                7 >= elem.length) ||
+                                                (7 >= elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".maxItems[" +
+                                                            _index4 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@maxLength 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem) &&
-                                                7 >= elem) ||
+                                                (7 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".maxItems[" +
+                                                            _index4 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -111,8 +166,18 @@ export const test_validateParse_TagArray = _test_validateParse(
                                     value: input.maxItems,
                                 }),
                             (((Array.isArray(input.both) &&
-                                3 <= input.both.length &&
-                                7 >= input.both.length) ||
+                                (3 <= input.both.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".both",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.both,
+                                    })) &&
+                                (7 >= input.both.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".both",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.both,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".both",
                                     expected: "Array<string>",
@@ -122,7 +187,17 @@ export const test_validateParse_TagArray = _test_validateParse(
                                     .map(
                                         (elem: any, _index5: number) =>
                                             ("string" === typeof elem &&
-                                                true === $is_uuid(elem)) ||
+                                                (true === $is_uuid(elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".both[" +
+                                                            _index5 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@format uuid)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +

--- a/test/generated/output/validateParse/test_validateParse_TagAtomicUnion.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagAtomicUnion.ts
@@ -26,11 +26,26 @@ export const test_validateParse_TagAtomicUnion = _test_validateParse(
                     ): boolean =>
                         [
                             ("string" === typeof input.value &&
-                                3 <= input.value.length &&
-                                7 >= input.value.length) ||
+                                (3 <= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@minLength 3)",
+                                        value: input.value,
+                                    })) &&
+                                (7 >= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.value,
+                                    }))) ||
                                 ("number" === typeof input.value &&
                                     Number.isFinite(input.value) &&
-                                    3 <= input.value) ||
+                                    (3 <= input.value ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".value",
+                                            expected: "number (@minimum 3)",
+                                            value: input.value,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "(number | string)",

--- a/test/generated/output/validateParse/test_validateParse_TagCustom.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagCustom.ts
@@ -24,31 +24,46 @@ export const test_validateParse_TagCustom = _test_validateParse(
                     ): boolean =>
                         [
                             ("string" === typeof input.id &&
-                                true === $is_uuid(input.id)) ||
+                                (true === $is_uuid(input.id) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".id",
+                                        expected: "string (@format uuid)",
+                                        value: input.id,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".id",
                                     expected: "string",
                                     value: input.id,
                                 }),
-                            ("string" === typeof input.dolloar &&
-                                $is_custom(
+                            ("string" === typeof input.dollar &&
+                                ($is_custom(
                                     "dollar",
                                     "string",
                                     "",
-                                    input.dolloar,
-                                )) ||
+                                    input.dollar,
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".dollar",
+                                        expected: "string (@dollar)",
+                                        value: input.dollar,
+                                    }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".dolloar",
+                                    path: _path + ".dollar",
                                     expected: "string",
-                                    value: input.dolloar,
+                                    value: input.dollar,
                                 }),
                             ("string" === typeof input.postfix &&
-                                $is_custom(
+                                ($is_custom(
                                     "postfix",
                                     "string",
                                     "abcd",
                                     input.postfix,
-                                )) ||
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".postfix",
+                                        expected: "string (@postfix abcd)",
+                                        value: input.postfix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".postfix",
                                     expected: "string",
@@ -56,12 +71,17 @@ export const test_validateParse_TagCustom = _test_validateParse(
                                 }),
                             ("number" === typeof input.log &&
                                 Number.isFinite(input.log) &&
-                                $is_custom(
+                                ($is_custom(
                                     "powerOf",
                                     "number",
                                     "10",
                                     input.log,
-                                )) ||
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".log",
+                                        expected: "number (@powerOf 10)",
+                                        value: input.log,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".log",
                                     expected: "number",

--- a/test/generated/output/validateParse/test_validateParse_TagFormat.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagFormat.ts
@@ -29,63 +29,108 @@ export const test_validateParse_TagFormat = _test_validateParse(
                     ): boolean =>
                         [
                             ("string" === typeof input.uuid &&
-                                true === $is_uuid(input.uuid)) ||
+                                (true === $is_uuid(input.uuid) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uuid",
+                                        expected: "string (@format uuid)",
+                                        value: input.uuid,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uuid",
                                     expected: "string",
                                     value: input.uuid,
                                 }),
                             ("string" === typeof input.email &&
-                                true === $is_email(input.email)) ||
+                                (true === $is_email(input.email) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".email",
+                                        expected: "string (@format email)",
+                                        value: input.email,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".email",
                                     expected: "string",
                                     value: input.email,
                                 }),
                             ("string" === typeof input.url &&
-                                true === $is_url(input.url)) ||
+                                (true === $is_url(input.url) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".url",
+                                        expected: "string (@format url)",
+                                        value: input.url,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".url",
                                     expected: "string",
                                     value: input.url,
                                 }),
                             ("string" === typeof input.ipv4 &&
-                                true === $is_ipv4(input.ipv4)) ||
+                                (true === $is_ipv4(input.ipv4) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv4",
+                                        expected: "string (@format ipv4)",
+                                        value: input.ipv4,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",
                                     expected: "string",
                                     value: input.ipv4,
                                 }),
                             ("string" === typeof input.ipv6 &&
-                                true === $is_ipv6(input.ipv6)) ||
+                                (true === $is_ipv6(input.ipv6) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv6",
+                                        expected: "string (@format ipv6)",
+                                        value: input.ipv6,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv6",
                                     expected: "string",
                                     value: input.ipv6,
                                 }),
                             ("string" === typeof input.date &&
-                                true === $is_date(input.date)) ||
+                                (true === $is_date(input.date) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".date",
+                                        expected: "string (@format date)",
+                                        value: input.date,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".date",
                                     expected: "string",
                                     value: input.date,
                                 }),
                             ("string" === typeof input.date_time &&
-                                true === $is_datetime(input.date_time)) ||
+                                (true === $is_datetime(input.date_time) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".date_time",
+                                        expected: "string (@format datetime)",
+                                        value: input.date_time,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".date_time",
                                     expected: "string",
                                     value: input.date_time,
                                 }),
                             ("string" === typeof input.datetime &&
-                                true === $is_datetime(input.datetime)) ||
+                                (true === $is_datetime(input.datetime) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".datetime",
+                                        expected: "string (@format datetime)",
+                                        value: input.datetime,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".datetime",
                                     expected: "string",
                                     value: input.datetime,
                                 }),
                             ("string" === typeof input.dateTime &&
-                                true === $is_datetime(input.dateTime)) ||
+                                (true === $is_datetime(input.dateTime) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".dateTime",
+                                        expected: "string (@format datetime)",
+                                        value: input.dateTime,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".dateTime",
                                     expected: "string",

--- a/test/generated/output/validateParse/test_validateParse_TagLength.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagLength.ts
@@ -22,29 +22,54 @@ export const test_validateParse_TagLength = _test_validateParse(
                     ): boolean =>
                         [
                             ("string" === typeof input.fixed &&
-                                5 === input.fixed.length) ||
+                                (5 === input.fixed.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".fixed",
+                                        expected: "string (@length 5)",
+                                        value: input.fixed,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".fixed",
                                     expected: "string",
                                     value: input.fixed,
                                 }),
                             ("string" === typeof input.minimum &&
-                                3 <= input.minimum.length) ||
+                                (3 <= input.minimum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "string (@minLength 3)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "string",
                                     value: input.minimum,
                                 }),
                             ("string" === typeof input.maximum &&
-                                7 >= input.maximum.length) ||
+                                (7 >= input.maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "string",
                                     value: input.maximum,
                                 }),
                             ("string" === typeof input.minimum_and_maximum &&
-                                3 <= input.minimum_and_maximum.length &&
-                                7 >= input.minimum_and_maximum.length) ||
+                                (3 <= input.minimum_and_maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum_and_maximum",
+                                        expected: "string (@minLength 3)",
+                                        value: input.minimum_and_maximum,
+                                    })) &&
+                                (7 >= input.minimum_and_maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum_and_maximum",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.minimum_and_maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum_and_maximum",
                                     expected: "string",

--- a/test/generated/output/validateParse/test_validateParse_TagMatrix.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagMatrix.ts
@@ -23,7 +23,12 @@ export const test_validateParse_TagMatrix = _test_validateParse(
                     ): boolean =>
                         [
                             (((Array.isArray(input.matrix) &&
-                                3 === input.matrix.length) ||
+                                (3 === input.matrix.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".matrix",
+                                        expected: "Array.length (@items 3)",
+                                        value: input.matrix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".matrix",
                                     expected: "Array<Array<string>>",
@@ -33,7 +38,17 @@ export const test_validateParse_TagMatrix = _test_validateParse(
                                     .map(
                                         (elem: any, _index1: number) =>
                                             (((Array.isArray(elem) &&
-                                                3 === elem.length) ||
+                                                (3 === elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".matrix[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected:
+                                                            "Array.length (@items 3)",
+                                                        value: elem,
+                                                    }))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
@@ -51,10 +66,25 @@ export const test_validateParse_TagMatrix = _test_validateParse(
                                                         ) =>
                                                             ("string" ===
                                                                 typeof elem &&
-                                                                true ===
+                                                                (true ===
                                                                     $is_uuid(
                                                                         elem,
-                                                                    )) ||
+                                                                    ) ||
+                                                                    $report(
+                                                                        _exceptionable,
+                                                                        {
+                                                                            path:
+                                                                                _path +
+                                                                                ".matrix[" +
+                                                                                _index1 +
+                                                                                "][" +
+                                                                                _index2 +
+                                                                                "]",
+                                                                            expected:
+                                                                                "string (@format uuid)",
+                                                                            value: elem,
+                                                                        },
+                                                                    ))) ||
                                                             $report(
                                                                 _exceptionable,
                                                                 {

--- a/test/generated/output/validateParse/test_validateParse_TagObjectUnion.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagObjectUnion.ts
@@ -27,7 +27,12 @@ export const test_validateParse_TagObjectUnion = _test_validateParse(
                         [
                             ("number" === typeof input.value &&
                                 Number.isFinite(input.value) &&
-                                3 <= input.value) ||
+                                (3 <= input.value ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "number (@minimum 3)",
+                                        value: input.value,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "number",
@@ -41,8 +46,18 @@ export const test_validateParse_TagObjectUnion = _test_validateParse(
                     ): boolean =>
                         [
                             ("string" === typeof input.value &&
-                                3 <= input.value.length &&
-                                7 >= input.value.length) ||
+                                (3 <= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@minLength 3)",
+                                        value: input.value,
+                                    })) &&
+                                (7 >= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.value,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "string",

--- a/test/generated/output/validateParse/test_validateParse_TagPattern.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagPattern.ts
@@ -22,40 +22,64 @@ export const test_validateParse_TagPattern = _test_validateParse(
                     ): boolean =>
                         [
                             ("string" === typeof input.uuid &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                    ).test(input.uuid)) ||
+                                    ).test(input.uuid) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uuid",
+                                        expected:
+                                            "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                        value: input.uuid,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uuid",
                                     expected: "string",
                                     value: input.uuid,
                                 }),
                             ("string" === typeof input.email &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                    ).test(input.email)) ||
+                                    ).test(input.email) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".email",
+                                        expected:
+                                            'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                        value: input.email,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".email",
                                     expected: "string",
                                     value: input.email,
                                 }),
                             ("string" === typeof input.ipv4 &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                    ).test(input.ipv4)) ||
+                                    ).test(input.ipv4) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv4",
+                                        expected:
+                                            "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                        value: input.ipv4,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",
                                     expected: "string",
                                     value: input.ipv4,
                                 }),
                             ("string" === typeof input.ipv6 &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                    ).test(input.ipv6)) ||
+                                    ).test(input.ipv6) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv6",
+                                        expected:
+                                            "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                        value: input.ipv6,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv6",
                                     expected: "string",

--- a/test/generated/output/validateParse/test_validateParse_TagRange.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagRange.ts
@@ -23,7 +23,13 @@ export const test_validateParse_TagRange = _test_validateParse(
                         [
                             ("number" === typeof input.greater &&
                                 Number.isFinite(input.greater) &&
-                                3 < input.greater) ||
+                                (3 < input.greater ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater",
                                     expected: "number",
@@ -31,7 +37,12 @@ export const test_validateParse_TagRange = _test_validateParse(
                                 }),
                             ("number" === typeof input.greater_equal &&
                                 Number.isFinite(input.greater_equal) &&
-                                3 <= input.greater_equal) ||
+                                (3 <= input.greater_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal",
                                     expected: "number",
@@ -39,7 +50,13 @@ export const test_validateParse_TagRange = _test_validateParse(
                                 }),
                             ("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
-                                7 > input.less) ||
+                                (7 > input.less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number",
@@ -47,31 +64,70 @@ export const test_validateParse_TagRange = _test_validateParse(
                                 }),
                             ("number" === typeof input.less_equal &&
                                 Number.isFinite(input.less_equal) &&
-                                7 >= input.less_equal) ||
+                                (7 >= input.less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".less_equal",
                                     expected: "number",
                                     value: input.less_equal,
                                 }),
                             ("number" === typeof input.greater_less &&
-                                3 < input.greater_less &&
-                                7 > input.greater_less) ||
+                                (3 < input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater_less,
+                                    })) &&
+                                (7 > input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.greater_less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number",
                                     value: input.greater_less,
                                 }),
                             ("number" === typeof input.greater_equal_less &&
-                                3 <= input.greater_equal_less &&
-                                7 > input.greater_equal_less) ||
+                                (3 <= input.greater_equal_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal_less,
+                                    })) &&
+                                (7 > input.greater_equal_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.greater_equal_less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less",
                                     expected: "number",
                                     value: input.greater_equal_less,
                                 }),
                             ("number" === typeof input.greater_less_equal &&
-                                3 < input.greater_less_equal &&
-                                7 >= input.greater_less_equal) ||
+                                (3 < input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                (7 >= input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.greater_less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number",
@@ -79,8 +135,20 @@ export const test_validateParse_TagRange = _test_validateParse(
                                 }),
                             ("number" ===
                                 typeof input.greater_equal_less_equal &&
-                                3 <= input.greater_equal_less_equal &&
-                                7 >= input.greater_equal_less_equal) ||
+                                (3 <= input.greater_equal_less_equal ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
+                                (7 >= input.greater_equal_less_equal ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.greater_equal_less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
                                     expected: "number",

--- a/test/generated/output/validateParse/test_validateParse_TagStep.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagStep.ts
@@ -22,34 +22,87 @@ export const test_validateParse_TagStep = _test_validateParse(
                     ): boolean =>
                         [
                             ("number" === typeof input.exclusiveMinimum &&
-                                0 === (input.exclusiveMinimum % 5) - 3 &&
-                                3 < input.exclusiveMinimum) ||
+                                (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected: "number (@step 5)",
+                                        value: input.exclusiveMinimum,
+                                    })) &&
+                                (3 < input.exclusiveMinimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.exclusiveMinimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".exclusiveMinimum",
                                     expected: "number",
                                     value: input.exclusiveMinimum,
                                 }),
                             ("number" === typeof input.minimum &&
-                                0 === (input.minimum % 5) - 3 &&
-                                3 <= input.minimum) ||
+                                (0 === (input.minimum % 5) - 3 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@step 5)",
+                                        value: input.minimum,
+                                    })) &&
+                                (3 <= input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@minimum 3)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "number",
                                     value: input.minimum,
                                 }),
                             ("number" === typeof input.range &&
-                                0 === (input.range % 5) - 0 &&
-                                0 < input.range &&
-                                100 > input.range) ||
+                                (0 === (input.range % 5) - 0 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected: "number (@step 5)",
+                                        value: input.range,
+                                    })) &&
+                                (0 < input.range ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected:
+                                            "number (@exclusiveMinimum 0)",
+                                        value: input.range,
+                                    })) &&
+                                (100 > input.range ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected:
+                                            "number (@exclusiveMaximum 100)",
+                                        value: input.range,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".range",
                                     expected: "number",
                                     value: input.range,
                                 }),
                             ("number" === typeof input.multipleOf &&
-                                0 === input.multipleOf % 5 &&
-                                3 <= input.multipleOf &&
-                                99 >= input.multipleOf) ||
+                                (0 === input.multipleOf % 5 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@multipleOf 5)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                (3 <= input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@minimum 3)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                (99 >= input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@maximum 99)",
+                                        value: input.multipleOf,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number",

--- a/test/generated/output/validateParse/test_validateParse_TagTuple.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagTuple.ts
@@ -37,24 +37,58 @@ export const test_validateParse_TagTuple = _test_validateParse(
                                     })) &&
                                 [
                                     ("string" === typeof input.tuple[0] &&
-                                        3 <= input.tuple[0].length &&
-                                        7 >= input.tuple[0].length) ||
+                                        (3 <= input.tuple[0].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[0]",
+                                                expected:
+                                                    "string (@minLength 3)",
+                                                value: input.tuple[0],
+                                            })) &&
+                                        (7 >= input.tuple[0].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[0]",
+                                                expected:
+                                                    "string (@maxLength 7)",
+                                                value: input.tuple[0],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[0]",
                                             expected: "string",
                                             value: input.tuple[0],
                                         }),
                                     ("number" === typeof input.tuple[1] &&
-                                        3 <= input.tuple[1] &&
-                                        7 >= input.tuple[1]) ||
+                                        (3 <= input.tuple[1] ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[1]",
+                                                expected: "number (@minimum 3)",
+                                                value: input.tuple[1],
+                                            })) &&
+                                        (7 >= input.tuple[1] ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[1]",
+                                                expected: "number (@maximum 7)",
+                                                value: input.tuple[1],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[1]",
                                             expected: "number",
                                             value: input.tuple[1],
                                         }),
                                     (((Array.isArray(input.tuple[2]) &&
-                                        3 <= input.tuple[2].length &&
-                                        7 >= input.tuple[2].length) ||
+                                        (3 <= input.tuple[2].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[2]",
+                                                expected:
+                                                    "Array.length (@minItems 3)",
+                                                value: input.tuple[2],
+                                            })) &&
+                                        (7 >= input.tuple[2].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[2]",
+                                                expected:
+                                                    "Array.length (@maxItems 7)",
+                                                value: input.tuple[2],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[2]",
                                             expected: "Array<string>",
@@ -64,8 +98,34 @@ export const test_validateParse_TagTuple = _test_validateParse(
                                             .map(
                                                 (elem: any, _index1: number) =>
                                                     ("string" === typeof elem &&
-                                                        3 <= elem.length &&
-                                                        7 >= elem.length) ||
+                                                        (3 <= elem.length ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[2][" +
+                                                                        _index1 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "string (@minLength 3)",
+                                                                    value: elem,
+                                                                },
+                                                            )) &&
+                                                        (7 >= elem.length ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[2][" +
+                                                                        _index1 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "string (@maxLength 7)",
+                                                                    value: elem,
+                                                                },
+                                                            ))) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
@@ -83,8 +143,20 @@ export const test_validateParse_TagTuple = _test_validateParse(
                                             value: input.tuple[2],
                                         }),
                                     (((Array.isArray(input.tuple[3]) &&
-                                        3 <= input.tuple[3].length &&
-                                        7 >= input.tuple[3].length) ||
+                                        (3 <= input.tuple[3].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[3]",
+                                                expected:
+                                                    "Array.length (@minItems 3)",
+                                                value: input.tuple[3],
+                                            })) &&
+                                        (7 >= input.tuple[3].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[3]",
+                                                expected:
+                                                    "Array.length (@maxItems 7)",
+                                                value: input.tuple[3],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[3]",
                                             expected: "Array<number>",
@@ -94,8 +166,34 @@ export const test_validateParse_TagTuple = _test_validateParse(
                                             .map(
                                                 (elem: any, _index2: number) =>
                                                     ("number" === typeof elem &&
-                                                        3 <= elem &&
-                                                        7 >= elem) ||
+                                                        (3 <= elem ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[3][" +
+                                                                        _index2 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "number (@minimum 3)",
+                                                                    value: elem,
+                                                                },
+                                                            )) &&
+                                                        (7 >= elem ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[3][" +
+                                                                        _index2 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "number (@maximum 7)",
+                                                                    value: elem,
+                                                                },
+                                                            ))) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +

--- a/test/generated/output/validateParse/test_validateParse_TagType.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagType.ts
@@ -23,7 +23,12 @@ export const test_validateParse_TagType = _test_validateParse(
                         [
                             ("number" === typeof input.int &&
                                 Number.isFinite(input.int) &&
-                                parseInt(input.int) === input.int) ||
+                                (parseInt(input.int) === input.int ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".int",
                                     expected: "number",
@@ -31,8 +36,18 @@ export const test_validateParse_TagType = _test_validateParse(
                                 }),
                             ("number" === typeof input.uint &&
                                 Number.isFinite(input.uint) &&
-                                parseInt(input.uint) === input.uint &&
-                                0 <= input.uint) ||
+                                (parseInt(input.uint) === input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (0 <= input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number",

--- a/test/generated/output/validateParse/test_validateParse_UltimateUnion.ts
+++ b/test/generated/output/validateParse/test_validateParse_UltimateUnion.ts
@@ -1218,8 +1218,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             undefined === input.minimum ||
                                 ("number" === typeof input.minimum &&
                                     Number.isFinite(input.minimum) &&
-                                    parseInt(input.minimum) ===
-                                        input.minimum) ||
+                                    (parseInt(input.minimum) ===
+                                        input.minimum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "(number | undefined)",
@@ -1228,8 +1233,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             undefined === input.maximum ||
                                 ("number" === typeof input.maximum &&
                                     Number.isFinite(input.maximum) &&
-                                    parseInt(input.maximum) ===
-                                        input.maximum) ||
+                                    (parseInt(input.maximum) ===
+                                        input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "(number | undefined)",
@@ -1252,8 +1262,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             undefined === input.multipleOf ||
                                 ("number" === typeof input.multipleOf &&
                                     Number.isFinite(input.multipleOf) &&
-                                    parseInt(input.multipleOf) ===
-                                        input.multipleOf) ||
+                                    (parseInt(input.multipleOf) ===
+                                        input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "(number | undefined)",
@@ -1622,9 +1637,19 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             undefined === input.minLength ||
                                 ("number" === typeof input.minLength &&
                                     Number.isFinite(input.minLength) &&
-                                    parseInt(input.minLength) ===
-                                        input.minLength &&
-                                    0 <= input.minLength) ||
+                                    (parseInt(input.minLength) ===
+                                        input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        })) &&
+                                    (0 <= input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minLength",
                                     expected: "(number | undefined)",
@@ -1633,9 +1658,19 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             undefined === input.maxLength ||
                                 ("number" === typeof input.maxLength &&
                                     Number.isFinite(input.maxLength) &&
-                                    parseInt(input.maxLength) ===
-                                        input.maxLength &&
-                                    0 <= input.maxLength) ||
+                                    (parseInt(input.maxLength) ===
+                                        input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxLength",
                                     expected: "(number | undefined)",
@@ -1838,9 +1873,19 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             undefined === input.minItems ||
                                 ("number" === typeof input.minItems &&
                                     Number.isFinite(input.minItems) &&
-                                    parseInt(input.minItems) ===
-                                        input.minItems &&
-                                    0 <= input.minItems) ||
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
                                     expected: "(number | undefined)",
@@ -1849,9 +1894,19 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             undefined === input.maxItems ||
                                 ("number" === typeof input.maxItems &&
                                     Number.isFinite(input.maxItems) &&
-                                    parseInt(input.maxItems) ===
-                                        input.maxItems &&
-                                    0 <= input.maxItems) ||
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "(number | undefined)",

--- a/test/generated/output/validatePrune/test_validatePrune_TagArray.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagArray.ts
@@ -25,7 +25,12 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                     ): boolean =>
                         [
                             (((Array.isArray(input.items) &&
-                                3 === input.items.length) ||
+                                (3 === input.items.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected: "Array.length (@items 3)",
+                                        value: input.items,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".items",
                                     expected: "Array<string>",
@@ -35,7 +40,17 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                                     .map(
                                         (elem: any, _index2: number) =>
                                             ("string" === typeof elem &&
-                                                true === $is_uuid(elem)) ||
+                                                (true === $is_uuid(elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".items[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@format uuid)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -53,7 +68,12 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                                     value: input.items,
                                 }),
                             (((Array.isArray(input.minItems) &&
-                                3 <= input.minItems.length) ||
+                                (3 <= input.minItems.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.minItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
                                     expected: "Array<number>",
@@ -64,7 +84,17 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                                         (elem: any, _index3: number) =>
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem) &&
-                                                3 <= elem) ||
+                                                (3 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".minItems[" +
+                                                            _index3 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 3)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -82,7 +112,12 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                                     value: input.minItems,
                                 }),
                             (((Array.isArray(input.maxItems) &&
-                                7 >= input.maxItems.length) ||
+                                (7 >= input.maxItems.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.maxItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "Array<(number | string)>",
@@ -92,10 +127,30 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                                     .map(
                                         (elem: any, _index4: number) =>
                                             ("string" === typeof elem &&
-                                                7 >= elem.length) ||
+                                                (7 >= elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".maxItems[" +
+                                                            _index4 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@maxLength 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem) &&
-                                                7 >= elem) ||
+                                                (7 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".maxItems[" +
+                                                            _index4 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -113,8 +168,18 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                                     value: input.maxItems,
                                 }),
                             (((Array.isArray(input.both) &&
-                                3 <= input.both.length &&
-                                7 >= input.both.length) ||
+                                (3 <= input.both.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".both",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.both,
+                                    })) &&
+                                (7 >= input.both.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".both",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.both,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".both",
                                     expected: "Array<string>",
@@ -124,7 +189,17 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                                     .map(
                                         (elem: any, _index5: number) =>
                                             ("string" === typeof elem &&
-                                                true === $is_uuid(elem)) ||
+                                                (true === $is_uuid(elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".both[" +
+                                                            _index5 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@format uuid)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +

--- a/test/generated/output/validatePrune/test_validatePrune_TagAtomicUnion.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagAtomicUnion.ts
@@ -24,11 +24,26 @@ export const test_validatePrune_TagAtomicUnion = _test_validatePrune(
                     ): boolean =>
                         [
                             ("string" === typeof input.value &&
-                                3 <= input.value.length &&
-                                7 >= input.value.length) ||
+                                (3 <= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@minLength 3)",
+                                        value: input.value,
+                                    })) &&
+                                (7 >= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.value,
+                                    }))) ||
                                 ("number" === typeof input.value &&
                                     Number.isFinite(input.value) &&
-                                    3 <= input.value) ||
+                                    (3 <= input.value ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".value",
+                                            expected: "number (@minimum 3)",
+                                            value: input.value,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "(number | string)",

--- a/test/generated/output/validatePrune/test_validatePrune_TagBigInt.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagBigInt.ts
@@ -28,29 +28,54 @@ export const test_validatePrune_TagBigInt = _test_validatePrune(
                                     value: input.value,
                                 }),
                             ("bigint" === typeof input.ranged &&
-                                0n <= input.ranged &&
-                                100n >= input.ranged) ||
+                                (0n <= input.ranged ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ranged",
+                                        expected: "bigint (@minimum 0)",
+                                        value: input.ranged,
+                                    })) &&
+                                (100n >= input.ranged ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ranged",
+                                        expected: "bigint (@maximum 100)",
+                                        value: input.ranged,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ranged",
                                     expected: "bigint",
                                     value: input.ranged,
                                 }),
                             ("bigint" === typeof input.minimum &&
-                                0n <= input.minimum) ||
+                                (0n <= input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "bigint (@minimum 0)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "bigint",
                                     value: input.minimum,
                                 }),
                             ("bigint" === typeof input.maximum &&
-                                100n >= input.maximum) ||
+                                (100n >= input.maximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "bigint (@maximum 100)",
+                                        value: input.maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "bigint",
                                     value: input.maximum,
                                 }),
                             ("bigint" === typeof input.multipleOf &&
-                                0n === input.multipleOf % 3n) ||
+                                (0n === input.multipleOf % 3n ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "bigint (@multipleOf 3)",
+                                        value: input.multipleOf,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "bigint",

--- a/test/generated/output/validatePrune/test_validatePrune_TagCustom.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagCustom.ts
@@ -24,31 +24,46 @@ export const test_validatePrune_TagCustom = _test_validatePrune(
                     ): boolean =>
                         [
                             ("string" === typeof input.id &&
-                                true === $is_uuid(input.id)) ||
+                                (true === $is_uuid(input.id) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".id",
+                                        expected: "string (@format uuid)",
+                                        value: input.id,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".id",
                                     expected: "string",
                                     value: input.id,
                                 }),
-                            ("string" === typeof input.dolloar &&
-                                $is_custom(
+                            ("string" === typeof input.dollar &&
+                                ($is_custom(
                                     "dollar",
                                     "string",
                                     "",
-                                    input.dolloar,
-                                )) ||
+                                    input.dollar,
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".dollar",
+                                        expected: "string (@dollar)",
+                                        value: input.dollar,
+                                    }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".dolloar",
+                                    path: _path + ".dollar",
                                     expected: "string",
-                                    value: input.dolloar,
+                                    value: input.dollar,
                                 }),
                             ("string" === typeof input.postfix &&
-                                $is_custom(
+                                ($is_custom(
                                     "postfix",
                                     "string",
                                     "abcd",
                                     input.postfix,
-                                )) ||
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".postfix",
+                                        expected: "string (@postfix abcd)",
+                                        value: input.postfix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".postfix",
                                     expected: "string",
@@ -56,12 +71,17 @@ export const test_validatePrune_TagCustom = _test_validatePrune(
                                 }),
                             ("number" === typeof input.log &&
                                 Number.isFinite(input.log) &&
-                                $is_custom(
+                                ($is_custom(
                                     "powerOf",
                                     "number",
                                     "10",
                                     input.log,
-                                )) ||
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".log",
+                                        expected: "number (@powerOf 10)",
+                                        value: input.log,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".log",
                                     expected: "number",
@@ -97,7 +117,7 @@ export const test_validatePrune_TagCustom = _test_validatePrune(
                     for (const key of Object.keys(input)) {
                         if (
                             "id" === key ||
-                            "dolloar" === key ||
+                            "dollar" === key ||
                             "postfix" === key ||
                             "log" === key
                         )

--- a/test/generated/output/validatePrune/test_validatePrune_TagFormat.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagFormat.ts
@@ -29,63 +29,108 @@ export const test_validatePrune_TagFormat = _test_validatePrune(
                     ): boolean =>
                         [
                             ("string" === typeof input.uuid &&
-                                true === $is_uuid(input.uuid)) ||
+                                (true === $is_uuid(input.uuid) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uuid",
+                                        expected: "string (@format uuid)",
+                                        value: input.uuid,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uuid",
                                     expected: "string",
                                     value: input.uuid,
                                 }),
                             ("string" === typeof input.email &&
-                                true === $is_email(input.email)) ||
+                                (true === $is_email(input.email) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".email",
+                                        expected: "string (@format email)",
+                                        value: input.email,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".email",
                                     expected: "string",
                                     value: input.email,
                                 }),
                             ("string" === typeof input.url &&
-                                true === $is_url(input.url)) ||
+                                (true === $is_url(input.url) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".url",
+                                        expected: "string (@format url)",
+                                        value: input.url,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".url",
                                     expected: "string",
                                     value: input.url,
                                 }),
                             ("string" === typeof input.ipv4 &&
-                                true === $is_ipv4(input.ipv4)) ||
+                                (true === $is_ipv4(input.ipv4) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv4",
+                                        expected: "string (@format ipv4)",
+                                        value: input.ipv4,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",
                                     expected: "string",
                                     value: input.ipv4,
                                 }),
                             ("string" === typeof input.ipv6 &&
-                                true === $is_ipv6(input.ipv6)) ||
+                                (true === $is_ipv6(input.ipv6) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv6",
+                                        expected: "string (@format ipv6)",
+                                        value: input.ipv6,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv6",
                                     expected: "string",
                                     value: input.ipv6,
                                 }),
                             ("string" === typeof input.date &&
-                                true === $is_date(input.date)) ||
+                                (true === $is_date(input.date) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".date",
+                                        expected: "string (@format date)",
+                                        value: input.date,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".date",
                                     expected: "string",
                                     value: input.date,
                                 }),
                             ("string" === typeof input.date_time &&
-                                true === $is_datetime(input.date_time)) ||
+                                (true === $is_datetime(input.date_time) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".date_time",
+                                        expected: "string (@format datetime)",
+                                        value: input.date_time,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".date_time",
                                     expected: "string",
                                     value: input.date_time,
                                 }),
                             ("string" === typeof input.datetime &&
-                                true === $is_datetime(input.datetime)) ||
+                                (true === $is_datetime(input.datetime) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".datetime",
+                                        expected: "string (@format datetime)",
+                                        value: input.datetime,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".datetime",
                                     expected: "string",
                                     value: input.datetime,
                                 }),
                             ("string" === typeof input.dateTime &&
-                                true === $is_datetime(input.dateTime)) ||
+                                (true === $is_datetime(input.dateTime) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".dateTime",
+                                        expected: "string (@format datetime)",
+                                        value: input.dateTime,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".dateTime",
                                     expected: "string",

--- a/test/generated/output/validatePrune/test_validatePrune_TagInfinite.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagInfinite.ts
@@ -29,8 +29,18 @@ export const test_validatePrune_TagInfinite = _test_validatePrune(
                                     value: input.value,
                                 }),
                             ("number" === typeof input.ranged &&
-                                0 <= input.ranged &&
-                                100 >= input.ranged) ||
+                                (0 <= input.ranged ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ranged",
+                                        expected: "number (@minimum 0)",
+                                        value: input.ranged,
+                                    })) &&
+                                (100 >= input.ranged ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ranged",
+                                        expected: "number (@maximum 100)",
+                                        value: input.ranged,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ranged",
                                     expected: "number",
@@ -38,7 +48,12 @@ export const test_validatePrune_TagInfinite = _test_validatePrune(
                                 }),
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                0 <= input.minimum) ||
+                                (0 <= input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@minimum 0)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "number",
@@ -46,14 +61,24 @@ export const test_validatePrune_TagInfinite = _test_validatePrune(
                                 }),
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                100 >= input.maximum) ||
+                                (100 >= input.maximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@maximum 100)",
+                                        value: input.maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "number",
                                     value: input.maximum,
                                 }),
                             ("number" === typeof input.multipleOf &&
-                                0 === input.multipleOf % 3) ||
+                                (0 === input.multipleOf % 3 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@multipleOf 3)",
+                                        value: input.multipleOf,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number",
@@ -61,7 +86,12 @@ export const test_validatePrune_TagInfinite = _test_validatePrune(
                                 }),
                             ("number" === typeof input.typed &&
                                 Number.isFinite(input.typed) &&
-                                parseInt(input.typed) === input.typed) ||
+                                (parseInt(input.typed) === input.typed ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".typed",
+                                        expected: "number (@type int)",
+                                        value: input.typed,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number",

--- a/test/generated/output/validatePrune/test_validatePrune_TagLength.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagLength.ts
@@ -24,29 +24,54 @@ export const test_validatePrune_TagLength = _test_validatePrune(
                     ): boolean =>
                         [
                             ("string" === typeof input.fixed &&
-                                5 === input.fixed.length) ||
+                                (5 === input.fixed.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".fixed",
+                                        expected: "string (@length 5)",
+                                        value: input.fixed,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".fixed",
                                     expected: "string",
                                     value: input.fixed,
                                 }),
                             ("string" === typeof input.minimum &&
-                                3 <= input.minimum.length) ||
+                                (3 <= input.minimum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "string (@minLength 3)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "string",
                                     value: input.minimum,
                                 }),
                             ("string" === typeof input.maximum &&
-                                7 >= input.maximum.length) ||
+                                (7 >= input.maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "string",
                                     value: input.maximum,
                                 }),
                             ("string" === typeof input.minimum_and_maximum &&
-                                3 <= input.minimum_and_maximum.length &&
-                                7 >= input.minimum_and_maximum.length) ||
+                                (3 <= input.minimum_and_maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum_and_maximum",
+                                        expected: "string (@minLength 3)",
+                                        value: input.minimum_and_maximum,
+                                    })) &&
+                                (7 >= input.minimum_and_maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum_and_maximum",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.minimum_and_maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum_and_maximum",
                                     expected: "string",

--- a/test/generated/output/validatePrune/test_validatePrune_TagMatrix.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagMatrix.ts
@@ -23,7 +23,12 @@ export const test_validatePrune_TagMatrix = _test_validatePrune(
                     ): boolean =>
                         [
                             (((Array.isArray(input.matrix) &&
-                                3 === input.matrix.length) ||
+                                (3 === input.matrix.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".matrix",
+                                        expected: "Array.length (@items 3)",
+                                        value: input.matrix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".matrix",
                                     expected: "Array<Array<string>>",
@@ -33,7 +38,17 @@ export const test_validatePrune_TagMatrix = _test_validatePrune(
                                     .map(
                                         (elem: any, _index1: number) =>
                                             (((Array.isArray(elem) &&
-                                                3 === elem.length) ||
+                                                (3 === elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".matrix[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected:
+                                                            "Array.length (@items 3)",
+                                                        value: elem,
+                                                    }))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
@@ -51,10 +66,25 @@ export const test_validatePrune_TagMatrix = _test_validatePrune(
                                                         ) =>
                                                             ("string" ===
                                                                 typeof elem &&
-                                                                true ===
+                                                                (true ===
                                                                     $is_uuid(
                                                                         elem,
-                                                                    )) ||
+                                                                    ) ||
+                                                                    $report(
+                                                                        _exceptionable,
+                                                                        {
+                                                                            path:
+                                                                                _path +
+                                                                                ".matrix[" +
+                                                                                _index1 +
+                                                                                "][" +
+                                                                                _index2 +
+                                                                                "]",
+                                                                            expected:
+                                                                                "string (@format uuid)",
+                                                                            value: elem,
+                                                                        },
+                                                                    ))) ||
                                                             $report(
                                                                 _exceptionable,
                                                                 {

--- a/test/generated/output/validatePrune/test_validatePrune_TagNaN.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagNaN.ts
@@ -29,8 +29,18 @@ export const test_validatePrune_TagNaN = _test_validatePrune(
                                     value: input.value,
                                 }),
                             ("number" === typeof input.ranged &&
-                                0 <= input.ranged &&
-                                100 >= input.ranged) ||
+                                (0 <= input.ranged ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ranged",
+                                        expected: "number (@minimum 0)",
+                                        value: input.ranged,
+                                    })) &&
+                                (100 >= input.ranged ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ranged",
+                                        expected: "number (@maximum 100)",
+                                        value: input.ranged,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ranged",
                                     expected: "number",
@@ -38,7 +48,12 @@ export const test_validatePrune_TagNaN = _test_validatePrune(
                                 }),
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                0 <= input.minimum) ||
+                                (0 <= input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@minimum 0)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "number",
@@ -46,14 +61,24 @@ export const test_validatePrune_TagNaN = _test_validatePrune(
                                 }),
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                100 >= input.maximum) ||
+                                (100 >= input.maximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@maximum 100)",
+                                        value: input.maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "number",
                                     value: input.maximum,
                                 }),
                             ("number" === typeof input.multipleOf &&
-                                0 === input.multipleOf % 3) ||
+                                (0 === input.multipleOf % 3 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@multipleOf 3)",
+                                        value: input.multipleOf,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number",
@@ -61,7 +86,12 @@ export const test_validatePrune_TagNaN = _test_validatePrune(
                                 }),
                             ("number" === typeof input.typed &&
                                 Number.isFinite(input.typed) &&
-                                parseInt(input.typed) === input.typed) ||
+                                (parseInt(input.typed) === input.typed ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".typed",
+                                        expected: "number (@type int)",
+                                        value: input.typed,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number",

--- a/test/generated/output/validatePrune/test_validatePrune_TagObjectUnion.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagObjectUnion.ts
@@ -25,7 +25,12 @@ export const test_validatePrune_TagObjectUnion = _test_validatePrune(
                         [
                             ("number" === typeof input.value &&
                                 Number.isFinite(input.value) &&
-                                3 <= input.value) ||
+                                (3 <= input.value ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "number (@minimum 3)",
+                                        value: input.value,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "number",
@@ -39,8 +44,18 @@ export const test_validatePrune_TagObjectUnion = _test_validatePrune(
                     ): boolean =>
                         [
                             ("string" === typeof input.value &&
-                                3 <= input.value.length &&
-                                7 >= input.value.length) ||
+                                (3 <= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@minLength 3)",
+                                        value: input.value,
+                                    })) &&
+                                (7 >= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.value,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "string",

--- a/test/generated/output/validatePrune/test_validatePrune_TagPattern.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagPattern.ts
@@ -22,40 +22,64 @@ export const test_validatePrune_TagPattern = _test_validatePrune(
                     ): boolean =>
                         [
                             ("string" === typeof input.uuid &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                    ).test(input.uuid)) ||
+                                    ).test(input.uuid) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uuid",
+                                        expected:
+                                            "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                        value: input.uuid,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uuid",
                                     expected: "string",
                                     value: input.uuid,
                                 }),
                             ("string" === typeof input.email &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                    ).test(input.email)) ||
+                                    ).test(input.email) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".email",
+                                        expected:
+                                            'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                        value: input.email,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".email",
                                     expected: "string",
                                     value: input.email,
                                 }),
                             ("string" === typeof input.ipv4 &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                    ).test(input.ipv4)) ||
+                                    ).test(input.ipv4) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv4",
+                                        expected:
+                                            "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                        value: input.ipv4,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",
                                     expected: "string",
                                     value: input.ipv4,
                                 }),
                             ("string" === typeof input.ipv6 &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                    ).test(input.ipv6)) ||
+                                    ).test(input.ipv6) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv6",
+                                        expected:
+                                            "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                        value: input.ipv6,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv6",
                                     expected: "string",

--- a/test/generated/output/validatePrune/test_validatePrune_TagRange.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagRange.ts
@@ -25,7 +25,13 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                         [
                             ("number" === typeof input.greater &&
                                 Number.isFinite(input.greater) &&
-                                3 < input.greater) ||
+                                (3 < input.greater ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater",
                                     expected: "number",
@@ -33,7 +39,12 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                 }),
                             ("number" === typeof input.greater_equal &&
                                 Number.isFinite(input.greater_equal) &&
-                                3 <= input.greater_equal) ||
+                                (3 <= input.greater_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal",
                                     expected: "number",
@@ -41,7 +52,13 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                 }),
                             ("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
-                                7 > input.less) ||
+                                (7 > input.less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number",
@@ -49,31 +66,70 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                 }),
                             ("number" === typeof input.less_equal &&
                                 Number.isFinite(input.less_equal) &&
-                                7 >= input.less_equal) ||
+                                (7 >= input.less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".less_equal",
                                     expected: "number",
                                     value: input.less_equal,
                                 }),
                             ("number" === typeof input.greater_less &&
-                                3 < input.greater_less &&
-                                7 > input.greater_less) ||
+                                (3 < input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater_less,
+                                    })) &&
+                                (7 > input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.greater_less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number",
                                     value: input.greater_less,
                                 }),
                             ("number" === typeof input.greater_equal_less &&
-                                3 <= input.greater_equal_less &&
-                                7 > input.greater_equal_less) ||
+                                (3 <= input.greater_equal_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal_less,
+                                    })) &&
+                                (7 > input.greater_equal_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.greater_equal_less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less",
                                     expected: "number",
                                     value: input.greater_equal_less,
                                 }),
                             ("number" === typeof input.greater_less_equal &&
-                                3 < input.greater_less_equal &&
-                                7 >= input.greater_less_equal) ||
+                                (3 < input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                (7 >= input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.greater_less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number",
@@ -81,8 +137,20 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                 }),
                             ("number" ===
                                 typeof input.greater_equal_less_equal &&
-                                3 <= input.greater_equal_less_equal &&
-                                7 >= input.greater_equal_less_equal) ||
+                                (3 <= input.greater_equal_less_equal ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
+                                (7 >= input.greater_equal_less_equal ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.greater_equal_less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
                                     expected: "number",

--- a/test/generated/output/validatePrune/test_validatePrune_TagStep.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagStep.ts
@@ -24,34 +24,87 @@ export const test_validatePrune_TagStep = _test_validatePrune(
                     ): boolean =>
                         [
                             ("number" === typeof input.exclusiveMinimum &&
-                                0 === (input.exclusiveMinimum % 5) - 3 &&
-                                3 < input.exclusiveMinimum) ||
+                                (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected: "number (@step 5)",
+                                        value: input.exclusiveMinimum,
+                                    })) &&
+                                (3 < input.exclusiveMinimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.exclusiveMinimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".exclusiveMinimum",
                                     expected: "number",
                                     value: input.exclusiveMinimum,
                                 }),
                             ("number" === typeof input.minimum &&
-                                0 === (input.minimum % 5) - 3 &&
-                                3 <= input.minimum) ||
+                                (0 === (input.minimum % 5) - 3 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@step 5)",
+                                        value: input.minimum,
+                                    })) &&
+                                (3 <= input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@minimum 3)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "number",
                                     value: input.minimum,
                                 }),
                             ("number" === typeof input.range &&
-                                0 === (input.range % 5) - 0 &&
-                                0 < input.range &&
-                                100 > input.range) ||
+                                (0 === (input.range % 5) - 0 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected: "number (@step 5)",
+                                        value: input.range,
+                                    })) &&
+                                (0 < input.range ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected:
+                                            "number (@exclusiveMinimum 0)",
+                                        value: input.range,
+                                    })) &&
+                                (100 > input.range ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected:
+                                            "number (@exclusiveMaximum 100)",
+                                        value: input.range,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".range",
                                     expected: "number",
                                     value: input.range,
                                 }),
                             ("number" === typeof input.multipleOf &&
-                                0 === input.multipleOf % 5 &&
-                                3 <= input.multipleOf &&
-                                99 >= input.multipleOf) ||
+                                (0 === input.multipleOf % 5 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@multipleOf 5)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                (3 <= input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@minimum 3)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                (99 >= input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@maximum 99)",
+                                        value: input.multipleOf,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number",

--- a/test/generated/output/validatePrune/test_validatePrune_TagTuple.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagTuple.ts
@@ -37,24 +37,58 @@ export const test_validatePrune_TagTuple = _test_validatePrune(
                                     })) &&
                                 [
                                     ("string" === typeof input.tuple[0] &&
-                                        3 <= input.tuple[0].length &&
-                                        7 >= input.tuple[0].length) ||
+                                        (3 <= input.tuple[0].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[0]",
+                                                expected:
+                                                    "string (@minLength 3)",
+                                                value: input.tuple[0],
+                                            })) &&
+                                        (7 >= input.tuple[0].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[0]",
+                                                expected:
+                                                    "string (@maxLength 7)",
+                                                value: input.tuple[0],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[0]",
                                             expected: "string",
                                             value: input.tuple[0],
                                         }),
                                     ("number" === typeof input.tuple[1] &&
-                                        3 <= input.tuple[1] &&
-                                        7 >= input.tuple[1]) ||
+                                        (3 <= input.tuple[1] ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[1]",
+                                                expected: "number (@minimum 3)",
+                                                value: input.tuple[1],
+                                            })) &&
+                                        (7 >= input.tuple[1] ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[1]",
+                                                expected: "number (@maximum 7)",
+                                                value: input.tuple[1],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[1]",
                                             expected: "number",
                                             value: input.tuple[1],
                                         }),
                                     (((Array.isArray(input.tuple[2]) &&
-                                        3 <= input.tuple[2].length &&
-                                        7 >= input.tuple[2].length) ||
+                                        (3 <= input.tuple[2].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[2]",
+                                                expected:
+                                                    "Array.length (@minItems 3)",
+                                                value: input.tuple[2],
+                                            })) &&
+                                        (7 >= input.tuple[2].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[2]",
+                                                expected:
+                                                    "Array.length (@maxItems 7)",
+                                                value: input.tuple[2],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[2]",
                                             expected: "Array<string>",
@@ -64,8 +98,34 @@ export const test_validatePrune_TagTuple = _test_validatePrune(
                                             .map(
                                                 (elem: any, _index1: number) =>
                                                     ("string" === typeof elem &&
-                                                        3 <= elem.length &&
-                                                        7 >= elem.length) ||
+                                                        (3 <= elem.length ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[2][" +
+                                                                        _index1 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "string (@minLength 3)",
+                                                                    value: elem,
+                                                                },
+                                                            )) &&
+                                                        (7 >= elem.length ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[2][" +
+                                                                        _index1 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "string (@maxLength 7)",
+                                                                    value: elem,
+                                                                },
+                                                            ))) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
@@ -83,8 +143,20 @@ export const test_validatePrune_TagTuple = _test_validatePrune(
                                             value: input.tuple[2],
                                         }),
                                     (((Array.isArray(input.tuple[3]) &&
-                                        3 <= input.tuple[3].length &&
-                                        7 >= input.tuple[3].length) ||
+                                        (3 <= input.tuple[3].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[3]",
+                                                expected:
+                                                    "Array.length (@minItems 3)",
+                                                value: input.tuple[3],
+                                            })) &&
+                                        (7 >= input.tuple[3].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[3]",
+                                                expected:
+                                                    "Array.length (@maxItems 7)",
+                                                value: input.tuple[3],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[3]",
                                             expected: "Array<number>",
@@ -94,8 +166,34 @@ export const test_validatePrune_TagTuple = _test_validatePrune(
                                             .map(
                                                 (elem: any, _index2: number) =>
                                                     ("number" === typeof elem &&
-                                                        3 <= elem &&
-                                                        7 >= elem) ||
+                                                        (3 <= elem ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[3][" +
+                                                                        _index2 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "number (@minimum 3)",
+                                                                    value: elem,
+                                                                },
+                                                            )) &&
+                                                        (7 >= elem ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[3][" +
+                                                                        _index2 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "number (@maximum 7)",
+                                                                    value: elem,
+                                                                },
+                                                            ))) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +

--- a/test/generated/output/validatePrune/test_validatePrune_TagType.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagType.ts
@@ -25,7 +25,12 @@ export const test_validatePrune_TagType = _test_validatePrune(
                         [
                             ("number" === typeof input.int &&
                                 Number.isFinite(input.int) &&
-                                parseInt(input.int) === input.int) ||
+                                (parseInt(input.int) === input.int ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".int",
                                     expected: "number",
@@ -33,8 +38,18 @@ export const test_validatePrune_TagType = _test_validatePrune(
                                 }),
                             ("number" === typeof input.uint &&
                                 Number.isFinite(input.uint) &&
-                                parseInt(input.uint) === input.uint &&
-                                0 <= input.uint) ||
+                                (parseInt(input.uint) === input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (0 <= input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number",

--- a/test/generated/output/validateStringify/test_validateStringify_TagArray.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagArray.ts
@@ -25,7 +25,12 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                     ): boolean =>
                         [
                             (((Array.isArray(input.items) &&
-                                3 === input.items.length) ||
+                                (3 === input.items.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected: "Array.length (@items 3)",
+                                        value: input.items,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".items",
                                     expected: "Array<string>",
@@ -35,7 +40,17 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                                     .map(
                                         (elem: any, _index2: number) =>
                                             ("string" === typeof elem &&
-                                                true === $is_uuid(elem)) ||
+                                                (true === $is_uuid(elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".items[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@format uuid)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -53,7 +68,12 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                                     value: input.items,
                                 }),
                             (((Array.isArray(input.minItems) &&
-                                3 <= input.minItems.length) ||
+                                (3 <= input.minItems.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.minItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
                                     expected: "Array<number>",
@@ -64,7 +84,17 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                                         (elem: any, _index3: number) =>
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem) &&
-                                                3 <= elem) ||
+                                                (3 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".minItems[" +
+                                                            _index3 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 3)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -82,7 +112,12 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                                     value: input.minItems,
                                 }),
                             (((Array.isArray(input.maxItems) &&
-                                7 >= input.maxItems.length) ||
+                                (7 >= input.maxItems.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.maxItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "Array<(number | string)>",
@@ -92,10 +127,30 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                                     .map(
                                         (elem: any, _index4: number) =>
                                             ("string" === typeof elem &&
-                                                7 >= elem.length) ||
+                                                (7 >= elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".maxItems[" +
+                                                            _index4 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@maxLength 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem) &&
-                                                7 >= elem) ||
+                                                (7 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".maxItems[" +
+                                                            _index4 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 7)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
@@ -113,8 +168,18 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                                     value: input.maxItems,
                                 }),
                             (((Array.isArray(input.both) &&
-                                3 <= input.both.length &&
-                                7 >= input.both.length) ||
+                                (3 <= input.both.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".both",
+                                        expected: "Array.length (@minItems 3)",
+                                        value: input.both,
+                                    })) &&
+                                (7 >= input.both.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".both",
+                                        expected: "Array.length (@maxItems 7)",
+                                        value: input.both,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".both",
                                     expected: "Array<string>",
@@ -124,7 +189,17 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                                     .map(
                                         (elem: any, _index5: number) =>
                                             ("string" === typeof elem &&
-                                                true === $is_uuid(elem)) ||
+                                                (true === $is_uuid(elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".both[" +
+                                                            _index5 +
+                                                            "]",
+                                                        expected:
+                                                            "string (@format uuid)",
+                                                        value: elem,
+                                                    }))) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +

--- a/test/generated/output/validateStringify/test_validateStringify_TagAtomicUnion.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagAtomicUnion.ts
@@ -24,11 +24,26 @@ export const test_validateStringify_TagAtomicUnion = _test_validateStringify(
                     ): boolean =>
                         [
                             ("string" === typeof input.value &&
-                                3 <= input.value.length &&
-                                7 >= input.value.length) ||
+                                (3 <= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@minLength 3)",
+                                        value: input.value,
+                                    })) &&
+                                (7 >= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.value,
+                                    }))) ||
                                 ("number" === typeof input.value &&
                                     Number.isFinite(input.value) &&
-                                    3 <= input.value) ||
+                                    (3 <= input.value ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".value",
+                                            expected: "number (@minimum 3)",
+                                            value: input.value,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "(number | string)",

--- a/test/generated/output/validateStringify/test_validateStringify_TagCustom.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagCustom.ts
@@ -24,31 +24,46 @@ export const test_validateStringify_TagCustom = _test_validateStringify(
                     ): boolean =>
                         [
                             ("string" === typeof input.id &&
-                                true === $is_uuid(input.id)) ||
+                                (true === $is_uuid(input.id) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".id",
+                                        expected: "string (@format uuid)",
+                                        value: input.id,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".id",
                                     expected: "string",
                                     value: input.id,
                                 }),
-                            ("string" === typeof input.dolloar &&
-                                $is_custom(
+                            ("string" === typeof input.dollar &&
+                                ($is_custom(
                                     "dollar",
                                     "string",
                                     "",
-                                    input.dolloar,
-                                )) ||
+                                    input.dollar,
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".dollar",
+                                        expected: "string (@dollar)",
+                                        value: input.dollar,
+                                    }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".dolloar",
+                                    path: _path + ".dollar",
                                     expected: "string",
-                                    value: input.dolloar,
+                                    value: input.dollar,
                                 }),
                             ("string" === typeof input.postfix &&
-                                $is_custom(
+                                ($is_custom(
                                     "postfix",
                                     "string",
                                     "abcd",
                                     input.postfix,
-                                )) ||
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".postfix",
+                                        expected: "string (@postfix abcd)",
+                                        value: input.postfix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".postfix",
                                     expected: "string",
@@ -56,12 +71,17 @@ export const test_validateStringify_TagCustom = _test_validateStringify(
                                 }),
                             ("number" === typeof input.log &&
                                 Number.isFinite(input.log) &&
-                                $is_custom(
+                                ($is_custom(
                                     "powerOf",
                                     "number",
                                     "10",
                                     input.log,
-                                )) ||
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".log",
+                                        expected: "number (@powerOf 10)",
+                                        value: input.log,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".log",
                                     expected: "number",
@@ -96,8 +116,8 @@ export const test_validateStringify_TagCustom = _test_validateStringify(
                 const $is_uuid = (typia.validateStringify as any).is_uuid;
                 const $is_custom = (typia.validateStringify as any).is_custom;
                 const $so0 = (input: any): any =>
-                    `{"id":${'"' + input.id + '"'},"dolloar":${$string(
-                        input.dolloar,
+                    `{"id":${'"' + input.id + '"'},"dollar":${$string(
+                        input.dollar,
                     )},"postfix":${$string(input.postfix)},"log":${$number(
                         input.log,
                     )}}`;

--- a/test/generated/output/validateStringify/test_validateStringify_TagFormat.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagFormat.ts
@@ -30,63 +30,108 @@ export const test_validateStringify_TagFormat = _test_validateStringify(
                     ): boolean =>
                         [
                             ("string" === typeof input.uuid &&
-                                true === $is_uuid(input.uuid)) ||
+                                (true === $is_uuid(input.uuid) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uuid",
+                                        expected: "string (@format uuid)",
+                                        value: input.uuid,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uuid",
                                     expected: "string",
                                     value: input.uuid,
                                 }),
                             ("string" === typeof input.email &&
-                                true === $is_email(input.email)) ||
+                                (true === $is_email(input.email) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".email",
+                                        expected: "string (@format email)",
+                                        value: input.email,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".email",
                                     expected: "string",
                                     value: input.email,
                                 }),
                             ("string" === typeof input.url &&
-                                true === $is_url(input.url)) ||
+                                (true === $is_url(input.url) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".url",
+                                        expected: "string (@format url)",
+                                        value: input.url,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".url",
                                     expected: "string",
                                     value: input.url,
                                 }),
                             ("string" === typeof input.ipv4 &&
-                                true === $is_ipv4(input.ipv4)) ||
+                                (true === $is_ipv4(input.ipv4) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv4",
+                                        expected: "string (@format ipv4)",
+                                        value: input.ipv4,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",
                                     expected: "string",
                                     value: input.ipv4,
                                 }),
                             ("string" === typeof input.ipv6 &&
-                                true === $is_ipv6(input.ipv6)) ||
+                                (true === $is_ipv6(input.ipv6) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv6",
+                                        expected: "string (@format ipv6)",
+                                        value: input.ipv6,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv6",
                                     expected: "string",
                                     value: input.ipv6,
                                 }),
                             ("string" === typeof input.date &&
-                                true === $is_date(input.date)) ||
+                                (true === $is_date(input.date) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".date",
+                                        expected: "string (@format date)",
+                                        value: input.date,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".date",
                                     expected: "string",
                                     value: input.date,
                                 }),
                             ("string" === typeof input.date_time &&
-                                true === $is_datetime(input.date_time)) ||
+                                (true === $is_datetime(input.date_time) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".date_time",
+                                        expected: "string (@format datetime)",
+                                        value: input.date_time,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".date_time",
                                     expected: "string",
                                     value: input.date_time,
                                 }),
                             ("string" === typeof input.datetime &&
-                                true === $is_datetime(input.datetime)) ||
+                                (true === $is_datetime(input.datetime) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".datetime",
+                                        expected: "string (@format datetime)",
+                                        value: input.datetime,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".datetime",
                                     expected: "string",
                                     value: input.datetime,
                                 }),
                             ("string" === typeof input.dateTime &&
-                                true === $is_datetime(input.dateTime)) ||
+                                (true === $is_datetime(input.dateTime) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".dateTime",
+                                        expected: "string (@format datetime)",
+                                        value: input.dateTime,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".dateTime",
                                     expected: "string",

--- a/test/generated/output/validateStringify/test_validateStringify_TagLength.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagLength.ts
@@ -24,29 +24,54 @@ export const test_validateStringify_TagLength = _test_validateStringify(
                     ): boolean =>
                         [
                             ("string" === typeof input.fixed &&
-                                5 === input.fixed.length) ||
+                                (5 === input.fixed.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".fixed",
+                                        expected: "string (@length 5)",
+                                        value: input.fixed,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".fixed",
                                     expected: "string",
                                     value: input.fixed,
                                 }),
                             ("string" === typeof input.minimum &&
-                                3 <= input.minimum.length) ||
+                                (3 <= input.minimum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "string (@minLength 3)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "string",
                                     value: input.minimum,
                                 }),
                             ("string" === typeof input.maximum &&
-                                7 >= input.maximum.length) ||
+                                (7 >= input.maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "string",
                                     value: input.maximum,
                                 }),
                             ("string" === typeof input.minimum_and_maximum &&
-                                3 <= input.minimum_and_maximum.length &&
-                                7 >= input.minimum_and_maximum.length) ||
+                                (3 <= input.minimum_and_maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum_and_maximum",
+                                        expected: "string (@minLength 3)",
+                                        value: input.minimum_and_maximum,
+                                    })) &&
+                                (7 >= input.minimum_and_maximum.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum_and_maximum",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.minimum_and_maximum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum_and_maximum",
                                     expected: "string",

--- a/test/generated/output/validateStringify/test_validateStringify_TagMatrix.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagMatrix.ts
@@ -23,7 +23,12 @@ export const test_validateStringify_TagMatrix = _test_validateStringify(
                     ): boolean =>
                         [
                             (((Array.isArray(input.matrix) &&
-                                3 === input.matrix.length) ||
+                                (3 === input.matrix.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".matrix",
+                                        expected: "Array.length (@items 3)",
+                                        value: input.matrix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".matrix",
                                     expected: "Array<Array<string>>",
@@ -33,7 +38,17 @@ export const test_validateStringify_TagMatrix = _test_validateStringify(
                                     .map(
                                         (elem: any, _index1: number) =>
                                             (((Array.isArray(elem) &&
-                                                3 === elem.length) ||
+                                                (3 === elem.length ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".matrix[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected:
+                                                            "Array.length (@items 3)",
+                                                        value: elem,
+                                                    }))) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
@@ -51,10 +66,25 @@ export const test_validateStringify_TagMatrix = _test_validateStringify(
                                                         ) =>
                                                             ("string" ===
                                                                 typeof elem &&
-                                                                true ===
+                                                                (true ===
                                                                     $is_uuid(
                                                                         elem,
-                                                                    )) ||
+                                                                    ) ||
+                                                                    $report(
+                                                                        _exceptionable,
+                                                                        {
+                                                                            path:
+                                                                                _path +
+                                                                                ".matrix[" +
+                                                                                _index1 +
+                                                                                "][" +
+                                                                                _index2 +
+                                                                                "]",
+                                                                            expected:
+                                                                                "string (@format uuid)",
+                                                                            value: elem,
+                                                                        },
+                                                                    ))) ||
                                                             $report(
                                                                 _exceptionable,
                                                                 {

--- a/test/generated/output/validateStringify/test_validateStringify_TagObjectUnion.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagObjectUnion.ts
@@ -25,7 +25,12 @@ export const test_validateStringify_TagObjectUnion = _test_validateStringify(
                         [
                             ("number" === typeof input.value &&
                                 Number.isFinite(input.value) &&
-                                3 <= input.value) ||
+                                (3 <= input.value ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "number (@minimum 3)",
+                                        value: input.value,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "number",
@@ -39,8 +44,18 @@ export const test_validateStringify_TagObjectUnion = _test_validateStringify(
                     ): boolean =>
                         [
                             ("string" === typeof input.value &&
-                                3 <= input.value.length &&
-                                7 >= input.value.length) ||
+                                (3 <= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@minLength 3)",
+                                        value: input.value,
+                                    })) &&
+                                (7 >= input.value.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".value",
+                                        expected: "string (@maxLength 7)",
+                                        value: input.value,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".value",
                                     expected: "string",

--- a/test/generated/output/validateStringify/test_validateStringify_TagPattern.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagPattern.ts
@@ -22,40 +22,64 @@ export const test_validateStringify_TagPattern = _test_validateStringify(
                     ): boolean =>
                         [
                             ("string" === typeof input.uuid &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/,
-                                    ).test(input.uuid)) ||
+                                    ).test(input.uuid) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uuid",
+                                        expected:
+                                            "string (@pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$)",
+                                        value: input.uuid,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uuid",
                                     expected: "string",
                                     value: input.uuid,
                                 }),
                             ("string" === typeof input.email &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/,
-                                    ).test(input.email)) ||
+                                    ).test(input.email) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".email",
+                                        expected:
+                                            'string (@pattern ^(([^<>()[\\]\\.,;:\\s@\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\"]+)*)|(\\".+\\"))@(([^<>()[\\]\\.,;:\\s@\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\"]{2,})$)',
+                                        value: input.email,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".email",
                                     expected: "string",
                                     value: input.email,
                                 }),
                             ("string" === typeof input.ipv4 &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
-                                    ).test(input.ipv4)) ||
+                                    ).test(input.ipv4) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv4",
+                                        expected:
+                                            "string (@pattern (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)",
+                                        value: input.ipv4,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",
                                     expected: "string",
                                     value: input.ipv4,
                                 }),
                             ("string" === typeof input.ipv6 &&
-                                true ===
+                                (true ===
                                     RegExp(
                                         /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/,
-                                    ).test(input.ipv6)) ||
+                                    ).test(input.ipv6) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".ipv6",
+                                        expected:
+                                            "string (@pattern (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)",
+                                        value: input.ipv6,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv6",
                                     expected: "string",

--- a/test/generated/output/validateStringify/test_validateStringify_TagRange.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagRange.ts
@@ -25,7 +25,13 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                         [
                             ("number" === typeof input.greater &&
                                 Number.isFinite(input.greater) &&
-                                3 < input.greater) ||
+                                (3 < input.greater ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater",
                                     expected: "number",
@@ -33,7 +39,12 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                 }),
                             ("number" === typeof input.greater_equal &&
                                 Number.isFinite(input.greater_equal) &&
-                                3 <= input.greater_equal) ||
+                                (3 <= input.greater_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal",
                                     expected: "number",
@@ -41,7 +52,13 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                 }),
                             ("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
-                                7 > input.less) ||
+                                (7 > input.less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number",
@@ -49,31 +66,70 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                 }),
                             ("number" === typeof input.less_equal &&
                                 Number.isFinite(input.less_equal) &&
-                                7 >= input.less_equal) ||
+                                (7 >= input.less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".less_equal",
                                     expected: "number",
                                     value: input.less_equal,
                                 }),
                             ("number" === typeof input.greater_less &&
-                                3 < input.greater_less &&
-                                7 > input.greater_less) ||
+                                (3 < input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater_less,
+                                    })) &&
+                                (7 > input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.greater_less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number",
                                     value: input.greater_less,
                                 }),
                             ("number" === typeof input.greater_equal_less &&
-                                3 <= input.greater_equal_less &&
-                                7 > input.greater_equal_less) ||
+                                (3 <= input.greater_equal_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal_less,
+                                    })) &&
+                                (7 > input.greater_equal_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected:
+                                            "number (@exclusiveMaximum 7)",
+                                        value: input.greater_equal_less,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less",
                                     expected: "number",
                                     value: input.greater_equal_less,
                                 }),
                             ("number" === typeof input.greater_less_equal &&
-                                3 < input.greater_less_equal &&
-                                7 >= input.greater_less_equal) ||
+                                (3 < input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                (7 >= input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.greater_less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number",
@@ -81,8 +137,20 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                 }),
                             ("number" ===
                                 typeof input.greater_equal_less_equal &&
-                                3 <= input.greater_equal_less_equal &&
-                                7 >= input.greater_equal_less_equal) ||
+                                (3 <= input.greater_equal_less_equal ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@minimum 3)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
+                                (7 >= input.greater_equal_less_equal ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@maximum 7)",
+                                        value: input.greater_equal_less_equal,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
                                     expected: "number",

--- a/test/generated/output/validateStringify/test_validateStringify_TagStep.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagStep.ts
@@ -24,34 +24,87 @@ export const test_validateStringify_TagStep = _test_validateStringify(
                     ): boolean =>
                         [
                             ("number" === typeof input.exclusiveMinimum &&
-                                0 === (input.exclusiveMinimum % 5) - 3 &&
-                                3 < input.exclusiveMinimum) ||
+                                (0 === (input.exclusiveMinimum % 5) - 3 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected: "number (@step 5)",
+                                        value: input.exclusiveMinimum,
+                                    })) &&
+                                (3 < input.exclusiveMinimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected:
+                                            "number (@exclusiveMinimum 3)",
+                                        value: input.exclusiveMinimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".exclusiveMinimum",
                                     expected: "number",
                                     value: input.exclusiveMinimum,
                                 }),
                             ("number" === typeof input.minimum &&
-                                0 === (input.minimum % 5) - 3 &&
-                                3 <= input.minimum) ||
+                                (0 === (input.minimum % 5) - 3 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@step 5)",
+                                        value: input.minimum,
+                                    })) &&
+                                (3 <= input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@minimum 3)",
+                                        value: input.minimum,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "number",
                                     value: input.minimum,
                                 }),
                             ("number" === typeof input.range &&
-                                0 === (input.range % 5) - 0 &&
-                                0 < input.range &&
-                                100 > input.range) ||
+                                (0 === (input.range % 5) - 0 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected: "number (@step 5)",
+                                        value: input.range,
+                                    })) &&
+                                (0 < input.range ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected:
+                                            "number (@exclusiveMinimum 0)",
+                                        value: input.range,
+                                    })) &&
+                                (100 > input.range ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".range",
+                                        expected:
+                                            "number (@exclusiveMaximum 100)",
+                                        value: input.range,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".range",
                                     expected: "number",
                                     value: input.range,
                                 }),
                             ("number" === typeof input.multipleOf &&
-                                0 === input.multipleOf % 5 &&
-                                3 <= input.multipleOf &&
-                                99 >= input.multipleOf) ||
+                                (0 === input.multipleOf % 5 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@multipleOf 5)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                (3 <= input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@minimum 3)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                (99 >= input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@maximum 99)",
+                                        value: input.multipleOf,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number",

--- a/test/generated/output/validateStringify/test_validateStringify_TagTuple.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagTuple.ts
@@ -37,24 +37,58 @@ export const test_validateStringify_TagTuple = _test_validateStringify(
                                     })) &&
                                 [
                                     ("string" === typeof input.tuple[0] &&
-                                        3 <= input.tuple[0].length &&
-                                        7 >= input.tuple[0].length) ||
+                                        (3 <= input.tuple[0].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[0]",
+                                                expected:
+                                                    "string (@minLength 3)",
+                                                value: input.tuple[0],
+                                            })) &&
+                                        (7 >= input.tuple[0].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[0]",
+                                                expected:
+                                                    "string (@maxLength 7)",
+                                                value: input.tuple[0],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[0]",
                                             expected: "string",
                                             value: input.tuple[0],
                                         }),
                                     ("number" === typeof input.tuple[1] &&
-                                        3 <= input.tuple[1] &&
-                                        7 >= input.tuple[1]) ||
+                                        (3 <= input.tuple[1] ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[1]",
+                                                expected: "number (@minimum 3)",
+                                                value: input.tuple[1],
+                                            })) &&
+                                        (7 >= input.tuple[1] ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[1]",
+                                                expected: "number (@maximum 7)",
+                                                value: input.tuple[1],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[1]",
                                             expected: "number",
                                             value: input.tuple[1],
                                         }),
                                     (((Array.isArray(input.tuple[2]) &&
-                                        3 <= input.tuple[2].length &&
-                                        7 >= input.tuple[2].length) ||
+                                        (3 <= input.tuple[2].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[2]",
+                                                expected:
+                                                    "Array.length (@minItems 3)",
+                                                value: input.tuple[2],
+                                            })) &&
+                                        (7 >= input.tuple[2].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[2]",
+                                                expected:
+                                                    "Array.length (@maxItems 7)",
+                                                value: input.tuple[2],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[2]",
                                             expected: "Array<string>",
@@ -64,8 +98,34 @@ export const test_validateStringify_TagTuple = _test_validateStringify(
                                             .map(
                                                 (elem: any, _index1: number) =>
                                                     ("string" === typeof elem &&
-                                                        3 <= elem.length &&
-                                                        7 >= elem.length) ||
+                                                        (3 <= elem.length ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[2][" +
+                                                                        _index1 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "string (@minLength 3)",
+                                                                    value: elem,
+                                                                },
+                                                            )) &&
+                                                        (7 >= elem.length ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[2][" +
+                                                                        _index1 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "string (@maxLength 7)",
+                                                                    value: elem,
+                                                                },
+                                                            ))) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
@@ -83,8 +143,20 @@ export const test_validateStringify_TagTuple = _test_validateStringify(
                                             value: input.tuple[2],
                                         }),
                                     (((Array.isArray(input.tuple[3]) &&
-                                        3 <= input.tuple[3].length &&
-                                        7 >= input.tuple[3].length) ||
+                                        (3 <= input.tuple[3].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[3]",
+                                                expected:
+                                                    "Array.length (@minItems 3)",
+                                                value: input.tuple[3],
+                                            })) &&
+                                        (7 >= input.tuple[3].length ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".tuple[3]",
+                                                expected:
+                                                    "Array.length (@maxItems 7)",
+                                                value: input.tuple[3],
+                                            }))) ||
                                         $report(_exceptionable, {
                                             path: _path + ".tuple[3]",
                                             expected: "Array<number>",
@@ -94,8 +166,34 @@ export const test_validateStringify_TagTuple = _test_validateStringify(
                                             .map(
                                                 (elem: any, _index2: number) =>
                                                     ("number" === typeof elem &&
-                                                        3 <= elem &&
-                                                        7 >= elem) ||
+                                                        (3 <= elem ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[3][" +
+                                                                        _index2 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "number (@minimum 3)",
+                                                                    value: elem,
+                                                                },
+                                                            )) &&
+                                                        (7 >= elem ||
+                                                            $report(
+                                                                _exceptionable,
+                                                                {
+                                                                    path:
+                                                                        _path +
+                                                                        ".tuple[3][" +
+                                                                        _index2 +
+                                                                        "]",
+                                                                    expected:
+                                                                        "number (@maximum 7)",
+                                                                    value: elem,
+                                                                },
+                                                            ))) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +

--- a/test/generated/output/validateStringify/test_validateStringify_TagType.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagType.ts
@@ -25,7 +25,12 @@ export const test_validateStringify_TagType = _test_validateStringify(
                         [
                             ("number" === typeof input.int &&
                                 Number.isFinite(input.int) &&
-                                parseInt(input.int) === input.int) ||
+                                (parseInt(input.int) === input.int ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".int",
                                     expected: "number",
@@ -33,8 +38,18 @@ export const test_validateStringify_TagType = _test_validateStringify(
                                 }),
                             ("number" === typeof input.uint &&
                                 Number.isFinite(input.uint) &&
-                                parseInt(input.uint) === input.uint &&
-                                0 <= input.uint) ||
+                                (parseInt(input.uint) === input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (0 <= input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number",

--- a/test/generated/output/validateStringify/test_validateStringify_UltimateUnion.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_UltimateUnion.ts
@@ -1220,8 +1220,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             undefined === input.minimum ||
                                 ("number" === typeof input.minimum &&
                                     Number.isFinite(input.minimum) &&
-                                    parseInt(input.minimum) ===
-                                        input.minimum) ||
+                                    (parseInt(input.minimum) ===
+                                        input.minimum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "(number | undefined)",
@@ -1230,8 +1235,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             undefined === input.maximum ||
                                 ("number" === typeof input.maximum &&
                                     Number.isFinite(input.maximum) &&
-                                    parseInt(input.maximum) ===
-                                        input.maximum) ||
+                                    (parseInt(input.maximum) ===
+                                        input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "(number | undefined)",
@@ -1254,8 +1264,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             undefined === input.multipleOf ||
                                 ("number" === typeof input.multipleOf &&
                                     Number.isFinite(input.multipleOf) &&
-                                    parseInt(input.multipleOf) ===
-                                        input.multipleOf) ||
+                                    (parseInt(input.multipleOf) ===
+                                        input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "(number | undefined)",
@@ -1624,9 +1639,19 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             undefined === input.minLength ||
                                 ("number" === typeof input.minLength &&
                                     Number.isFinite(input.minLength) &&
-                                    parseInt(input.minLength) ===
-                                        input.minLength &&
-                                    0 <= input.minLength) ||
+                                    (parseInt(input.minLength) ===
+                                        input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        })) &&
+                                    (0 <= input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minLength",
                                     expected: "(number | undefined)",
@@ -1635,9 +1660,19 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             undefined === input.maxLength ||
                                 ("number" === typeof input.maxLength &&
                                     Number.isFinite(input.maxLength) &&
-                                    parseInt(input.maxLength) ===
-                                        input.maxLength &&
-                                    0 <= input.maxLength) ||
+                                    (parseInt(input.maxLength) ===
+                                        input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxLength",
                                     expected: "(number | undefined)",
@@ -1840,9 +1875,19 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             undefined === input.minItems ||
                                 ("number" === typeof input.minItems &&
                                     Number.isFinite(input.minItems) &&
-                                    parseInt(input.minItems) ===
-                                        input.minItems &&
-                                    0 <= input.minItems) ||
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
                                     expected: "(number | undefined)",
@@ -1851,9 +1896,19 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             undefined === input.maxItems ||
                                 ("number" === typeof input.maxItems &&
                                     Number.isFinite(input.maxItems) &&
-                                    parseInt(input.maxItems) ===
-                                        input.maxItems &&
-                                    0 <= input.maxItems) ||
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "(number | undefined)",

--- a/test/issues/560.ts
+++ b/test/issues/560.ts
@@ -1,31 +1,31 @@
 import typia from "typia";
-import { v4 } from "uuid";
 
 import { TagCustom } from "../structures/TagCustom";
 
-TagCustom.generate;
+const validate = (title: string) => (action?: (custom: TagCustom) => void) => {
+    const custom: TagCustom = TagCustom.generate();
+    if (action) action(custom);
 
-console.log(
-    typia.createIs<TagCustom>()({
-        id: v4(),
-        dolloar: "1234",
-        postfix: "abcdabcd",
-        log: 100,
-    }),
-);
+    try {
+        typia.assert(custom);
+        console.log("assert:", title, "OK");
+    } catch (exp) {
+        const guard: typia.TypeGuardError = exp as typia.TypeGuardError;
+        console.log("assert:", title, guard.expected);
+    }
 
-// (input) => {
-//     const $is_uuid = typia_1.default.createIs.is_uuid;
-//     const $is_custom = typia_1.default.createIs.is_custom;
-//     const $io0 = (input) =>
-//         "string" === typeof input.id &&
-//         true === $is_uuid(input.id) &&
-//         "string" === typeof input.dolloar &&
-//         $is_custom("dolloar", "string", "", input.dolloar) &&
-//         "string" === typeof input.postfix &&
-//         $is_custom("postfix", "string", "abcd", input.postfix) &&
-//         "number" === typeof input.log &&
-//         Number.isFinite(input.log) &&
-//         $is_custom("powerOf", "number", "10", input.log);
-//     return "object" === typeof input && null !== input && $io0(input);
-// };
+    const result: typia.IValidation = typia.validate(custom);
+    if (result.success) console.log("validate:", title, "OK");
+    else
+        console.log(
+            "validate:",
+            title,
+            result.errors.map((e) => e.expected),
+        );
+};
+
+validate("success")();
+validate("id")((custom) => (custom.id = "1234"));
+validate("dolloar")((custom) => (custom.dollar = "1234"));
+validate("postfix")((custom) => (custom.postfix = "abcdabc"));
+validate("log")((custom) => (custom.log = 101));

--- a/test/schemas/json/ajv/TagCustom.json
+++ b/test/schemas/json/ajv/TagCustom.json
@@ -34,7 +34,7 @@
             "x-typia-required": true,
             "format": "uuid"
           },
-          "dolloar": {
+          "dollar": {
             "type": "string",
             "nullable": false,
             "description": "Custom feature composed with \"$\" + number",
@@ -83,7 +83,7 @@
         "nullable": false,
         "required": [
           "id",
-          "dolloar",
+          "dollar",
           "postfix",
           "log"
         ],

--- a/test/schemas/json/swagger/TagCustom.json
+++ b/test/schemas/json/swagger/TagCustom.json
@@ -33,7 +33,7 @@
             "x-typia-required": true,
             "format": "uuid"
           },
-          "dolloar": {
+          "dollar": {
             "type": "string",
             "nullable": false,
             "description": "Custom feature composed with \"$\" + number",
@@ -82,7 +82,7 @@
         "nullable": false,
         "required": [
           "id",
-          "dolloar",
+          "dollar",
           "postfix",
           "log"
         ],

--- a/test/structures/TagCustom.ts
+++ b/test/structures/TagCustom.ts
@@ -18,7 +18,7 @@ export interface TagCustom {
      *
      * @dollar
      */
-    dolloar: string;
+    dollar: string;
 
     /**
      * Custom feature composed with string + "abcd"
@@ -38,7 +38,7 @@ export namespace TagCustom {
     export function generate(): TagCustom {
         return {
             id: v4(),
-            dolloar: "$" + RandomGenerator.integer(),
+            dollar: "$" + RandomGenerator.integer(),
             postfix: RandomGenerator.string() + "abcd",
             log: 100,
         };
@@ -50,8 +50,8 @@ export namespace TagCustom {
             return ["$input.id"];
         },
         (input) => {
-            input.dolloar = RandomGenerator.integer().toString();
-            return ["$input.dolloar"];
+            input.dollar = RandomGenerator.integer().toString();
+            return ["$input.dollar"];
         },
         (input) => {
             input.postfix = RandomGenerator.string() + "dcba";


### PR DESCRIPTION
```typescript
export class TypeGuardError extends Error {
    public readonly method: string;
    public readonly path: string | undefined;
    public readonly expected: string;
    public readonly value: any;
}

export type IValidation<T = unknown> =
    | IValidation.ISuccess<T>
    | IValidation.IFailure;
export namespace IValidation {
    export interface ISuccess<T = unknown> {
        success: true;
        data: T;
        errors: [];
    }
    export interface IFailure {
        success: false;
        errors: IError[];
    }
    export interface IError {
        path: string;
        expected: string;
        value: any;
    }
}
```

Exact expected type expression when type error from comment tags being occured.

The expected value would be like below:

  - `string (@format uuid)`
  - `number (@powerOf 10)`
  - `string (@dollar)`