### PR TITLE
Do not check invalid `@type` tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -66,7 +66,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "3.8.4"
+    "typia": "3.8.5"
   },
   "peerDependencies": {
     "typescript": ">= 4.5.2"

--- a/src/factories/MetadataTagFactory.ts
+++ b/src/factories/MetadataTagFactory.ts
@@ -83,13 +83,11 @@ export namespace MetadataTagFactory {
         /* -----------------------------------------------------------
             NUMBER
         ----------------------------------------------------------- */
-        type: (identifier, metadata, text, output) => {
-            validate(identifier, metadata, output, "type", "number", []);
-            if (text !== "int" && text !== "uint")
-                throw new Error(
-                    `${LABEL}: invalid type tag on "${identifier()}".`,
-                );
-            return { kind: "type", value: text };
+        type: (_identifier, metadata, text, _output) => {
+            return has_atomic(metadata)("number") &&
+                (text === "int" || text === "uint")
+                ? { kind: "type", value: text }
+                : null;
         },
         minimum: (identifier, metadata, text, output) => {
             validate(identifier, metadata, output, "minimum", "number", [

--- a/src/factories/internal/metadata/emplace_metadata_object.ts
+++ b/src/factories/internal/metadata/emplace_metadata_object.ts
@@ -51,11 +51,11 @@ export const emplace_metadata_object =
                 // COMMENTS AND TAGS
                 const description: string | undefined =
                     CommentFactory.string(
-                        symbol?.getDocumentationComment(checker) || [],
-                    ) || undefined;
+                        symbol?.getDocumentationComment(checker) ?? [],
+                    ) ?? undefined;
                 const jsDocTags: ts.JSDocTagInfo[] = (
-                    symbol?.getJsDocTags() || []
-                ).filter(filter || (() => true));
+                    symbol?.getJsDocTags() ?? []
+                ).filter(filter ?? (() => true));
 
                 // THE PROPERTY
                 const property = MetadataProperty.create({
@@ -77,7 +77,7 @@ export const emplace_metadata_object =
         for (const prop of parent.getApparentProperties()) {
             // CHECK INTERNAL TAG
             if (
-                (prop.getJsDocTags(checker) || []).find(
+                (prop.getJsDocTags(checker) ?? []).find(
                     (tag) => tag.name === "internal",
                 ) !== undefined
             )
@@ -85,7 +85,7 @@ export const emplace_metadata_object =
 
             // CHECK NODE IS A FORMAL PROPERTY
             const [node, type] = (() => {
-                const node = (prop.getDeclarations() || [])[0] as
+                const node = (prop.getDeclarations() ?? [])[0] as
                     | ts.PropertyDeclaration
                     | undefined;
                 const type: ts.Type | undefined = node

--- a/src/programmers/AssertProgrammer.ts
+++ b/src/programmers/AssertProgrammer.ts
@@ -85,7 +85,7 @@ export namespace AssertProgrammer {
                         ...importer.declare(modulo),
                         StatementFactory.constant(
                             "__is",
-                            IsProgrammer.write(project)(modulo)(equals)(
+                            IsProgrammer.write(project)(modulo, true)(equals)(
                                 type,
                                 name ??
                                     TypeFactory.getFullName(project.checker)(

--- a/src/programmers/IsProgrammer.ts
+++ b/src/programmers/IsProgrammer.ts
@@ -12,6 +12,7 @@ import { CheckerProgrammer } from "./CheckerProgrammer";
 import { FunctionImporter } from "./helpers/FunctionImporeter";
 import { IExpressionEntry } from "./helpers/IExpressionEntry";
 import { OptionPredicator } from "./helpers/OptionPredicator";
+import { disable_function_importer_declare } from "./helpers/disable_function_importer_declare";
 import { check_object } from "./internal/check_object";
 import { feature_object_entries } from "./internal/feature_object_entries";
 
@@ -103,9 +104,12 @@ export namespace IsProgrammer {
 
     export const write =
         (project: IProject) =>
-        (modulo: ts.LeftHandSideExpression) =>
+        (modulo: ts.LeftHandSideExpression, disable?: boolean) =>
         (equals: boolean) => {
-            const importer: FunctionImporter = new FunctionImporter();
+            const importer: FunctionImporter =
+                disable === true
+                    ? disable_function_importer_declare(new FunctionImporter())
+                    : new FunctionImporter();
 
             // CONFIGURATION
             const config: CheckerProgrammer.IConfig = {

--- a/src/programmers/ValidateProgrammer.ts
+++ b/src/programmers/ValidateProgrammer.ts
@@ -87,7 +87,7 @@ export namespace ValidateProgrammer {
                     [
                         StatementFactory.constant(
                             "__is",
-                            IsProgrammer.write(project)(modulo)(equals)(
+                            IsProgrammer.write(project)(modulo, true)(equals)(
                                 type,
                                 name ??
                                     TypeFactory.getFullName(project.checker)(

--- a/src/programmers/helpers/disable_function_importer_declare.ts
+++ b/src/programmers/helpers/disable_function_importer_declare.ts
@@ -1,0 +1,21 @@
+import ts from "typescript";
+
+import { FunctionImporter } from "./FunctionImporeter";
+
+export const disable_function_importer_declare = (
+    importer: FunctionImporter,
+): FunctionImporter => disable(importer) as FunctionImporter;
+
+const disable = (importer: FunctionImporter): MethodOnly<FunctionImporter> => ({
+    empty: (): boolean => importer.empty(),
+    use: (name: string): ts.Identifier => importer.use(name),
+    useLocal: (name: string): string => importer.useLocal(name),
+    hasLocal: (name: string): boolean => importer.hasLocal(name),
+    declare: (_modulo: ts.LeftHandSideExpression): ts.Statement[] => [],
+    increment: (): number => importer.increment(),
+    trace: (): void => importer.trace(),
+});
+
+type MethodOnly<T> = {
+    [P in keyof T]: T[P] extends Function ? T[P] : never;
+};

--- a/test/generated/output/assert/test_assert_DynamicArray.ts
+++ b/test/generated/output/assert/test_assert_DynamicArray.ts
@@ -10,7 +10,6 @@ export const test_assert_DynamicArray = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $join = (typia.assert as any).join;
             const __is = (input: any): input is DynamicArray => {
-                const $join = (typia.assert as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/assert/test_assert_DynamicComposite.ts
+++ b/test/generated/output/assert/test_assert_DynamicComposite.ts
@@ -10,7 +10,6 @@ export const test_assert_DynamicComposite = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $join = (typia.assert as any).join;
             const __is = (input: any): input is DynamicComposite => {
-                const $join = (typia.assert as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "string" === typeof input.name &&

--- a/test/generated/output/assert/test_assert_DynamicNever.ts
+++ b/test/generated/output/assert/test_assert_DynamicNever.ts
@@ -10,7 +10,6 @@ export const test_assert_DynamicNever = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $join = (typia.assert as any).join;
             const __is = (input: any): input is DynamicNever => {
-                const $join = (typia.assert as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/assert/test_assert_DynamicSimple.ts
+++ b/test/generated/output/assert/test_assert_DynamicSimple.ts
@@ -10,7 +10,6 @@ export const test_assert_DynamicSimple = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $join = (typia.assert as any).join;
             const __is = (input: any): input is DynamicSimple => {
-                const $join = (typia.assert as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/assert/test_assert_DynamicTemplate.ts
+++ b/test/generated/output/assert/test_assert_DynamicTemplate.ts
@@ -10,7 +10,6 @@ export const test_assert_DynamicTemplate = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $join = (typia.assert as any).join;
             const __is = (input: any): input is DynamicTemplate => {
-                const $join = (typia.assert as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/assert/test_assert_DynamicTree.ts
+++ b/test/generated/output/assert/test_assert_DynamicTree.ts
@@ -10,7 +10,6 @@ export const test_assert_DynamicTree = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $join = (typia.assert as any).join;
             const __is = (input: any): input is DynamicTree => {
-                const $join = (typia.assert as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "number" === typeof input.sequence &&

--- a/test/generated/output/assert/test_assert_DynamicUndefined.ts
+++ b/test/generated/output/assert/test_assert_DynamicUndefined.ts
@@ -10,7 +10,6 @@ export const test_assert_DynamicUndefined = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $join = (typia.assert as any).join;
             const __is = (input: any): input is DynamicUndefined => {
-                const $join = (typia.assert as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/assert/test_assert_DynamicUnion.ts
+++ b/test/generated/output/assert/test_assert_DynamicUnion.ts
@@ -10,7 +10,6 @@ export const test_assert_DynamicUnion = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $join = (typia.assert as any).join;
             const __is = (input: any): input is DynamicUnion => {
-                const $join = (typia.assert as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/assert/test_assert_ObjectDynamic.ts
+++ b/test/generated/output/assert/test_assert_ObjectDynamic.ts
@@ -10,7 +10,6 @@ export const test_assert_ObjectDynamic = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $join = (typia.assert as any).join;
             const __is = (input: any): input is ObjectDynamic => {
-                const $join = (typia.assert as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/assert/test_assert_TagArray.ts
+++ b/test/generated/output/assert/test_assert_TagArray.ts
@@ -10,7 +10,6 @@ export const test_assert_TagArray = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $is_uuid = (typia.assert as any).is_uuid;
             const __is = (input: any): input is Array<TagArray.Type> => {
-                const $is_uuid = (typia.assert as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     3 === input.items.length &&

--- a/test/generated/output/assert/test_assert_TagCustom.ts
+++ b/test/generated/output/assert/test_assert_TagCustom.ts
@@ -11,8 +11,6 @@ export const test_assert_TagCustom = _test_assert(
             const $is_uuid = (typia.assert as any).is_uuid;
             const $is_custom = (typia.assert as any).is_custom;
             const __is = (input: any): input is TagCustom => {
-                const $is_uuid = (typia.assert as any).is_uuid;
-                const $is_custom = (typia.assert as any).is_custom;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     $is_uuid(input.id) &&

--- a/test/generated/output/assert/test_assert_TagFormat.ts
+++ b/test/generated/output/assert/test_assert_TagFormat.ts
@@ -16,13 +16,6 @@ export const test_assert_TagFormat = _test_assert(
             const $is_date = (typia.assert as any).is_date;
             const $is_datetime = (typia.assert as any).is_datetime;
             const __is = (input: any): input is TagFormat => {
-                const $is_uuid = (typia.assert as any).is_uuid;
-                const $is_email = (typia.assert as any).is_email;
-                const $is_url = (typia.assert as any).is_url;
-                const $is_ipv4 = (typia.assert as any).is_ipv4;
-                const $is_ipv6 = (typia.assert as any).is_ipv6;
-                const $is_date = (typia.assert as any).is_date;
-                const $is_datetime = (typia.assert as any).is_datetime;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.uuid &&
                     $is_uuid(input.uuid) &&

--- a/test/generated/output/assert/test_assert_TagMatrix.ts
+++ b/test/generated/output/assert/test_assert_TagMatrix.ts
@@ -10,7 +10,6 @@ export const test_assert_TagMatrix = _test_assert(
             const $guard = (typia.assert as any).guard;
             const $is_uuid = (typia.assert as any).is_uuid;
             const __is = (input: any): input is TagMatrix => {
-                const $is_uuid = (typia.assert as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.matrix) &&
                     3 === input.matrix.length &&

--- a/test/generated/output/assert/test_assert_UltimateUnion.ts
+++ b/test/generated/output/assert/test_assert_UltimateUnion.ts
@@ -12,7 +12,6 @@ export const test_assert_UltimateUnion = _test_assert(
             const __is = (
                 input: any,
             ): input is Array<typia.IJsonApplication> => {
-                const $join = (typia.assert as any).join;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.schemas) &&
                     input.schemas.every(

--- a/test/generated/output/assertClone/test_assertClone_DynamicArray.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicArray.ts
@@ -11,7 +11,6 @@ export const test_assertClone_DynamicArray = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $join = (typia.assertClone as any).join;
                 const __is = (input: any): input is DynamicArray => {
-                    const $join = (typia.assertClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertClone/test_assertClone_DynamicComposite.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicComposite.ts
@@ -11,7 +11,6 @@ export const test_assertClone_DynamicComposite = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $join = (typia.assertClone as any).join;
                 const __is = (input: any): input is DynamicComposite => {
-                    const $join = (typia.assertClone as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "string" === typeof input.name &&

--- a/test/generated/output/assertClone/test_assertClone_DynamicNever.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicNever.ts
@@ -11,7 +11,6 @@ export const test_assertClone_DynamicNever = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $join = (typia.assertClone as any).join;
                 const __is = (input: any): input is DynamicNever => {
-                    const $join = (typia.assertClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertClone/test_assertClone_DynamicSimple.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicSimple.ts
@@ -11,7 +11,6 @@ export const test_assertClone_DynamicSimple = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $join = (typia.assertClone as any).join;
                 const __is = (input: any): input is DynamicSimple => {
-                    const $join = (typia.assertClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertClone/test_assertClone_DynamicTemplate.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicTemplate.ts
@@ -11,7 +11,6 @@ export const test_assertClone_DynamicTemplate = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $join = (typia.assertClone as any).join;
                 const __is = (input: any): input is DynamicTemplate => {
-                    const $join = (typia.assertClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertClone/test_assertClone_DynamicTree.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicTree.ts
@@ -11,7 +11,6 @@ export const test_assertClone_DynamicTree = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $join = (typia.assertClone as any).join;
                 const __is = (input: any): input is DynamicTree => {
-                    const $join = (typia.assertClone as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "number" === typeof input.sequence &&

--- a/test/generated/output/assertClone/test_assertClone_DynamicUndefined.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicUndefined.ts
@@ -11,7 +11,6 @@ export const test_assertClone_DynamicUndefined = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $join = (typia.assertClone as any).join;
                 const __is = (input: any): input is DynamicUndefined => {
-                    const $join = (typia.assertClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertClone/test_assertClone_DynamicUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicUnion.ts
@@ -11,7 +11,6 @@ export const test_assertClone_DynamicUnion = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $join = (typia.assertClone as any).join;
                 const __is = (input: any): input is DynamicUnion => {
-                    const $join = (typia.assertClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertClone/test_assertClone_ObjectDynamic.ts
+++ b/test/generated/output/assertClone/test_assertClone_ObjectDynamic.ts
@@ -11,7 +11,6 @@ export const test_assertClone_ObjectDynamic = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $join = (typia.assertClone as any).join;
                 const __is = (input: any): input is ObjectDynamic => {
-                    const $join = (typia.assertClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertClone/test_assertClone_TagArray.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagArray.ts
@@ -11,7 +11,6 @@ export const test_assertClone_TagArray = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $is_uuid = (typia.assertClone as any).is_uuid;
                 const __is = (input: any): input is Array<TagArray.Type> => {
-                    const $is_uuid = (typia.assertClone as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         3 === input.items.length &&

--- a/test/generated/output/assertClone/test_assertClone_TagCustom.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagCustom.ts
@@ -12,8 +12,6 @@ export const test_assertClone_TagCustom = _test_assertClone(
                 const $is_uuid = (typia.assertClone as any).is_uuid;
                 const $is_custom = (typia.assertClone as any).is_custom;
                 const __is = (input: any): input is TagCustom => {
-                    const $is_uuid = (typia.assertClone as any).is_uuid;
-                    const $is_custom = (typia.assertClone as any).is_custom;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         $is_uuid(input.id) &&

--- a/test/generated/output/assertClone/test_assertClone_TagFormat.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagFormat.ts
@@ -17,13 +17,6 @@ export const test_assertClone_TagFormat = _test_assertClone(
                 const $is_date = (typia.assertClone as any).is_date;
                 const $is_datetime = (typia.assertClone as any).is_datetime;
                 const __is = (input: any): input is TagFormat => {
-                    const $is_uuid = (typia.assertClone as any).is_uuid;
-                    const $is_email = (typia.assertClone as any).is_email;
-                    const $is_url = (typia.assertClone as any).is_url;
-                    const $is_ipv4 = (typia.assertClone as any).is_ipv4;
-                    const $is_ipv6 = (typia.assertClone as any).is_ipv6;
-                    const $is_date = (typia.assertClone as any).is_date;
-                    const $is_datetime = (typia.assertClone as any).is_datetime;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.uuid &&
                         $is_uuid(input.uuid) &&

--- a/test/generated/output/assertClone/test_assertClone_TagMatrix.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagMatrix.ts
@@ -11,7 +11,6 @@ export const test_assertClone_TagMatrix = _test_assertClone(
                 const $guard = (typia.assertClone as any).guard;
                 const $is_uuid = (typia.assertClone as any).is_uuid;
                 const __is = (input: any): input is TagMatrix => {
-                    const $is_uuid = (typia.assertClone as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.matrix) &&
                         3 === input.matrix.length &&

--- a/test/generated/output/assertClone/test_assertClone_UltimateUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_UltimateUnion.ts
@@ -13,7 +13,6 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                 const __is = (
                     input: any,
                 ): input is Array<typia.IJsonApplication> => {
-                    const $join = (typia.assertClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.schemas) &&
                         input.schemas.every(

--- a/test/generated/output/assertEquals/test_assertEquals_DynamicComposite.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_DynamicComposite.ts
@@ -13,7 +13,6 @@ export const test_assertEquals_DynamicComposite = _test_assertEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is DynamicComposite => {
-                const $join = (typia.assertEquals as any).join;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/assertEquals/test_assertEquals_DynamicTemplate.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_DynamicTemplate.ts
@@ -13,7 +13,6 @@ export const test_assertEquals_DynamicTemplate = _test_assertEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is DynamicTemplate => {
-                const $join = (typia.assertEquals as any).join;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/assertEquals/test_assertEquals_DynamicUnion.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_DynamicUnion.ts
@@ -13,7 +13,6 @@ export const test_assertEquals_DynamicUnion = _test_assertEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is DynamicUnion => {
-                const $join = (typia.assertEquals as any).join;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/assertEquals/test_assertEquals_TagArray.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagArray.ts
@@ -14,7 +14,6 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is Array<TagArray.Type> => {
-                const $is_uuid = (typia.assertEquals as any).is_uuid;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/assertEquals/test_assertEquals_TagCustom.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagCustom.ts
@@ -15,8 +15,6 @@ export const test_assertEquals_TagCustom = _test_assertEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is TagCustom => {
-                const $is_uuid = (typia.assertEquals as any).is_uuid;
-                const $is_custom = (typia.assertEquals as any).is_custom;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/assertEquals/test_assertEquals_TagFormat.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagFormat.ts
@@ -20,13 +20,6 @@ export const test_assertEquals_TagFormat = _test_assertEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is TagFormat => {
-                const $is_uuid = (typia.assertEquals as any).is_uuid;
-                const $is_email = (typia.assertEquals as any).is_email;
-                const $is_url = (typia.assertEquals as any).is_url;
-                const $is_ipv4 = (typia.assertEquals as any).is_ipv4;
-                const $is_ipv6 = (typia.assertEquals as any).is_ipv6;
-                const $is_date = (typia.assertEquals as any).is_date;
-                const $is_datetime = (typia.assertEquals as any).is_datetime;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/assertEquals/test_assertEquals_TagMatrix.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagMatrix.ts
@@ -14,7 +14,6 @@ export const test_assertEquals_TagMatrix = _test_assertEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is TagMatrix => {
-                const $is_uuid = (typia.assertEquals as any).is_uuid;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/assertParse/test_assertParse_DynamicArray.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicArray.ts
@@ -11,7 +11,6 @@ export const test_assertParse_DynamicArray = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is DynamicArray => {
-                    const $join = (typia.assertParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertParse/test_assertParse_DynamicComposite.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicComposite.ts
@@ -11,7 +11,6 @@ export const test_assertParse_DynamicComposite = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is DynamicComposite => {
-                    const $join = (typia.assertParse as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "string" === typeof input.name &&

--- a/test/generated/output/assertParse/test_assertParse_DynamicNever.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicNever.ts
@@ -11,7 +11,6 @@ export const test_assertParse_DynamicNever = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is DynamicNever => {
-                    const $join = (typia.assertParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertParse/test_assertParse_DynamicSimple.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicSimple.ts
@@ -11,7 +11,6 @@ export const test_assertParse_DynamicSimple = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is DynamicSimple => {
-                    const $join = (typia.assertParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertParse/test_assertParse_DynamicTemplate.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicTemplate.ts
@@ -11,7 +11,6 @@ export const test_assertParse_DynamicTemplate = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is DynamicTemplate => {
-                    const $join = (typia.assertParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertParse/test_assertParse_DynamicTree.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicTree.ts
@@ -11,7 +11,6 @@ export const test_assertParse_DynamicTree = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is DynamicTree => {
-                    const $join = (typia.assertParse as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "number" === typeof input.sequence &&

--- a/test/generated/output/assertParse/test_assertParse_DynamicUndefined.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicUndefined.ts
@@ -11,7 +11,6 @@ export const test_assertParse_DynamicUndefined = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is DynamicUndefined => {
-                    const $join = (typia.assertParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertParse/test_assertParse_DynamicUnion.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicUnion.ts
@@ -11,7 +11,6 @@ export const test_assertParse_DynamicUnion = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is DynamicUnion => {
-                    const $join = (typia.assertParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertParse/test_assertParse_ObjectDynamic.ts
+++ b/test/generated/output/assertParse/test_assertParse_ObjectDynamic.ts
@@ -11,7 +11,6 @@ export const test_assertParse_ObjectDynamic = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is ObjectDynamic => {
-                    const $join = (typia.assertParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertParse/test_assertParse_TagArray.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagArray.ts
@@ -11,7 +11,6 @@ export const test_assertParse_TagArray = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $is_uuid = (typia.assertParse as any).is_uuid;
                 const __is = (input: any): input is TagArray => {
-                    const $is_uuid = (typia.assertParse as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         3 === input.items.length &&

--- a/test/generated/output/assertParse/test_assertParse_TagCustom.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagCustom.ts
@@ -12,8 +12,6 @@ export const test_assertParse_TagCustom = _test_assertParse(
                 const $is_uuid = (typia.assertParse as any).is_uuid;
                 const $is_custom = (typia.assertParse as any).is_custom;
                 const __is = (input: any): input is TagCustom => {
-                    const $is_uuid = (typia.assertParse as any).is_uuid;
-                    const $is_custom = (typia.assertParse as any).is_custom;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         $is_uuid(input.id) &&

--- a/test/generated/output/assertParse/test_assertParse_TagFormat.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagFormat.ts
@@ -17,13 +17,6 @@ export const test_assertParse_TagFormat = _test_assertParse(
                 const $is_date = (typia.assertParse as any).is_date;
                 const $is_datetime = (typia.assertParse as any).is_datetime;
                 const __is = (input: any): input is TagFormat => {
-                    const $is_uuid = (typia.assertParse as any).is_uuid;
-                    const $is_email = (typia.assertParse as any).is_email;
-                    const $is_url = (typia.assertParse as any).is_url;
-                    const $is_ipv4 = (typia.assertParse as any).is_ipv4;
-                    const $is_ipv6 = (typia.assertParse as any).is_ipv6;
-                    const $is_date = (typia.assertParse as any).is_date;
-                    const $is_datetime = (typia.assertParse as any).is_datetime;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.uuid &&
                         $is_uuid(input.uuid) &&

--- a/test/generated/output/assertParse/test_assertParse_TagMatrix.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagMatrix.ts
@@ -11,7 +11,6 @@ export const test_assertParse_TagMatrix = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $is_uuid = (typia.assertParse as any).is_uuid;
                 const __is = (input: any): input is TagMatrix => {
-                    const $is_uuid = (typia.assertParse as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.matrix) &&
                         3 === input.matrix.length &&

--- a/test/generated/output/assertParse/test_assertParse_UltimateUnion.ts
+++ b/test/generated/output/assertParse/test_assertParse_UltimateUnion.ts
@@ -11,7 +11,6 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                 const $guard = (typia.assertParse as any).guard;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is UltimateUnion => {
-                    const $join = (typia.assertParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.schemas) &&
                         input.schemas.every(

--- a/test/generated/output/assertPrune/test_assertPrune_DynamicComposite.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_DynamicComposite.ts
@@ -11,7 +11,6 @@ export const test_assertPrune_DynamicComposite = _test_assertPrune(
                 const $guard = (typia.assertPrune as any).guard;
                 const $join = (typia.assertPrune as any).join;
                 const __is = (input: any): input is DynamicComposite => {
-                    const $join = (typia.assertPrune as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "string" === typeof input.name &&

--- a/test/generated/output/assertPrune/test_assertPrune_DynamicTemplate.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_DynamicTemplate.ts
@@ -11,7 +11,6 @@ export const test_assertPrune_DynamicTemplate = _test_assertPrune(
                 const $guard = (typia.assertPrune as any).guard;
                 const $join = (typia.assertPrune as any).join;
                 const __is = (input: any): input is DynamicTemplate => {
-                    const $join = (typia.assertPrune as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertPrune/test_assertPrune_DynamicUnion.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_DynamicUnion.ts
@@ -11,7 +11,6 @@ export const test_assertPrune_DynamicUnion = _test_assertPrune(
                 const $guard = (typia.assertPrune as any).guard;
                 const $join = (typia.assertPrune as any).join;
                 const __is = (input: any): input is DynamicUnion => {
-                    const $join = (typia.assertPrune as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertPrune/test_assertPrune_TagArray.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagArray.ts
@@ -11,7 +11,6 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                 const $guard = (typia.assertPrune as any).guard;
                 const $is_uuid = (typia.assertPrune as any).is_uuid;
                 const __is = (input: any): input is Array<TagArray.Type> => {
-                    const $is_uuid = (typia.assertPrune as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         3 === input.items.length &&

--- a/test/generated/output/assertPrune/test_assertPrune_TagCustom.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagCustom.ts
@@ -12,8 +12,6 @@ export const test_assertPrune_TagCustom = _test_assertPrune(
                 const $is_uuid = (typia.assertPrune as any).is_uuid;
                 const $is_custom = (typia.assertPrune as any).is_custom;
                 const __is = (input: any): input is TagCustom => {
-                    const $is_uuid = (typia.assertPrune as any).is_uuid;
-                    const $is_custom = (typia.assertPrune as any).is_custom;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         $is_uuid(input.id) &&

--- a/test/generated/output/assertPrune/test_assertPrune_TagFormat.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagFormat.ts
@@ -17,13 +17,6 @@ export const test_assertPrune_TagFormat = _test_assertPrune(
                 const $is_date = (typia.assertPrune as any).is_date;
                 const $is_datetime = (typia.assertPrune as any).is_datetime;
                 const __is = (input: any): input is TagFormat => {
-                    const $is_uuid = (typia.assertPrune as any).is_uuid;
-                    const $is_email = (typia.assertPrune as any).is_email;
-                    const $is_url = (typia.assertPrune as any).is_url;
-                    const $is_ipv4 = (typia.assertPrune as any).is_ipv4;
-                    const $is_ipv6 = (typia.assertPrune as any).is_ipv6;
-                    const $is_date = (typia.assertPrune as any).is_date;
-                    const $is_datetime = (typia.assertPrune as any).is_datetime;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.uuid &&
                         $is_uuid(input.uuid) &&

--- a/test/generated/output/assertPrune/test_assertPrune_TagMatrix.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagMatrix.ts
@@ -11,7 +11,6 @@ export const test_assertPrune_TagMatrix = _test_assertPrune(
                 const $guard = (typia.assertPrune as any).guard;
                 const $is_uuid = (typia.assertPrune as any).is_uuid;
                 const __is = (input: any): input is TagMatrix => {
-                    const $is_uuid = (typia.assertPrune as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.matrix) &&
                         3 === input.matrix.length &&

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicArray.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicArray.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_DynamicArray = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $join = (typia.assertStringify as any).join;
                 const __is = (input: any): input is DynamicArray => {
-                    const $join = (typia.assertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicComposite.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicComposite.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_DynamicComposite = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $join = (typia.assertStringify as any).join;
                 const __is = (input: any): input is DynamicComposite => {
-                    const $join = (typia.assertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "string" === typeof input.name &&

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicNever.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicNever.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_DynamicNever = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $join = (typia.assertStringify as any).join;
                 const __is = (input: any): input is DynamicNever => {
-                    const $join = (typia.assertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicSimple.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicSimple.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_DynamicSimple = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $join = (typia.assertStringify as any).join;
                 const __is = (input: any): input is DynamicSimple => {
-                    const $join = (typia.assertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicTemplate.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicTemplate.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_DynamicTemplate = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $join = (typia.assertStringify as any).join;
                 const __is = (input: any): input is DynamicTemplate => {
-                    const $join = (typia.assertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicTree.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicTree.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_DynamicTree = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $join = (typia.assertStringify as any).join;
                 const __is = (input: any): input is DynamicTree => {
-                    const $join = (typia.assertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "number" === typeof input.sequence &&

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicUndefined.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicUndefined.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_DynamicUndefined = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $join = (typia.assertStringify as any).join;
                 const __is = (input: any): input is DynamicUndefined => {
-                    const $join = (typia.assertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicUnion.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicUnion.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_DynamicUnion = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $join = (typia.assertStringify as any).join;
                 const __is = (input: any): input is DynamicUnion => {
-                    const $join = (typia.assertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertStringify/test_assertStringify_ObjectDynamic.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_ObjectDynamic.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_ObjectDynamic = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $join = (typia.assertStringify as any).join;
                 const __is = (input: any): input is ObjectDynamic => {
-                    const $join = (typia.assertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/assertStringify/test_assertStringify_TagArray.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagArray.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $is_uuid = (typia.assertStringify as any).is_uuid;
                 const __is = (input: any): input is Array<TagArray.Type> => {
-                    const $is_uuid = (typia.assertStringify as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         3 === input.items.length &&

--- a/test/generated/output/assertStringify/test_assertStringify_TagCustom.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagCustom.ts
@@ -12,8 +12,6 @@ export const test_assertStringify_TagCustom = _test_assertStringify(
                 const $is_uuid = (typia.assertStringify as any).is_uuid;
                 const $is_custom = (typia.assertStringify as any).is_custom;
                 const __is = (input: any): input is TagCustom => {
-                    const $is_uuid = (typia.assertStringify as any).is_uuid;
-                    const $is_custom = (typia.assertStringify as any).is_custom;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         $is_uuid(input.id) &&

--- a/test/generated/output/assertStringify/test_assertStringify_TagFormat.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagFormat.ts
@@ -17,14 +17,6 @@ export const test_assertStringify_TagFormat = _test_assertStringify(
                 const $is_date = (typia.assertStringify as any).is_date;
                 const $is_datetime = (typia.assertStringify as any).is_datetime;
                 const __is = (input: any): input is TagFormat => {
-                    const $is_uuid = (typia.assertStringify as any).is_uuid;
-                    const $is_email = (typia.assertStringify as any).is_email;
-                    const $is_url = (typia.assertStringify as any).is_url;
-                    const $is_ipv4 = (typia.assertStringify as any).is_ipv4;
-                    const $is_ipv6 = (typia.assertStringify as any).is_ipv6;
-                    const $is_date = (typia.assertStringify as any).is_date;
-                    const $is_datetime = (typia.assertStringify as any)
-                        .is_datetime;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.uuid &&
                         $is_uuid(input.uuid) &&

--- a/test/generated/output/assertStringify/test_assertStringify_TagMatrix.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagMatrix.ts
@@ -11,7 +11,6 @@ export const test_assertStringify_TagMatrix = _test_assertStringify(
                 const $guard = (typia.assertStringify as any).guard;
                 const $is_uuid = (typia.assertStringify as any).is_uuid;
                 const __is = (input: any): input is TagMatrix => {
-                    const $is_uuid = (typia.assertStringify as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.matrix) &&
                         3 === input.matrix.length &&

--- a/test/generated/output/assertStringify/test_assertStringify_UltimateUnion.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_UltimateUnion.ts
@@ -13,7 +13,6 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                 const __is = (
                     input: any,
                 ): input is Array<typia.IJsonApplication> => {
-                    const $join = (typia.assertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.schemas) &&
                         input.schemas.every(

--- a/test/generated/output/createAssert/test_createAssert_DynamicArray.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicArray.ts
@@ -9,7 +9,6 @@ export const test_createAssert_DynamicArray = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is DynamicArray => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createAssert/test_createAssert_DynamicComposite.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicComposite.ts
@@ -9,7 +9,6 @@ export const test_createAssert_DynamicComposite = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is DynamicComposite => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 "string" === typeof input.name &&

--- a/test/generated/output/createAssert/test_createAssert_DynamicNever.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicNever.ts
@@ -9,7 +9,6 @@ export const test_createAssert_DynamicNever = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is DynamicNever => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createAssert/test_createAssert_DynamicSimple.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicSimple.ts
@@ -9,7 +9,6 @@ export const test_createAssert_DynamicSimple = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is DynamicSimple => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createAssert/test_createAssert_DynamicTemplate.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicTemplate.ts
@@ -9,7 +9,6 @@ export const test_createAssert_DynamicTemplate = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is DynamicTemplate => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createAssert/test_createAssert_DynamicTree.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicTree.ts
@@ -9,7 +9,6 @@ export const test_createAssert_DynamicTree = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is DynamicTree => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 "number" === typeof input.sequence &&

--- a/test/generated/output/createAssert/test_createAssert_DynamicUndefined.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicUndefined.ts
@@ -9,7 +9,6 @@ export const test_createAssert_DynamicUndefined = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is DynamicUndefined => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createAssert/test_createAssert_DynamicUnion.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicUnion.ts
@@ -9,7 +9,6 @@ export const test_createAssert_DynamicUnion = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is DynamicUnion => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createAssert/test_createAssert_ObjectDynamic.ts
+++ b/test/generated/output/createAssert/test_createAssert_ObjectDynamic.ts
@@ -9,7 +9,6 @@ export const test_createAssert_ObjectDynamic = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is ObjectDynamic => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createAssert/test_createAssert_TagArray.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagArray.ts
@@ -9,7 +9,6 @@ export const test_createAssert_TagArray = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $is_uuid = (typia.createAssert as any).is_uuid;
         const __is = (input: any): input is TagArray => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 3 === input.items.length &&

--- a/test/generated/output/createAssert/test_createAssert_TagCustom.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagCustom.ts
@@ -10,8 +10,6 @@ export const test_createAssert_TagCustom = _test_assert(
         const $is_uuid = (typia.createAssert as any).is_uuid;
         const $is_custom = (typia.createAssert as any).is_custom;
         const __is = (input: any): input is TagCustom => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
-            const $is_custom = (typia.createAssert as any).is_custom;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 $is_uuid(input.id) &&

--- a/test/generated/output/createAssert/test_createAssert_TagFormat.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagFormat.ts
@@ -15,13 +15,6 @@ export const test_createAssert_TagFormat = _test_assert(
         const $is_date = (typia.createAssert as any).is_date;
         const $is_datetime = (typia.createAssert as any).is_datetime;
         const __is = (input: any): input is TagFormat => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
-            const $is_email = (typia.createAssert as any).is_email;
-            const $is_url = (typia.createAssert as any).is_url;
-            const $is_ipv4 = (typia.createAssert as any).is_ipv4;
-            const $is_ipv6 = (typia.createAssert as any).is_ipv6;
-            const $is_date = (typia.createAssert as any).is_date;
-            const $is_datetime = (typia.createAssert as any).is_datetime;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.uuid &&
                 $is_uuid(input.uuid) &&

--- a/test/generated/output/createAssert/test_createAssert_TagMatrix.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagMatrix.ts
@@ -9,7 +9,6 @@ export const test_createAssert_TagMatrix = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $is_uuid = (typia.createAssert as any).is_uuid;
         const __is = (input: any): input is TagMatrix => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.matrix) &&
                 3 === input.matrix.length &&

--- a/test/generated/output/createAssert/test_createAssert_UltimateUnion.ts
+++ b/test/generated/output/createAssert/test_createAssert_UltimateUnion.ts
@@ -9,7 +9,6 @@ export const test_createAssert_UltimateUnion = _test_assert(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is UltimateUnion => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.schemas) &&
                 input.schemas.every(

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicArray.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicArray.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_DynamicArray = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is DynamicArray => {
-                const $join = (typia.createAssertClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicComposite.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicComposite.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_DynamicComposite = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is DynamicComposite => {
-                const $join = (typia.createAssertClone as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "string" === typeof input.name &&

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicNever.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicNever.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_DynamicNever = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is DynamicNever => {
-                const $join = (typia.createAssertClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicSimple.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicSimple.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_DynamicSimple = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is DynamicSimple => {
-                const $join = (typia.createAssertClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicTemplate.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicTemplate.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_DynamicTemplate = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is DynamicTemplate => {
-                const $join = (typia.createAssertClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicTree.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicTree.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_DynamicTree = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is DynamicTree => {
-                const $join = (typia.createAssertClone as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "number" === typeof input.sequence &&

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicUndefined.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicUndefined.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_DynamicUndefined = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is DynamicUndefined => {
-                const $join = (typia.createAssertClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicUnion.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_DynamicUnion = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is DynamicUnion => {
-                const $join = (typia.createAssertClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertClone/test_createAssertClone_ObjectDynamic.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_ObjectDynamic.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_ObjectDynamic = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is ObjectDynamic => {
-                const $join = (typia.createAssertClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagArray.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagArray.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_TagArray = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $is_uuid = (typia.createAssertClone as any).is_uuid;
             const __is = (input: any): input is TagArray => {
-                const $is_uuid = (typia.createAssertClone as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     3 === input.items.length &&

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagCustom.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagCustom.ts
@@ -11,8 +11,6 @@ export const test_createAssertClone_TagCustom = _test_assertClone(
             const $is_uuid = (typia.createAssertClone as any).is_uuid;
             const $is_custom = (typia.createAssertClone as any).is_custom;
             const __is = (input: any): input is TagCustom => {
-                const $is_uuid = (typia.createAssertClone as any).is_uuid;
-                const $is_custom = (typia.createAssertClone as any).is_custom;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     $is_uuid(input.id) &&

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagFormat.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagFormat.ts
@@ -16,14 +16,6 @@ export const test_createAssertClone_TagFormat = _test_assertClone(
             const $is_date = (typia.createAssertClone as any).is_date;
             const $is_datetime = (typia.createAssertClone as any).is_datetime;
             const __is = (input: any): input is TagFormat => {
-                const $is_uuid = (typia.createAssertClone as any).is_uuid;
-                const $is_email = (typia.createAssertClone as any).is_email;
-                const $is_url = (typia.createAssertClone as any).is_url;
-                const $is_ipv4 = (typia.createAssertClone as any).is_ipv4;
-                const $is_ipv6 = (typia.createAssertClone as any).is_ipv6;
-                const $is_date = (typia.createAssertClone as any).is_date;
-                const $is_datetime = (typia.createAssertClone as any)
-                    .is_datetime;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.uuid &&
                     $is_uuid(input.uuid) &&

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagMatrix.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagMatrix.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_TagMatrix = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $is_uuid = (typia.createAssertClone as any).is_uuid;
             const __is = (input: any): input is TagMatrix => {
-                const $is_uuid = (typia.createAssertClone as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.matrix) &&
                     3 === input.matrix.length &&

--- a/test/generated/output/createAssertClone/test_createAssertClone_UltimateUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_UltimateUnion.ts
@@ -10,7 +10,6 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
             const $guard = (typia.createAssertClone as any).guard;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is UltimateUnion => {
-                const $join = (typia.createAssertClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.schemas) &&
                     input.schemas.every(

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicComposite.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicComposite.ts
@@ -12,7 +12,6 @@ export const test_createAssertEquals_DynamicComposite = _test_assertEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is DynamicComposite => {
-            const $join = (typia.createAssertEquals as any).join;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicTemplate.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicTemplate.ts
@@ -12,7 +12,6 @@ export const test_createAssertEquals_DynamicTemplate = _test_assertEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is DynamicTemplate => {
-            const $join = (typia.createAssertEquals as any).join;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicUnion.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicUnion.ts
@@ -12,7 +12,6 @@ export const test_createAssertEquals_DynamicUnion = _test_assertEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is DynamicUnion => {
-            const $join = (typia.createAssertEquals as any).join;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagArray.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagArray.ts
@@ -13,7 +13,6 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is TagArray => {
-            const $is_uuid = (typia.createAssertEquals as any).is_uuid;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagCustom.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagCustom.ts
@@ -14,8 +14,6 @@ export const test_createAssertEquals_TagCustom = _test_assertEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is TagCustom => {
-            const $is_uuid = (typia.createAssertEquals as any).is_uuid;
-            const $is_custom = (typia.createAssertEquals as any).is_custom;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagFormat.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagFormat.ts
@@ -19,13 +19,6 @@ export const test_createAssertEquals_TagFormat = _test_assertEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is TagFormat => {
-            const $is_uuid = (typia.createAssertEquals as any).is_uuid;
-            const $is_email = (typia.createAssertEquals as any).is_email;
-            const $is_url = (typia.createAssertEquals as any).is_url;
-            const $is_ipv4 = (typia.createAssertEquals as any).is_ipv4;
-            const $is_ipv6 = (typia.createAssertEquals as any).is_ipv6;
-            const $is_date = (typia.createAssertEquals as any).is_date;
-            const $is_datetime = (typia.createAssertEquals as any).is_datetime;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagMatrix.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagMatrix.ts
@@ -13,7 +13,6 @@ export const test_createAssertEquals_TagMatrix = _test_assertEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is TagMatrix => {
-            const $is_uuid = (typia.createAssertEquals as any).is_uuid;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicArray.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicArray.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_DynamicArray = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is DynamicArray => {
-                const $join = (typia.createAssertParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicComposite.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicComposite.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_DynamicComposite = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is DynamicComposite => {
-                const $join = (typia.createAssertParse as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "string" === typeof input.name &&

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicNever.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicNever.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_DynamicNever = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is DynamicNever => {
-                const $join = (typia.createAssertParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicSimple.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicSimple.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_DynamicSimple = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is DynamicSimple => {
-                const $join = (typia.createAssertParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicTemplate.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicTemplate.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_DynamicTemplate = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is DynamicTemplate => {
-                const $join = (typia.createAssertParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicTree.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicTree.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_DynamicTree = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is DynamicTree => {
-                const $join = (typia.createAssertParse as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "number" === typeof input.sequence &&

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicUndefined.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicUndefined.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_DynamicUndefined = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is DynamicUndefined => {
-                const $join = (typia.createAssertParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicUnion.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicUnion.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_DynamicUnion = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is DynamicUnion => {
-                const $join = (typia.createAssertParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertParse/test_createAssertParse_ObjectDynamic.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_ObjectDynamic.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_ObjectDynamic = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is ObjectDynamic => {
-                const $join = (typia.createAssertParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagArray.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagArray.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_TagArray = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $is_uuid = (typia.createAssertParse as any).is_uuid;
             const __is = (input: any): input is TagArray => {
-                const $is_uuid = (typia.createAssertParse as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     3 === input.items.length &&

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagCustom.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagCustom.ts
@@ -11,8 +11,6 @@ export const test_createAssertParse_TagCustom = _test_assertParse(
             const $is_uuid = (typia.createAssertParse as any).is_uuid;
             const $is_custom = (typia.createAssertParse as any).is_custom;
             const __is = (input: any): input is TagCustom => {
-                const $is_uuid = (typia.createAssertParse as any).is_uuid;
-                const $is_custom = (typia.createAssertParse as any).is_custom;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     $is_uuid(input.id) &&

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagFormat.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagFormat.ts
@@ -16,14 +16,6 @@ export const test_createAssertParse_TagFormat = _test_assertParse(
             const $is_date = (typia.createAssertParse as any).is_date;
             const $is_datetime = (typia.createAssertParse as any).is_datetime;
             const __is = (input: any): input is TagFormat => {
-                const $is_uuid = (typia.createAssertParse as any).is_uuid;
-                const $is_email = (typia.createAssertParse as any).is_email;
-                const $is_url = (typia.createAssertParse as any).is_url;
-                const $is_ipv4 = (typia.createAssertParse as any).is_ipv4;
-                const $is_ipv6 = (typia.createAssertParse as any).is_ipv6;
-                const $is_date = (typia.createAssertParse as any).is_date;
-                const $is_datetime = (typia.createAssertParse as any)
-                    .is_datetime;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.uuid &&
                     $is_uuid(input.uuid) &&

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagMatrix.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagMatrix.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_TagMatrix = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $is_uuid = (typia.createAssertParse as any).is_uuid;
             const __is = (input: any): input is TagMatrix => {
-                const $is_uuid = (typia.createAssertParse as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.matrix) &&
                     3 === input.matrix.length &&

--- a/test/generated/output/createAssertParse/test_createAssertParse_UltimateUnion.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_UltimateUnion.ts
@@ -10,7 +10,6 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
             const $guard = (typia.createAssertParse as any).guard;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is UltimateUnion => {
-                const $join = (typia.createAssertParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.schemas) &&
                     input.schemas.every(

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicComposite.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicComposite.ts
@@ -10,7 +10,6 @@ export const test_createAssertPrune_DynamicComposite = _test_assertPrune(
             const $guard = (typia.createAssertPrune as any).guard;
             const $join = (typia.createAssertPrune as any).join;
             const __is = (input: any): input is DynamicComposite => {
-                const $join = (typia.createAssertPrune as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "string" === typeof input.name &&

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicTemplate.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicTemplate.ts
@@ -10,7 +10,6 @@ export const test_createAssertPrune_DynamicTemplate = _test_assertPrune(
             const $guard = (typia.createAssertPrune as any).guard;
             const $join = (typia.createAssertPrune as any).join;
             const __is = (input: any): input is DynamicTemplate => {
-                const $join = (typia.createAssertPrune as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicUnion.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicUnion.ts
@@ -10,7 +10,6 @@ export const test_createAssertPrune_DynamicUnion = _test_assertPrune(
             const $guard = (typia.createAssertPrune as any).guard;
             const $join = (typia.createAssertPrune as any).join;
             const __is = (input: any): input is DynamicUnion => {
-                const $join = (typia.createAssertPrune as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagArray.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagArray.ts
@@ -10,7 +10,6 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
             const $guard = (typia.createAssertPrune as any).guard;
             const $is_uuid = (typia.createAssertPrune as any).is_uuid;
             const __is = (input: any): input is TagArray => {
-                const $is_uuid = (typia.createAssertPrune as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     3 === input.items.length &&

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagCustom.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagCustom.ts
@@ -11,8 +11,6 @@ export const test_createAssertPrune_TagCustom = _test_assertPrune(
             const $is_uuid = (typia.createAssertPrune as any).is_uuid;
             const $is_custom = (typia.createAssertPrune as any).is_custom;
             const __is = (input: any): input is TagCustom => {
-                const $is_uuid = (typia.createAssertPrune as any).is_uuid;
-                const $is_custom = (typia.createAssertPrune as any).is_custom;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     $is_uuid(input.id) &&

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagFormat.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagFormat.ts
@@ -16,14 +16,6 @@ export const test_createAssertPrune_TagFormat = _test_assertPrune(
             const $is_date = (typia.createAssertPrune as any).is_date;
             const $is_datetime = (typia.createAssertPrune as any).is_datetime;
             const __is = (input: any): input is TagFormat => {
-                const $is_uuid = (typia.createAssertPrune as any).is_uuid;
-                const $is_email = (typia.createAssertPrune as any).is_email;
-                const $is_url = (typia.createAssertPrune as any).is_url;
-                const $is_ipv4 = (typia.createAssertPrune as any).is_ipv4;
-                const $is_ipv6 = (typia.createAssertPrune as any).is_ipv6;
-                const $is_date = (typia.createAssertPrune as any).is_date;
-                const $is_datetime = (typia.createAssertPrune as any)
-                    .is_datetime;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.uuid &&
                     $is_uuid(input.uuid) &&

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagMatrix.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagMatrix.ts
@@ -10,7 +10,6 @@ export const test_createAssertPrune_TagMatrix = _test_assertPrune(
             const $guard = (typia.createAssertPrune as any).guard;
             const $is_uuid = (typia.createAssertPrune as any).is_uuid;
             const __is = (input: any): input is TagMatrix => {
-                const $is_uuid = (typia.createAssertPrune as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.matrix) &&
                     3 === input.matrix.length &&

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicArray.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicArray.ts
@@ -10,7 +10,6 @@ export const test_createAssertStringify_DynamicArray = _test_assertStringify(
             const $guard = (typia.createAssertStringify as any).guard;
             const $join = (typia.createAssertStringify as any).join;
             const __is = (input: any): input is DynamicArray => {
-                const $join = (typia.createAssertStringify as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicComposite.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicComposite.ts
@@ -11,7 +11,6 @@ export const test_createAssertStringify_DynamicComposite =
                 const $guard = (typia.createAssertStringify as any).guard;
                 const $join = (typia.createAssertStringify as any).join;
                 const __is = (input: any): input is DynamicComposite => {
-                    const $join = (typia.createAssertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "string" === typeof input.name &&

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicNever.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicNever.ts
@@ -10,7 +10,6 @@ export const test_createAssertStringify_DynamicNever = _test_assertStringify(
             const $guard = (typia.createAssertStringify as any).guard;
             const $join = (typia.createAssertStringify as any).join;
             const __is = (input: any): input is DynamicNever => {
-                const $join = (typia.createAssertStringify as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicSimple.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicSimple.ts
@@ -10,7 +10,6 @@ export const test_createAssertStringify_DynamicSimple = _test_assertStringify(
             const $guard = (typia.createAssertStringify as any).guard;
             const $join = (typia.createAssertStringify as any).join;
             const __is = (input: any): input is DynamicSimple => {
-                const $join = (typia.createAssertStringify as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicTemplate.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicTemplate.ts
@@ -10,7 +10,6 @@ export const test_createAssertStringify_DynamicTemplate = _test_assertStringify(
             const $guard = (typia.createAssertStringify as any).guard;
             const $join = (typia.createAssertStringify as any).join;
             const __is = (input: any): input is DynamicTemplate => {
-                const $join = (typia.createAssertStringify as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicTree.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicTree.ts
@@ -10,7 +10,6 @@ export const test_createAssertStringify_DynamicTree = _test_assertStringify(
             const $guard = (typia.createAssertStringify as any).guard;
             const $join = (typia.createAssertStringify as any).join;
             const __is = (input: any): input is DynamicTree => {
-                const $join = (typia.createAssertStringify as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "number" === typeof input.sequence &&

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicUndefined.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicUndefined.ts
@@ -11,7 +11,6 @@ export const test_createAssertStringify_DynamicUndefined =
                 const $guard = (typia.createAssertStringify as any).guard;
                 const $join = (typia.createAssertStringify as any).join;
                 const __is = (input: any): input is DynamicUndefined => {
-                    const $join = (typia.createAssertStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicUnion.ts
@@ -10,7 +10,6 @@ export const test_createAssertStringify_DynamicUnion = _test_assertStringify(
             const $guard = (typia.createAssertStringify as any).guard;
             const $join = (typia.createAssertStringify as any).join;
             const __is = (input: any): input is DynamicUnion => {
-                const $join = (typia.createAssertStringify as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_ObjectDynamic.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_ObjectDynamic.ts
@@ -10,7 +10,6 @@ export const test_createAssertStringify_ObjectDynamic = _test_assertStringify(
             const $guard = (typia.createAssertStringify as any).guard;
             const $join = (typia.createAssertStringify as any).join;
             const __is = (input: any): input is ObjectDynamic => {
-                const $join = (typia.createAssertStringify as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagArray.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagArray.ts
@@ -10,7 +10,6 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
             const $guard = (typia.createAssertStringify as any).guard;
             const $is_uuid = (typia.createAssertStringify as any).is_uuid;
             const __is = (input: any): input is TagArray => {
-                const $is_uuid = (typia.createAssertStringify as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     3 === input.items.length &&

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagCustom.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagCustom.ts
@@ -11,9 +11,6 @@ export const test_createAssertStringify_TagCustom = _test_assertStringify(
             const $is_uuid = (typia.createAssertStringify as any).is_uuid;
             const $is_custom = (typia.createAssertStringify as any).is_custom;
             const __is = (input: any): input is TagCustom => {
-                const $is_uuid = (typia.createAssertStringify as any).is_uuid;
-                const $is_custom = (typia.createAssertStringify as any)
-                    .is_custom;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     $is_uuid(input.id) &&

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagFormat.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagFormat.ts
@@ -17,14 +17,6 @@ export const test_createAssertStringify_TagFormat = _test_assertStringify(
             const $is_datetime = (typia.createAssertStringify as any)
                 .is_datetime;
             const __is = (input: any): input is TagFormat => {
-                const $is_uuid = (typia.createAssertStringify as any).is_uuid;
-                const $is_email = (typia.createAssertStringify as any).is_email;
-                const $is_url = (typia.createAssertStringify as any).is_url;
-                const $is_ipv4 = (typia.createAssertStringify as any).is_ipv4;
-                const $is_ipv6 = (typia.createAssertStringify as any).is_ipv6;
-                const $is_date = (typia.createAssertStringify as any).is_date;
-                const $is_datetime = (typia.createAssertStringify as any)
-                    .is_datetime;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.uuid &&
                     $is_uuid(input.uuid) &&

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagMatrix.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagMatrix.ts
@@ -10,7 +10,6 @@ export const test_createAssertStringify_TagMatrix = _test_assertStringify(
             const $guard = (typia.createAssertStringify as any).guard;
             const $is_uuid = (typia.createAssertStringify as any).is_uuid;
             const __is = (input: any): input is TagMatrix => {
-                const $is_uuid = (typia.createAssertStringify as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.matrix) &&
                     3 === input.matrix.length &&

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_UltimateUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_UltimateUnion.ts
@@ -10,7 +10,6 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
             const $guard = (typia.createAssertStringify as any).guard;
             const $join = (typia.createAssertStringify as any).join;
             const __is = (input: any): input is UltimateUnion => {
-                const $join = (typia.createAssertStringify as any).join;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.schemas) &&
                     input.schemas.every(

--- a/test/generated/output/createRandom/test_createRandom_DynamicArray.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicArray.ts
@@ -33,7 +33,6 @@ export const test_createRandom_DynamicArray = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<DynamicArray> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createRandom/test_createRandom_DynamicComposite.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicComposite.ts
@@ -111,7 +111,6 @@ export const test_createRandom_DynamicComposite = _test_random(
         const __is = (
             input: any,
         ): input is typia.Primitive<DynamicComposite> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 "string" === typeof input.name &&

--- a/test/generated/output/createRandom/test_createRandom_DynamicNever.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicNever.ts
@@ -27,7 +27,6 @@ export const test_createRandom_DynamicNever = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<DynamicNever> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createRandom/test_createRandom_DynamicSimple.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicSimple.ts
@@ -30,7 +30,6 @@ export const test_createRandom_DynamicSimple = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<DynamicSimple> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createRandom/test_createRandom_DynamicTemplate.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicTemplate.ts
@@ -82,7 +82,6 @@ export const test_createRandom_DynamicTemplate = _test_random(
         const __is = (
             input: any,
         ): input is typia.Primitive<DynamicTemplate> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createRandom/test_createRandom_DynamicTree.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicTree.ts
@@ -42,7 +42,6 @@ export const test_createRandom_DynamicTree = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<DynamicTree> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 "number" === typeof input.sequence &&

--- a/test/generated/output/createRandom/test_createRandom_DynamicUndefined.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicUndefined.ts
@@ -29,7 +29,6 @@ export const test_createRandom_DynamicUndefined = _test_random(
         const __is = (
             input: any,
         ): input is typia.Primitive<DynamicUndefined> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createRandom/test_createRandom_DynamicUnion.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicUnion.ts
@@ -80,7 +80,6 @@ export const test_createRandom_DynamicUnion = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<DynamicUnion> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createRandom/test_createRandom_ObjectDynamic.ts
+++ b/test/generated/output/createRandom/test_createRandom_ObjectDynamic.ts
@@ -40,7 +40,6 @@ export const test_createRandom_ObjectDynamic = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<ObjectDynamic> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createRandom/test_createRandom_TagArray.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagArray.ts
@@ -113,7 +113,6 @@ export const test_createRandom_TagArray = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $is_uuid = (typia.createAssert as any).is_uuid;
         const __is = (input: any): input is typia.Primitive<TagArray> => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 3 === input.items.length &&

--- a/test/generated/output/createRandom/test_createRandom_TagCustom.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagCustom.ts
@@ -47,8 +47,6 @@ export const test_createRandom_TagCustom = _test_random(
         const $is_uuid = (typia.createAssert as any).is_uuid;
         const $is_custom = (typia.createAssert as any).is_custom;
         const __is = (input: any): input is typia.Primitive<TagCustom> => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
-            const $is_custom = (typia.createAssert as any).is_custom;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 $is_uuid(input.id) &&

--- a/test/generated/output/createRandom/test_createRandom_TagFormat.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagFormat.ts
@@ -95,13 +95,6 @@ export const test_createRandom_TagFormat = _test_random(
         const $is_date = (typia.createAssert as any).is_date;
         const $is_datetime = (typia.createAssert as any).is_datetime;
         const __is = (input: any): input is typia.Primitive<TagFormat> => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
-            const $is_email = (typia.createAssert as any).is_email;
-            const $is_url = (typia.createAssert as any).is_url;
-            const $is_ipv4 = (typia.createAssert as any).is_ipv4;
-            const $is_ipv6 = (typia.createAssert as any).is_ipv6;
-            const $is_date = (typia.createAssert as any).is_date;
-            const $is_datetime = (typia.createAssert as any).is_datetime;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.uuid &&
                 $is_uuid(input.uuid) &&

--- a/test/generated/output/createRandom/test_createRandom_TagMatrix.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagMatrix.ts
@@ -39,7 +39,6 @@ export const test_createRandom_TagMatrix = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $is_uuid = (typia.createAssert as any).is_uuid;
         const __is = (input: any): input is typia.Primitive<TagMatrix> => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.matrix) &&
                 3 === input.matrix.length &&

--- a/test/generated/output/createRandom/test_createRandom_UltimateUnion.ts
+++ b/test/generated/output/createRandom/test_createRandom_UltimateUnion.ts
@@ -2376,7 +2376,6 @@ export const test_createRandom_UltimateUnion = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<UltimateUnion> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.schemas) &&
                 input.schemas.every(

--- a/test/generated/output/createValidate/test_createValidate_DynamicArray.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicArray.ts
@@ -7,7 +7,6 @@ export const test_createValidate_DynamicArray = _test_validate(
     DynamicArray.generate,
     (input: any): typia.IValidation<DynamicArray> => {
         const __is = (input: any): input is DynamicArray => {
-            const $join = (typia.createValidate as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createValidate/test_createValidate_DynamicComposite.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicComposite.ts
@@ -7,7 +7,6 @@ export const test_createValidate_DynamicComposite = _test_validate(
     DynamicComposite.generate,
     (input: any): typia.IValidation<DynamicComposite> => {
         const __is = (input: any): input is DynamicComposite => {
-            const $join = (typia.createValidate as any).join;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 "string" === typeof input.name &&

--- a/test/generated/output/createValidate/test_createValidate_DynamicNever.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicNever.ts
@@ -7,7 +7,6 @@ export const test_createValidate_DynamicNever = _test_validate(
     DynamicNever.generate,
     (input: any): typia.IValidation<DynamicNever> => {
         const __is = (input: any): input is DynamicNever => {
-            const $join = (typia.createValidate as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createValidate/test_createValidate_DynamicSimple.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicSimple.ts
@@ -7,7 +7,6 @@ export const test_createValidate_DynamicSimple = _test_validate(
     DynamicSimple.generate,
     (input: any): typia.IValidation<DynamicSimple> => {
         const __is = (input: any): input is DynamicSimple => {
-            const $join = (typia.createValidate as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createValidate/test_createValidate_DynamicTemplate.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicTemplate.ts
@@ -7,7 +7,6 @@ export const test_createValidate_DynamicTemplate = _test_validate(
     DynamicTemplate.generate,
     (input: any): typia.IValidation<DynamicTemplate> => {
         const __is = (input: any): input is DynamicTemplate => {
-            const $join = (typia.createValidate as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createValidate/test_createValidate_DynamicTree.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicTree.ts
@@ -7,7 +7,6 @@ export const test_createValidate_DynamicTree = _test_validate(
     DynamicTree.generate,
     (input: any): typia.IValidation<DynamicTree> => {
         const __is = (input: any): input is DynamicTree => {
-            const $join = (typia.createValidate as any).join;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 "number" === typeof input.sequence &&

--- a/test/generated/output/createValidate/test_createValidate_DynamicUndefined.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicUndefined.ts
@@ -7,7 +7,6 @@ export const test_createValidate_DynamicUndefined = _test_validate(
     DynamicUndefined.generate,
     (input: any): typia.IValidation<DynamicUndefined> => {
         const __is = (input: any): input is DynamicUndefined => {
-            const $join = (typia.createValidate as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createValidate/test_createValidate_DynamicUnion.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicUnion.ts
@@ -7,7 +7,6 @@ export const test_createValidate_DynamicUnion = _test_validate(
     DynamicUnion.generate,
     (input: any): typia.IValidation<DynamicUnion> => {
         const __is = (input: any): input is DynamicUnion => {
-            const $join = (typia.createValidate as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createValidate/test_createValidate_ObjectDynamic.ts
+++ b/test/generated/output/createValidate/test_createValidate_ObjectDynamic.ts
@@ -7,7 +7,6 @@ export const test_createValidate_ObjectDynamic = _test_validate(
     ObjectDynamic.generate,
     (input: any): typia.IValidation<ObjectDynamic> => {
         const __is = (input: any): input is ObjectDynamic => {
-            const $join = (typia.createValidate as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/createValidate/test_createValidate_TagArray.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagArray.ts
@@ -7,7 +7,6 @@ export const test_createValidate_TagArray = _test_validate(
     TagArray.generate,
     (input: any): typia.IValidation<TagArray> => {
         const __is = (input: any): input is TagArray => {
-            const $is_uuid = (typia.createValidate as any).is_uuid;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 3 === input.items.length &&

--- a/test/generated/output/createValidate/test_createValidate_TagCustom.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagCustom.ts
@@ -7,8 +7,6 @@ export const test_createValidate_TagCustom = _test_validate(
     TagCustom.generate,
     (input: any): typia.IValidation<TagCustom> => {
         const __is = (input: any): input is TagCustom => {
-            const $is_uuid = (typia.createValidate as any).is_uuid;
-            const $is_custom = (typia.createValidate as any).is_custom;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 $is_uuid(input.id) &&

--- a/test/generated/output/createValidate/test_createValidate_TagFormat.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagFormat.ts
@@ -7,13 +7,6 @@ export const test_createValidate_TagFormat = _test_validate(
     TagFormat.generate,
     (input: any): typia.IValidation<TagFormat> => {
         const __is = (input: any): input is TagFormat => {
-            const $is_uuid = (typia.createValidate as any).is_uuid;
-            const $is_email = (typia.createValidate as any).is_email;
-            const $is_url = (typia.createValidate as any).is_url;
-            const $is_ipv4 = (typia.createValidate as any).is_ipv4;
-            const $is_ipv6 = (typia.createValidate as any).is_ipv6;
-            const $is_date = (typia.createValidate as any).is_date;
-            const $is_datetime = (typia.createValidate as any).is_datetime;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.uuid &&
                 $is_uuid(input.uuid) &&

--- a/test/generated/output/createValidate/test_createValidate_TagMatrix.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagMatrix.ts
@@ -7,7 +7,6 @@ export const test_createValidate_TagMatrix = _test_validate(
     TagMatrix.generate,
     (input: any): typia.IValidation<TagMatrix> => {
         const __is = (input: any): input is TagMatrix => {
-            const $is_uuid = (typia.createValidate as any).is_uuid;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.matrix) &&
                 3 === input.matrix.length &&

--- a/test/generated/output/createValidate/test_createValidate_UltimateUnion.ts
+++ b/test/generated/output/createValidate/test_createValidate_UltimateUnion.ts
@@ -7,7 +7,6 @@ export const test_createValidate_UltimateUnion = _test_validate(
     UltimateUnion.generate,
     (input: any): typia.IValidation<UltimateUnion> => {
         const __is = (input: any): input is UltimateUnion => {
-            const $join = (typia.createValidate as any).join;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.schemas) &&
                 input.schemas.every(

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicArray.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicArray.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_DynamicArray = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<DynamicArray>> => {
         const validate = (input: any): typia.IValidation<DynamicArray> => {
             const __is = (input: any): input is DynamicArray => {
-                const $join = (typia.createValidateClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicComposite.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicComposite.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_DynamicComposite = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<DynamicComposite>> => {
         const validate = (input: any): typia.IValidation<DynamicComposite> => {
             const __is = (input: any): input is DynamicComposite => {
-                const $join = (typia.createValidateClone as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "string" === typeof input.name &&

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicNever.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicNever.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_DynamicNever = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<DynamicNever>> => {
         const validate = (input: any): typia.IValidation<DynamicNever> => {
             const __is = (input: any): input is DynamicNever => {
-                const $join = (typia.createValidateClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicSimple.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicSimple.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_DynamicSimple = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<DynamicSimple>> => {
         const validate = (input: any): typia.IValidation<DynamicSimple> => {
             const __is = (input: any): input is DynamicSimple => {
-                const $join = (typia.createValidateClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicTemplate.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicTemplate.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_DynamicTemplate = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<DynamicTemplate>> => {
         const validate = (input: any): typia.IValidation<DynamicTemplate> => {
             const __is = (input: any): input is DynamicTemplate => {
-                const $join = (typia.createValidateClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicTree.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicTree.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_DynamicTree = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<DynamicTree>> => {
         const validate = (input: any): typia.IValidation<DynamicTree> => {
             const __is = (input: any): input is DynamicTree => {
-                const $join = (typia.createValidateClone as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "number" === typeof input.sequence &&

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicUndefined.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicUndefined.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_DynamicUndefined = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<DynamicUndefined>> => {
         const validate = (input: any): typia.IValidation<DynamicUndefined> => {
             const __is = (input: any): input is DynamicUndefined => {
-                const $join = (typia.createValidateClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicUnion.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_DynamicUnion = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<DynamicUnion>> => {
         const validate = (input: any): typia.IValidation<DynamicUnion> => {
             const __is = (input: any): input is DynamicUnion => {
-                const $join = (typia.createValidateClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateClone/test_createValidateClone_ObjectDynamic.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_ObjectDynamic.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_ObjectDynamic = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<ObjectDynamic>> => {
         const validate = (input: any): typia.IValidation<ObjectDynamic> => {
             const __is = (input: any): input is ObjectDynamic => {
-                const $join = (typia.createValidateClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagArray.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagArray.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_TagArray = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<TagArray>> => {
         const validate = (input: any): typia.IValidation<TagArray> => {
             const __is = (input: any): input is TagArray => {
-                const $is_uuid = (typia.createValidateClone as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     3 === input.items.length &&

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagCustom.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagCustom.ts
@@ -8,8 +8,6 @@ export const test_createValidateClone_TagCustom = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<TagCustom>> => {
         const validate = (input: any): typia.IValidation<TagCustom> => {
             const __is = (input: any): input is TagCustom => {
-                const $is_uuid = (typia.createValidateClone as any).is_uuid;
-                const $is_custom = (typia.createValidateClone as any).is_custom;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     $is_uuid(input.id) &&

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagFormat.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagFormat.ts
@@ -8,14 +8,6 @@ export const test_createValidateClone_TagFormat = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<TagFormat>> => {
         const validate = (input: any): typia.IValidation<TagFormat> => {
             const __is = (input: any): input is TagFormat => {
-                const $is_uuid = (typia.createValidateClone as any).is_uuid;
-                const $is_email = (typia.createValidateClone as any).is_email;
-                const $is_url = (typia.createValidateClone as any).is_url;
-                const $is_ipv4 = (typia.createValidateClone as any).is_ipv4;
-                const $is_ipv6 = (typia.createValidateClone as any).is_ipv6;
-                const $is_date = (typia.createValidateClone as any).is_date;
-                const $is_datetime = (typia.createValidateClone as any)
-                    .is_datetime;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.uuid &&
                     $is_uuid(input.uuid) &&

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagMatrix.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagMatrix.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_TagMatrix = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<TagMatrix>> => {
         const validate = (input: any): typia.IValidation<TagMatrix> => {
             const __is = (input: any): input is TagMatrix => {
-                const $is_uuid = (typia.createValidateClone as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.matrix) &&
                     3 === input.matrix.length &&

--- a/test/generated/output/createValidateClone/test_createValidateClone_UltimateUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_UltimateUnion.ts
@@ -8,7 +8,6 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
     (input: any): typia.IValidation<typia.Primitive<UltimateUnion>> => {
         const validate = (input: any): typia.IValidation<UltimateUnion> => {
             const __is = (input: any): input is UltimateUnion => {
-                const $join = (typia.createValidateClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.schemas) &&
                     input.schemas.every(

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicComposite.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicComposite.ts
@@ -10,7 +10,6 @@ export const test_createValidateEquals_DynamicComposite = _test_validateEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is DynamicComposite => {
-            const $join = (typia.createValidateEquals as any).join;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicTemplate.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicTemplate.ts
@@ -10,7 +10,6 @@ export const test_createValidateEquals_DynamicTemplate = _test_validateEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is DynamicTemplate => {
-            const $join = (typia.createValidateEquals as any).join;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicUnion.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicUnion.ts
@@ -10,7 +10,6 @@ export const test_createValidateEquals_DynamicUnion = _test_validateEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is DynamicUnion => {
-            const $join = (typia.createValidateEquals as any).join;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagArray.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagArray.ts
@@ -10,7 +10,6 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is TagArray => {
-            const $is_uuid = (typia.createValidateEquals as any).is_uuid;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagCustom.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagCustom.ts
@@ -10,8 +10,6 @@ export const test_createValidateEquals_TagCustom = _test_validateEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is TagCustom => {
-            const $is_uuid = (typia.createValidateEquals as any).is_uuid;
-            const $is_custom = (typia.createValidateEquals as any).is_custom;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagFormat.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagFormat.ts
@@ -10,14 +10,6 @@ export const test_createValidateEquals_TagFormat = _test_validateEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is TagFormat => {
-            const $is_uuid = (typia.createValidateEquals as any).is_uuid;
-            const $is_email = (typia.createValidateEquals as any).is_email;
-            const $is_url = (typia.createValidateEquals as any).is_url;
-            const $is_ipv4 = (typia.createValidateEquals as any).is_ipv4;
-            const $is_ipv6 = (typia.createValidateEquals as any).is_ipv6;
-            const $is_date = (typia.createValidateEquals as any).is_date;
-            const $is_datetime = (typia.createValidateEquals as any)
-                .is_datetime;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagMatrix.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagMatrix.ts
@@ -10,7 +10,6 @@ export const test_createValidateEquals_TagMatrix = _test_validateEquals(
             input: any,
             _exceptionable: boolean = true,
         ): input is TagMatrix => {
-            const $is_uuid = (typia.createValidateEquals as any).is_uuid;
             const $io0 = (
                 input: any,
                 _exceptionable: boolean = true,

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicArray.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicArray.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_DynamicArray = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<DynamicArray>> => {
         const validate = (input: any): typia.IValidation<DynamicArray> => {
             const __is = (input: any): input is DynamicArray => {
-                const $join = (typia.createValidateParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicComposite.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicComposite.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_DynamicComposite = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<DynamicComposite>> => {
         const validate = (input: any): typia.IValidation<DynamicComposite> => {
             const __is = (input: any): input is DynamicComposite => {
-                const $join = (typia.createValidateParse as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "string" === typeof input.name &&

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicNever.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicNever.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_DynamicNever = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<DynamicNever>> => {
         const validate = (input: any): typia.IValidation<DynamicNever> => {
             const __is = (input: any): input is DynamicNever => {
-                const $join = (typia.createValidateParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicSimple.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicSimple.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_DynamicSimple = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<DynamicSimple>> => {
         const validate = (input: any): typia.IValidation<DynamicSimple> => {
             const __is = (input: any): input is DynamicSimple => {
-                const $join = (typia.createValidateParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicTemplate.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicTemplate.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_DynamicTemplate = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<DynamicTemplate>> => {
         const validate = (input: any): typia.IValidation<DynamicTemplate> => {
             const __is = (input: any): input is DynamicTemplate => {
-                const $join = (typia.createValidateParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicTree.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicTree.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_DynamicTree = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<DynamicTree>> => {
         const validate = (input: any): typia.IValidation<DynamicTree> => {
             const __is = (input: any): input is DynamicTree => {
-                const $join = (typia.createValidateParse as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "number" === typeof input.sequence &&

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicUndefined.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicUndefined.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_DynamicUndefined = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<DynamicUndefined>> => {
         const validate = (input: any): typia.IValidation<DynamicUndefined> => {
             const __is = (input: any): input is DynamicUndefined => {
-                const $join = (typia.createValidateParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicUnion.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicUnion.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_DynamicUnion = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<DynamicUnion>> => {
         const validate = (input: any): typia.IValidation<DynamicUnion> => {
             const __is = (input: any): input is DynamicUnion => {
-                const $join = (typia.createValidateParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateParse/test_createValidateParse_ObjectDynamic.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_ObjectDynamic.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_ObjectDynamic = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<ObjectDynamic>> => {
         const validate = (input: any): typia.IValidation<ObjectDynamic> => {
             const __is = (input: any): input is ObjectDynamic => {
-                const $join = (typia.createValidateParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagArray.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagArray.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_TagArray = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<TagArray>> => {
         const validate = (input: any): typia.IValidation<TagArray> => {
             const __is = (input: any): input is TagArray => {
-                const $is_uuid = (typia.createValidateParse as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     3 === input.items.length &&

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagCustom.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagCustom.ts
@@ -8,8 +8,6 @@ export const test_createValidateParse_TagCustom = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<TagCustom>> => {
         const validate = (input: any): typia.IValidation<TagCustom> => {
             const __is = (input: any): input is TagCustom => {
-                const $is_uuid = (typia.createValidateParse as any).is_uuid;
-                const $is_custom = (typia.createValidateParse as any).is_custom;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     $is_uuid(input.id) &&

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagFormat.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagFormat.ts
@@ -8,14 +8,6 @@ export const test_createValidateParse_TagFormat = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<TagFormat>> => {
         const validate = (input: any): typia.IValidation<TagFormat> => {
             const __is = (input: any): input is TagFormat => {
-                const $is_uuid = (typia.createValidateParse as any).is_uuid;
-                const $is_email = (typia.createValidateParse as any).is_email;
-                const $is_url = (typia.createValidateParse as any).is_url;
-                const $is_ipv4 = (typia.createValidateParse as any).is_ipv4;
-                const $is_ipv6 = (typia.createValidateParse as any).is_ipv6;
-                const $is_date = (typia.createValidateParse as any).is_date;
-                const $is_datetime = (typia.createValidateParse as any)
-                    .is_datetime;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.uuid &&
                     $is_uuid(input.uuid) &&

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagMatrix.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagMatrix.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_TagMatrix = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<TagMatrix>> => {
         const validate = (input: any): typia.IValidation<TagMatrix> => {
             const __is = (input: any): input is TagMatrix => {
-                const $is_uuid = (typia.createValidateParse as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.matrix) &&
                     3 === input.matrix.length &&

--- a/test/generated/output/createValidateParse/test_createValidateParse_UltimateUnion.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_UltimateUnion.ts
@@ -8,7 +8,6 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
     (input: string): typia.IValidation<typia.Primitive<UltimateUnion>> => {
         const validate = (input: any): typia.IValidation<UltimateUnion> => {
             const __is = (input: any): input is UltimateUnion => {
-                const $join = (typia.createValidateParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.schemas) &&
                     input.schemas.every(

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicComposite.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicComposite.ts
@@ -8,7 +8,6 @@ export const test_createValidatePrune_DynamicComposite = _test_validatePrune(
     (input: any): typia.IValidation<DynamicComposite> => {
         const validate = (input: any): typia.IValidation<DynamicComposite> => {
             const __is = (input: any): input is DynamicComposite => {
-                const $join = (typia.createValidatePrune as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "string" === typeof input.name &&

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicTemplate.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicTemplate.ts
@@ -8,7 +8,6 @@ export const test_createValidatePrune_DynamicTemplate = _test_validatePrune(
     (input: any): typia.IValidation<DynamicTemplate> => {
         const validate = (input: any): typia.IValidation<DynamicTemplate> => {
             const __is = (input: any): input is DynamicTemplate => {
-                const $join = (typia.createValidatePrune as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicUnion.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicUnion.ts
@@ -8,7 +8,6 @@ export const test_createValidatePrune_DynamicUnion = _test_validatePrune(
     (input: any): typia.IValidation<DynamicUnion> => {
         const validate = (input: any): typia.IValidation<DynamicUnion> => {
             const __is = (input: any): input is DynamicUnion => {
-                const $join = (typia.createValidatePrune as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagArray.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagArray.ts
@@ -8,7 +8,6 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
     (input: any): typia.IValidation<TagArray> => {
         const validate = (input: any): typia.IValidation<TagArray> => {
             const __is = (input: any): input is TagArray => {
-                const $is_uuid = (typia.createValidatePrune as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     3 === input.items.length &&

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagCustom.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagCustom.ts
@@ -8,8 +8,6 @@ export const test_createValidatePrune_TagCustom = _test_validatePrune(
     (input: any): typia.IValidation<TagCustom> => {
         const validate = (input: any): typia.IValidation<TagCustom> => {
             const __is = (input: any): input is TagCustom => {
-                const $is_uuid = (typia.createValidatePrune as any).is_uuid;
-                const $is_custom = (typia.createValidatePrune as any).is_custom;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     $is_uuid(input.id) &&

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagFormat.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagFormat.ts
@@ -8,14 +8,6 @@ export const test_createValidatePrune_TagFormat = _test_validatePrune(
     (input: any): typia.IValidation<TagFormat> => {
         const validate = (input: any): typia.IValidation<TagFormat> => {
             const __is = (input: any): input is TagFormat => {
-                const $is_uuid = (typia.createValidatePrune as any).is_uuid;
-                const $is_email = (typia.createValidatePrune as any).is_email;
-                const $is_url = (typia.createValidatePrune as any).is_url;
-                const $is_ipv4 = (typia.createValidatePrune as any).is_ipv4;
-                const $is_ipv6 = (typia.createValidatePrune as any).is_ipv6;
-                const $is_date = (typia.createValidatePrune as any).is_date;
-                const $is_datetime = (typia.createValidatePrune as any)
-                    .is_datetime;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.uuid &&
                     $is_uuid(input.uuid) &&

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagMatrix.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagMatrix.ts
@@ -8,7 +8,6 @@ export const test_createValidatePrune_TagMatrix = _test_validatePrune(
     (input: any): typia.IValidation<TagMatrix> => {
         const validate = (input: any): typia.IValidation<TagMatrix> => {
             const __is = (input: any): input is TagMatrix => {
-                const $is_uuid = (typia.createValidatePrune as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.matrix) &&
                     3 === input.matrix.length &&

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicArray.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicArray.ts
@@ -9,7 +9,6 @@ export const test_createValidateStringify_DynamicArray =
         (input: DynamicArray): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<DynamicArray> => {
                 const __is = (input: any): input is DynamicArray => {
-                    const $join = (typia.createValidateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicComposite.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicComposite.ts
@@ -11,7 +11,6 @@ export const test_createValidateStringify_DynamicComposite =
                 input: any,
             ): typia.IValidation<DynamicComposite> => {
                 const __is = (input: any): input is DynamicComposite => {
-                    const $join = (typia.createValidateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "string" === typeof input.name &&

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicNever.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicNever.ts
@@ -9,7 +9,6 @@ export const test_createValidateStringify_DynamicNever =
         (input: DynamicNever): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<DynamicNever> => {
                 const __is = (input: any): input is DynamicNever => {
-                    const $join = (typia.createValidateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicSimple.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicSimple.ts
@@ -9,7 +9,6 @@ export const test_createValidateStringify_DynamicSimple =
         (input: DynamicSimple): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<DynamicSimple> => {
                 const __is = (input: any): input is DynamicSimple => {
-                    const $join = (typia.createValidateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicTemplate.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicTemplate.ts
@@ -11,7 +11,6 @@ export const test_createValidateStringify_DynamicTemplate =
                 input: any,
             ): typia.IValidation<DynamicTemplate> => {
                 const __is = (input: any): input is DynamicTemplate => {
-                    const $join = (typia.createValidateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicTree.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicTree.ts
@@ -8,7 +8,6 @@ export const test_createValidateStringify_DynamicTree = _test_validateStringify(
     (input: DynamicTree): typia.IValidation<string> => {
         const validate = (input: any): typia.IValidation<DynamicTree> => {
             const __is = (input: any): input is DynamicTree => {
-                const $join = (typia.createValidateStringify as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "number" === typeof input.sequence &&

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicUndefined.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicUndefined.ts
@@ -11,7 +11,6 @@ export const test_createValidateStringify_DynamicUndefined =
                 input: any,
             ): typia.IValidation<DynamicUndefined> => {
                 const __is = (input: any): input is DynamicUndefined => {
-                    const $join = (typia.createValidateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicUnion.ts
@@ -9,7 +9,6 @@ export const test_createValidateStringify_DynamicUnion =
         (input: DynamicUnion): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<DynamicUnion> => {
                 const __is = (input: any): input is DynamicUnion => {
-                    const $join = (typia.createValidateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_ObjectDynamic.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_ObjectDynamic.ts
@@ -9,7 +9,6 @@ export const test_createValidateStringify_ObjectDynamic =
         (input: ObjectDynamic): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<ObjectDynamic> => {
                 const __is = (input: any): input is ObjectDynamic => {
-                    const $join = (typia.createValidateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagArray.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagArray.ts
@@ -8,7 +8,6 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
     (input: TagArray): typia.IValidation<string> => {
         const validate = (input: any): typia.IValidation<TagArray> => {
             const __is = (input: any): input is TagArray => {
-                const $is_uuid = (typia.createValidateStringify as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     3 === input.items.length &&

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagCustom.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagCustom.ts
@@ -8,9 +8,6 @@ export const test_createValidateStringify_TagCustom = _test_validateStringify(
     (input: TagCustom): typia.IValidation<string> => {
         const validate = (input: any): typia.IValidation<TagCustom> => {
             const __is = (input: any): input is TagCustom => {
-                const $is_uuid = (typia.createValidateStringify as any).is_uuid;
-                const $is_custom = (typia.createValidateStringify as any)
-                    .is_custom;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     $is_uuid(input.id) &&

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagFormat.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagFormat.ts
@@ -8,15 +8,6 @@ export const test_createValidateStringify_TagFormat = _test_validateStringify(
     (input: TagFormat): typia.IValidation<string> => {
         const validate = (input: any): typia.IValidation<TagFormat> => {
             const __is = (input: any): input is TagFormat => {
-                const $is_uuid = (typia.createValidateStringify as any).is_uuid;
-                const $is_email = (typia.createValidateStringify as any)
-                    .is_email;
-                const $is_url = (typia.createValidateStringify as any).is_url;
-                const $is_ipv4 = (typia.createValidateStringify as any).is_ipv4;
-                const $is_ipv6 = (typia.createValidateStringify as any).is_ipv6;
-                const $is_date = (typia.createValidateStringify as any).is_date;
-                const $is_datetime = (typia.createValidateStringify as any)
-                    .is_datetime;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.uuid &&
                     $is_uuid(input.uuid) &&

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagMatrix.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagMatrix.ts
@@ -8,7 +8,6 @@ export const test_createValidateStringify_TagMatrix = _test_validateStringify(
     (input: TagMatrix): typia.IValidation<string> => {
         const validate = (input: any): typia.IValidation<TagMatrix> => {
             const __is = (input: any): input is TagMatrix => {
-                const $is_uuid = (typia.createValidateStringify as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.matrix) &&
                     3 === input.matrix.length &&

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_UltimateUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_UltimateUnion.ts
@@ -9,7 +9,6 @@ export const test_createValidateStringify_UltimateUnion =
         (input: UltimateUnion): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<UltimateUnion> => {
                 const __is = (input: any): input is UltimateUnion => {
-                    const $join = (typia.createValidateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.schemas) &&
                         input.schemas.every(

--- a/test/generated/output/random/test_random_DynamicArray.ts
+++ b/test/generated/output/random/test_random_DynamicArray.ts
@@ -38,7 +38,6 @@ export const test_random_DynamicArray = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<DynamicArray> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/random/test_random_DynamicComposite.ts
+++ b/test/generated/output/random/test_random_DynamicComposite.ts
@@ -124,7 +124,6 @@ export const test_random_DynamicComposite = _test_random(
         const __is = (
             input: any,
         ): input is typia.Primitive<DynamicComposite> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 "string" === typeof input.name &&

--- a/test/generated/output/random/test_random_DynamicNever.ts
+++ b/test/generated/output/random/test_random_DynamicNever.ts
@@ -32,7 +32,6 @@ export const test_random_DynamicNever = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<DynamicNever> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/random/test_random_DynamicSimple.ts
+++ b/test/generated/output/random/test_random_DynamicSimple.ts
@@ -36,7 +36,6 @@ export const test_random_DynamicSimple = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<DynamicSimple> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/random/test_random_DynamicTemplate.ts
+++ b/test/generated/output/random/test_random_DynamicTemplate.ts
@@ -89,7 +89,6 @@ export const test_random_DynamicTemplate = _test_random(
         const __is = (
             input: any,
         ): input is typia.Primitive<DynamicTemplate> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/random/test_random_DynamicTree.ts
+++ b/test/generated/output/random/test_random_DynamicTree.ts
@@ -46,7 +46,6 @@ export const test_random_DynamicTree = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<DynamicTree> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 "number" === typeof input.sequence &&

--- a/test/generated/output/random/test_random_DynamicUndefined.ts
+++ b/test/generated/output/random/test_random_DynamicUndefined.ts
@@ -34,7 +34,6 @@ export const test_random_DynamicUndefined = _test_random(
         const __is = (
             input: any,
         ): input is typia.Primitive<DynamicUndefined> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/random/test_random_DynamicUnion.ts
+++ b/test/generated/output/random/test_random_DynamicUnion.ts
@@ -89,7 +89,6 @@ export const test_random_DynamicUnion = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<DynamicUnion> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/random/test_random_ObjectDynamic.ts
+++ b/test/generated/output/random/test_random_ObjectDynamic.ts
@@ -48,7 +48,6 @@ export const test_random_ObjectDynamic = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<ObjectDynamic> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Object.keys(input).every((key) => {
                     const value = input[key];

--- a/test/generated/output/random/test_random_TagArray.ts
+++ b/test/generated/output/random/test_random_TagArray.ts
@@ -114,7 +114,6 @@ export const test_random_TagArray = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $is_uuid = (typia.createAssert as any).is_uuid;
         const __is = (input: any): input is typia.Primitive<TagArray> => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 3 === input.items.length &&

--- a/test/generated/output/random/test_random_TagCustom.ts
+++ b/test/generated/output/random/test_random_TagCustom.ts
@@ -48,8 +48,6 @@ export const test_random_TagCustom = _test_random(
         const $is_uuid = (typia.createAssert as any).is_uuid;
         const $is_custom = (typia.createAssert as any).is_custom;
         const __is = (input: any): input is typia.Primitive<TagCustom> => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
-            const $is_custom = (typia.createAssert as any).is_custom;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.id &&
                 $is_uuid(input.id) &&

--- a/test/generated/output/random/test_random_TagFormat.ts
+++ b/test/generated/output/random/test_random_TagFormat.ts
@@ -96,13 +96,6 @@ export const test_random_TagFormat = _test_random(
         const $is_date = (typia.createAssert as any).is_date;
         const $is_datetime = (typia.createAssert as any).is_datetime;
         const __is = (input: any): input is typia.Primitive<TagFormat> => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
-            const $is_email = (typia.createAssert as any).is_email;
-            const $is_url = (typia.createAssert as any).is_url;
-            const $is_ipv4 = (typia.createAssert as any).is_ipv4;
-            const $is_ipv6 = (typia.createAssert as any).is_ipv6;
-            const $is_date = (typia.createAssert as any).is_date;
-            const $is_datetime = (typia.createAssert as any).is_datetime;
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.uuid &&
                 $is_uuid(input.uuid) &&

--- a/test/generated/output/random/test_random_TagMatrix.ts
+++ b/test/generated/output/random/test_random_TagMatrix.ts
@@ -40,7 +40,6 @@ export const test_random_TagMatrix = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $is_uuid = (typia.createAssert as any).is_uuid;
         const __is = (input: any): input is typia.Primitive<TagMatrix> => {
-            const $is_uuid = (typia.createAssert as any).is_uuid;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.matrix) &&
                 3 === input.matrix.length &&

--- a/test/generated/output/random/test_random_UltimateUnion.ts
+++ b/test/generated/output/random/test_random_UltimateUnion.ts
@@ -2566,7 +2566,6 @@ export const test_random_UltimateUnion = _test_random(
         const $guard = (typia.createAssert as any).guard;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<UltimateUnion> => {
-            const $join = (typia.createAssert as any).join;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.schemas) &&
                 input.schemas.every(

--- a/test/generated/output/validate/test_validate_DynamicArray.ts
+++ b/test/generated/output/validate/test_validate_DynamicArray.ts
@@ -8,7 +8,6 @@ export const test_validate_DynamicArray = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<DynamicArray> => {
             const __is = (input: any): input is DynamicArray => {
-                const $join = (typia.validate as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/validate/test_validate_DynamicComposite.ts
+++ b/test/generated/output/validate/test_validate_DynamicComposite.ts
@@ -8,7 +8,6 @@ export const test_validate_DynamicComposite = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<DynamicComposite> => {
             const __is = (input: any): input is DynamicComposite => {
-                const $join = (typia.validate as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "string" === typeof input.name &&

--- a/test/generated/output/validate/test_validate_DynamicNever.ts
+++ b/test/generated/output/validate/test_validate_DynamicNever.ts
@@ -8,7 +8,6 @@ export const test_validate_DynamicNever = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<DynamicNever> => {
             const __is = (input: any): input is DynamicNever => {
-                const $join = (typia.validate as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/validate/test_validate_DynamicSimple.ts
+++ b/test/generated/output/validate/test_validate_DynamicSimple.ts
@@ -8,7 +8,6 @@ export const test_validate_DynamicSimple = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<DynamicSimple> => {
             const __is = (input: any): input is DynamicSimple => {
-                const $join = (typia.validate as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/validate/test_validate_DynamicTemplate.ts
+++ b/test/generated/output/validate/test_validate_DynamicTemplate.ts
@@ -8,7 +8,6 @@ export const test_validate_DynamicTemplate = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<DynamicTemplate> => {
             const __is = (input: any): input is DynamicTemplate => {
-                const $join = (typia.validate as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/validate/test_validate_DynamicTree.ts
+++ b/test/generated/output/validate/test_validate_DynamicTree.ts
@@ -8,7 +8,6 @@ export const test_validate_DynamicTree = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<DynamicTree> => {
             const __is = (input: any): input is DynamicTree => {
-                const $join = (typia.validate as any).join;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     "number" === typeof input.sequence &&

--- a/test/generated/output/validate/test_validate_DynamicUndefined.ts
+++ b/test/generated/output/validate/test_validate_DynamicUndefined.ts
@@ -8,7 +8,6 @@ export const test_validate_DynamicUndefined = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<DynamicUndefined> => {
             const __is = (input: any): input is DynamicUndefined => {
-                const $join = (typia.validate as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/validate/test_validate_DynamicUnion.ts
+++ b/test/generated/output/validate/test_validate_DynamicUnion.ts
@@ -8,7 +8,6 @@ export const test_validate_DynamicUnion = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<DynamicUnion> => {
             const __is = (input: any): input is DynamicUnion => {
-                const $join = (typia.validate as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/validate/test_validate_ObjectDynamic.ts
+++ b/test/generated/output/validate/test_validate_ObjectDynamic.ts
@@ -8,7 +8,6 @@ export const test_validate_ObjectDynamic = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<ObjectDynamic> => {
             const __is = (input: any): input is ObjectDynamic => {
-                const $join = (typia.validate as any).join;
                 const $io0 = (input: any): boolean =>
                     Object.keys(input).every((key) => {
                         const value = input[key];

--- a/test/generated/output/validate/test_validate_TagArray.ts
+++ b/test/generated/output/validate/test_validate_TagArray.ts
@@ -8,7 +8,6 @@ export const test_validate_TagArray = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<Array<TagArray.Type>> => {
             const __is = (input: any): input is Array<TagArray.Type> => {
-                const $is_uuid = (typia.validate as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     3 === input.items.length &&

--- a/test/generated/output/validate/test_validate_TagCustom.ts
+++ b/test/generated/output/validate/test_validate_TagCustom.ts
@@ -8,8 +8,6 @@ export const test_validate_TagCustom = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<TagCustom> => {
             const __is = (input: any): input is TagCustom => {
-                const $is_uuid = (typia.validate as any).is_uuid;
-                const $is_custom = (typia.validate as any).is_custom;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.id &&
                     $is_uuid(input.id) &&

--- a/test/generated/output/validate/test_validate_TagFormat.ts
+++ b/test/generated/output/validate/test_validate_TagFormat.ts
@@ -8,13 +8,6 @@ export const test_validate_TagFormat = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<TagFormat> => {
             const __is = (input: any): input is TagFormat => {
-                const $is_uuid = (typia.validate as any).is_uuid;
-                const $is_email = (typia.validate as any).is_email;
-                const $is_url = (typia.validate as any).is_url;
-                const $is_ipv4 = (typia.validate as any).is_ipv4;
-                const $is_ipv6 = (typia.validate as any).is_ipv6;
-                const $is_date = (typia.validate as any).is_date;
-                const $is_datetime = (typia.validate as any).is_datetime;
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.uuid &&
                     $is_uuid(input.uuid) &&

--- a/test/generated/output/validate/test_validate_TagMatrix.ts
+++ b/test/generated/output/validate/test_validate_TagMatrix.ts
@@ -8,7 +8,6 @@ export const test_validate_TagMatrix = _test_validate(
     (input) =>
         ((input: any): typia.IValidation<TagMatrix> => {
             const __is = (input: any): input is TagMatrix => {
-                const $is_uuid = (typia.validate as any).is_uuid;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.matrix) &&
                     3 === input.matrix.length &&

--- a/test/generated/output/validate/test_validate_UltimateUnion.ts
+++ b/test/generated/output/validate/test_validate_UltimateUnion.ts
@@ -10,7 +10,6 @@ export const test_validate_UltimateUnion = _test_validate(
             const __is = (
                 input: any,
             ): input is Array<typia.IJsonApplication> => {
-                const $join = (typia.validate as any).join;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.schemas) &&
                     input.schemas.every(

--- a/test/generated/output/validateClone/test_validateClone_DynamicArray.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicArray.ts
@@ -9,7 +9,6 @@ export const test_validateClone_DynamicArray = _test_validateClone(
         ((input: any): typia.IValidation<typia.Primitive<DynamicArray>> => {
             const validate = (input: any): typia.IValidation<DynamicArray> => {
                 const __is = (input: any): input is DynamicArray => {
-                    const $join = (typia.validateClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateClone/test_validateClone_DynamicComposite.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicComposite.ts
@@ -11,7 +11,6 @@ export const test_validateClone_DynamicComposite = _test_validateClone(
                 input: any,
             ): typia.IValidation<DynamicComposite> => {
                 const __is = (input: any): input is DynamicComposite => {
-                    const $join = (typia.validateClone as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "string" === typeof input.name &&

--- a/test/generated/output/validateClone/test_validateClone_DynamicNever.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicNever.ts
@@ -9,7 +9,6 @@ export const test_validateClone_DynamicNever = _test_validateClone(
         ((input: any): typia.IValidation<typia.Primitive<DynamicNever>> => {
             const validate = (input: any): typia.IValidation<DynamicNever> => {
                 const __is = (input: any): input is DynamicNever => {
-                    const $join = (typia.validateClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateClone/test_validateClone_DynamicSimple.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicSimple.ts
@@ -9,7 +9,6 @@ export const test_validateClone_DynamicSimple = _test_validateClone(
         ((input: any): typia.IValidation<typia.Primitive<DynamicSimple>> => {
             const validate = (input: any): typia.IValidation<DynamicSimple> => {
                 const __is = (input: any): input is DynamicSimple => {
-                    const $join = (typia.validateClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateClone/test_validateClone_DynamicTemplate.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicTemplate.ts
@@ -11,7 +11,6 @@ export const test_validateClone_DynamicTemplate = _test_validateClone(
                 input: any,
             ): typia.IValidation<DynamicTemplate> => {
                 const __is = (input: any): input is DynamicTemplate => {
-                    const $join = (typia.validateClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateClone/test_validateClone_DynamicTree.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicTree.ts
@@ -9,7 +9,6 @@ export const test_validateClone_DynamicTree = _test_validateClone(
         ((input: any): typia.IValidation<typia.Primitive<DynamicTree>> => {
             const validate = (input: any): typia.IValidation<DynamicTree> => {
                 const __is = (input: any): input is DynamicTree => {
-                    const $join = (typia.validateClone as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "number" === typeof input.sequence &&

--- a/test/generated/output/validateClone/test_validateClone_DynamicUndefined.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicUndefined.ts
@@ -11,7 +11,6 @@ export const test_validateClone_DynamicUndefined = _test_validateClone(
                 input: any,
             ): typia.IValidation<DynamicUndefined> => {
                 const __is = (input: any): input is DynamicUndefined => {
-                    const $join = (typia.validateClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateClone/test_validateClone_DynamicUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicUnion.ts
@@ -9,7 +9,6 @@ export const test_validateClone_DynamicUnion = _test_validateClone(
         ((input: any): typia.IValidation<typia.Primitive<DynamicUnion>> => {
             const validate = (input: any): typia.IValidation<DynamicUnion> => {
                 const __is = (input: any): input is DynamicUnion => {
-                    const $join = (typia.validateClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateClone/test_validateClone_ObjectDynamic.ts
+++ b/test/generated/output/validateClone/test_validateClone_ObjectDynamic.ts
@@ -9,7 +9,6 @@ export const test_validateClone_ObjectDynamic = _test_validateClone(
         ((input: any): typia.IValidation<typia.Primitive<ObjectDynamic>> => {
             const validate = (input: any): typia.IValidation<ObjectDynamic> => {
                 const __is = (input: any): input is ObjectDynamic => {
-                    const $join = (typia.validateClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateClone/test_validateClone_TagArray.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagArray.ts
@@ -13,7 +13,6 @@ export const test_validateClone_TagArray = _test_validateClone(
                 input: any,
             ): typia.IValidation<Array<TagArray.Type>> => {
                 const __is = (input: any): input is Array<TagArray.Type> => {
-                    const $is_uuid = (typia.validateClone as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         3 === input.items.length &&

--- a/test/generated/output/validateClone/test_validateClone_TagCustom.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagCustom.ts
@@ -9,8 +9,6 @@ export const test_validateClone_TagCustom = _test_validateClone(
         ((input: any): typia.IValidation<typia.Primitive<TagCustom>> => {
             const validate = (input: any): typia.IValidation<TagCustom> => {
                 const __is = (input: any): input is TagCustom => {
-                    const $is_uuid = (typia.validateClone as any).is_uuid;
-                    const $is_custom = (typia.validateClone as any).is_custom;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         $is_uuid(input.id) &&

--- a/test/generated/output/validateClone/test_validateClone_TagFormat.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagFormat.ts
@@ -9,14 +9,6 @@ export const test_validateClone_TagFormat = _test_validateClone(
         ((input: any): typia.IValidation<typia.Primitive<TagFormat>> => {
             const validate = (input: any): typia.IValidation<TagFormat> => {
                 const __is = (input: any): input is TagFormat => {
-                    const $is_uuid = (typia.validateClone as any).is_uuid;
-                    const $is_email = (typia.validateClone as any).is_email;
-                    const $is_url = (typia.validateClone as any).is_url;
-                    const $is_ipv4 = (typia.validateClone as any).is_ipv4;
-                    const $is_ipv6 = (typia.validateClone as any).is_ipv6;
-                    const $is_date = (typia.validateClone as any).is_date;
-                    const $is_datetime = (typia.validateClone as any)
-                        .is_datetime;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.uuid &&
                         $is_uuid(input.uuid) &&

--- a/test/generated/output/validateClone/test_validateClone_TagMatrix.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagMatrix.ts
@@ -9,7 +9,6 @@ export const test_validateClone_TagMatrix = _test_validateClone(
         ((input: any): typia.IValidation<typia.Primitive<TagMatrix>> => {
             const validate = (input: any): typia.IValidation<TagMatrix> => {
                 const __is = (input: any): input is TagMatrix => {
-                    const $is_uuid = (typia.validateClone as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.matrix) &&
                         3 === input.matrix.length &&

--- a/test/generated/output/validateClone/test_validateClone_UltimateUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_UltimateUnion.ts
@@ -17,7 +17,6 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                 const __is = (
                     input: any,
                 ): input is Array<typia.IJsonApplication> => {
-                    const $join = (typia.validateClone as any).join;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.schemas) &&
                         input.schemas.every(

--- a/test/generated/output/validateEquals/test_validateEquals_DynamicComposite.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_DynamicComposite.ts
@@ -11,7 +11,6 @@ export const test_validateEquals_DynamicComposite = _test_validateEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is DynamicComposite => {
-                const $join = (typia.validateEquals as any).join;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/validateEquals/test_validateEquals_DynamicTemplate.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_DynamicTemplate.ts
@@ -11,7 +11,6 @@ export const test_validateEquals_DynamicTemplate = _test_validateEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is DynamicTemplate => {
-                const $join = (typia.validateEquals as any).join;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/validateEquals/test_validateEquals_DynamicUnion.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_DynamicUnion.ts
@@ -11,7 +11,6 @@ export const test_validateEquals_DynamicUnion = _test_validateEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is DynamicUnion => {
-                const $join = (typia.validateEquals as any).join;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/validateEquals/test_validateEquals_TagArray.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagArray.ts
@@ -11,7 +11,6 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is Array<TagArray.Type> => {
-                const $is_uuid = (typia.validateEquals as any).is_uuid;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/validateEquals/test_validateEquals_TagCustom.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagCustom.ts
@@ -11,8 +11,6 @@ export const test_validateEquals_TagCustom = _test_validateEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is TagCustom => {
-                const $is_uuid = (typia.validateEquals as any).is_uuid;
-                const $is_custom = (typia.validateEquals as any).is_custom;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/validateEquals/test_validateEquals_TagFormat.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagFormat.ts
@@ -11,13 +11,6 @@ export const test_validateEquals_TagFormat = _test_validateEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is TagFormat => {
-                const $is_uuid = (typia.validateEquals as any).is_uuid;
-                const $is_email = (typia.validateEquals as any).is_email;
-                const $is_url = (typia.validateEquals as any).is_url;
-                const $is_ipv4 = (typia.validateEquals as any).is_ipv4;
-                const $is_ipv6 = (typia.validateEquals as any).is_ipv6;
-                const $is_date = (typia.validateEquals as any).is_date;
-                const $is_datetime = (typia.validateEquals as any).is_datetime;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/validateEquals/test_validateEquals_TagMatrix.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagMatrix.ts
@@ -11,7 +11,6 @@ export const test_validateEquals_TagMatrix = _test_validateEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): input is TagMatrix => {
-                const $is_uuid = (typia.validateEquals as any).is_uuid;
                 const $io0 = (
                     input: any,
                     _exceptionable: boolean = true,

--- a/test/generated/output/validateParse/test_validateParse_DynamicArray.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicArray.ts
@@ -9,7 +9,6 @@ export const test_validateParse_DynamicArray = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<DynamicArray>> => {
             const validate = (input: any): typia.IValidation<DynamicArray> => {
                 const __is = (input: any): input is DynamicArray => {
-                    const $join = (typia.validateParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateParse/test_validateParse_DynamicComposite.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicComposite.ts
@@ -13,7 +13,6 @@ export const test_validateParse_DynamicComposite = _test_validateParse(
                 input: any,
             ): typia.IValidation<DynamicComposite> => {
                 const __is = (input: any): input is DynamicComposite => {
-                    const $join = (typia.validateParse as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "string" === typeof input.name &&

--- a/test/generated/output/validateParse/test_validateParse_DynamicNever.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicNever.ts
@@ -9,7 +9,6 @@ export const test_validateParse_DynamicNever = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<DynamicNever>> => {
             const validate = (input: any): typia.IValidation<DynamicNever> => {
                 const __is = (input: any): input is DynamicNever => {
-                    const $join = (typia.validateParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateParse/test_validateParse_DynamicSimple.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicSimple.ts
@@ -9,7 +9,6 @@ export const test_validateParse_DynamicSimple = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<DynamicSimple>> => {
             const validate = (input: any): typia.IValidation<DynamicSimple> => {
                 const __is = (input: any): input is DynamicSimple => {
-                    const $join = (typia.validateParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateParse/test_validateParse_DynamicTemplate.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicTemplate.ts
@@ -13,7 +13,6 @@ export const test_validateParse_DynamicTemplate = _test_validateParse(
                 input: any,
             ): typia.IValidation<DynamicTemplate> => {
                 const __is = (input: any): input is DynamicTemplate => {
-                    const $join = (typia.validateParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateParse/test_validateParse_DynamicTree.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicTree.ts
@@ -9,7 +9,6 @@ export const test_validateParse_DynamicTree = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<DynamicTree>> => {
             const validate = (input: any): typia.IValidation<DynamicTree> => {
                 const __is = (input: any): input is DynamicTree => {
-                    const $join = (typia.validateParse as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "number" === typeof input.sequence &&

--- a/test/generated/output/validateParse/test_validateParse_DynamicUndefined.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicUndefined.ts
@@ -13,7 +13,6 @@ export const test_validateParse_DynamicUndefined = _test_validateParse(
                 input: any,
             ): typia.IValidation<DynamicUndefined> => {
                 const __is = (input: any): input is DynamicUndefined => {
-                    const $join = (typia.validateParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateParse/test_validateParse_DynamicUnion.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicUnion.ts
@@ -9,7 +9,6 @@ export const test_validateParse_DynamicUnion = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<DynamicUnion>> => {
             const validate = (input: any): typia.IValidation<DynamicUnion> => {
                 const __is = (input: any): input is DynamicUnion => {
-                    const $join = (typia.validateParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateParse/test_validateParse_ObjectDynamic.ts
+++ b/test/generated/output/validateParse/test_validateParse_ObjectDynamic.ts
@@ -9,7 +9,6 @@ export const test_validateParse_ObjectDynamic = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<ObjectDynamic>> => {
             const validate = (input: any): typia.IValidation<ObjectDynamic> => {
                 const __is = (input: any): input is ObjectDynamic => {
-                    const $join = (typia.validateParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateParse/test_validateParse_TagArray.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagArray.ts
@@ -9,7 +9,6 @@ export const test_validateParse_TagArray = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<TagArray>> => {
             const validate = (input: any): typia.IValidation<TagArray> => {
                 const __is = (input: any): input is TagArray => {
-                    const $is_uuid = (typia.validateParse as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         3 === input.items.length &&

--- a/test/generated/output/validateParse/test_validateParse_TagCustom.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagCustom.ts
@@ -9,8 +9,6 @@ export const test_validateParse_TagCustom = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<TagCustom>> => {
             const validate = (input: any): typia.IValidation<TagCustom> => {
                 const __is = (input: any): input is TagCustom => {
-                    const $is_uuid = (typia.validateParse as any).is_uuid;
-                    const $is_custom = (typia.validateParse as any).is_custom;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         $is_uuid(input.id) &&

--- a/test/generated/output/validateParse/test_validateParse_TagFormat.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagFormat.ts
@@ -9,14 +9,6 @@ export const test_validateParse_TagFormat = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<TagFormat>> => {
             const validate = (input: any): typia.IValidation<TagFormat> => {
                 const __is = (input: any): input is TagFormat => {
-                    const $is_uuid = (typia.validateParse as any).is_uuid;
-                    const $is_email = (typia.validateParse as any).is_email;
-                    const $is_url = (typia.validateParse as any).is_url;
-                    const $is_ipv4 = (typia.validateParse as any).is_ipv4;
-                    const $is_ipv6 = (typia.validateParse as any).is_ipv6;
-                    const $is_date = (typia.validateParse as any).is_date;
-                    const $is_datetime = (typia.validateParse as any)
-                        .is_datetime;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.uuid &&
                         $is_uuid(input.uuid) &&

--- a/test/generated/output/validateParse/test_validateParse_TagMatrix.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagMatrix.ts
@@ -9,7 +9,6 @@ export const test_validateParse_TagMatrix = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<TagMatrix>> => {
             const validate = (input: any): typia.IValidation<TagMatrix> => {
                 const __is = (input: any): input is TagMatrix => {
-                    const $is_uuid = (typia.validateParse as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.matrix) &&
                         3 === input.matrix.length &&

--- a/test/generated/output/validateParse/test_validateParse_UltimateUnion.ts
+++ b/test/generated/output/validateParse/test_validateParse_UltimateUnion.ts
@@ -9,7 +9,6 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
         ((input: string): typia.IValidation<typia.Primitive<UltimateUnion>> => {
             const validate = (input: any): typia.IValidation<UltimateUnion> => {
                 const __is = (input: any): input is UltimateUnion => {
-                    const $join = (typia.validateParse as any).join;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.schemas) &&
                         input.schemas.every(

--- a/test/generated/output/validatePrune/test_validatePrune_DynamicComposite.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_DynamicComposite.ts
@@ -11,7 +11,6 @@ export const test_validatePrune_DynamicComposite = _test_validatePrune(
                 input: any,
             ): typia.IValidation<DynamicComposite> => {
                 const __is = (input: any): input is DynamicComposite => {
-                    const $join = (typia.validatePrune as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "string" === typeof input.name &&

--- a/test/generated/output/validatePrune/test_validatePrune_DynamicTemplate.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_DynamicTemplate.ts
@@ -11,7 +11,6 @@ export const test_validatePrune_DynamicTemplate = _test_validatePrune(
                 input: any,
             ): typia.IValidation<DynamicTemplate> => {
                 const __is = (input: any): input is DynamicTemplate => {
-                    const $join = (typia.validatePrune as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validatePrune/test_validatePrune_DynamicUnion.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_DynamicUnion.ts
@@ -9,7 +9,6 @@ export const test_validatePrune_DynamicUnion = _test_validatePrune(
         ((input: any): typia.IValidation<DynamicUnion> => {
             const validate = (input: any): typia.IValidation<DynamicUnion> => {
                 const __is = (input: any): input is DynamicUnion => {
-                    const $join = (typia.validatePrune as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validatePrune/test_validatePrune_TagArray.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagArray.ts
@@ -11,7 +11,6 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                 input: any,
             ): typia.IValidation<Array<TagArray.Type>> => {
                 const __is = (input: any): input is Array<TagArray.Type> => {
-                    const $is_uuid = (typia.validatePrune as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         3 === input.items.length &&

--- a/test/generated/output/validatePrune/test_validatePrune_TagCustom.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagCustom.ts
@@ -9,8 +9,6 @@ export const test_validatePrune_TagCustom = _test_validatePrune(
         ((input: any): typia.IValidation<TagCustom> => {
             const validate = (input: any): typia.IValidation<TagCustom> => {
                 const __is = (input: any): input is TagCustom => {
-                    const $is_uuid = (typia.validatePrune as any).is_uuid;
-                    const $is_custom = (typia.validatePrune as any).is_custom;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         $is_uuid(input.id) &&

--- a/test/generated/output/validatePrune/test_validatePrune_TagFormat.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagFormat.ts
@@ -9,14 +9,6 @@ export const test_validatePrune_TagFormat = _test_validatePrune(
         ((input: any): typia.IValidation<TagFormat> => {
             const validate = (input: any): typia.IValidation<TagFormat> => {
                 const __is = (input: any): input is TagFormat => {
-                    const $is_uuid = (typia.validatePrune as any).is_uuid;
-                    const $is_email = (typia.validatePrune as any).is_email;
-                    const $is_url = (typia.validatePrune as any).is_url;
-                    const $is_ipv4 = (typia.validatePrune as any).is_ipv4;
-                    const $is_ipv6 = (typia.validatePrune as any).is_ipv6;
-                    const $is_date = (typia.validatePrune as any).is_date;
-                    const $is_datetime = (typia.validatePrune as any)
-                        .is_datetime;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.uuid &&
                         $is_uuid(input.uuid) &&

--- a/test/generated/output/validatePrune/test_validatePrune_TagMatrix.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagMatrix.ts
@@ -9,7 +9,6 @@ export const test_validatePrune_TagMatrix = _test_validatePrune(
         ((input: any): typia.IValidation<TagMatrix> => {
             const validate = (input: any): typia.IValidation<TagMatrix> => {
                 const __is = (input: any): input is TagMatrix => {
-                    const $is_uuid = (typia.validatePrune as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.matrix) &&
                         3 === input.matrix.length &&

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicArray.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicArray.ts
@@ -9,7 +9,6 @@ export const test_validateStringify_DynamicArray = _test_validateStringify(
         ((input: DynamicArray): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<DynamicArray> => {
                 const __is = (input: any): input is DynamicArray => {
-                    const $join = (typia.validateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicComposite.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicComposite.ts
@@ -11,7 +11,6 @@ export const test_validateStringify_DynamicComposite = _test_validateStringify(
                 input: any,
             ): typia.IValidation<DynamicComposite> => {
                 const __is = (input: any): input is DynamicComposite => {
-                    const $join = (typia.validateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "string" === typeof input.name &&

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicNever.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicNever.ts
@@ -9,7 +9,6 @@ export const test_validateStringify_DynamicNever = _test_validateStringify(
         ((input: DynamicNever): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<DynamicNever> => {
                 const __is = (input: any): input is DynamicNever => {
-                    const $join = (typia.validateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicSimple.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicSimple.ts
@@ -9,7 +9,6 @@ export const test_validateStringify_DynamicSimple = _test_validateStringify(
         ((input: DynamicSimple): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<DynamicSimple> => {
                 const __is = (input: any): input is DynamicSimple => {
-                    const $join = (typia.validateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicTemplate.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicTemplate.ts
@@ -11,7 +11,6 @@ export const test_validateStringify_DynamicTemplate = _test_validateStringify(
                 input: any,
             ): typia.IValidation<DynamicTemplate> => {
                 const __is = (input: any): input is DynamicTemplate => {
-                    const $join = (typia.validateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicTree.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicTree.ts
@@ -9,7 +9,6 @@ export const test_validateStringify_DynamicTree = _test_validateStringify(
         ((input: DynamicTree): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<DynamicTree> => {
                 const __is = (input: any): input is DynamicTree => {
-                    const $join = (typia.validateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         "number" === typeof input.sequence &&

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicUndefined.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicUndefined.ts
@@ -11,7 +11,6 @@ export const test_validateStringify_DynamicUndefined = _test_validateStringify(
                 input: any,
             ): typia.IValidation<DynamicUndefined> => {
                 const __is = (input: any): input is DynamicUndefined => {
-                    const $join = (typia.validateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicUnion.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicUnion.ts
@@ -9,7 +9,6 @@ export const test_validateStringify_DynamicUnion = _test_validateStringify(
         ((input: DynamicUnion): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<DynamicUnion> => {
                 const __is = (input: any): input is DynamicUnion => {
-                    const $join = (typia.validateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateStringify/test_validateStringify_ObjectDynamic.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_ObjectDynamic.ts
@@ -9,7 +9,6 @@ export const test_validateStringify_ObjectDynamic = _test_validateStringify(
         ((input: ObjectDynamic): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<ObjectDynamic> => {
                 const __is = (input: any): input is ObjectDynamic => {
-                    const $join = (typia.validateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Object.keys(input).every((key) => {
                             const value = input[key];

--- a/test/generated/output/validateStringify/test_validateStringify_TagArray.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagArray.ts
@@ -11,7 +11,6 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                 input: any,
             ): typia.IValidation<Array<TagArray.Type>> => {
                 const __is = (input: any): input is Array<TagArray.Type> => {
-                    const $is_uuid = (typia.validateStringify as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         3 === input.items.length &&

--- a/test/generated/output/validateStringify/test_validateStringify_TagCustom.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagCustom.ts
@@ -9,9 +9,6 @@ export const test_validateStringify_TagCustom = _test_validateStringify(
         ((input: TagCustom): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<TagCustom> => {
                 const __is = (input: any): input is TagCustom => {
-                    const $is_uuid = (typia.validateStringify as any).is_uuid;
-                    const $is_custom = (typia.validateStringify as any)
-                        .is_custom;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.id &&
                         $is_uuid(input.id) &&

--- a/test/generated/output/validateStringify/test_validateStringify_TagFormat.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagFormat.ts
@@ -9,14 +9,6 @@ export const test_validateStringify_TagFormat = _test_validateStringify(
         ((input: TagFormat): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<TagFormat> => {
                 const __is = (input: any): input is TagFormat => {
-                    const $is_uuid = (typia.validateStringify as any).is_uuid;
-                    const $is_email = (typia.validateStringify as any).is_email;
-                    const $is_url = (typia.validateStringify as any).is_url;
-                    const $is_ipv4 = (typia.validateStringify as any).is_ipv4;
-                    const $is_ipv6 = (typia.validateStringify as any).is_ipv6;
-                    const $is_date = (typia.validateStringify as any).is_date;
-                    const $is_datetime = (typia.validateStringify as any)
-                        .is_datetime;
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.uuid &&
                         $is_uuid(input.uuid) &&

--- a/test/generated/output/validateStringify/test_validateStringify_TagMatrix.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagMatrix.ts
@@ -9,7 +9,6 @@ export const test_validateStringify_TagMatrix = _test_validateStringify(
         ((input: TagMatrix): typia.IValidation<string> => {
             const validate = (input: any): typia.IValidation<TagMatrix> => {
                 const __is = (input: any): input is TagMatrix => {
-                    const $is_uuid = (typia.validateStringify as any).is_uuid;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.matrix) &&
                         3 === input.matrix.length &&

--- a/test/generated/output/validateStringify/test_validateStringify_UltimateUnion.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_UltimateUnion.ts
@@ -13,7 +13,6 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                 const __is = (
                     input: any,
                 ): input is Array<typia.IJsonApplication> => {
-                    const $join = (typia.validateStringify as any).join;
                     const $io0 = (input: any): boolean =>
                         Array.isArray(input.schemas) &&
                         input.schemas.every(

--- a/test/issues/invalid-type-tags.ts
+++ b/test/issues/invalid-type-tags.ts
@@ -1,0 +1,40 @@
+import typia from "typia";
+
+/**
+ * There are some fucking documentation libraries enforcing user to write invalid
+ * `@type` tagged comments like below, even in TypeScript.
+ *
+ * In such reason, `typia` needs to stop throwing compilation error when invalid
+ * `@type` tag being used
+ *
+ * @type {number}
+ * @type {string}
+ */
+interface IInvalidTag {
+    /**
+     * @type {string}
+     */
+    string: string;
+
+    /**
+     * @type {number}
+     */
+    number: number;
+
+    /**
+     * @type {int}
+     */
+    int: number;
+
+    /**
+     * @type uint
+     */
+    valid: number;
+
+    /**
+     * @type int
+     */
+    invalid: string;
+}
+
+console.log(typia.createIs<IInvalidTag>().toString());

--- a/test/schemas/json/ajv/ArrayAny.json
+++ b/test/schemas/json/ajv/ArrayAny.json
@@ -13,90 +13,108 @@
           "anys": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "undefindable1": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "undefindable2": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "nullables1": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullables2": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "both1": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "both2": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "both3": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "union": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ArrayHierarchical.json
+++ b/test/schemas/json/ajv/ArrayHierarchical.json
@@ -17,23 +17,27 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "serial": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "established_at": {
             "$ref": "components#/schemas/ArrayHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -41,10 +45,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ArrayHierarchical.IDepartment",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -66,12 +72,14 @@
           "time": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "zone": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -90,23 +98,27 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sales": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "components#/schemas/ArrayHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -114,10 +126,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ArrayHierarchical.IEmployee",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -139,29 +153,34 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "age": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "grade": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "employeed_at": {
             "$ref": "components#/schemas/ArrayHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ArrayRecursive.json
+++ b/test/schemas/json/ajv/ArrayRecursive.json
@@ -15,33 +15,39 @@
             "type": "array",
             "items": {
               "$recursiveRef": "components#/schemas/ArrayRecursive.ICategory",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "components#/schemas/ArrayRecursive.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -63,12 +69,14 @@
           "time": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "zone": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ArrayRecursiveUnionExplicit.json
+++ b/test/schemas/json/ajv/ArrayRecursiveUnionExplicit.json
@@ -34,18 +34,21 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -55,34 +58,41 @@
               "oneOf": [
                 {
                   "$recursiveRef": "components#/schemas/ArrayRecursiveUnionExplicit.IDirectory",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.IImageFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.ITextFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.IZipFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/ArrayRecursiveUnionExplicit.IShortcut",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -92,6 +102,7 @@
               "directory"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -113,42 +124,49 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "height": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "url": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -158,6 +176,7 @@
               "file"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -167,6 +186,7 @@
               "jpg"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -192,30 +212,35 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "content": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -225,6 +250,7 @@
               "file"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -234,6 +260,7 @@
               "txt"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -257,30 +284,35 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "count": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -290,6 +322,7 @@
               "file"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -299,6 +332,7 @@
               "zip"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -323,18 +357,21 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -342,30 +379,36 @@
             "oneOf": [
               {
                 "$recursiveRef": "components#/schemas/ArrayRecursiveUnionExplicit.IDirectory",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.IImageFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.ITextFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.IZipFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$recursiveRef": "components#/schemas/ArrayRecursiveUnionExplicit.IShortcut",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -375,6 +418,7 @@
               "file"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -384,6 +428,7 @@
               "lnk"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ArrayRecursiveUnionImplicit.json
+++ b/test/schemas/json/ajv/ArrayRecursiveUnionImplicit.json
@@ -37,18 +37,21 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -58,39 +61,47 @@
               "oneOf": [
                 {
                   "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IDirectory",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IImageFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.ITextFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IZipFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IShortcut",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -116,24 +127,28 @@
               "write"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -143,39 +158,47 @@
               "oneOf": [
                 {
                   "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IDirectory",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IImageFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.ITextFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IZipFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IShortcut",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -197,42 +220,49 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "height": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "url": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -256,30 +286,35 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "content": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -301,30 +336,35 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "count": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -347,18 +387,21 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -366,35 +409,42 @@
             "oneOf": [
               {
                 "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IDirectory",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IImageFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.ITextFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IZipFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IShortcut",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ArraySimple.json
+++ b/test/schemas/json/ajv/ArraySimple.json
@@ -17,12 +17,14 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -30,10 +32,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ArraySimple.IHobby",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -53,18 +57,21 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "body": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "rank": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ClassGetter.json
+++ b/test/schemas/json/ajv/ClassGetter.json
@@ -13,18 +13,21 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "dead": {
             "type": "boolean",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ClassMethod.json
+++ b/test/schemas/json/ajv/ClassMethod.json
@@ -13,12 +13,14 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "age": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ClassPropertyAssignment.json
+++ b/test/schemas/json/ajv/ClassPropertyAssignment.json
@@ -13,12 +13,14 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -28,6 +30,7 @@
               "assignment"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -37,12 +40,14 @@
               false
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "incremental": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ConstantAtomicUnion.json
+++ b/test/schemas/json/ajv/ConstantAtomicUnion.json
@@ -47,6 +47,7 @@
               "key"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ConstantAtomicWrapper.json
+++ b/test/schemas/json/ajv/ConstantAtomicWrapper.json
@@ -32,6 +32,7 @@
           "value": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -49,6 +50,7 @@
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -66,6 +68,7 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/DynamicArray.json
+++ b/test/schemas/json/ajv/DynamicArray.json
@@ -17,10 +17,12 @@
           "items": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": false,
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }

--- a/test/schemas/json/ajv/DynamicComposite.json
+++ b/test/schemas/json/ajv/DynamicComposite.json
@@ -13,12 +13,14 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -33,18 +35,21 @@
           "^-?\\d+\\.?\\d*$": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(prefix_(.*))": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "((.*)_postfix)$": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -53,28 +58,33 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/DynamicConstant.json
+++ b/test/schemas/json/ajv/DynamicConstant.json
@@ -13,24 +13,28 @@
           "a": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "b": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "c": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "d": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/DynamicEnumeration.json
+++ b/test/schemas/json/ajv/DynamicEnumeration.json
@@ -13,60 +13,70 @@
           "ar": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "zh-Hans": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "zh-Hant": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "en": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "fr": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "de": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "ja": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "ko": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "pt": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "ru": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/DynamicSimple.json
+++ b/test/schemas/json/ajv/DynamicSimple.json
@@ -15,6 +15,7 @@
         "additionalProperties": {
           "type": "number",
           "nullable": false,
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }

--- a/test/schemas/json/ajv/DynamicTemplate.json
+++ b/test/schemas/json/ajv/DynamicTemplate.json
@@ -16,24 +16,28 @@
           "^(prefix_(.*))": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "((.*)_postfix)$": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(value_-?\\d+\\.?\\d*)$": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/DynamicTree.json
+++ b/test/schemas/json/ajv/DynamicTree.json
@@ -13,17 +13,20 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "children": {
             "$ref": "components#/schemas/Record_lt_string_comma__space_DynamicTree_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -44,6 +47,7 @@
         "x-typia-jsDocTags": [],
         "additionalProperties": {
           "$ref": "components#/schemas/DynamicTree",
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }

--- a/test/schemas/json/ajv/DynamicUnion.json
+++ b/test/schemas/json/ajv/DynamicUnion.json
@@ -16,24 +16,28 @@
           "^-?\\d+\\.?\\d*$": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(prefix_(.*))": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "((.*)_postfix)$": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(value_between_-?\\d+\\.?\\d*_and_-?\\d+\\.?\\d*)$": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/MapAlias.json
+++ b/test/schemas/json/ajv/MapAlias.json
@@ -12,26 +12,31 @@
         "properties": {
           "boolean": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "number": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "strings": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrays": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "objects": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/MapSimple.json
+++ b/test/schemas/json/ajv/MapSimple.json
@@ -12,26 +12,31 @@
         "properties": {
           "boolean": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "number": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "strings": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrays": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "objects": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/NativeAlias.json
+++ b/test/schemas/json/ajv/NativeAlias.json
@@ -13,91 +13,109 @@
           "date": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint8Array": {
             "$ref": "#/components/schemas/Uint8Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint8ClampedArray": {
             "$ref": "#/components/schemas/Uint8ClampedArray",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint16Array": {
             "$ref": "#/components/schemas/Uint16Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint32Array": {
             "$ref": "#/components/schemas/Uint32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "bigUint64Array": {
             "$ref": "#/components/schemas/BigUint64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int8Array": {
             "$ref": "#/components/schemas/Int8Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int16Array": {
             "$ref": "#/components/schemas/Int16Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int32Array": {
             "$ref": "#/components/schemas/Int32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "bigInt64Array": {
             "$ref": "#/components/schemas/BigInt64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "float32Array": {
             "$ref": "#/components/schemas/Float32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "float64Array": {
             "$ref": "#/components/schemas/Float64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "buffer": {
             "$ref": "components#/schemas/__type",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrayBuffer": {
             "$ref": "#/components/schemas/ArrayBuffer",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sharedArrayBuffer": {
             "$ref": "#/components/schemas/SharedArrayBuffer",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "dataView": {
             "$ref": "#/components/schemas/DataView",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "weakSet": {
             "$ref": "#/components/schemas/WeakSet",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "weakMap": {
             "$ref": "#/components/schemas/WeakMap",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -201,6 +219,7 @@
               "Buffer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -209,10 +228,12 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/NativeSimple.json
+++ b/test/schemas/json/ajv/NativeSimple.json
@@ -13,91 +13,109 @@
           "date": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint8Array": {
             "$ref": "#/components/schemas/Uint8Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint8ClampedArray": {
             "$ref": "#/components/schemas/Uint8ClampedArray",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint16Array": {
             "$ref": "#/components/schemas/Uint16Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint32Array": {
             "$ref": "#/components/schemas/Uint32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "bigUint64Array": {
             "$ref": "#/components/schemas/BigUint64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int8Array": {
             "$ref": "#/components/schemas/Int8Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int16Array": {
             "$ref": "#/components/schemas/Int16Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int32Array": {
             "$ref": "#/components/schemas/Int32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "bigInt64Array": {
             "$ref": "#/components/schemas/BigInt64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "float32Array": {
             "$ref": "#/components/schemas/Float32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "float64Array": {
             "$ref": "#/components/schemas/Float64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "buffer": {
             "$ref": "components#/schemas/__type",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrayBuffer": {
             "$ref": "#/components/schemas/ArrayBuffer",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sharedArrayBuffer": {
             "$ref": "#/components/schemas/SharedArrayBuffer",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "dataView": {
             "$ref": "#/components/schemas/DataView",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "weakSet": {
             "$ref": "#/components/schemas/WeakSet",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "weakMap": {
             "$ref": "#/components/schemas/WeakMap",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -201,6 +219,7 @@
               "Buffer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -209,10 +228,12 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/NativeUnion.json
+++ b/test/schemas/json/ajv/NativeUnion.json
@@ -17,6 +17,7 @@
           "date": {
             "type": "string",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -24,30 +25,36 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/Uint8Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Uint8ClampedArray",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Uint16Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Uint32Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/BigUint64Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -55,25 +62,30 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/Int8Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Int16Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Int32Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/BigInt64Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -81,15 +93,18 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/Float32Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Float64Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -97,25 +112,30 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ArrayBuffer",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/SharedArrayBuffer",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/DataView",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/__type",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -123,15 +143,18 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/WeakSet",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/WeakMap",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -241,6 +264,7 @@
               "Buffer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -249,10 +273,12 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectAlias.json
+++ b/test/schemas/json/ajv/ObjectAlias.json
@@ -17,18 +17,21 @@
           "id": {
             "type": "string",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -41,6 +44,7 @@
                   1
                 ],
                 "nullable": true,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
@@ -51,22 +55,26 @@
                   "female"
                 ],
                 "nullable": true,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "age": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "dead": {
             "type": "boolean",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectDynamic.json
+++ b/test/schemas/json/ajv/ObjectDynamic.json
@@ -17,22 +17,26 @@
             {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "type": "boolean",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             }
           ],
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }

--- a/test/schemas/json/ajv/ObjectGeneric.json
+++ b/test/schemas/json/ajv/ObjectGeneric.json
@@ -32,11 +32,13 @@
           "value": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child": {
             "$ref": "components#/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -44,10 +46,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -67,12 +71,14 @@
           "child_value": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child_next": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -91,11 +97,13 @@
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child": {
             "$ref": "components#/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -103,10 +111,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -126,12 +136,14 @@
           "child_value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child_next": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -150,11 +162,13 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child": {
             "$ref": "components#/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -162,10 +176,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -185,12 +201,14 @@
           "child_value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child_next": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectGenericAlias.json
+++ b/test/schemas/json/ajv/ObjectGenericAlias.json
@@ -13,6 +13,7 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectGenericArray.json
+++ b/test/schemas/json/ajv/ObjectGenericArray.json
@@ -12,6 +12,7 @@
         "properties": {
           "pagination": {
             "$ref": "components#/schemas/ObjectGenericArray.IPagination",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -19,10 +20,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectGenericArray.IPerson",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -41,24 +44,28 @@
           "page": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "limit": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "total_count": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "total_pages": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -79,12 +86,14 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "age": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectGenericUnion.json
+++ b/test/schemas/json/ajv/ObjectGenericUnion.json
@@ -20,23 +20,27 @@
           "writer": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "answer": {
             "$ref": "components#/schemas/ObjectGenericUnion.ISaleAnswer.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "hit": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -44,16 +48,19 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectGenericUnion.ISaleArticle.IContent",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -76,12 +83,14 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "hit": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -89,16 +98,19 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectGenericUnion.ISaleArticle.IContent",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -119,24 +131,28 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "body": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -144,10 +160,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -169,18 +187,21 @@
           "url": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "extension": {
             "type": "string",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -200,23 +221,27 @@
           "writer": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "answer": {
             "$ref": "components#/schemas/ObjectGenericUnion.ISaleAnswer.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "hit": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -224,16 +249,19 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectGenericUnion.ISaleReview.IContent",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -256,30 +284,35 @@
           "score": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "body": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -287,10 +320,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectHierarchical.json
+++ b/test/schemas/json/ajv/ObjectHierarchical.json
@@ -13,33 +13,39 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "channel": {
             "$ref": "components#/schemas/ObjectHierarchical.IChannel",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "member": {
             "$ref": "components#/schemas/ObjectHierarchical.IMember.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "account": {
             "$ref": "components#/schemas/ObjectHierarchical.IAccount.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "href": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "referrer": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -49,35 +55,41 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false,
                 "x-typia-rest": false
               }
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -102,41 +114,48 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "exclusive": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "priority": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -160,12 +179,14 @@
           "time": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "zone": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -184,16 +205,19 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "account": {
             "$ref": "components#/schemas/ObjectHierarchical.IAccount",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "enterprise": {
             "$ref": "components#/schemas/ObjectHierarchical.IEnterprise.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -202,21 +226,25 @@
             "items": {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "authorized": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -239,17 +267,20 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -269,28 +300,33 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "account": {
             "$ref": "components#/schemas/ObjectHierarchical.IAccount",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "grade": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -312,17 +348,20 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectInternal.json
+++ b/test/schemas/json/ajv/ObjectInternal.json
@@ -13,12 +13,14 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectIntersection.json
+++ b/test/schemas/json/ajv/ObjectIntersection.json
@@ -13,18 +13,21 @@
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "vulnerable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectJsonTag.json
+++ b/test/schemas/json/ajv/ObjectJsonTag.json
@@ -14,6 +14,7 @@
             "type": "string",
             "nullable": false,
             "deprecated": true,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "deprecated"

--- a/test/schemas/json/ajv/ObjectLiteralProperty.json
+++ b/test/schemas/json/ajv/ObjectLiteralProperty.json
@@ -13,12 +13,14 @@
           "something-interesting-do-you-want?": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "or-something-crazy-do-you-want?": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectLiteralType.json
+++ b/test/schemas/json/ajv/ObjectLiteralType.json
@@ -13,18 +13,21 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "age": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectNullable.json
+++ b/test/schemas/json/ajv/ObjectNullable.json
@@ -32,16 +32,19 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "manufacturer": {
             "$ref": "components#/schemas/ObjectNullable.IManufacturer",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "brand": {
             "$ref": "components#/schemas/ObjectNullable.IBrand.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -49,15 +52,18 @@
             "oneOf": [
               {
                 "$ref": "components#/schemas/ObjectNullable.IManufacturer.Nullable",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ObjectNullable.IBrand.Nullable",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -81,12 +87,14 @@
               "manufacturer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -108,12 +116,14 @@
               "brand"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -135,12 +145,14 @@
               "manufacturer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectOptional.json
+++ b/test/schemas/json/ajv/ObjectOptional.json
@@ -13,24 +13,28 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }

--- a/test/schemas/json/ajv/ObjectPrimitive.json
+++ b/test/schemas/json/ajv/ObjectPrimitive.json
@@ -13,6 +13,7 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -24,18 +25,21 @@
               "html"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "body": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -43,22 +47,26 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectPrimitive.IFile",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "secret": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -82,30 +90,35 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "extension": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "url": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectPropertyNullable.json
+++ b/test/schemas/json/ajv/ObjectPropertyNullable.json
@@ -62,6 +62,7 @@
           "value": {
             "type": "boolean",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -79,6 +80,7 @@
           "value": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -96,6 +98,7 @@
           "value": {
             "type": "string",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -112,6 +115,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/ObjectPropertyNullable.IMember.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -129,30 +133,35 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "grade": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "serial": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "activated": {
             "type": "boolean",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectRecursive.json
+++ b/test/schemas/json/ajv/ObjectRecursive.json
@@ -13,35 +13,41 @@
         "properties": {
           "parent": {
             "$recursiveRef": "components#/schemas/ObjectRecursive.IDepartment.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "components#/schemas/ObjectRecursive.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -64,35 +70,41 @@
         "properties": {
           "parent": {
             "$recursiveRef": "components#/schemas/ObjectRecursive.IDepartment.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "components#/schemas/ObjectRecursive.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -115,12 +127,14 @@
           "time": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "zone": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectSimple.json
+++ b/test/schemas/json/ajv/ObjectSimple.json
@@ -12,21 +12,25 @@
         "properties": {
           "scale": {
             "$ref": "components#/schemas/ObjectSimple.IPoint3D",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "position": {
             "$ref": "components#/schemas/ObjectSimple.IPoint3D",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "rotate": {
             "$ref": "components#/schemas/ObjectSimple.IPoint3D",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "pivot": {
             "$ref": "components#/schemas/ObjectSimple.IPoint3D",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -47,18 +51,21 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "z": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectTuple.json
+++ b/test/schemas/json/ajv/ObjectTuple.json
@@ -27,18 +27,21 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -58,18 +61,21 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "mobile": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectUndefined.json
+++ b/test/schemas/json/ajv/ObjectUndefined.json
@@ -17,6 +17,7 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -25,31 +26,37 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               }
             ],
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "classroom": {
             "$ref": "components#/schemas/ObjectUndefined.IClassroom",
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "grade": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "unknown": {
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -68,12 +75,14 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectUnionComposite.json
+++ b/test/schemas/json/ajv/ObjectUnionComposite.json
@@ -42,12 +42,14 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -65,11 +67,13 @@
         "properties": {
           "p1": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -87,16 +91,19 @@
         "properties": {
           "p1": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -115,21 +122,25 @@
         "properties": {
           "p1": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p4": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -151,10 +162,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -171,6 +184,7 @@
         "properties": {
           "outer": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPolyline",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -178,10 +192,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectUnionComposite.IPolyline",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -201,15 +217,18 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "inner": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -227,12 +246,14 @@
         "properties": {
           "centroid": {
             "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "radius": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectUnionDouble.json
+++ b/test/schemas/json/ajv/ObjectUnionDouble.json
@@ -23,6 +23,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/__type",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -30,15 +31,18 @@
             "oneOf": [
               {
                 "$ref": "components#/schemas/ObjectUnionDouble.IAA",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ObjectUnionDouble.IAB",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -57,6 +61,7 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -73,6 +78,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/__type.o1",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -90,6 +96,7 @@
           "y": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -106,6 +113,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/__type.o2",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -123,6 +131,7 @@
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -139,6 +148,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/__type.o3",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -146,15 +156,18 @@
             "oneOf": [
               {
                 "$ref": "components#/schemas/ObjectUnionDouble.IBA",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ObjectUnionDouble.IBB",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -173,6 +186,7 @@
           "x": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -189,6 +203,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/__type.o4",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -206,6 +221,7 @@
           "y": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -222,6 +238,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/__type.o5",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -241,10 +258,12 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectUnionExplicit.json
+++ b/test/schemas/json/ajv/ObjectUnionExplicit.json
@@ -39,12 +39,14 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -54,6 +56,7 @@
               "point"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -72,11 +75,13 @@
         "properties": {
           "p1": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -86,6 +91,7 @@
               "line"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -105,12 +111,14 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -128,16 +136,19 @@
         "properties": {
           "p1": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -147,6 +158,7 @@
               "triangle"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -166,21 +178,25 @@
         "properties": {
           "p1": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p4": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -190,6 +206,7 @@
               "rectangle"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -212,10 +229,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -225,6 +244,7 @@
               "polyline"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -242,6 +262,7 @@
         "properties": {
           "outer": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPolyline",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -249,10 +270,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectUnionExplicit.IPolyline",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -262,6 +285,7 @@
               "polygon"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -282,10 +306,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -302,12 +328,14 @@
         "properties": {
           "centroid": {
             "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "radius": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -317,6 +345,7 @@
               "circle"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ObjectUnionImplicit.json
+++ b/test/schemas/json/ajv/ObjectUnionImplicit.json
@@ -39,18 +39,21 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "slope": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -68,23 +71,27 @@
         "properties": {
           "p1": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "distance": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -102,34 +109,40 @@
         "properties": {
           "p1": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "height": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "area": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -148,39 +161,46 @@
         "properties": {
           "p1": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p4": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "height": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "area": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -202,16 +222,19 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "length": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -228,6 +251,7 @@
         "properties": {
           "outer": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPolyline",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -235,16 +259,19 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/ObjectUnionImplicit.IPolyline",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "area": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -261,18 +288,21 @@
         "properties": {
           "centroid": {
             "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "radius": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "area": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }

--- a/test/schemas/json/ajv/ObjectUnionNonPredictable.json
+++ b/test/schemas/json/ajv/ObjectUnionNonPredictable.json
@@ -16,6 +16,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -34,20 +35,24 @@
             "oneOf": [
               {
                 "$ref": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_number_gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_string_gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -64,6 +69,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_boolean_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -81,6 +87,7 @@
           "value": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -97,6 +104,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_number_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -114,6 +122,7 @@
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -130,6 +139,7 @@
         "properties": {
           "value": {
             "$ref": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_string_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -147,6 +157,7 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/SetAlias.json
+++ b/test/schemas/json/ajv/SetAlias.json
@@ -12,26 +12,31 @@
         "properties": {
           "booleans": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "numbers": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "strings": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrays": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "objects": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/SetSimple.json
+++ b/test/schemas/json/ajv/SetSimple.json
@@ -12,26 +12,31 @@
         "properties": {
           "booleans": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "numbers": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "strings": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrays": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "objects": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/TagArray.json
+++ b/test/schemas/json/ajv/TagArray.json
@@ -19,6 +19,7 @@
             "items": {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-metaTags": [
                 {
                   "kind": "items",
@@ -54,6 +55,7 @@
               "format": "uuid"
             },
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "items",
@@ -92,6 +94,7 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-metaTags": [
                 {
                   "kind": "minItems",
@@ -127,6 +130,7 @@
               "minimum": 3
             },
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minItems",
@@ -168,6 +172,7 @@
                 {
                   "type": "string",
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "maxItems",
@@ -218,6 +223,7 @@
                 {
                   "type": "number",
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "maxItems",
@@ -266,6 +272,7 @@
                   "maximum": 7
                 }
               ],
+              "description": "",
               "x-typia-metaTags": [
                 {
                   "kind": "maxItems",
@@ -313,6 +320,7 @@
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "maxItems",
@@ -365,6 +373,7 @@
             "items": {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-metaTags": [
                 {
                   "kind": "minItems",
@@ -413,6 +422,7 @@
               "format": "uuid"
             },
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minItems",

--- a/test/schemas/json/ajv/TagAtomicUnion.json
+++ b/test/schemas/json/ajv/TagAtomicUnion.json
@@ -19,6 +19,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-metaTags": [
                   {
                     "kind": "minimum",
@@ -70,6 +71,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-metaTags": [
                   {
                     "kind": "minimum",
@@ -118,6 +120,7 @@
                 "minimum": 3
               }
             ],
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",

--- a/test/schemas/json/ajv/TagDefault.json
+++ b/test/schemas/json/ajv/TagDefault.json
@@ -13,6 +13,7 @@
           "boolean": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -31,6 +32,7 @@
           "number": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -49,6 +51,7 @@
           "string": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -67,6 +70,7 @@
           "text": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -85,6 +89,7 @@
           "template": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -106,6 +111,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -142,6 +148,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -178,6 +185,7 @@
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -212,6 +220,7 @@
                 "default": true
               }
             ],
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -249,6 +258,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -266,6 +276,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -283,6 +294,7 @@
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -299,6 +311,7 @@
                 "default": true
               }
             ],
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -318,6 +331,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -335,6 +349,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -353,6 +368,7 @@
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -368,6 +384,7 @@
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -387,6 +404,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -405,6 +423,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -422,6 +441,7 @@
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -437,6 +457,7 @@
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -454,6 +475,7 @@
           "vulnerable_range": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",
@@ -501,6 +523,7 @@
           "vulnerable_template": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -521,6 +544,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -558,6 +582,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -594,6 +619,7 @@
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -628,6 +654,7 @@
                 "default": true
               }
             ],
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",

--- a/test/schemas/json/ajv/TagLength.json
+++ b/test/schemas/json/ajv/TagLength.json
@@ -17,6 +17,7 @@
           "fixed": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "length",
@@ -40,6 +41,7 @@
           "minimum": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minLength",
@@ -64,6 +66,7 @@
           "maximum": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "maxLength",
@@ -88,6 +91,7 @@
           "minimum_and_maximum": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minLength",

--- a/test/schemas/json/ajv/TagObjectUnion.json
+++ b/test/schemas/json/ajv/TagObjectUnion.json
@@ -24,6 +24,7 @@
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",
@@ -59,6 +60,7 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minLength",

--- a/test/schemas/json/ajv/TagPattern.json
+++ b/test/schemas/json/ajv/TagPattern.json
@@ -13,6 +13,7 @@
           "uuid": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "pattern",
@@ -37,6 +38,7 @@
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "pattern",
@@ -61,6 +63,7 @@
           "ipv4": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "pattern",
@@ -85,6 +88,7 @@
           "ipv6": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "pattern",

--- a/test/schemas/json/ajv/TagRange.json
+++ b/test/schemas/json/ajv/TagRange.json
@@ -17,6 +17,7 @@
           "greater": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "exclusiveMinimum",
@@ -42,6 +43,7 @@
           "greater_equal": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",
@@ -66,6 +68,7 @@
           "less": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "exclusiveMaximum",
@@ -91,6 +94,7 @@
           "less_equal": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "maximum",
@@ -115,6 +119,7 @@
           "greater_less": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "exclusiveMinimum",
@@ -155,6 +160,7 @@
           "greater_equal_less": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",
@@ -194,6 +200,7 @@
           "greater_less_equal": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "exclusiveMinimum",
@@ -233,6 +240,7 @@
           "greater_equal_less_equal": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",

--- a/test/schemas/json/ajv/TagStep.json
+++ b/test/schemas/json/ajv/TagStep.json
@@ -17,6 +17,7 @@
           "exclusiveMinimum": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "step",
@@ -55,6 +56,7 @@
           "minimum": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "step",
@@ -92,6 +94,7 @@
           "range": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "step",
@@ -145,6 +148,7 @@
           "multipleOf": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "multipleOf",

--- a/test/schemas/json/ajv/TagTuple.json
+++ b/test/schemas/json/ajv/TagTuple.json
@@ -16,6 +16,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-metaTags": [
                   {
                     "kind": "minItems",
@@ -106,6 +107,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-metaTags": [
                   {
                     "kind": "minItems",
@@ -198,6 +200,7 @@
                 "items": {
                   "type": "string",
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "minItems",
@@ -286,6 +289,7 @@
                   "maxLength": 7
                 },
                 "nullable": false,
+                "description": "",
                 "x-typia-metaTags": [
                   {
                     "kind": "minItems",
@@ -378,6 +382,7 @@
                 "items": {
                   "type": "number",
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "minItems",
@@ -467,6 +472,7 @@
                   "maximum": 7
                 },
                 "nullable": false,
+                "description": "",
                 "x-typia-metaTags": [
                   {
                     "kind": "minItems",
@@ -557,6 +563,7 @@
               }
             ],
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minItems",

--- a/test/schemas/json/ajv/TemplateAtomic.json
+++ b/test/schemas/json/ajv/TemplateAtomic.json
@@ -13,6 +13,7 @@
           "prefix": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(prefix_(.*))"
@@ -20,6 +21,7 @@
           "postfix": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "((.*)_postfix)$"
@@ -27,6 +29,7 @@
           "middle_string": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(the_(.*)_value)$"
@@ -34,6 +37,7 @@
           "middle_string_empty": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(the_(.*)_value)$"
@@ -41,6 +45,7 @@
           "middle_numeric": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(the_-?\\d+\\.?\\d*_value)$"
@@ -52,12 +57,14 @@
               "the_true_value"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "ipv4": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*)$"
@@ -65,6 +72,7 @@
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "((.*)@(.*)\\.(.*))"

--- a/test/schemas/json/ajv/TemplateConstant.json
+++ b/test/schemas/json/ajv/TemplateConstant.json
@@ -22,6 +22,7 @@
               "prefix_C"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -33,6 +34,7 @@
               "1_postfix"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -50,6 +52,7 @@
               "the_1_value_with_label_C"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/TemplateUnion.json
+++ b/test/schemas/json/ajv/TemplateUnion.json
@@ -17,6 +17,7 @@
           "prefix": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^((prefix_(.*))|(prefix_-?\\d+\\.?\\d*))$"
@@ -24,6 +25,7 @@
           "postfix": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "(((.*)_postfix)|(-?\\d+\\.?\\d*_postfix))$"
@@ -31,6 +33,7 @@
           "middle": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(the_false_value|the_true_value|(the_-?\\d+\\.?\\d*_value))$"
@@ -40,6 +43,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false,
                 "pattern": "^(the_A_value|the_B_value|-?\\d+\\.?\\d*|true|false|(the_-?\\d+\\.?\\d*_value))$"
@@ -47,21 +51,25 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/__type",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -82,6 +90,7 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ToJsonArray.json
+++ b/test/schemas/json/ajv/ToJsonArray.json
@@ -65,6 +65,7 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ToJsonDouble.json
+++ b/test/schemas/json/ajv/ToJsonDouble.json
@@ -13,12 +13,14 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "flag": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ToJsonTuple.json
+++ b/test/schemas/json/ajv/ToJsonTuple.json
@@ -40,12 +40,14 @@
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/ToJsonUnion.json
+++ b/test/schemas/json/ajv/ToJsonUnion.json
@@ -37,18 +37,21 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "mobile": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -68,18 +71,21 @@
           "manufacturer": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "brand": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/TupleRestObject.json
+++ b/test/schemas/json/ajv/TupleRestObject.json
@@ -57,6 +57,7 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/ajv/UltimateUnion.json
+++ b/test/schemas/json/ajv/UltimateUnion.json
@@ -20,84 +20,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IInteger",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.INumber",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IString",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "components": {
             "$ref": "components#/schemas/IJsonComponents",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -108,12 +125,14 @@
               "ajv"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "prefix": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -136,16 +155,19 @@
             "items": {
               "type": "boolean",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "default": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -155,30 +177,35 @@
               "boolean"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -188,84 +215,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -273,28 +317,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -317,6 +366,7 @@
               "type"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -327,6 +377,7 @@
               "uint"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -348,12 +399,14 @@
               "minimum"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -375,12 +428,14 @@
               "maximum"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -402,12 +457,14 @@
               "exclusiveMinimum"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -429,12 +486,14 @@
               "exclusiveMaximum"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -456,12 +515,14 @@
               "multipleOf"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -483,12 +544,14 @@
               "step"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -510,6 +573,7 @@
               "format"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -525,6 +589,7 @@
               "datetime"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -546,12 +611,14 @@
               "pattern"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -573,12 +640,14 @@
               "length"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -600,12 +669,14 @@
               "minLength"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -627,12 +698,14 @@
               "maxLength"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -654,12 +727,14 @@
               "items"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -681,12 +756,14 @@
               "minItems"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -708,12 +785,14 @@
               "maxItems"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -732,6 +811,7 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -739,10 +819,12 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo.IText",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -760,12 +842,14 @@
           "text": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "kind": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -786,16 +870,19 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "default": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -805,30 +892,35 @@
               "number"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -838,84 +930,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -923,28 +1032,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -966,16 +1080,19 @@
             "items": {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "default": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -985,30 +1102,35 @@
               "string"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1018,84 +1140,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1103,28 +1242,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -1144,6 +1288,7 @@
           "default": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1153,30 +1298,35 @@
               "boolean"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1186,84 +1336,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1271,28 +1438,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -1311,6 +1483,7 @@
           "minimum": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -1334,6 +1507,7 @@
           "maximum": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -1357,18 +1531,21 @@
           "exclusiveMinimum": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "exclusiveMaximum": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "multipleOf": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -1392,6 +1569,7 @@
           "default": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1401,30 +1579,35 @@
               "integer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1434,84 +1617,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1519,28 +1719,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -1559,36 +1764,42 @@
           "minimum": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "maximum": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "exclusiveMinimum": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "exclusiveMaximum": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "multipleOf": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "default": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1598,30 +1809,35 @@
               "number"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1631,84 +1847,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1716,28 +1949,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -1756,6 +1994,7 @@
           "minLength": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -1780,6 +2019,7 @@
           "maxLength": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -1804,18 +2044,21 @@
           "pattern": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "format": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "default": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1825,30 +2068,35 @@
               "string"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1858,84 +2106,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1943,28 +2208,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -1985,81 +2255,97 @@
             "oneOf": [
               {
                 "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IInteger",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.INumber",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IString",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IReference",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "minItems": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -2084,6 +2370,7 @@
           "maxItems": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -2107,6 +2394,7 @@
           },
           "x-typia-tuple": {
             "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2116,30 +2404,35 @@
               "array"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2149,84 +2442,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2234,28 +2544,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -2279,79 +2594,95 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IInteger",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.INumber",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IString",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -2361,30 +2692,35 @@
               "array"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2394,84 +2730,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2479,28 +2832,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -2524,97 +2882,116 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IInteger",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.INumber",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IString",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2624,84 +3001,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2709,28 +3103,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -2748,24 +3147,28 @@
           "$ref": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2775,84 +3178,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2860,28 +3280,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -2899,24 +3324,28 @@
           "$recursiveRef": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2926,84 +3355,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3011,28 +3457,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -3053,24 +3504,28 @@
               "null"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3080,84 +3535,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3165,28 +3637,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -3204,18 +3681,21 @@
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3225,84 +3705,101 @@
               "oneOf": [
                 {
                   "$ref": "components#/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3310,28 +3807,33 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -3345,6 +3847,7 @@
         "properties": {
           "schemas": {
             "$ref": "components#/schemas/Record_lt_string_comma__space_IJsonComponents.IObject_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -3363,6 +3866,7 @@
         "x-typia-jsDocTags": [],
         "additionalProperties": {
           "$ref": "components#/schemas/IJsonComponents.IObject",
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }
@@ -3374,12 +3878,14 @@
           "$id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "$recursiveAnchor": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3389,22 +3895,26 @@
               "object"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "properties": {
             "$ref": "components#/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "patternProperties": {
             "$ref": "components#/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3412,75 +3922,90 @@
             "oneOf": [
               {
                 "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IInteger",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.INumber",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IString",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IReference",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               }
             ],
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3489,16 +4014,19 @@
             "items": {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3506,15 +4034,18 @@
             "type": "array",
             "items": {
               "$ref": "components#/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-patternProperties": {
             "$ref": "components#/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3522,75 +4053,90 @@
             "oneOf": [
               {
                 "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IInteger",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.INumber",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IString",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IReference",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               }
             ],
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -3613,75 +4159,90 @@
           "oneOf": [
             {
               "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "components#/schemas/IJsonSchema.IBoolean",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "components#/schemas/IJsonSchema.IInteger",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "components#/schemas/IJsonSchema.INumber",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "components#/schemas/IJsonSchema.IString",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "components#/schemas/IJsonSchema.IReference",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "components#/schemas/IJsonSchema.INullOnly",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "components#/schemas/IJsonSchema.IUnknown",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             }
           ],
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }

--- a/test/schemas/json/swagger/ArrayAny.json
+++ b/test/schemas/json/swagger/ArrayAny.json
@@ -12,90 +12,108 @@
           "anys": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "undefindable1": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "undefindable2": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "nullables1": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullables2": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "both1": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "both2": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "both3": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "union": {
             "type": "array",
             "items": {
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ArrayHierarchical.json
+++ b/test/schemas/json/swagger/ArrayHierarchical.json
@@ -16,23 +16,27 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "serial": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "established_at": {
             "$ref": "#/components/schemas/ArrayHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -40,10 +44,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ArrayHierarchical.IDepartment",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -64,12 +70,14 @@
           "time": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "zone": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -87,23 +95,27 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sales": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "#/components/schemas/ArrayHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -111,10 +123,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ArrayHierarchical.IEmployee",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -135,29 +149,34 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "age": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "grade": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "employeed_at": {
             "$ref": "#/components/schemas/ArrayHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ArrayRecursive.json
+++ b/test/schemas/json/swagger/ArrayRecursive.json
@@ -13,33 +13,39 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ArrayRecursive.ICategory",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "#/components/schemas/ArrayRecursive.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -60,12 +66,14 @@
           "time": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "zone": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ArrayRecursiveUnionExplicit.json
+++ b/test/schemas/json/swagger/ArrayRecursiveUnionExplicit.json
@@ -32,18 +32,21 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -53,34 +56,41 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IDirectory",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IImageFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.ITextFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IZipFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IShortcut",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -90,6 +100,7 @@
               "directory"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -110,42 +121,49 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "height": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "url": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -155,6 +173,7 @@
               "file"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -164,6 +183,7 @@
               "jpg"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -188,30 +208,35 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "content": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -221,6 +246,7 @@
               "file"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -230,6 +256,7 @@
               "txt"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -252,30 +279,35 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "count": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -285,6 +317,7 @@
               "file"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -294,6 +327,7 @@
               "zip"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -316,18 +350,21 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -335,30 +372,36 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IDirectory",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IImageFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.ITextFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IZipFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IShortcut",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -368,6 +411,7 @@
               "file"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -377,6 +421,7 @@
               "lnk"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ArrayRecursiveUnionImplicit.json
+++ b/test/schemas/json/swagger/ArrayRecursiveUnionImplicit.json
@@ -35,18 +35,21 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -56,39 +59,47 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IImageFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ITextFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IZipFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -112,24 +123,28 @@
               "write"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -139,39 +154,47 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IImageFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ITextFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IZipFile",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -192,42 +215,49 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "height": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "url": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -250,30 +280,35 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "content": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -294,30 +329,35 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "size": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "count": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -338,18 +378,21 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "path": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -357,35 +400,42 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IImageFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ITextFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IZipFile",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ArraySimple.json
+++ b/test/schemas/json/swagger/ArraySimple.json
@@ -16,12 +16,14 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -29,10 +31,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ArraySimple.IHobby",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -51,18 +55,21 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "body": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "rank": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ClassGetter.json
+++ b/test/schemas/json/swagger/ClassGetter.json
@@ -12,18 +12,21 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "dead": {
             "type": "boolean",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ClassMethod.json
+++ b/test/schemas/json/swagger/ClassMethod.json
@@ -12,12 +12,14 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "age": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ClassPropertyAssignment.json
+++ b/test/schemas/json/swagger/ClassPropertyAssignment.json
@@ -12,12 +12,14 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -27,6 +29,7 @@
               "assignment"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -36,12 +39,14 @@
               false
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "incremental": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ConstantAtomicUnion.json
+++ b/test/schemas/json/swagger/ConstantAtomicUnion.json
@@ -46,6 +46,7 @@
               "key"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ConstantAtomicWrapper.json
+++ b/test/schemas/json/swagger/ConstantAtomicWrapper.json
@@ -48,6 +48,7 @@
           "value": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -64,6 +65,7 @@
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -80,6 +82,7 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/DynamicArray.json
+++ b/test/schemas/json/swagger/DynamicArray.json
@@ -16,10 +16,12 @@
           "items": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": false,
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         },
@@ -28,10 +30,12 @@
           "items": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": false,
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }

--- a/test/schemas/json/swagger/DynamicComposite.json
+++ b/test/schemas/json/swagger/DynamicComposite.json
@@ -12,12 +12,14 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -32,18 +34,21 @@
           "^-?\\d+\\.?\\d*$": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(prefix_(.*))": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "((.*)_postfix)$": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -52,28 +57,33 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/DynamicConstant.json
+++ b/test/schemas/json/swagger/DynamicConstant.json
@@ -12,24 +12,28 @@
           "a": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "b": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "c": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "d": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/DynamicEnumeration.json
+++ b/test/schemas/json/swagger/DynamicEnumeration.json
@@ -12,60 +12,70 @@
           "ar": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "zh-Hans": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "zh-Hant": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "en": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "fr": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "de": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "ja": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "ko": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "pt": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "ru": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/DynamicSimple.json
+++ b/test/schemas/json/swagger/DynamicSimple.json
@@ -14,12 +14,14 @@
         "x-typia-additionalProperties": {
           "type": "number",
           "nullable": false,
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         },
         "additionalProperties": {
           "type": "number",
           "nullable": false,
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }

--- a/test/schemas/json/swagger/DynamicTemplate.json
+++ b/test/schemas/json/swagger/DynamicTemplate.json
@@ -15,24 +15,28 @@
           "^(prefix_(.*))": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "((.*)_postfix)$": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(value_-?\\d+\\.?\\d*)$": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/DynamicTree.json
+++ b/test/schemas/json/swagger/DynamicTree.json
@@ -12,17 +12,20 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "children": {
             "$ref": "#/components/schemas/Record_lt_string_comma__space_DynamicTree_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -42,11 +45,13 @@
         "x-typia-jsDocTags": [],
         "x-typia-additionalProperties": {
           "$ref": "#/components/schemas/DynamicTree",
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         },
         "additionalProperties": {
           "$ref": "#/components/schemas/DynamicTree",
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }

--- a/test/schemas/json/swagger/DynamicUnion.json
+++ b/test/schemas/json/swagger/DynamicUnion.json
@@ -15,24 +15,28 @@
           "^-?\\d+\\.?\\d*$": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(prefix_(.*))": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "((.*)_postfix)$": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "^(value_between_-?\\d+\\.?\\d*_and_-?\\d+\\.?\\d*)$": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/MapAlias.json
+++ b/test/schemas/json/swagger/MapAlias.json
@@ -11,26 +11,31 @@
         "properties": {
           "boolean": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "number": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "strings": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrays": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "objects": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/MapSimple.json
+++ b/test/schemas/json/swagger/MapSimple.json
@@ -11,26 +11,31 @@
         "properties": {
           "boolean": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "number": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "strings": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrays": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "objects": {
             "$ref": "#/components/schemas/Map",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/NativeAlias.json
+++ b/test/schemas/json/swagger/NativeAlias.json
@@ -12,91 +12,109 @@
           "date": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint8Array": {
             "$ref": "#/components/schemas/Uint8Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint8ClampedArray": {
             "$ref": "#/components/schemas/Uint8ClampedArray",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint16Array": {
             "$ref": "#/components/schemas/Uint16Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint32Array": {
             "$ref": "#/components/schemas/Uint32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "bigUint64Array": {
             "$ref": "#/components/schemas/BigUint64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int8Array": {
             "$ref": "#/components/schemas/Int8Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int16Array": {
             "$ref": "#/components/schemas/Int16Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int32Array": {
             "$ref": "#/components/schemas/Int32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "bigInt64Array": {
             "$ref": "#/components/schemas/BigInt64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "float32Array": {
             "$ref": "#/components/schemas/Float32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "float64Array": {
             "$ref": "#/components/schemas/Float64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "buffer": {
             "$ref": "#/components/schemas/__type",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrayBuffer": {
             "$ref": "#/components/schemas/ArrayBuffer",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sharedArrayBuffer": {
             "$ref": "#/components/schemas/SharedArrayBuffer",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "dataView": {
             "$ref": "#/components/schemas/DataView",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "weakSet": {
             "$ref": "#/components/schemas/WeakSet",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "weakMap": {
             "$ref": "#/components/schemas/WeakMap",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -188,6 +206,7 @@
               "Buffer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -196,10 +215,12 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/NativeSimple.json
+++ b/test/schemas/json/swagger/NativeSimple.json
@@ -12,91 +12,109 @@
           "date": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint8Array": {
             "$ref": "#/components/schemas/Uint8Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint8ClampedArray": {
             "$ref": "#/components/schemas/Uint8ClampedArray",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint16Array": {
             "$ref": "#/components/schemas/Uint16Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "uint32Array": {
             "$ref": "#/components/schemas/Uint32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "bigUint64Array": {
             "$ref": "#/components/schemas/BigUint64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int8Array": {
             "$ref": "#/components/schemas/Int8Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int16Array": {
             "$ref": "#/components/schemas/Int16Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "int32Array": {
             "$ref": "#/components/schemas/Int32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "bigInt64Array": {
             "$ref": "#/components/schemas/BigInt64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "float32Array": {
             "$ref": "#/components/schemas/Float32Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "float64Array": {
             "$ref": "#/components/schemas/Float64Array",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "buffer": {
             "$ref": "#/components/schemas/__type",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrayBuffer": {
             "$ref": "#/components/schemas/ArrayBuffer",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sharedArrayBuffer": {
             "$ref": "#/components/schemas/SharedArrayBuffer",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "dataView": {
             "$ref": "#/components/schemas/DataView",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "weakSet": {
             "$ref": "#/components/schemas/WeakSet",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "weakMap": {
             "$ref": "#/components/schemas/WeakMap",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -188,6 +206,7 @@
               "Buffer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -196,10 +215,12 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/NativeUnion.json
+++ b/test/schemas/json/swagger/NativeUnion.json
@@ -16,6 +16,7 @@
           "date": {
             "type": "string",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -23,30 +24,36 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/Uint8Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Uint8ClampedArray",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Uint16Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Uint32Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/BigUint64Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -54,25 +61,30 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/Int8Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Int16Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Int32Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/BigInt64Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -80,15 +92,18 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/Float32Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/Float64Array",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -96,25 +111,30 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ArrayBuffer",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/SharedArrayBuffer",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/DataView",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/__type",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -122,15 +142,18 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/WeakSet",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/WeakMap",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -225,6 +248,7 @@
               "Buffer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -233,10 +257,12 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectAlias.json
+++ b/test/schemas/json/swagger/ObjectAlias.json
@@ -16,18 +16,21 @@
           "id": {
             "type": "string",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -40,6 +43,7 @@
                   1
                 ],
                 "nullable": true,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
@@ -50,22 +54,26 @@
                   "female"
                 ],
                 "nullable": true,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "age": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "dead": {
             "type": "boolean",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectDynamic.json
+++ b/test/schemas/json/swagger/ObjectDynamic.json
@@ -16,22 +16,26 @@
             {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "type": "boolean",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             }
           ],
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         },
@@ -40,22 +44,26 @@
             {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "type": "boolean",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             }
           ],
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }

--- a/test/schemas/json/swagger/ObjectGeneric.json
+++ b/test/schemas/json/swagger/ObjectGeneric.json
@@ -48,11 +48,13 @@
           "value": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child": {
             "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -60,10 +62,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -82,12 +86,14 @@
           "child_value": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child_next": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -105,11 +111,13 @@
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child": {
             "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -117,10 +125,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -139,12 +149,14 @@
           "child_value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child_next": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -162,11 +174,13 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child": {
             "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -174,10 +188,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -196,12 +212,14 @@
           "child_value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "child_next": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectGenericAlias.json
+++ b/test/schemas/json/swagger/ObjectGenericAlias.json
@@ -12,6 +12,7 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectGenericArray.json
+++ b/test/schemas/json/swagger/ObjectGenericArray.json
@@ -11,6 +11,7 @@
         "properties": {
           "pagination": {
             "$ref": "#/components/schemas/ObjectGenericArray.IPagination",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -18,10 +19,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGenericArray.IPerson",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -39,24 +42,28 @@
           "page": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "limit": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "total_count": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "total_pages": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -76,12 +83,14 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "age": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectGenericUnion.json
+++ b/test/schemas/json/swagger/ObjectGenericUnion.json
@@ -19,23 +19,27 @@
           "writer": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "answer": {
             "$ref": "#/components/schemas/ObjectGenericUnion.ISaleAnswer.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "hit": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -43,16 +47,19 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGenericUnion.ISaleArticle.IContent",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -74,12 +81,14 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "hit": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -87,16 +96,19 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGenericUnion.ISaleArticle.IContent",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -116,24 +128,28 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "body": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -141,10 +157,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -165,18 +183,21 @@
           "url": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "extension": {
             "type": "string",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -195,23 +216,27 @@
           "writer": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "answer": {
             "$ref": "#/components/schemas/ObjectGenericUnion.ISaleAnswer.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "hit": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -219,16 +244,19 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGenericUnion.ISaleReview.IContent",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -250,30 +278,35 @@
           "score": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "body": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -281,10 +314,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectHierarchical.json
+++ b/test/schemas/json/swagger/ObjectHierarchical.json
@@ -12,33 +12,39 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "channel": {
             "$ref": "#/components/schemas/ObjectHierarchical.IChannel",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "member": {
             "$ref": "#/components/schemas/ObjectHierarchical.IMember.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "account": {
             "$ref": "#/components/schemas/ObjectHierarchical.IAccount.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "href": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "referrer": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -47,6 +53,7 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
@@ -57,38 +64,45 @@
                 {
                   "type": "number",
                   "nullable": false,
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "type": "number",
                   "nullable": false,
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "type": "number",
                   "nullable": false,
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "type": "number",
                   "nullable": false,
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false,
                   "x-typia-rest": false
                 }
               ],
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -112,41 +126,48 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "exclusive": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "priority": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -169,12 +190,14 @@
           "time": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "zone": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -192,16 +215,19 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "account": {
             "$ref": "#/components/schemas/ObjectHierarchical.IAccount",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "enterprise": {
             "$ref": "#/components/schemas/ObjectHierarchical.IEnterprise.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -210,21 +236,25 @@
             "items": {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "authorized": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -246,17 +276,20 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -275,28 +308,33 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "account": {
             "$ref": "#/components/schemas/ObjectHierarchical.IAccount",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "grade": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -317,17 +355,20 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectInternal.json
+++ b/test/schemas/json/swagger/ObjectInternal.json
@@ -12,12 +12,14 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectIntersection.json
+++ b/test/schemas/json/swagger/ObjectIntersection.json
@@ -12,18 +12,21 @@
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "vulnerable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectJsonTag.json
+++ b/test/schemas/json/swagger/ObjectJsonTag.json
@@ -13,6 +13,7 @@
             "type": "string",
             "nullable": false,
             "deprecated": true,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "deprecated"

--- a/test/schemas/json/swagger/ObjectLiteralProperty.json
+++ b/test/schemas/json/swagger/ObjectLiteralProperty.json
@@ -12,12 +12,14 @@
           "something-interesting-do-you-want?": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "or-something-crazy-do-you-want?": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectLiteralType.json
+++ b/test/schemas/json/swagger/ObjectLiteralType.json
@@ -12,18 +12,21 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "age": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectNullable.json
+++ b/test/schemas/json/swagger/ObjectNullable.json
@@ -38,16 +38,19 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "manufacturer": {
             "$ref": "#/components/schemas/ObjectNullable.IManufacturer",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "brand": {
             "$ref": "#/components/schemas/ObjectNullable.IBrand.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -55,15 +58,18 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ObjectNullable.IManufacturer.Nullable",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ObjectNullable.IBrand.Nullable",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -86,12 +92,14 @@
               "manufacturer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -112,12 +120,14 @@
               "brand"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -138,12 +148,14 @@
               "manufacturer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectOptional.json
+++ b/test/schemas/json/swagger/ObjectOptional.json
@@ -12,24 +12,28 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }

--- a/test/schemas/json/swagger/ObjectPrimitive.json
+++ b/test/schemas/json/swagger/ObjectPrimitive.json
@@ -12,6 +12,7 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -23,18 +24,21 @@
               "html"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "body": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -42,22 +46,26 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectPrimitive.IFile",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "secret": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -80,30 +88,35 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "extension": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "url": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectPropertyNullable.json
+++ b/test/schemas/json/swagger/ObjectPropertyNullable.json
@@ -97,6 +97,7 @@
           "value": {
             "type": "boolean",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -113,6 +114,7 @@
           "value": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -129,6 +131,7 @@
           "value": {
             "type": "string",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -144,6 +147,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/ObjectPropertyNullable.IMember.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -160,30 +164,35 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "grade": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "serial": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "activated": {
             "type": "boolean",
             "nullable": true,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectRecursive.json
+++ b/test/schemas/json/swagger/ObjectRecursive.json
@@ -11,35 +11,41 @@
         "properties": {
           "parent": {
             "$ref": "#/components/schemas/ObjectRecursive.IDepartment.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectRecursive.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -60,35 +66,41 @@
         "properties": {
           "parent": {
             "$ref": "#/components/schemas/ObjectRecursive.IDepartment.Nullable",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "sequence": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectRecursive.ITimestamp",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -110,12 +122,14 @@
           "time": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "zone": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectSimple.json
+++ b/test/schemas/json/swagger/ObjectSimple.json
@@ -11,21 +11,25 @@
         "properties": {
           "scale": {
             "$ref": "#/components/schemas/ObjectSimple.IPoint3D",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "position": {
             "$ref": "#/components/schemas/ObjectSimple.IPoint3D",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "rotate": {
             "$ref": "#/components/schemas/ObjectSimple.IPoint3D",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "pivot": {
             "$ref": "#/components/schemas/ObjectSimple.IPoint3D",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -45,18 +49,21 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "z": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectTuple.json
+++ b/test/schemas/json/swagger/ObjectTuple.json
@@ -40,18 +40,21 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -70,18 +73,21 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "mobile": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectUndefined.json
+++ b/test/schemas/json/swagger/ObjectUndefined.json
@@ -16,6 +16,7 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -24,31 +25,37 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               }
             ],
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "classroom": {
             "$ref": "#/components/schemas/ObjectUndefined.IClassroom",
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "grade": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "unknown": {
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -66,12 +73,14 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectUnionComposite.json
+++ b/test/schemas/json/swagger/ObjectUnionComposite.json
@@ -41,12 +41,14 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -63,11 +65,13 @@
         "properties": {
           "p1": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -84,16 +88,19 @@
         "properties": {
           "p1": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -111,21 +118,25 @@
         "properties": {
           "p1": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p4": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -146,10 +157,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -165,6 +178,7 @@
         "properties": {
           "outer": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPolyline",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -172,10 +186,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionComposite.IPolyline",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -194,15 +210,18 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "inner": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -219,12 +238,14 @@
         "properties": {
           "centroid": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "radius": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectUnionDouble.json
+++ b/test/schemas/json/swagger/ObjectUnionDouble.json
@@ -22,6 +22,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/__type",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -29,15 +30,18 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ObjectUnionDouble.IAA",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ObjectUnionDouble.IAB",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -55,6 +59,7 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -70,6 +75,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/__type.o1",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -86,6 +92,7 @@
           "y": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -101,6 +108,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/__type.o2",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -117,6 +125,7 @@
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -132,6 +141,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/__type.o3",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -139,15 +149,18 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ObjectUnionDouble.IBA",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ObjectUnionDouble.IBB",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -165,6 +178,7 @@
           "x": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -180,6 +194,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/__type.o4",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -196,6 +211,7 @@
           "y": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -211,6 +227,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/__type.o5",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -229,10 +246,12 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectUnionExplicit.json
+++ b/test/schemas/json/swagger/ObjectUnionExplicit.json
@@ -38,12 +38,14 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -53,6 +55,7 @@
               "point"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -70,11 +73,13 @@
         "properties": {
           "p1": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -84,6 +89,7 @@
               "line"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -102,12 +108,14 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -124,16 +132,19 @@
         "properties": {
           "p1": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -143,6 +154,7 @@
               "triangle"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -161,21 +173,25 @@
         "properties": {
           "p1": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p4": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -185,6 +201,7 @@
               "rectangle"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -206,10 +223,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -219,6 +238,7 @@
               "polyline"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -235,6 +255,7 @@
         "properties": {
           "outer": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPolyline",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -242,10 +263,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionExplicit.IPolyline",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -255,6 +278,7 @@
               "polygon"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -274,10 +298,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -293,12 +319,14 @@
         "properties": {
           "centroid": {
             "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "radius": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -308,6 +336,7 @@
               "circle"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ObjectUnionImplicit.json
+++ b/test/schemas/json/swagger/ObjectUnionImplicit.json
@@ -38,18 +38,21 @@
           "x": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "y": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "slope": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -66,23 +69,27 @@
         "properties": {
           "p1": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "distance": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -99,34 +106,40 @@
         "properties": {
           "p1": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "height": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "area": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -144,39 +157,46 @@
         "properties": {
           "p1": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p4": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "height": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "area": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -197,16 +217,19 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "length": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -222,6 +245,7 @@
         "properties": {
           "outer": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPolyline",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -229,16 +253,19 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionImplicit.IPolyline",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "area": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -254,18 +281,21 @@
         "properties": {
           "centroid": {
             "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "radius": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "area": {
             "type": "number",
             "nullable": true,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }

--- a/test/schemas/json/swagger/ObjectUnionNonPredictable.json
+++ b/test/schemas/json/swagger/ObjectUnionNonPredictable.json
@@ -15,6 +15,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -32,20 +33,24 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_number_gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_string_gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -61,6 +66,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_boolean_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -77,6 +83,7 @@
           "value": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -92,6 +99,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_number_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -108,6 +116,7 @@
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -123,6 +132,7 @@
         "properties": {
           "value": {
             "$ref": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_string_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -139,6 +149,7 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/SetAlias.json
+++ b/test/schemas/json/swagger/SetAlias.json
@@ -11,26 +11,31 @@
         "properties": {
           "booleans": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "numbers": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "strings": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrays": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "objects": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/SetSimple.json
+++ b/test/schemas/json/swagger/SetSimple.json
@@ -11,26 +11,31 @@
         "properties": {
           "booleans": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "numbers": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "strings": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrays": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "objects": {
             "$ref": "#/components/schemas/Set",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/TagArray.json
+++ b/test/schemas/json/swagger/TagArray.json
@@ -18,6 +18,7 @@
             "items": {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-metaTags": [
                 {
                   "kind": "items",
@@ -53,6 +54,7 @@
               "format": "uuid"
             },
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "items",
@@ -91,6 +93,7 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-metaTags": [
                 {
                   "kind": "minItems",
@@ -126,6 +129,7 @@
               "minimum": 3
             },
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minItems",
@@ -167,6 +171,7 @@
                 {
                   "type": "string",
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "maxItems",
@@ -217,6 +222,7 @@
                 {
                   "type": "number",
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "maxItems",
@@ -265,6 +271,7 @@
                   "maximum": 7
                 }
               ],
+              "description": "",
               "x-typia-metaTags": [
                 {
                   "kind": "maxItems",
@@ -312,6 +319,7 @@
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "maxItems",
@@ -364,6 +372,7 @@
             "items": {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-metaTags": [
                 {
                   "kind": "minItems",
@@ -412,6 +421,7 @@
               "format": "uuid"
             },
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minItems",

--- a/test/schemas/json/swagger/TagAtomicUnion.json
+++ b/test/schemas/json/swagger/TagAtomicUnion.json
@@ -18,6 +18,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-metaTags": [
                   {
                     "kind": "minimum",
@@ -69,6 +70,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-metaTags": [
                   {
                     "kind": "minimum",
@@ -117,6 +119,7 @@
                 "minimum": 3
               }
             ],
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",

--- a/test/schemas/json/swagger/TagDefault.json
+++ b/test/schemas/json/swagger/TagDefault.json
@@ -12,6 +12,7 @@
           "boolean": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -30,6 +31,7 @@
           "number": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -48,6 +50,7 @@
           "string": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -66,6 +69,7 @@
           "text": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -84,6 +88,7 @@
           "template": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -105,6 +110,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -141,6 +147,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -177,6 +184,7 @@
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -211,6 +219,7 @@
                 "default": true
               }
             ],
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -248,6 +257,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -265,6 +275,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -282,6 +293,7 @@
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -298,6 +310,7 @@
                 "default": true
               }
             ],
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -317,6 +330,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -334,6 +348,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -352,6 +367,7 @@
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -367,6 +383,7 @@
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -386,6 +403,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -404,6 +422,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -421,6 +440,7 @@
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -436,6 +456,7 @@
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -453,6 +474,7 @@
           "vulnerable_range": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",
@@ -500,6 +522,7 @@
           "vulnerable_template": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -520,6 +543,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -557,6 +581,7 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -593,6 +618,7 @@
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-jsDocTags": [
                   {
                     "name": "default",
@@ -627,6 +653,7 @@
                 "default": true
               }
             ],
+            "description": "",
             "x-typia-jsDocTags": [
               {
                 "name": "default",

--- a/test/schemas/json/swagger/TagLength.json
+++ b/test/schemas/json/swagger/TagLength.json
@@ -16,6 +16,7 @@
           "fixed": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "length",
@@ -39,6 +40,7 @@
           "minimum": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minLength",
@@ -63,6 +65,7 @@
           "maximum": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "maxLength",
@@ -87,6 +90,7 @@
           "minimum_and_maximum": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minLength",

--- a/test/schemas/json/swagger/TagObjectUnion.json
+++ b/test/schemas/json/swagger/TagObjectUnion.json
@@ -23,6 +23,7 @@
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",
@@ -57,6 +58,7 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minLength",

--- a/test/schemas/json/swagger/TagPattern.json
+++ b/test/schemas/json/swagger/TagPattern.json
@@ -12,6 +12,7 @@
           "uuid": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "pattern",
@@ -36,6 +37,7 @@
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "pattern",
@@ -60,6 +62,7 @@
           "ipv4": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "pattern",
@@ -84,6 +87,7 @@
           "ipv6": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "pattern",

--- a/test/schemas/json/swagger/TagRange.json
+++ b/test/schemas/json/swagger/TagRange.json
@@ -16,6 +16,7 @@
           "greater": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "exclusiveMinimum",
@@ -41,6 +42,7 @@
           "greater_equal": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",
@@ -65,6 +67,7 @@
           "less": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "exclusiveMaximum",
@@ -90,6 +93,7 @@
           "less_equal": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "maximum",
@@ -114,6 +118,7 @@
           "greater_less": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "exclusiveMinimum",
@@ -154,6 +159,7 @@
           "greater_equal_less": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",
@@ -193,6 +199,7 @@
           "greater_less_equal": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "exclusiveMinimum",
@@ -232,6 +239,7 @@
           "greater_equal_less_equal": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minimum",

--- a/test/schemas/json/swagger/TagStep.json
+++ b/test/schemas/json/swagger/TagStep.json
@@ -16,6 +16,7 @@
           "exclusiveMinimum": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "step",
@@ -54,6 +55,7 @@
           "minimum": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "step",
@@ -91,6 +93,7 @@
           "range": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "step",
@@ -144,6 +147,7 @@
           "multipleOf": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "multipleOf",

--- a/test/schemas/json/swagger/TagTuple.json
+++ b/test/schemas/json/swagger/TagTuple.json
@@ -16,6 +16,7 @@
                 {
                   "type": "string",
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "minItems",
@@ -106,6 +107,7 @@
                 {
                   "type": "number",
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "minItems",
@@ -198,6 +200,7 @@
                   "items": {
                     "type": "string",
                     "nullable": false,
+                    "description": "",
                     "x-typia-metaTags": [
                       {
                         "kind": "minItems",
@@ -286,6 +289,7 @@
                     "maxLength": 7
                   },
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "minItems",
@@ -378,6 +382,7 @@
                   "items": {
                     "type": "number",
                     "nullable": false,
+                    "description": "",
                     "x-typia-metaTags": [
                       {
                         "kind": "minItems",
@@ -466,6 +471,7 @@
                     "maximum": 7
                   },
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "minItems",
@@ -554,6 +560,7 @@
                   "maxItems": 7
                 }
               ],
+              "description": "",
               "x-typia-metaTags": [
                 {
                   "kind": "minItems",
@@ -646,6 +653,7 @@
                 {
                   "type": "string",
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "minItems",
@@ -736,6 +744,7 @@
                 {
                   "type": "number",
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "minItems",
@@ -828,6 +837,7 @@
                   "items": {
                     "type": "string",
                     "nullable": false,
+                    "description": "",
                     "x-typia-metaTags": [
                       {
                         "kind": "minItems",
@@ -916,6 +926,7 @@
                     "maxLength": 7
                   },
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "minItems",
@@ -1008,6 +1019,7 @@
                   "items": {
                     "type": "number",
                     "nullable": false,
+                    "description": "",
                     "x-typia-metaTags": [
                       {
                         "kind": "minItems",
@@ -1097,6 +1109,7 @@
                     "maximum": 7
                   },
                   "nullable": false,
+                  "description": "",
                   "x-typia-metaTags": [
                     {
                       "kind": "minItems",
@@ -1187,6 +1200,7 @@
                 }
               ],
               "nullable": false,
+              "description": "",
               "x-typia-metaTags": [
                 {
                   "kind": "minItems",
@@ -1272,6 +1286,7 @@
               "x-typia-required": true,
               "x-typia-optional": false
             },
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "minItems",

--- a/test/schemas/json/swagger/TemplateAtomic.json
+++ b/test/schemas/json/swagger/TemplateAtomic.json
@@ -12,6 +12,7 @@
           "prefix": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(prefix_(.*))"
@@ -19,6 +20,7 @@
           "postfix": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "((.*)_postfix)$"
@@ -26,6 +28,7 @@
           "middle_string": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(the_(.*)_value)$"
@@ -33,6 +36,7 @@
           "middle_string_empty": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(the_(.*)_value)$"
@@ -40,6 +44,7 @@
           "middle_numeric": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(the_-?\\d+\\.?\\d*_value)$"
@@ -51,12 +56,14 @@
               "the_true_value"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "ipv4": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*)$"
@@ -64,6 +71,7 @@
           "email": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "((.*)@(.*)\\.(.*))"

--- a/test/schemas/json/swagger/TemplateConstant.json
+++ b/test/schemas/json/swagger/TemplateConstant.json
@@ -21,6 +21,7 @@
               "prefix_C"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -32,6 +33,7 @@
               "1_postfix"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -49,6 +51,7 @@
               "the_1_value_with_label_C"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/TemplateUnion.json
+++ b/test/schemas/json/swagger/TemplateUnion.json
@@ -16,6 +16,7 @@
           "prefix": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^((prefix_(.*))|(prefix_-?\\d+\\.?\\d*))$"
@@ -23,6 +24,7 @@
           "postfix": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "(((.*)_postfix)|(-?\\d+\\.?\\d*_postfix))$"
@@ -30,6 +32,7 @@
           "middle": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(the_false_value|the_true_value|(the_-?\\d+\\.?\\d*_value))$"
@@ -39,6 +42,7 @@
               {
                 "type": "string",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false,
                 "pattern": "^(the_A_value|the_B_value|-?\\d+\\.?\\d*|true|false|(the_-?\\d+\\.?\\d*_value))$"
@@ -46,21 +50,25 @@
               {
                 "type": "number",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "type": "boolean",
                 "nullable": false,
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/__type",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -80,6 +88,7 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ToJsonArray.json
+++ b/test/schemas/json/swagger/ToJsonArray.json
@@ -103,6 +103,7 @@
           "id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ToJsonDouble.json
+++ b/test/schemas/json/swagger/ToJsonDouble.json
@@ -12,12 +12,14 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "flag": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ToJsonTuple.json
+++ b/test/schemas/json/swagger/ToJsonTuple.json
@@ -62,12 +62,14 @@
           "code": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/ToJsonUnion.json
+++ b/test/schemas/json/swagger/ToJsonUnion.json
@@ -36,18 +36,21 @@
           "id": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "mobile": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -66,18 +69,21 @@
           "manufacturer": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "brand": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/TupleRestObject.json
+++ b/test/schemas/json/swagger/TupleRestObject.json
@@ -56,6 +56,7 @@
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }

--- a/test/schemas/json/swagger/UltimateUnion.json
+++ b/test/schemas/json/swagger/UltimateUnion.json
@@ -19,84 +19,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IBoolean",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IInteger",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.INumber",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IString",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IArray",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.ITuple",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IOneOf",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.INullOnly",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IUnknown",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "components": {
             "$ref": "#/components/schemas/IJsonComponents",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -107,12 +124,14 @@
               "ajv"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "prefix": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -134,16 +153,19 @@
             "items": {
               "type": "boolean",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "default": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -153,30 +175,35 @@
               "boolean"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -186,84 +213,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -271,28 +315,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -314,6 +363,7 @@
               "type"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -324,6 +374,7 @@
               "uint"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -344,12 +395,14 @@
               "minimum"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -370,12 +423,14 @@
               "maximum"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -396,12 +451,14 @@
               "exclusiveMinimum"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -422,12 +479,14 @@
               "exclusiveMaximum"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -448,12 +507,14 @@
               "multipleOf"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -474,12 +535,14 @@
               "step"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -500,6 +563,7 @@
               "format"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -515,6 +579,7 @@
               "datetime"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -535,12 +600,14 @@
               "pattern"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -561,12 +628,14 @@
               "length"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -587,12 +656,14 @@
               "minLength"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -613,12 +684,14 @@
               "maxLength"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -639,12 +712,14 @@
               "items"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -665,12 +740,14 @@
               "minItems"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -691,12 +768,14 @@
               "maxItems"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "value": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -714,6 +793,7 @@
           "name": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -721,10 +801,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo.IText",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -741,12 +823,14 @@
           "text": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "kind": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -766,16 +850,19 @@
             "items": {
               "type": "number",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "default": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -785,30 +872,35 @@
               "number"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -818,84 +910,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -903,28 +1012,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -945,16 +1059,19 @@
             "items": {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "default": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -964,30 +1081,35 @@
               "string"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -997,84 +1119,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1082,28 +1221,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -1122,6 +1266,7 @@
           "default": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1131,30 +1276,35 @@
               "boolean"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1164,84 +1314,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1249,28 +1416,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -1288,6 +1460,7 @@
           "minimum": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -1311,6 +1484,7 @@
           "maximum": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -1334,18 +1508,21 @@
           "exclusiveMinimum": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "exclusiveMaximum": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "multipleOf": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -1369,6 +1546,7 @@
           "default": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1378,30 +1556,35 @@
               "integer"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1411,84 +1594,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1496,28 +1696,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -1535,36 +1740,42 @@
           "minimum": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "maximum": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "exclusiveMinimum": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "exclusiveMaximum": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "multipleOf": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "default": {
             "type": "number",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1574,30 +1785,35 @@
               "number"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1607,84 +1823,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1692,28 +1925,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -1731,6 +1969,7 @@
           "minLength": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -1755,6 +1994,7 @@
           "maxLength": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -1779,18 +2019,21 @@
           "pattern": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "format": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "default": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1800,30 +2043,35 @@
               "string"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1833,84 +2081,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -1918,28 +2183,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -1958,81 +2228,97 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IBoolean",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IInteger",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.INumber",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IString",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IArray",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.ITuple",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IOneOf",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IReference",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.INullOnly",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IUnknown",
+                "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               }
             ],
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "minItems": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -2057,6 +2343,7 @@
           "maxItems": {
             "type": "integer",
             "nullable": false,
+            "description": "",
             "x-typia-metaTags": [
               {
                 "kind": "type",
@@ -2080,6 +2367,7 @@
           },
           "x-typia-tuple": {
             "$ref": "#/components/schemas/IJsonSchema.ITuple",
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2089,30 +2377,35 @@
               "array"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2122,84 +2415,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2207,28 +2517,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -2250,79 +2565,95 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IBoolean",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IInteger",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.INumber",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IString",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.ITuple",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IArray",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IOneOf",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.INullOnly",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IUnknown",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
@@ -2332,30 +2663,35 @@
               "array"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2365,84 +2701,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2450,28 +2803,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -2493,97 +2851,116 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IBoolean",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IInteger",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.INumber",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IString",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IOneOf",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.ITuple",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IArray",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.INullOnly",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
                   "$ref": "#/components/schemas/IJsonSchema.IUnknown",
+                  "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2593,84 +2970,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2678,28 +3072,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -2716,24 +3115,28 @@
           "$ref": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2743,84 +3146,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2828,28 +3248,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -2866,24 +3291,28 @@
           "$recursiveRef": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2893,84 +3322,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -2978,28 +3424,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -3019,24 +3470,28 @@
               "null"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3046,84 +3501,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3131,28 +3603,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -3169,18 +3646,21 @@
           "deprecated": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "title": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3190,84 +3670,101 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IType",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IStep",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IFormat",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IPattern",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.ILength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMinItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
                   "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
+                  "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 }
               ],
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3275,28 +3772,33 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-required": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-optional": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-rest": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -3309,6 +3811,7 @@
         "properties": {
           "schemas": {
             "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonComponents.IObject_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
@@ -3326,11 +3829,13 @@
         "x-typia-jsDocTags": [],
         "x-typia-additionalProperties": {
           "$ref": "#/components/schemas/IJsonComponents.IObject",
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         },
         "additionalProperties": {
           "$ref": "#/components/schemas/IJsonComponents.IObject",
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }
@@ -3341,12 +3846,14 @@
           "$id": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "$recursiveAnchor": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3356,22 +3863,26 @@
               "object"
             ],
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullable": {
             "type": "boolean",
             "nullable": false,
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "properties": {
             "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+            "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "patternProperties": {
             "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3379,75 +3890,90 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IBoolean",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IInteger",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.INumber",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IString",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IArray",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.ITuple",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IOneOf",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IReference",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.INullOnly",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IUnknown",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               }
             ],
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3456,16 +3982,19 @@
             "items": {
               "type": "string",
               "nullable": false,
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "description": {
             "type": "string",
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3473,15 +4002,18 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
+              "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
             },
             "nullable": false,
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "x-typia-patternProperties": {
             "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
@@ -3489,75 +4021,90 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IBoolean",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IInteger",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.INumber",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IString",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IArray",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.ITuple",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IOneOf",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IReference",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.INullOnly",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IUnknown",
+                "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               }
             ],
+            "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
@@ -3579,75 +4126,90 @@
           "oneOf": [
             {
               "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IBoolean",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IInteger",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.INumber",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IString",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IArray",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.ITuple",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IOneOf",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IReference",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.INullOnly",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IUnknown",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             }
           ],
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         },
@@ -3655,75 +4217,90 @@
           "oneOf": [
             {
               "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IBoolean",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IInteger",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.INumber",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IString",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IArray",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.ITuple",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IOneOf",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IReference",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.INullOnly",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
               "$ref": "#/components/schemas/IJsonSchema.IUnknown",
+              "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             }
           ],
+          "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }

--- a/website/pages/docs/validators/comment-tags.mdx
+++ b/website/pages/docs/validators/comment-tags.mdx
@@ -140,18 +140,20 @@ export const customValidators: CustomValidatorMap;
 export interface CustomValidatorMap {
     size(): number;
     size(name: string): number;
+    
+    // Type: {boolean, number, bigint, string}
     has: (name: string) => (type: keyof Customizable) => boolean;
-    get(
-        name: string,
-    ): <Type extends keyof Customizable>(
-        type: Type,
-    ) => CustomValidatorMap.Closure<Type> | undefined;
-    erase(name: string): (type: keyof Customizable) => boolean;
-    insert(
-        name: string, // tag name
-    ): <Type extends keyof Customizable>(
-        type: Type, // instance type -> boolean | number | bigint | string
-    ) => (closure: CustomValidatorMap.Closure<Type>) => boolean;
+    get:
+        (name: string) => 
+        <Type extends keyof Customizable>(type: Type) => 
+            CustomValidatorMap.Closure<Type> | undefined;
+    erase: 
+        (name: string) => 
+        (type: keyof Customizable) => boolean;
+    insert: 
+        (name: string) => 
+        <Type extends keyof Customizable>(type: Type) => 
+        (closure: CustomValidatorMap.Closure<Type>) => boolean;
 }
 export namespace CustomValidatorMap {
     export type Closure<Type extends keyof Customizable> = 
@@ -173,7 +175,7 @@ export interface Customizable {
 
 You can add custom comment tags for type validation.
 
-If you need addtional comment tag for type validation, just define it by yourself. Write your custom validation logic as a closure function, and register it through `typia.customValidationMap.insert()` function, reading above `CustomValidatorMap` type definition.
+If you need addtional comment tag for type validation, just define it by yourself. Write your custom validation logic as a closure function, and register it through `typia.customValidationMap.insert()` function, following above `CustomValidatorMap` and `Customizable` types.
 
 Note that, 1st parameter of `typia.customValidationMap.insert()` function means tag name, and 2nd parameter means instance type (`boolean|nubmer|bigint|string`). Also, when defining closure currying function of validation logic, 1st parameter means tag name and 2nd means input value.
 

--- a/website/pages/docs/validators/comment-tags.mdx
+++ b/website/pages/docs/validators/comment-tags.mdx
@@ -141,7 +141,7 @@ export interface CustomValidatorMap {
     size(): number;
     size(name: string): number;
     
-    // Type: {boolean, number, bigint, string}
+    // Type: {number, bigint, string}
     has: (name: string) => (type: keyof Customizable) => boolean;
     get:
         (name: string) => 

--- a/website/public/sitemap-0.xml
+++ b/website/public/sitemap-0.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://typia.io/</loc><lastmod>2023-05-08T17:46:43.056Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/</loc><lastmod>2023-05-08T17:46:43.056Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-05-08T17:46:43.056Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-05-08T17:46:43.057Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/</loc><lastmod>2023-05-10T07:44:28.842Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/website/public/sitemap-0.xml
+++ b/website/public/sitemap-0.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://typia.io/</loc><lastmod>2023-05-10T07:44:28.842Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-05-10T07:44:28.843Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/</loc><lastmod>2023-05-10T07:57:38.908Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
There are some fucking documentation libraries enforcing user to write invalid `@type` tagged comments like below, even in TypeScript.

In such reason, `typia` stops throwing compilation error when invalid `@type` tag comes. 

Of course, validation and random generation logic would not be affected by the invalid `@type` tag.