### PR TITLE
Complement #560 - determine custom validator spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 export function is<T>(input: unknown | T): input is T; // returns boolean
 export function assert<T>(input: unknown | T): T; // throws TypeGuardError
 export function validate<T>(input: unknown | T): IValidation<T>; // detailed
+export const customValidators: CustomValidatorMap; // can add custom validators
 
 // STRICT VALIDATORS
 export function equals<T>(input: unknown | T): input is T;
@@ -169,6 +170,7 @@ For more details, refer to the [Guide Documents (wiki)](https://github.com/samch
 >   - [strict validators](https://github.com/samchon/typia/wiki/Runtime-Validators#strict-validators)
 >   - [factory functions](https://github.com/samchon/typia/wiki/Runtime-Validators#factory-functions)
 >   - [comment tags](https://github.com/samchon/typia/wiki/Runtime-Validators#comment-tags)
+>   - [custom validators](https://github.com/samchon/typia/wiki/Runtime-Validators#custom-validators)
 > - **Enhanced JSON**
 >   - [JSON schema](https://github.com/samchon/typia/wiki/Enhanced-JSON#json-schema)
 >   - [`parse()` functions](https://github.com/samchon/typia/wiki/Enhanced-JSON#parse-functions)
@@ -198,6 +200,9 @@ export function createValidate<T>(): (input: unknown) => IValidation<T>;
 export function createEquals<T>(): (input: unknown) => input is T;
 export function createAssertEquals<T>(): (input: unknown) => T;
 export function createValidateEquals<T>(): (input: unknown) => IValidation<T>;
+
+// YOU CAN ADD CUSTOM VALIDATORS
+export const customValidators: CustomValidatorMap;
 ```
 
 `typia` supports three type of validator functions:
@@ -210,7 +215,10 @@ export function createValidateEquals<T>(): (input: unknown) => IValidation<T>;
 
 Also, if you want more strict validator functions that even do not allowing superfluous properties not written in the type `T`, you can use those functions instead; `equals()`, `assertEquals()`, `validateEquals()`. Otherwise you want to create resuable validator functions,  you can utilize factory functions like `createIs()` instead.
 
-When you want to add special validation logics, like limiting range of numeric values, you can do it through comment tags. If you want to know about it, visit the Guide Documents ([Features > Runtime Validators > Comment Tags](https://github.com/samchon/typia/wiki/Runtime-Validators#comment-tags)).
+When you want to add special validation logics, like limiting range of numeric values, you can do it through comment tags. Furthermore, you can add your custom validator logics. If you want to know about them, visit the Guide Documents:
+
+  - [Features > Runtime Validators > Comment Tags](https://github.com/samchon/typia/wiki/Runtime-Validators#comment-tags)
+  - [Features > Runtime Validators > Custom Validators](https://github.com/samchon/typia/wiki/Runtime-Validators#comment-tags).
 
 ### Enhanced JSON
 ```typescript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.7.0-dev.20230401-2",
+  "version": "3.7.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -13,6 +13,7 @@
 export function is<T>(input: unknown | T): input is T; // returns boolean
 export function assert<T>(input: unknown | T): T; // throws TypeGuardError
 export function validate<T>(input: unknown | T): IValidation<T>; // detailed
+export const customValidators: CustomValidatorMap; // can add custom validators
 
 // STRICT VALIDATORS
 export function equals<T>(input: unknown | T): input is T;
@@ -172,6 +173,7 @@ For more details, refer to the [Guide Documents (wiki)](https://github.com/samch
 >   - [strict validators](https://github.com/samchon/typia/wiki/Runtime-Validators#strict-validators)
 >   - [factory functions](https://github.com/samchon/typia/wiki/Runtime-Validators#factory-functions)
 >   - [comment tags](https://github.com/samchon/typia/wiki/Runtime-Validators#comment-tags)
+>   - [custom validators](https://github.com/samchon/typia/wiki/Runtime-Validators#custom-validators)
 > - **Enhanced JSON**
 >   - [JSON schema](https://github.com/samchon/typia/wiki/Enhanced-JSON#json-schema)
 >   - [`parse()` functions](https://github.com/samchon/typia/wiki/Enhanced-JSON#parse-functions)
@@ -201,6 +203,9 @@ export function createValidate<T>(): (input: unknown) => IValidation<T>;
 export function createEquals<T>(): (input: unknown) => input is T;
 export function createAssertEquals<T>(): (input: unknown) => T;
 export function createValidateEquals<T>(): (input: unknown) => IValidation<T>;
+
+// YOU CAN ADD CUSTOM VALIDATORS
+export const customValidators: CustomValidatorMap;
 ```
 
 `typia` supports three type of validator functions:
@@ -213,7 +218,10 @@ export function createValidateEquals<T>(): (input: unknown) => IValidation<T>;
 
 Also, if you want more strict validator functions that even do not allowing superfluous properties not written in the type `T`, you can use those functions instead; `equals()`, `assertEquals()`, `validateEquals()`. Otherwise you want to create resuable validator functions,  you can utilize factory functions like `createIs()` instead.
 
-When you want to add special validation logics, like limiting range of numeric values, you can do it through comment tags. If you want to know about it, visit the Guide Documents ([Features > Runtime Validators > Comment Tags](https://github.com/samchon/typia/wiki/Runtime-Validators#comment-tags)).
+When you want to add special validation logics, like limiting range of numeric values, you can do it through comment tags. Furthermore, you can add your custom validator logics. If you want to know about them, visit the Guide Documents:
+
+  - [Features > Runtime Validators > Comment Tags](https://github.com/samchon/typia/wiki/Runtime-Validators#comment-tags)
+  - [Features > Runtime Validators > Custom Validators](https://github.com/samchon/typia/wiki/Runtime-Validators#comment-tags).
 
 ### Enhanced JSON
 ```typescript

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.7.0-dev.20230401-2",
+  "version": "3.7.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -74,6 +74,6 @@
     "src"
   ],
   "dependencies": {
-    "typia": "3.7.0-dev.20230401-2"
+    "typia": "3.7.0"
   }
 }

--- a/src/CustomValidatorMap.ts
+++ b/src/CustomValidatorMap.ts
@@ -1,0 +1,126 @@
+import { Customizable } from "./typings/Customizable";
+
+/**
+ * Map of custom validators.
+ *
+ * Map of custom validator functions, storing tag name and type of target value
+ * as key, and custom validator function as value.
+ *
+ * When you want to add a custom validation logic utilizing comment tags, you
+ * can insert a custom validator function with specific tag name and type of
+ * the target value like below.
+ *
+ * ```ts
+ * typia.customValidators.insert("powerOf")("number")(
+ *     (text: string) => {
+ *         const denominator: number = Math.log(Number(text));
+ *         return (value: number) => {
+ *             value = Math.log(value) / denominator;
+ *             return value === Math.floor(value);
+ *         };
+ *     }
+ * );
+ * typia.customValidators.insert("dollar")("string")(
+ *     () => (value: string) => value.startsWith("$"),
+ * );
+ *
+ * interface TagCustom {
+ *    /**
+ *     * @powerOf 10
+ *     *\/
+ *    powerOf: number;
+ *
+ *    /**
+ *     * @dollar
+ *     *\/
+ *    dollar: string;
+ * }
+ * ```
+ *
+ * @author Jeongho Nam - https://github.com/samchon
+ */
+export interface CustomValidatorMap {
+    /**
+     * Get number of stored tags.
+     *
+     * @return Number of stored tags
+     */
+    size(): number;
+
+    /**
+     * Get number of stored types of the specified tag name.
+     *
+     * In other words, number of stored custom validator functions of
+     * the specified tag name.
+     *
+     * @param name Tag name
+     * @return Number of stored types function
+     */
+    size(name: string): number;
+
+    /**
+     * Test whether custom validator function exists or not.
+     *
+     * @param name Tag name
+     * @param type Type of the target value
+     * @returns Whether exists or not
+     */
+    has: (name: string) => (type: keyof Customizable) => boolean;
+
+    /**
+     * Get custom validator function.
+     *
+     * @param name Tag name
+     * @param type Type of the target value
+     * @returns Custom validator function or undefined value
+     */
+    get(
+        name: string,
+    ): <Type extends keyof Customizable>(
+        type: Type,
+    ) => CustomValidatorMap.Closure<Type> | undefined;
+
+    /**
+     * Insert a new custom validator function.
+     *
+     * You can add a custom validation logic utilizing comment tags,
+     * by inserting a function which returns a boolean value, with specific
+     * tag name and type of the target value.
+     *
+     * However, if you try to insert a duplicated tag name and type, the
+     * closure function would not be enrolled and `false` value would be
+     * returned.
+     *
+     * @param name Tag name
+     * @param type Type of the target value
+     * @param closure Custom validator function
+     * @returns Whether succeeded to insert or not
+     */
+    insert(
+        name: string,
+    ): <Type extends keyof Customizable>(
+        type: Type,
+    ) => (closure: CustomValidatorMap.Closure<Type>) => boolean;
+
+    /**
+     * Erase custom validator function.
+     *
+     * @param name Tag name
+     * @param type Type of the target value
+     * @returns Whether succeeded to erase or not
+     */
+    erase(name: string): (type: keyof Customizable) => boolean;
+}
+export namespace CustomValidatorMap {
+    /**
+     * Type of closure function of custom validation.
+     *
+     * @template Type Type of the target value
+     * @param text Text of the tag. For example, if the tag is `@powerOf 10`, `text` is 10.
+     * @param value Value to validate
+     * @returns Whether the value is valid or not
+     */
+    export type Closure<Type extends keyof Customizable> = (
+        text: string,
+    ) => (value: Customizable[Type]) => boolean;
+}

--- a/src/functional/$dictionary.ts
+++ b/src/functional/$dictionary.ts
@@ -3,8 +3,11 @@ import { Customizable } from "../typings/Customizable";
 export const $dictionary = (() => {
     const glob: {
         __typia_custom_validator: Map<
-            `${string}:${keyof Customizable}`,
-            (tagText: string) => (value: any) => boolean
+            `${string}`,
+            Map<
+                keyof Customizable,
+                (tagText: string) => (value: any) => boolean
+            >
         >;
     } =
         typeof global === "object" &&

--- a/src/functional/$is_custom.ts
+++ b/src/functional/$is_custom.ts
@@ -8,7 +8,7 @@ export function $is_custom<Type extends keyof Customizable>(
     text: string,
     value: Customizable[Type],
 ): boolean {
-    const validator = $dictionary.get(`${name}:${type}`);
+    const validator = $dictionary.get(name)?.get(type);
     if (validator === undefined) return true;
     return validator(text)(value);
 }

--- a/test/structures/TagCustom.ts
+++ b/test/structures/TagCustom.ts
@@ -66,15 +66,15 @@ export namespace TagCustom {
     export const RANDOM = false;
 }
 
-typia.addValidationTag("dollar")("string")(
+typia.customValidators.insert("dollar")("string")(
     () => (value: string) =>
         value.startsWith("$") &&
         !isNaN(Number(value.substring(1).split(",").join(""))),
 );
-typia.addValidationTag("postfix")("string")(
+typia.customValidators.insert("postfix")("string")(
     (text: string) => (value: string) => value.endsWith(text),
 );
-typia.addValidationTag("powerOf")("number")((text: string) => {
+typia.customValidators.insert("powerOf")("number")((text: string) => {
     const denominator: number = Math.log(Number(text));
     return (value: number) => {
         value = Math.log(value) / denominator;


### PR DESCRIPTION
Determine below spec:

```ts
typia.customValidators.insert("powerOf")("number")(
    (text: string) => {
        const denominator: number = Math.log(Number(text));
        return (value: number) => {
            value = Math.log(value) / denominator;
            return value === Math.floor(value);
        };
    }
);
typia.customValidators.insert("dollar")("string")(
    () => (value: string) => value.startsWith("$"),
);

interface TagCustom {
   /**
    * @powerOf 10
    */
   powerOf: number;

   /**
    * @dollar
    */
   dollar: string;
}
```