### PR TITLE
Use proper vite configuration

### DIFF
--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -125,10 +125,11 @@ Just configure `vite.config.ts` file below, that's all.
 ```typescript copy filename="vite.config.ts"
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import typescript from "@rollup/plugin-typescript";
+import typescript from "rollup-plugin-typescript2";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  esbuild: false,
   plugins: [
     react(),
     typescript()


### PR DESCRIPTION
Vite by default will still use its eslint parser. We need to disable it and use the forked plugin version to have transformers working

Before submitting a Pull Request, please test your code. 

If you created a new created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# PREPARE
npm run test:generate

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)