### PR TITLE
Fix #603 - emtpy tuple in object literal expression

### DIFF
--- a/src/factories/internal/metadata/iterate_metadata.ts
+++ b/src/factories/internal/metadata/iterate_metadata.ts
@@ -2,8 +2,7 @@ import ts from "typescript";
 
 import { Metadata } from "../../../metadata/Metadata";
 
-import { ArrayUtil } from "../../../utils/ArrayUtil";
-
+// import { ArrayUtil } from "../../../utils/ArrayUtil";
 import { MetadataCollection } from "../../MetadataCollection";
 import { MetadataFactory } from "../../MetadataFactory";
 import { iterate_metadata_array } from "./iterate_metadata_array";
@@ -43,18 +42,6 @@ export const iterate_metadata =
             )
         )
             return;
-
-        // VALIDATE NODE
-        const node: ts.TypeNode | undefined = checker.typeToTypeNode(
-            type,
-            undefined,
-            undefined,
-        );
-        if (node === undefined) {
-            // EMPTY TUPLE CASE CAN BE
-            ArrayUtil.set(meta.tuples, [], () => "[]");
-            return;
-        }
 
         // ITERATE CASES
         iterate_metadata_coalesce(meta, type) ||

--- a/test/issues/603.ts
+++ b/test/issues/603.ts
@@ -1,0 +1,4 @@
+import typia from "typia";
+
+console.log(typia.createIs<[{ foo: [] }]>().toString());
+console.log(typia.createIs<[]>().toString());


### PR DESCRIPTION
````typescript
typia.createIs<[{ foo: [] }]>()
```

When empty tuple property exists in object literal expression, `typia` could not understand it.

From now on, `typia` can understand it.