### PR TITLE
Setup wizard to configure `strictNullChecks: true`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -66,7 +66,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "3.8.1"
+    "typia": "3.8.2"
   },
   "peerDependencies": {
     "typescript": ">= 4.5.2"

--- a/src/executable/setup/PluginConfigurator.ts
+++ b/src/executable/setup/PluginConfigurator.ts
@@ -33,17 +33,28 @@ export namespace PluginConfigurator {
             return plugins;
         })();
 
-        const strict: boolean = compilerOptions.strict === true;
+        const strict: boolean | undefined = compilerOptions.strict as
+            | boolean
+            | undefined;
+        const strictNullChecks: boolean | undefined =
+            compilerOptions.strictNullChecks as boolean | undefined;
         const oldbie: comments.CommentObject | undefined = plugins.find(
             (p) =>
                 typeof p === "object" &&
                 p !== null &&
                 p.transform === "typia/lib/transform",
         );
-        if (strict === true && oldbie !== undefined) return;
+        if (
+            strictNullChecks !== false &&
+            (strict === true || strictNullChecks === true) &&
+            oldbie !== undefined
+        )
+            return;
 
         // DO CONFIGURE
-        compilerOptions.strict = true;
+        compilerOptions.strictNullChecks = true;
+        if (strict === undefined && strictNullChecks === undefined)
+            compilerOptions.strict = true;
         if (oldbie === undefined)
             plugins.push(
                 comments.parse(`


### PR DESCRIPTION
`nest new <directory>` command of `@nestjs/cli` has changed to configures `strictNullChecks: false`. 

In the past, it had configured `strict: false`.

Therefore, changed setup wizard of `typia` to consider `strictNullChecks` option, too.