### PR TITLE
Fix #599 - deprecated `ApplicationProgrammer.generate()` was wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -66,7 +66,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "3.8.0"
+    "typia": "3.8.1"
   },
   "peerDependencies": {
     "typescript": ">= 4.5.2"

--- a/src/programmers/ApplicationProgrammer.ts
+++ b/src/programmers/ApplicationProgrammer.ts
@@ -35,7 +35,7 @@ export namespace ApplicationProgrammer {
     export const generate = (
         metadatas: Array<Metadata>,
         options?: Partial<IOptions>,
-    ): IJsonApplication => generate(metadatas, options);
+    ): IJsonApplication => write(options)(metadatas);
 
     export const write =
         (options?: Partial<IOptions>) =>


### PR DESCRIPTION
Before submitting a Pull Request, please test your code. 

If you created a new created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# PREPARE
npm run test:generate

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)