### PR TITLE
Fix #573 - unable to run setup on Macbook + `pnpm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Your donation would encourage `typia` development.
 ## Setup
 ### Transformation
 ```bash
+npm install --save typia
 npx typia setup
 ```
 
@@ -111,6 +112,7 @@ npm run prepare
 ```bash
 # INSTALL TYPIA
 npm install --save typia
+npm install --save-dev typescript
 
 # GENERATE TRANSFORMED TYPESCRIPT CODES
 npx typia generate \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -67,6 +67,12 @@
     "url": "https://github.com/samchon/typia/issues"
   },
   "homepage": "https://github.com/samchon/typia#readme",
+  "dependencies": {
+    "commander": "^10.0.0",
+    "comment-json": "^4.2.3",
+    "inquirer": "^8.2.5",
+    "randexp": "^0.5.3"
+  },
   "peerDependencies": {
     "typescript": ">= 4.5.2 && < 5.0.0"
   },
@@ -94,14 +100,11 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "cli": "^1.0.1",
-    "commander": "^10.0.0",
-    "comment-json": "^4.2.3",
     "d3": "^5.16.0",
     "eslint-plugin-deprecation": "^1.3.2",
     "express": "^4.18.2",
     "fast-json-stringify": "^5.4.0",
     "fastify": "^4.9.2",
-    "inquirer": "^8.2.5",
     "io-ts": "^2.2.19",
     "jsdom": "^20.0.2",
     "physical-cpu-count": "^2.0.0",
@@ -126,8 +129,5 @@
     "lib",
     "src"
   ],
-  "dependencies": {
-    "randexp": "^0.5.3"
-  },
   "private": true
 }

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -62,6 +62,7 @@ Your donation would encourage `typia` development.
 ## Setup
 ### Transformation
 ```bash
+npm install --save typia
 npx typia setup
 ```
 
@@ -114,6 +115,7 @@ npm run prepare
 ```bash
 # INSTALL TYPIA
 npm install --save typia
+npm install --save-dev typescript
 
 # GENERATE TRANSFORMED TYPESCRIPT CODES
 npx typia generate \
@@ -298,55 +300,3 @@ If you need specific random data generation, utilize comment tags or do customiz
   - `nestia`: just CLI (command line interface) tool
 
 ![nestia-sdk-demo](https://user-images.githubusercontent.com/13158709/215004990-368c589d-7101-404e-b81b-fbc936382f05.gif)
-
-### Reactia
-> Not published yet, but soon
-
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/reactia/blob/master/LICENSE)
-[![Build Status](https://github.com/samchon/reactia/workflows/build/badge.svg)](https://github.com/samchon/reactia/actions?query=workflow%3Abuild)
-[![Guide Documents](https://img.shields.io/badge/wiki-documentation-forestgreen)](https://github.com/samchon/reactia/wiki)
-
-[Reactia](https://github.com/samchon/reactia) is an automatic React components generator, just by analyzing TypeScript type.
-
-  - `@reactia/core`: Core Library analyzing TypeScript type
-  - `@reactia/mui`: Material UI Theme for `core` and `nest`
-  - `@reactia/nest`: Automatic Frontend Application Builder for `NestJS`
-
-![Sample](https://user-images.githubusercontent.com/13158709/199074008-46b2dd67-02be-40b1-aa0f-74ac41f3e0a7.png)
-
-When you want to automate an individual component, just use `@reactia/core`.
-
-```tsx
-import ReactDOM from "react-dom";
-
-import typia from "typia";
-import { ReactiaComponent } from "@reactia/core";
-import { MuiInputTheme } from "@reactia/mui";
-
-const RequestInput = ReactiaComponent<IRequestDto>(MuiInputTheme());
-const input: IRequestDto = { ... };
-
-ReactDOM.render(
-    <RequestInput input={input} />,
-    document.body
-);
-```
-
-Otherwise, you can fully automate frontend application development through `@reactia/nest`.
-
-```tsx
-import React from "react";
-import ReactDOM from "react-dom";
-
-import { ISwagger } "@nestia/swagger";
-import { MuiApplicationTheme } from "@reactia/mui";
-import { ReactiaApplication } from "@reactia/nest";
-
-const swagger: ISwagger = await import("./swagger.json");
-const App: React.FC = ReactiaApplication(MuiApplicationTheme())(swagger);
-
-ReactDOM.render(
-    <App />,
-    document.body
-);
-```

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -64,6 +64,9 @@
     "url": "https://github.com/samchon/typia/issues"
   },
   "homepage": "https://github.com/samchon/typia#readme",
+  "dependencies": {
+    "typia": "3.7.4"
+  },
   "peerDependencies": {
     "typescript": ">= 4.5.2 && < 5.0.0"
   },
@@ -73,8 +76,5 @@
     "package.json",
     "lib",
     "src"
-  ],
-  "dependencies": {
-    "typia": "3.7.3"
-  }
+  ]
 }

--- a/src/executable/TypiaGenerateWizard.ts
+++ b/src/executable/TypiaGenerateWizard.ts
@@ -13,9 +13,7 @@ export namespace TypiaGenerateWizard {
 
         // LOAD PACKAGE.JSON INFO
         const pack: PackageManager = await PackageManager.mount();
-        const options: IArguments = await ArgumentParser.parse(pack)(false)(
-            inquiry,
-        );
+        const options: IArguments = await ArgumentParser.parse(pack)(inquiry);
         await TypiaFileFactory.generate(options);
     }
 
@@ -58,17 +56,17 @@ export namespace TypiaGenerateWizard {
                 )[name];
             };
         const configure = async () => {
-            const fileList: string[] = await (
+            const files: string[] = await (
                 await fs.promises.readdir(process.cwd())
             ).filter(
                 (str) =>
                     str.substring(0, 8) === "tsconfig" &&
                     str.substring(str.length - 5) === ".json",
             );
-            if (fileList.length === 0)
+            if (files.length === 0)
                 throw new Error(`Unable to find "tsconfig.json" file.`);
-            else if (fileList.length === 1) return fileList[0];
-            return select("tsconfig")("TS Config File")(fileList);
+            else if (files.length === 1) return files[0];
+            return select("tsconfig")("TS Config File")(files);
         };
 
         return action(async (options) => {

--- a/src/executable/TypiaSetupWizard.ts
+++ b/src/executable/TypiaSetupWizard.ts
@@ -20,14 +20,12 @@ export namespace TypiaSetupWizard {
 
         // PREPARE ASSETS
         const pack: PackageManager = await PackageManager.mount();
-        const args: IArguments = await ArgumentParser.parse(pack)(true)(
-            inquiry,
-        );
+        const args: IArguments = await ArgumentParser.parse(pack)(inquiry);
 
         // INSTALL TYPESCRIPT
         pack.install({ dev: true, modulo: "typescript", version: "4.9.5" });
         args.project ??= (() => {
-            CommandExecutor.run("npx tsc --init", false);
+            CommandExecutor.run("npx tsc --init");
             return (args.project = "tsconfig.json");
         })();
         pack.install({ dev: true, modulo: "ts-node" });
@@ -45,12 +43,11 @@ export namespace TypiaSetupWizard {
                         "ts-patch install && " + data.scripts.prepare;
                 else data.scripts.prepare = "ts-patch install";
             });
-            CommandExecutor.run("npm run prepare", false);
+            CommandExecutor.run("npm run prepare");
         }
 
-        // INSTALL AND CONFIGURE TYPIA
-        pack.install({ dev: false, modulo: "typia" });
-        await PluginConfigurator.configure(pack, args);
+        // CONFIGURE TYPIA
+        await PluginConfigurator.configure(args);
     }
 
     const inquiry: ArgumentParser.Inquiry<IArguments> = async (

--- a/src/executable/setup/ArgumentParser.ts
+++ b/src/executable/setup/ArgumentParser.ts
@@ -1,91 +1,45 @@
-import type CommanderModule from "commander";
-import type * as InquirerModule from "inquirer";
-import path from "path";
+import commander from "commander";
+import inquirer from "inquirer";
 
-import { FileRetriever } from "./FileRetriever";
 import { PackageManager } from "./PackageManager";
 
 export namespace ArgumentParser {
     export type Inquiry<T> = (
         pack: PackageManager,
-        command: CommanderModule.Command,
-        prompt: (
-            opt?: InquirerModule.StreamOptions,
-        ) => InquirerModule.PromptModule,
+        command: commander.Command,
+        prompt: (opt?: inquirer.StreamOptions) => inquirer.PromptModule,
         action: (closure: (options: Partial<T>) => Promise<T>) => Promise<T>,
     ) => Promise<T>;
 
     export const parse =
         (pack: PackageManager) =>
-        (erase: boolean) =>
         async <T>(
             inquiry: (
                 pack: PackageManager,
-                command: CommanderModule.Command,
-                prompt: (
-                    opt?: InquirerModule.StreamOptions,
-                ) => InquirerModule.PromptModule,
+                command: commander.Command,
+                prompt: (opt?: inquirer.StreamOptions) => inquirer.PromptModule,
                 action: (
                     closure: (options: Partial<T>) => Promise<T>,
                 ) => Promise<T>,
             ) => Promise<T>,
         ): Promise<T> => {
-            // INSTALL TEMPORARY PACKAGES
-            const newbie = {
-                commander: pack.install({
-                    dev: true,
-                    modulo: "commander",
-                    version: "10.0.0",
-                    silent: true,
-                }),
-                inquirer: pack.install({
-                    dev: true,
-                    modulo: "inquirer",
-                    version: "8.2.5",
-                    silent: true,
-                }),
-            };
-
-            // LOAD INSTALLED MODULES
-            const { program: command }: typeof CommanderModule =
-                await FileRetriever.require(
-                    path.join("node_modules", "commander"),
-                )(pack.directory);
-            const { createPromptModule: prompt }: typeof InquirerModule =
-                await FileRetriever.require(
-                    path.join("node_modules", "inquirer"),
-                )(pack.directory);
-
             // TAKE OPTIONS
             const action = (closure: (options: Partial<T>) => Promise<T>) =>
                 new Promise<T>((resolve, reject) => {
-                    command.action(async (options) => {
+                    commander.program.action(async (options) => {
                         try {
                             resolve(await closure(options));
                         } catch (exp) {
                             reject(exp);
                         }
                     });
-                    command.parseAsync().catch(reject);
+                    commander.program.parseAsync().catch(reject);
                 });
-            const output: T | Error = await (async () => {
-                try {
-                    return await inquiry(pack, command, prompt, action);
-                } catch (error) {
-                    return error as Error;
-                }
-            })();
-
-            // REMOVE TEMPORARY PACKAGES
-            if (erase === true) {
-                if (newbie.commander)
-                    pack.erase({ modulo: "commander", silent: true });
-                if (newbie.inquirer)
-                    pack.erase({ modulo: "inquirer", silent: true });
-            }
-
-            // RETURNS
-            if (output instanceof Error) throw output;
-            return output;
+            return inquiry(
+                pack,
+                commander.program,
+                inquirer.createPromptModule,
+                action,
+            );
         };
 }

--- a/src/executable/setup/CommandExecutor.ts
+++ b/src/executable/setup/CommandExecutor.ts
@@ -1,8 +1,8 @@
 import cp from "child_process";
 
 export namespace CommandExecutor {
-    export function run(str: string, silent: boolean): void {
-        if (silent === false) console.log(str);
+    export function run(str: string): void {
+        console.log(str);
         cp.execSync(str, { stdio: "ignore" });
     }
 }

--- a/src/executable/setup/FileRetriever.ts
+++ b/src/executable/setup/FileRetriever.ts
@@ -19,15 +19,4 @@ export namespace FileRetriever {
             else if (depth > 2) return null;
             return file(name)(path.join(directory, ".."), depth + 1);
         };
-
-    export const require =
-        (name: string) =>
-        async (directory: string, depth: number = 0) => {
-            const location: string | null = file(name)(directory, depth);
-            if (location === null)
-                throw new Error(
-                    `Unable to find installed module. Please report to the nestia - https://github.com/samchon/nestia/issues`,
-                );
-            return import(location);
-        };
 }

--- a/src/executable/setup/PackageManager.ts
+++ b/src/executable/setup/PackageManager.ts
@@ -37,21 +37,9 @@ export class PackageManager {
 
     public install(props: {
         dev: boolean;
-        silent?: boolean;
         modulo: string;
         version?: string;
     }): boolean {
-        const container = props.dev
-            ? this.data.devDependencies
-            : this.data.dependencies;
-        if (
-            !!container?.[props.modulo] &&
-            FileRetriever.file(path.join("node_modules", props.modulo))(
-                this.directory,
-            ) !== null
-        )
-            return false;
-
         const middle: string =
             this.manager === "yarn"
                 ? `add${props.dev ? " -D" : ""}`
@@ -60,17 +48,8 @@ export class PackageManager {
             `${this.manager} ${middle} ${props.modulo}${
                 props.version ? `@${props.version}` : ""
             }`,
-            !!props.silent,
         );
         return true;
-    }
-
-    public erase(props: { modulo: string; silent?: boolean }): void {
-        const middle: string = this.manager === "yarn" ? "remove" : "uninstall";
-        CommandExecutor.run(
-            `${this.manager} ${middle} ${props.modulo}`,
-            !!props.silent,
-        );
     }
 
     private constructor(

--- a/src/executable/typia.ts
+++ b/src/executable/typia.ts
@@ -1,7 +1,4 @@
 #!/usr/bin/env node
-import { TypiaGenerateWizard } from "./TypiaGenerateWizard";
-import { TypiaSetupWizard } from "./TypiaSetupWizard";
-
 const USAGE = `Wrong command has been detected. Use like below:
 
   npx typia setup \\
@@ -27,10 +24,29 @@ function halt(desc: string): never {
 }
 
 async function main(): Promise<void> {
+    try {
+        await import("comment-json");
+        await import("inquirer");
+        await import("commander");
+    } catch {
+        halt(`typia has not been installed. Run "npm i typia" before.`);
+    }
+
     const type: string | undefined = process.argv[2];
-    if (type === "setup") await TypiaSetupWizard.setup();
-    else if (type === "generate") await TypiaGenerateWizard.generate();
-    else halt(USAGE);
+    if (type === "setup") {
+        const { TypiaSetupWizard } = await import("./TypiaSetupWizard");
+        await TypiaSetupWizard.setup();
+    } else if (type === "generate") {
+        try {
+            await import("typescript");
+        } catch {
+            halt(
+                `typescript has not been installed. Run "npm i -D typescript" before.`,
+            );
+        }
+        const { TypiaGenerateWizard } = await import("./TypiaGenerateWizard");
+        await TypiaGenerateWizard.generate();
+    } else halt(USAGE);
 }
 main().catch((exp) => {
     console.error(exp);


### PR DESCRIPTION
When run `pnpm` commands on Macbook, it fails.

I've tried lots of alternative ways, but could not fix it.

Therefore, from now on, `npx typia setup` commands cannot be executed alone, and need pre-install like below:

```bash
npm install --save-dev typia
npx typia setup
```