### PR TITLE
Advanced `npx typia setup` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/executable/TypiaSetupWizard.ts
+++ b/src/executable/TypiaSetupWizard.ts
@@ -28,20 +28,21 @@ export namespace TypiaSetupWizard {
             CommandExecutor.run("npx tsc --init");
             return (args.project = "tsconfig.json");
         })();
-        pack.install({ dev: true, modulo: "ts-node" });
+        pack.install({ dev: true, modulo: "ts-node", version: "latest" });
 
         // INSTALL COMPILER
-        pack.install({ dev: true, modulo: args.compiler });
+        pack.install({ dev: true, modulo: args.compiler, version: "latest" });
         if (args.compiler === "ts-patch") {
             await pack.save((data) => {
                 data.scripts ??= {};
                 if (
                     typeof data.scripts.prepare === "string" &&
-                    data.scripts.prepare.indexOf("ts-patch install") === -1
-                )
-                    data.scripts.prepare =
-                        "ts-patch install && " + data.scripts.prepare;
-                else data.scripts.prepare = "ts-patch install";
+                    data.scripts.prepare.length
+                ) {
+                    if (data.scripts.prepare.indexOf("ts-patch install") === -1)
+                        data.scripts.prepare =
+                            "ts-patch install && " + data.scripts.prepare;
+                } else data.scripts.prepare = "ts-patch install";
             });
             CommandExecutor.run("npm run prepare");
         }

--- a/src/executable/setup/PackageManager.ts
+++ b/src/executable/setup/PackageManager.ts
@@ -38,7 +38,7 @@ export class PackageManager {
     public install(props: {
         dev: boolean;
         modulo: string;
-        version?: string;
+        version: `latest` | `${number}.${number}.${number}`;
     }): boolean {
         const middle: string =
             this.manager === "yarn"


### PR DESCRIPTION
Let `npx typia setup` to install latest version of `ttypescript` and `ts-patch`, therefore response for TS5 support update of them.