### PR TITLE
Change JSON schema strategy of AJV mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Check out the document in the [website](https://typia.io/docs/):
 ### 🏠 Home
   - [Introduction](https://typia.io/docs/)
   - [Setup](https://typia.io/docs/setup/)
+  - [Pure TypeScript](https://typia.io/docs/pure/)
   
 ### 📖 Features
   - Runtime Validators

--- a/benchmark/programs/server/internal/createFastifyServerBenchmarkProgram.ts
+++ b/benchmark/programs/server/internal/createFastifyServerBenchmarkProgram.ts
@@ -7,15 +7,12 @@ import { IStringifyServerProgram } from "./IStringifyServerPgoram";
 export const createFastifyServerBenchmarkProgram = async <T>(
     app: typia.IJsonApplication,
 ) => {
-    // DEFINE RESPONSE DTO THROUGH JSON-SCHEMA
-    const definitions: Record<string, typia.IJsonComponents.IObject> = {};
-    for (const [key, value] of Object.entries(app.components.schemas))
-        definitions[key.replace("#/definitions/", "")] = value;
+    // DEFINE JSON-SCHEMA
     const schema = {
         response: {
             200: {
                 ...app.schemas[0],
-                definitions,
+                ...app,
             },
         },
     };

--- a/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ArrayHierarchical.ts
+++ b/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ArrayHierarchical.ts
@@ -4,5 +4,5 @@ import { ArrayHierarchical } from "../../../../../test/structures/ArrayHierarchi
 import { createFastifyServerBenchmarkProgram } from "../createFastifyServerBenchmarkProgram";
 
 createFastifyServerBenchmarkProgram(
-    typia.application<[ArrayHierarchical[]], "ajv", "#/definitions">(),
+    typia.application<[ArrayHierarchical[]], "ajv">(),
 );

--- a/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ArrayRecursive.ts
+++ b/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ArrayRecursive.ts
@@ -4,5 +4,5 @@ import { ArrayRecursive } from "../../../../../test/structures/ArrayRecursive";
 import { createFastifyServerBenchmarkProgram } from "../createFastifyServerBenchmarkProgram";
 
 createFastifyServerBenchmarkProgram(
-    typia.application<[ArrayRecursive[]], "ajv", "#/definitions">(),
+    typia.application<[ArrayRecursive[]], "ajv">(),
 );

--- a/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ArrayRecursiveUnionExplicit.ts
+++ b/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ArrayRecursiveUnionExplicit.ts
@@ -4,9 +4,5 @@ import { ArrayRecursiveUnionExplicit } from "../../../../../test/structures/Arra
 import { createFastifyServerBenchmarkProgram } from "../createFastifyServerBenchmarkProgram";
 
 createFastifyServerBenchmarkProgram(
-    typia.application<
-        [ArrayRecursiveUnionExplicit[]],
-        "ajv",
-        "#/definitions"
-    >(),
+    typia.application<[ArrayRecursiveUnionExplicit[]], "ajv">(),
 );

--- a/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ArraySimple.ts
+++ b/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ArraySimple.ts
@@ -4,5 +4,5 @@ import { ArraySimple } from "../../../../../test/structures/ArraySimple";
 import { createFastifyServerBenchmarkProgram } from "../createFastifyServerBenchmarkProgram";
 
 createFastifyServerBenchmarkProgram(
-    typia.application<[ArraySimple[]], "ajv", "#/definitions">(),
+    typia.application<[ArraySimple[]], "ajv">(),
 );

--- a/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ObjectHierarchical.ts
+++ b/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ObjectHierarchical.ts
@@ -4,5 +4,5 @@ import { ObjectHierarchical } from "../../../../../test/structures/ObjectHierarc
 import { createFastifyServerBenchmarkProgram } from "../createFastifyServerBenchmarkProgram";
 
 createFastifyServerBenchmarkProgram(
-    typia.application<[ObjectHierarchical[]], "ajv", "#/definitions">(),
+    typia.application<[ObjectHierarchical[]], "ajv">(),
 );

--- a/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ObjectRecursive.ts
+++ b/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ObjectRecursive.ts
@@ -4,5 +4,5 @@ import { ObjectRecursive } from "../../../../../test/structures/ObjectRecursive"
 import { createFastifyServerBenchmarkProgram } from "../createFastifyServerBenchmarkProgram";
 
 createFastifyServerBenchmarkProgram(
-    typia.application<[ObjectRecursive[]], "ajv", "#/definitions">(),
+    typia.application<[ObjectRecursive[]], "ajv">(),
 );

--- a/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ObjectSimple.ts
+++ b/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ObjectSimple.ts
@@ -4,5 +4,5 @@ import { ObjectSimple } from "../../../../../test/structures/ObjectSimple";
 import { createFastifyServerBenchmarkProgram } from "../createFastifyServerBenchmarkProgram";
 
 createFastifyServerBenchmarkProgram(
-    typia.application<[ObjectSimple[]], "ajv", "#/definitions">(),
+    typia.application<[ObjectSimple[]], "ajv">(),
 );

--- a/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ObjectUnionExplicit.ts
+++ b/benchmark/programs/server/internal/fastify/benchmark-server-fastify-ObjectUnionExplicit.ts
@@ -4,5 +4,5 @@ import { ObjectUnionExplicit } from "../../../../../test/structures/ObjectUnionE
 import { createFastifyServerBenchmarkProgram } from "../createFastifyServerBenchmarkProgram";
 
 createFastifyServerBenchmarkProgram(
-    typia.application<[ObjectUnionExplicit[]], "ajv", "#/definitions">(),
+    typia.application<[ObjectUnionExplicit[]], "ajv">(),
 );

--- a/benchmark/programs/stringify/fast-json-stringify/createStringifyFastBenchmarkProgram.ts
+++ b/benchmark/programs/stringify/fast-json-stringify/createStringifyFastBenchmarkProgram.ts
@@ -8,10 +8,9 @@ export const createStringifyFastBenchmarkProgram = (
 ) => {
     const stringify = (() => {
         try {
-            return fast(app.schemas[0], {
-                schema: {
-                    components: app.components,
-                } as any,
+            return fast({
+                ...app.schemas[0],
+                ...app,
             });
         } catch {
             return null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -56,6 +56,7 @@ Check out the document in the [website](https://typia.io/docs/):
 ### 🏠 Home
   - [Introduction](https://typia.io/docs/)
   - [Setup](https://typia.io/docs/setup/)
+  - [Pure TypeScript](https://typia.io/docs/pure/)
   
 ### 📖 Features
   - Runtime Validators

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -66,7 +66,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "3.8.5"
+    "typia": "3.8.6"
   },
   "peerDependencies": {
     "typescript": ">= 4.5.2"

--- a/src/module.ts
+++ b/src/module.ts
@@ -488,7 +488,6 @@ export const customValidators: CustomValidatorMap = {
  *
  * @template Types Tuple of target types
  * @template Purpose Purpose of the JSON schema`
- * @template Prefix Prefix of the JSON components referenced by `$ref` tag
  * @return JSON schema application
  *
  * @author Jeongho Nam - https://github.com/samchon
@@ -512,17 +511,13 @@ export function application(): never;
  *
  * @template Types Tuple of target types
  * @template Purpose Purpose of the JSON schema
- * @template Prefix Prefix of the JSON components referenced by `$ref` tag
  * @return JSON schema application
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
 export function application<
     Types extends unknown[],
-    Purpose extends "swagger" | "ajv" = "swagger",
-    Prefix extends string = Purpose extends "swagger"
-        ? "#/components/schemas"
-        : "components#/schemas",
+    Purpose extends "ajv" | "swagger" = "swagger",
 >(): IJsonApplication;
 
 /**

--- a/src/programmers/ApplicationProgrammer.ts
+++ b/src/programmers/ApplicationProgrammer.ts
@@ -6,12 +6,8 @@ import { IJsonSchema } from "../schemas/IJsonSchema";
 import { application_schema } from "./internal/application_schema";
 
 export namespace ApplicationProgrammer {
-    export const AJV_PREFIX = "components#/schemas";
-    export const SWAGGER_PREFIX = "#/components/schemas";
-
     export interface IOptions {
-        purpose: "swagger" | "ajv";
-        prefix: string;
+        purpose: "ajv" | "swagger";
     }
 
     /**
@@ -22,9 +18,6 @@ export namespace ApplicationProgrammer {
             const purpose: "swagger" | "ajv" = options?.purpose ?? "swagger";
             return {
                 purpose,
-                prefix:
-                    options?.prefix ||
-                    (purpose === "swagger" ? SWAGGER_PREFIX : AJV_PREFIX),
             };
         };
     }
@@ -57,6 +50,7 @@ export namespace ApplicationProgrammer {
                 }),
                 components,
                 ...fullOptions,
+                prefix: "#/components/schemas",
             };
         };
 }

--- a/src/programmers/internal/JSON_SCHEMA_PREFIX.ts
+++ b/src/programmers/internal/JSON_SCHEMA_PREFIX.ts
@@ -1,0 +1,1 @@
+export const JSON_SCHEMA_PREFIX = "#/components/schemas";

--- a/src/programmers/internal/application_array.ts
+++ b/src/programmers/internal/application_array.ts
@@ -13,23 +13,19 @@ export const application_array =
     (components: IJsonComponents) =>
     (tuple?: IJsonSchema.ITuple) =>
     (metadata: Metadata) =>
-    (props: {
-        nullable: boolean;
-        attribute: IJsonSchema.IAttribute;
-    }): IJsonSchema.IArray => {
+    (attribute: IJsonSchema.IAttribute): IJsonSchema.IArray => {
         // SCHEMA
         const output: IJsonSchema.IArray = {
+            ...attribute,
             type: "array",
             items: application_schema(options)(false)(components)(metadata)(
-                props.attribute,
+                attribute,
             ),
-            nullable: props.nullable,
             "x-typia-tuple": tuple,
-            ...props.attribute,
         };
 
         // RANGE
-        for (const tag of props.attribute["x-typia-metaTags"] || [])
+        for (const tag of attribute["x-typia-metaTags"] ?? [])
             if (tag.kind === "minItems") output.minItems = tag.value;
             else if (tag.kind === "maxItems") output.maxItems = tag.value;
         return output;

--- a/src/programmers/internal/application_boolean.ts
+++ b/src/programmers/internal/application_boolean.ts
@@ -4,14 +4,12 @@ import { application_default } from "./application_default";
 /**
  * @internal
  */
-export const application_boolean = (props: {
-    nullable: boolean;
-    attribute: IJsonSchema.IAttribute;
-}): IJsonSchema.IBoolean => ({
-    type: "boolean",
-    nullable: props.nullable,
-    ...props.attribute,
-    default: application_default(props.attribute)(
+export const application_boolean = (
+    attribute: IJsonSchema.IAttribute,
+): IJsonSchema.IBoolean => ({
+    ...attribute,
+    default: application_default(attribute)(
         (def) => def === "true" || def === "false",
     )((str) => Boolean(str)),
+    type: "boolean",
 });

--- a/src/programmers/internal/application_constant.ts
+++ b/src/programmers/internal/application_constant.ts
@@ -8,15 +8,11 @@ import { application_default } from "./application_default";
  */
 export const application_constant =
     (constant: MetadataConstant) =>
-    (props: {
-        nullable: boolean;
-        attribute: IJsonSchema.IAttribute;
-    }): IJsonSchema.IEnumeration<any> => ({
+    (attribute: IJsonSchema.IAttribute): IJsonSchema.IEnumeration<any> => ({
+        ...attribute,
         type: constant.type,
         enum: constant.values as any,
-        nullable: props.nullable,
-        ...props.attribute,
-        default: application_default(props.attribute)((def) =>
+        default: application_default(attribute)((def) =>
             constant.values.some((v) => v.toString() === def),
         )(
             constant.type === "string"

--- a/src/programmers/internal/application_default.ts
+++ b/src/programmers/internal/application_default.ts
@@ -7,7 +7,7 @@ export const application_default =
     (attribute: IJsonSchema.IAttribute) =>
     (pred: (value: string) => boolean) =>
     <T>(caster: (str: string) => T): T | undefined => {
-        const defaults = (attribute["x-typia-jsDocTags"] || []).filter(
+        const defaults = (attribute["x-typia-jsDocTags"] ?? []).filter(
             (tag) => tag.name === "default",
         );
         for (const def of defaults)

--- a/src/programmers/internal/application_native.ts
+++ b/src/programmers/internal/application_native.ts
@@ -2,6 +2,7 @@ import { IJsonComponents } from "../../schemas/IJsonComponents";
 
 import { IJsonSchema } from "../../module";
 import { ApplicationProgrammer } from "../ApplicationProgrammer";
+import { JSON_SCHEMA_PREFIX } from "./JSON_SCHEMA_PREFIX";
 
 /**
  * @internal
@@ -14,19 +15,22 @@ export const application_native =
         nullable: boolean;
         attribute: IJsonSchema.IAttribute;
     }): IJsonSchema.IReference => {
-        const key: string = name + (props.nullable ? ".Nullable" : "");
-        if (components.schemas[key] === undefined)
-            components.schemas[key] = {
-                type: "object",
-                $id:
-                    options.purpose === "ajv"
-                        ? options.prefix + "/" + key
-                        : undefined,
-                properties: {},
-                nullable: props.nullable,
-            };
+        const key: string =
+            options.purpose === "ajv"
+                ? name
+                : `${name}${props.nullable ? ".Nullable" : ""}`;
+        components.schemas[key] ??= {
+            type: "object",
+            $id:
+                options.purpose === "ajv"
+                    ? `${JSON_SCHEMA_PREFIX}/${key}`
+                    : undefined,
+            properties: {},
+            nullable:
+                options.purpose === "swagger" ? props.nullable : undefined,
+        };
         return {
-            $ref: `#/components/schemas/${name}`,
             ...props.attribute,
+            $ref: `${JSON_SCHEMA_PREFIX}/${key}`,
         };
     };

--- a/src/programmers/internal/application_number.ts
+++ b/src/programmers/internal/application_number.ts
@@ -4,16 +4,14 @@ import { application_default } from "./application_default";
 /**
  * @internal
  */
-export const application_number = (props: {
-    nullable: boolean;
-    attribute: IJsonSchema.IAttribute;
-}): IJsonSchema.INumber | IJsonSchema.IInteger => {
+export const application_number = (
+    attribute: IJsonSchema.IAttribute,
+): IJsonSchema.INumber | IJsonSchema.IInteger => {
     const output: IJsonSchema.INumber | IJsonSchema.IInteger = {
+        ...attribute,
         type: "number" as "number" | "integer",
-        nullable: props.nullable,
-        ...props.attribute,
     };
-    for (const tag of props.attribute["x-typia-metaTags"] || []) {
+    for (const tag of attribute["x-typia-metaTags"] ?? []) {
         // CHECK TYPE
         if (
             tag.kind === "type" &&
@@ -37,7 +35,7 @@ export const application_number = (props: {
     // WHEN UNSIGNED INT
     if (
         output.type === "integer" &&
-        (props.attribute["x-typia-metaTags"] || []).find(
+        (attribute["x-typia-metaTags"] ?? []).find(
             (tag) => tag.kind === "type" && tag.value === "uint",
         )
     )
@@ -52,7 +50,7 @@ export const application_number = (props: {
         }
 
     // DEFAULT CONFIGURATION
-    output.default = application_default(props.attribute)((str) => {
+    output.default = application_default(attribute)((str) => {
         const value: number = Number(str);
         const conditions: boolean[] = [!Number.isNaN(value)];
         if (output.minimum !== undefined)

--- a/src/programmers/internal/application_string.ts
+++ b/src/programmers/internal/application_string.ts
@@ -7,39 +7,38 @@ import { application_default_string } from "./application_default_string";
 /**
  * @internal
  */
-export const application_string = (
-    meta: Metadata,
-    attribute: IJsonSchema.IAttribute,
-): IJsonSchema.IString => {
-    const output: IJsonSchema.IString = {
-        type: "string",
-        nullable: meta.nullable,
-        ...attribute,
+export const application_string =
+    (meta: Metadata) =>
+    (attribute: IJsonSchema.IAttribute): IJsonSchema.IString => {
+        const output: IJsonSchema.IString = {
+            ...attribute,
+            type: "string",
+        };
+
+        // FORMAT TAG OF METADATA
+        const formatJsdocTag = attribute["x-typia-jsDocTags"]?.find(
+            (tag) => tag.name === "format",
+        );
+        if (formatJsdocTag?.text?.length)
+            output.format = formatJsdocTag?.text.map((t) => t.text).join(" ");
+
+        // REGULAR TAGS COMPATIBLE WITH JSON-SCHEMA
+        for (const tag of attribute["x-typia-metaTags"] ?? []) {
+            // RANGE
+            if (tag.kind === "minLength") output.minLength = tag.value;
+            else if (tag.kind === "maxLength") output.maxLength = tag.value;
+            // FORMAT AND PATTERN
+            else if (tag.kind === "format")
+                output.format = emendFormat(tag.value);
+            else if (tag.kind === "pattern") output.pattern = tag.value;
+        }
+
+        // DEFAULT CONFIGURATION
+        output.default = application_default_string(meta)(attribute)(output);
+
+        // RETURNS
+        return output;
     };
-
-    // FORMAT TAG OF METADATA
-    const formatJsdocTag = attribute["x-typia-jsDocTags"]?.find(
-        (tag) => tag.name === "format",
-    );
-    if (formatJsdocTag?.text?.length)
-        output.format = formatJsdocTag?.text.map((t) => t.text).join(" ");
-
-    // REGULAR TAGS COMPATIBLE WITH JSON-SCHEMA
-    for (const tag of attribute["x-typia-metaTags"] ?? []) {
-        // RANGE
-        if (tag.kind === "minLength") output.minLength = tag.value;
-        else if (tag.kind === "maxLength") output.maxLength = tag.value;
-        // FORMAT AND PATTERN
-        else if (tag.kind === "format") output.format = emendFormat(tag.value);
-        else if (tag.kind === "pattern") output.pattern = tag.value;
-    }
-
-    // DEFAULT CONFIGURATION
-    output.default = application_default_string(meta)(attribute)(output);
-
-    // RETURNS
-    return output;
-};
 
 const emendFormat = (tag: IMetadataTag.IFormat["value"]) =>
     tag === "datetime" ? "date-time" : tag;

--- a/src/programmers/internal/application_templates.ts
+++ b/src/programmers/internal/application_templates.ts
@@ -13,7 +13,6 @@ export const application_templates =
         // CONSTRUCT PATTERN
         const output: IJsonSchema.IString = {
             type: "string",
-            nullable: meta.nullable,
             ...attribute,
         };
         output.pattern = metadata_to_pattern(true)(meta);

--- a/src/programmers/internal/application_tuple.ts
+++ b/src/programmers/internal/application_tuple.ts
@@ -12,20 +12,16 @@ export const application_tuple =
     (options: ApplicationProgrammer.IOptions) =>
     (components: IJsonComponents) =>
     (items: Array<Metadata>) =>
-    (props: {
-        nullable: boolean;
-        attribute: IJsonSchema.IAttribute;
-    }): IJsonSchema.ITuple => ({
+    (attribute: IJsonSchema.IAttribute): IJsonSchema.ITuple => ({
         type: "array",
         items: items.map((meta, i) =>
             application_schema(options)(false)(components)(meta.rest ?? meta)({
-                ...props.attribute,
+                ...attribute,
                 "x-typia-rest":
                     i === items.length - 1 ? meta.rest !== null : undefined,
                 "x-typia-required": meta.required,
                 "x-typia-optional": meta.optional,
             }),
         ),
-        nullable: props.nullable,
-        ...props.attribute,
+        ...attribute,
     });

--- a/src/schemas/IJsonApplication.ts
+++ b/src/schemas/IJsonApplication.ts
@@ -5,5 +5,9 @@ export interface IJsonApplication {
     schemas: IJsonSchema[];
     components: IJsonComponents;
     purpose: "swagger" | "ajv";
+
+    /**
+     * @deprecated Always "#/components/schemas"
+     */
     prefix: string;
 }

--- a/src/schemas/IJsonComponents.ts
+++ b/src/schemas/IJsonComponents.ts
@@ -7,11 +7,18 @@ export interface IJsonComponents {
 }
 export namespace IJsonComponents {
     export interface IObject {
+        /**
+         * Used only when ajv mode.
+         */
         $id?: string;
         $recursiveAnchor?: boolean;
 
         type: "object";
-        nullable: boolean;
+
+        /**
+         * Only when swagger mode.
+         */
+        nullable?: boolean;
 
         properties: Record<string, IJsonSchema>;
         patternProperties?: Record<string, IJsonSchema>;

--- a/src/schemas/IJsonSchema.ts
+++ b/src/schemas/IJsonSchema.ts
@@ -115,7 +115,11 @@ export namespace IJsonSchema {
 
     export interface ISignificant<Literal extends string> extends IAttribute {
         type: Literal;
-        nullable: boolean;
+
+        /**
+         * Only when swagger mode.
+         */
+        nullable?: boolean;
     }
     export interface IAttribute {
         deprecated?: boolean;

--- a/src/transformers/features/miscellaneous/ApplicationTransformer.ts
+++ b/src/transformers/features/miscellaneous/ApplicationTransformer.ts
@@ -42,16 +42,6 @@ export namespace ApplicationTransformer {
                 (str) => str === "swagger" || str === "ajv",
                 () => "swagger",
             );
-            const prefix: string = get_parameter(
-                checker,
-                "Prefix",
-                expression.typeArguments[2],
-                () => true,
-                () =>
-                    purpose === "swagger"
-                        ? "#/components/schemas"
-                        : "components#/schemas",
-            );
 
             //----
             // GENERATORS
@@ -74,7 +64,6 @@ export namespace ApplicationTransformer {
             // APPLICATION
             const app: IJsonApplication = ApplicationProgrammer.write({
                 purpose,
-                prefix,
             })(metadatas);
 
             // RETURNS WITH LITERAL EXPRESSION

--- a/test/generated/output/assert/test_assert_UltimateUnion.ts
+++ b/test/generated/output/assert/test_assert_UltimateUnion.ts
@@ -8,6 +8,7 @@ export const test_assert_UltimateUnion = _test_assert(
     (input) =>
         ((input: any): Array<typia.IJsonApplication> => {
             const $guard = (typia.assert as any).guard;
+            const $is_custom = (typia.assert as any).is_custom;
             const $join = (typia.assert as any).join;
             const __is = (
                 input: any,
@@ -25,7 +26,13 @@ export const test_assert_UltimateUnion = _test_assert(
                     null !== input.components &&
                     $io32(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                    "string" === typeof input.prefix;
+                    "string" === typeof input.prefix &&
+                    $is_custom(
+                        "deprecated",
+                        "string",
+                        'Always "#/components/schemas"',
+                        input.prefix,
+                    );
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -34,7 +41,8 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -148,7 +156,8 @@ export const test_assert_UltimateUnion = _test_assert(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -185,7 +194,8 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -218,7 +228,8 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -268,7 +279,8 @@ export const test_assert_UltimateUnion = _test_assert(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -315,7 +327,8 @@ export const test_assert_UltimateUnion = _test_assert(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -362,7 +375,8 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -411,7 +425,8 @@ export const test_assert_UltimateUnion = _test_assert(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -450,7 +465,8 @@ export const test_assert_UltimateUnion = _test_assert(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -660,7 +676,8 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -919,7 +936,19 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '("ajv" | "swagger")',
                                 value: input.purpose,
                             })) &&
-                        ("string" === typeof input.prefix ||
+                        (("string" === typeof input.prefix &&
+                            ($is_custom(
+                                "deprecated",
+                                "string",
+                                'Always "#/components/schemas"',
+                                input.prefix,
+                            ) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".prefix",
+                                    expected:
+                                        'string (@deprecated Always "#/components/schemas")',
+                                    value: input.prefix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected: "string",
@@ -958,10 +987,11 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '"boolean"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1432,10 +1462,11 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '"number"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1574,10 +1605,11 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '"string"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1701,10 +1733,11 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '"boolean"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1886,10 +1919,11 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '"integer"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2052,10 +2086,11 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '"number"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2235,10 +2270,11 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '"string"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2423,10 +2459,11 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '"array"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2568,10 +2605,11 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '"array"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -3342,10 +3380,11 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: '"object"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (("object" === typeof input.properties &&

--- a/test/generated/output/assertClone/test_assertClone_UltimateUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_UltimateUnion.ts
@@ -9,6 +9,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
         ((input: any): typia.Primitive<Array<typia.IJsonApplication>> => {
             const assert = (input: any): Array<typia.IJsonApplication> => {
                 const $guard = (typia.assertClone as any).guard;
+                const $is_custom = (typia.assertClone as any).is_custom;
                 const $join = (typia.assertClone as any).join;
                 const __is = (
                     input: any,
@@ -27,7 +28,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         $io32(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose) &&
-                        "string" === typeof input.prefix;
+                        "string" === typeof input.prefix &&
+                        $is_custom(
+                            "deprecated",
+                            "string",
+                            'Always "#/components/schemas"',
+                            input.prefix,
+                        );
                     const $io1 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
@@ -36,7 +43,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -152,7 +160,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -189,7 +198,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -222,7 +232,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -273,7 +284,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "integer" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -320,7 +332,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -367,7 +380,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -416,7 +430,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 null !== input["x-typia-tuple"] &&
                                 $io26(input["x-typia-tuple"]))) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -455,7 +470,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 $iu2(elem),
                         ) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -665,7 +681,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
@@ -929,7 +946,19 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '("ajv" | "swagger")',
                                     value: input.purpose,
                                 })) &&
-                            ("string" === typeof input.prefix ||
+                            (("string" === typeof input.prefix &&
+                                ($is_custom(
+                                    "deprecated",
+                                    "string",
+                                    'Always "#/components/schemas"',
+                                    input.prefix,
+                                ) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".prefix",
+                                        expected:
+                                            'string (@deprecated Always "#/components/schemas")',
+                                        value: input.prefix,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".prefix",
                                     expected: "string",
@@ -969,10 +998,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '"boolean"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1450,10 +1480,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '"number"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1598,10 +1629,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '"string"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1727,10 +1759,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '"boolean"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1916,10 +1949,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '"integer"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2084,10 +2118,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '"number"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2269,10 +2304,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '"string"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2461,10 +2497,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '"array"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2611,10 +2648,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '"array"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -3401,10 +3439,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: '"object"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (("object" === typeof input.properties &&
@@ -4082,6 +4121,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
             ): typia.Primitive<Array<typia.IJsonApplication>> => {
                 const $join = (typia.assertClone as any).join;
                 const $throws = (typia.assertClone as any).throws;
+                const $is_custom = (typia.assertClone as any).is_custom;
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -4090,7 +4130,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4185,7 +4226,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4222,7 +4264,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4255,7 +4298,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4301,7 +4345,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4344,7 +4389,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4389,7 +4435,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4436,7 +4483,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4475,7 +4523,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4685,7 +4734,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&

--- a/test/generated/output/assertParse/test_assertParse_UltimateUnion.ts
+++ b/test/generated/output/assertParse/test_assertParse_UltimateUnion.ts
@@ -9,6 +9,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
         ((input: string): typia.Primitive<UltimateUnion> => {
             const assert = (input: any): UltimateUnion => {
                 const $guard = (typia.assertParse as any).guard;
+                const $is_custom = (typia.assertParse as any).is_custom;
                 const $join = (typia.assertParse as any).join;
                 const __is = (input: any): input is UltimateUnion => {
                     const $io0 = (input: any): boolean =>
@@ -25,7 +26,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         $io32(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose) &&
-                        "string" === typeof input.prefix;
+                        "string" === typeof input.prefix &&
+                        $is_custom(
+                            "deprecated",
+                            "string",
+                            'Always "#/components/schemas"',
+                            input.prefix,
+                        );
                     const $io1 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
@@ -34,7 +41,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -150,7 +158,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -187,7 +196,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -220,7 +230,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -271,7 +282,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "integer" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -318,7 +330,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -365,7 +378,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -414,7 +428,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 null !== input["x-typia-tuple"] &&
                                 $io26(input["x-typia-tuple"]))) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -453,7 +468,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 $iu2(elem),
                         ) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -663,7 +679,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
@@ -927,7 +944,19 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '("ajv" | "swagger")',
                                     value: input.purpose,
                                 })) &&
-                            ("string" === typeof input.prefix ||
+                            (("string" === typeof input.prefix &&
+                                ($is_custom(
+                                    "deprecated",
+                                    "string",
+                                    'Always "#/components/schemas"',
+                                    input.prefix,
+                                ) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".prefix",
+                                        expected:
+                                            'string (@deprecated Always "#/components/schemas")',
+                                        value: input.prefix,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".prefix",
                                     expected: "string",
@@ -967,10 +996,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '"boolean"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1448,10 +1478,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '"number"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1596,10 +1627,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '"string"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1725,10 +1757,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '"boolean"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1914,10 +1947,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '"integer"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2082,10 +2116,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '"number"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2267,10 +2302,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '"string"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2459,10 +2495,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '"array"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2609,10 +2646,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '"array"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -3399,10 +3437,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: '"object"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (("object" === typeof input.properties &&

--- a/test/generated/output/assertStringify/test_assertStringify_UltimateUnion.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_UltimateUnion.ts
@@ -9,6 +9,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
         ((input: any): string => {
             const assert = (input: any): Array<typia.IJsonApplication> => {
                 const $guard = (typia.assertStringify as any).guard;
+                const $is_custom = (typia.assertStringify as any).is_custom;
                 const $join = (typia.assertStringify as any).join;
                 const __is = (
                     input: any,
@@ -27,7 +28,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         $io32(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose) &&
-                        "string" === typeof input.prefix;
+                        "string" === typeof input.prefix &&
+                        $is_custom(
+                            "deprecated",
+                            "string",
+                            'Always "#/components/schemas"',
+                            input.prefix,
+                        );
                     const $io1 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
@@ -36,7 +43,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -152,7 +160,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -189,7 +198,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -222,7 +232,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -273,7 +284,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "integer" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -320,7 +332,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -367,7 +380,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -416,7 +430,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 null !== input["x-typia-tuple"] &&
                                 $io26(input["x-typia-tuple"]))) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -455,7 +470,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 $iu2(elem),
                         ) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -665,7 +681,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
@@ -929,7 +946,19 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '("ajv" | "swagger")',
                                     value: input.purpose,
                                 })) &&
-                            ("string" === typeof input.prefix ||
+                            (("string" === typeof input.prefix &&
+                                ($is_custom(
+                                    "deprecated",
+                                    "string",
+                                    'Always "#/components/schemas"',
+                                    input.prefix,
+                                ) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".prefix",
+                                        expected:
+                                            'string (@deprecated Always "#/components/schemas")',
+                                        value: input.prefix,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".prefix",
                                     expected: "string",
@@ -969,10 +998,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '"boolean"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1450,10 +1480,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '"number"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1598,10 +1629,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '"string"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1727,10 +1759,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '"boolean"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -1916,10 +1949,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '"integer"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2084,10 +2118,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '"number"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2269,10 +2304,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '"string"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2461,10 +2497,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '"array"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -2611,10 +2648,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '"array"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -3401,10 +3439,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: '"object"',
                                     value: input.type,
                                 })) &&
-                            ("boolean" === typeof input.nullable ||
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $guard(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 })) &&
                             (("object" === typeof input.properties &&
@@ -4085,6 +4124,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                 const $number = (typia.assertStringify as any).number;
                 const $tail = (typia.assertStringify as any).tail;
                 const $join = (typia.assertStringify as any).join;
+                const $is_custom = (typia.assertStringify as any).is_custom;
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -4093,7 +4133,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4188,7 +4229,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4225,7 +4267,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4258,7 +4301,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4304,7 +4348,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4347,7 +4392,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4392,7 +4438,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4439,7 +4486,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4478,7 +4526,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -4688,7 +4737,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -4904,6 +4954,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -4982,7 +5040,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"boolean"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so2 = (input: any): any =>
                     `{"kind":${(() => {
                         if ("string" === typeof input.kind)
@@ -5196,6 +5254,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -5274,7 +5340,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"number"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so20 = (input: any): any =>
                     `{${
                         undefined === input["default"]
@@ -5282,6 +5348,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $string(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -5363,7 +5437,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"string"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so21 = (input: any): any =>
                     `{${
                         undefined === input["default"]
@@ -5371,6 +5445,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? input["default"]
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -5450,7 +5532,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"boolean"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so22 = (input: any): any =>
                     `{${
                         undefined === input.minimum
@@ -5498,6 +5580,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $number(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -5577,7 +5667,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"integer"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so23 = (input: any): any =>
                     `{${
                         undefined === input.minimum
@@ -5625,6 +5715,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $number(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -5704,7 +5802,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"number"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so24 = (input: any): any =>
                     `{${
                         undefined === input.minLength
@@ -5744,6 +5842,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $string(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -5823,7 +5929,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"string"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so25 = (input: any): any =>
                     `{${
                         undefined === input.minItems
@@ -5847,6 +5953,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             : `"x-typia-tuple":${
                                   undefined !== input["x-typia-tuple"]
                                       ? $so26(input["x-typia-tuple"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -5926,9 +6040,17 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"array"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so26 = (input: any): any =>
                     `{${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -6007,7 +6129,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"array"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so27 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
@@ -6399,6 +6521,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.patternProperties
                             ? ""
                             : `"patternProperties":${
@@ -6475,9 +6605,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"object"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable},"properties":${$so35(
-                        input.properties,
-                    )}}`;
+                    })()},"properties":${$so35(input.properties)}}`;
                 const $so35 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {

--- a/test/generated/output/clone/test_clone_UltimateUnion.ts
+++ b/test/generated/output/clone/test_clone_UltimateUnion.ts
@@ -11,13 +11,15 @@ export const test_clone_UltimateUnion = _test_clone(
         ): typia.Primitive<Array<typia.IJsonApplication>> => {
             const $join = (typia.clone as any).join;
             const $throws = (typia.clone as any).throws;
+            const $is_custom = (typia.clone as any).is_custom;
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -105,7 +107,8 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -140,7 +143,8 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -173,7 +177,8 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -219,7 +224,8 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -262,7 +268,8 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -307,7 +314,8 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -354,7 +362,8 @@ export const test_clone_UltimateUnion = _test_clone(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -393,7 +402,8 @@ export const test_clone_UltimateUnion = _test_clone(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -602,7 +612,8 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&

--- a/test/generated/output/createAssert/test_createAssert_UltimateUnion.ts
+++ b/test/generated/output/createAssert/test_createAssert_UltimateUnion.ts
@@ -7,6 +7,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
     UltimateUnion.generate,
     (input: any): UltimateUnion => {
         const $guard = (typia.createAssert as any).guard;
+        const $is_custom = (typia.createAssert as any).is_custom;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is UltimateUnion => {
             const $io0 = (input: any): boolean =>
@@ -22,14 +23,21 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 null !== input.components &&
                 $io32(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                "string" === typeof input.prefix;
+                "string" === typeof input.prefix &&
+                $is_custom(
+                    "deprecated",
+                    "string",
+                    'Always "#/components/schemas"',
+                    input.prefix,
+                );
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -143,7 +151,8 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -178,7 +187,8 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -211,7 +221,8 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -261,7 +272,8 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -308,7 +320,8 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -355,7 +368,8 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -404,7 +418,8 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -443,7 +458,8 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -652,7 +668,8 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
@@ -899,7 +916,19 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '("ajv" | "swagger")',
                             value: input.purpose,
                         })) &&
-                    ("string" === typeof input.prefix ||
+                    (("string" === typeof input.prefix &&
+                        ($is_custom(
+                            "deprecated",
+                            "string",
+                            'Always "#/components/schemas"',
+                            input.prefix,
+                        ) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".prefix",
+                                expected:
+                                    'string (@deprecated Always "#/components/schemas")',
+                                value: input.prefix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".prefix",
                             expected: "string",
@@ -938,10 +967,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '"boolean"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -1411,10 +1441,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '"number"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -1552,10 +1583,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '"string"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -1678,10 +1710,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '"boolean"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -1861,10 +1894,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '"integer"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -2026,10 +2060,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '"number"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -2206,10 +2241,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '"string"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -2392,10 +2428,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '"array"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -2535,10 +2572,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '"array"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -3301,10 +3339,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: '"object"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (("object" === typeof input.properties &&

--- a/test/generated/output/createAssertClone/test_createAssertClone_UltimateUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_UltimateUnion.ts
@@ -8,6 +8,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
     (input: any): typia.Primitive<UltimateUnion> => {
         const assert = (input: any): UltimateUnion => {
             const $guard = (typia.createAssertClone as any).guard;
+            const $is_custom = (typia.createAssertClone as any).is_custom;
             const $join = (typia.createAssertClone as any).join;
             const __is = (input: any): input is UltimateUnion => {
                 const $io0 = (input: any): boolean =>
@@ -23,7 +24,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     null !== input.components &&
                     $io32(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                    "string" === typeof input.prefix;
+                    "string" === typeof input.prefix &&
+                    $is_custom(
+                        "deprecated",
+                        "string",
+                        'Always "#/components/schemas"',
+                        input.prefix,
+                    );
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -32,7 +39,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -146,7 +154,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -183,7 +192,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -216,7 +226,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -266,7 +277,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -313,7 +325,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -360,7 +373,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -409,7 +423,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -448,7 +463,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -658,7 +674,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -917,7 +934,19 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '("ajv" | "swagger")',
                                 value: input.purpose,
                             })) &&
-                        ("string" === typeof input.prefix ||
+                        (("string" === typeof input.prefix &&
+                            ($is_custom(
+                                "deprecated",
+                                "string",
+                                'Always "#/components/schemas"',
+                                input.prefix,
+                            ) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".prefix",
+                                    expected:
+                                        'string (@deprecated Always "#/components/schemas")',
+                                    value: input.prefix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected: "string",
@@ -956,10 +985,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '"boolean"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1430,10 +1460,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '"number"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1572,10 +1603,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '"string"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1699,10 +1731,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '"boolean"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1884,10 +1917,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '"integer"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2050,10 +2084,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '"number"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2233,10 +2268,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '"string"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2421,10 +2457,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '"array"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2566,10 +2603,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '"array"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -3340,10 +3378,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: '"object"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (("object" === typeof input.properties &&
@@ -3909,13 +3948,15 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
         ): typia.Primitive<UltimateUnion> => {
             const $join = (typia.createAssertClone as any).join;
             const $throws = (typia.createAssertClone as any).throws;
+            const $is_custom = (typia.createAssertClone as any).is_custom;
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4003,7 +4044,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4038,7 +4080,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4071,7 +4114,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4117,7 +4161,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4160,7 +4205,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4205,7 +4251,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4252,7 +4299,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4291,7 +4339,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4500,7 +4549,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&

--- a/test/generated/output/createAssertParse/test_createAssertParse_UltimateUnion.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_UltimateUnion.ts
@@ -8,6 +8,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
     (input: string): typia.Primitive<UltimateUnion> => {
         const assert = (input: any): UltimateUnion => {
             const $guard = (typia.createAssertParse as any).guard;
+            const $is_custom = (typia.createAssertParse as any).is_custom;
             const $join = (typia.createAssertParse as any).join;
             const __is = (input: any): input is UltimateUnion => {
                 const $io0 = (input: any): boolean =>
@@ -23,7 +24,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     null !== input.components &&
                     $io32(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                    "string" === typeof input.prefix;
+                    "string" === typeof input.prefix &&
+                    $is_custom(
+                        "deprecated",
+                        "string",
+                        'Always "#/components/schemas"',
+                        input.prefix,
+                    );
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -32,7 +39,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -146,7 +154,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -183,7 +192,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -216,7 +226,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -266,7 +277,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -313,7 +325,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -360,7 +373,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -409,7 +423,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -448,7 +463,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -658,7 +674,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -917,7 +934,19 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '("ajv" | "swagger")',
                                 value: input.purpose,
                             })) &&
-                        ("string" === typeof input.prefix ||
+                        (("string" === typeof input.prefix &&
+                            ($is_custom(
+                                "deprecated",
+                                "string",
+                                'Always "#/components/schemas"',
+                                input.prefix,
+                            ) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".prefix",
+                                    expected:
+                                        'string (@deprecated Always "#/components/schemas")',
+                                    value: input.prefix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected: "string",
@@ -956,10 +985,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '"boolean"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1430,10 +1460,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '"number"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1572,10 +1603,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '"string"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1699,10 +1731,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '"boolean"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1884,10 +1917,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '"integer"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2050,10 +2084,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '"number"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2233,10 +2268,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '"string"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2421,10 +2457,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '"array"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2566,10 +2603,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '"array"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -3340,10 +3378,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: '"object"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (("object" === typeof input.properties &&

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_UltimateUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_UltimateUnion.ts
@@ -8,6 +8,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
     (input: any): string => {
         const assert = (input: any): UltimateUnion => {
             const $guard = (typia.createAssertStringify as any).guard;
+            const $is_custom = (typia.createAssertStringify as any).is_custom;
             const $join = (typia.createAssertStringify as any).join;
             const __is = (input: any): input is UltimateUnion => {
                 const $io0 = (input: any): boolean =>
@@ -23,7 +24,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     null !== input.components &&
                     $io32(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                    "string" === typeof input.prefix;
+                    "string" === typeof input.prefix &&
+                    $is_custom(
+                        "deprecated",
+                        "string",
+                        'Always "#/components/schemas"',
+                        input.prefix,
+                    );
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -32,7 +39,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -146,7 +154,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -183,7 +192,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -216,7 +226,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -266,7 +277,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -313,7 +325,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -360,7 +373,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -409,7 +423,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -448,7 +463,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -658,7 +674,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -917,7 +934,19 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '("ajv" | "swagger")',
                                 value: input.purpose,
                             })) &&
-                        ("string" === typeof input.prefix ||
+                        (("string" === typeof input.prefix &&
+                            ($is_custom(
+                                "deprecated",
+                                "string",
+                                'Always "#/components/schemas"',
+                                input.prefix,
+                            ) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".prefix",
+                                    expected:
+                                        'string (@deprecated Always "#/components/schemas")',
+                                    value: input.prefix,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected: "string",
@@ -956,10 +985,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '"boolean"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1430,10 +1460,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '"number"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1572,10 +1603,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '"string"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1699,10 +1731,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '"boolean"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -1884,10 +1917,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '"integer"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2050,10 +2084,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '"number"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2233,10 +2268,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '"string"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2421,10 +2457,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '"array"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -2566,10 +2603,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '"array"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (undefined === input.deprecated ||
@@ -3340,10 +3378,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: '"object"',
                                 value: input.type,
                             })) &&
-                        ("boolean" === typeof input.nullable ||
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $guard(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             })) &&
                         (("object" === typeof input.properties &&
@@ -3910,13 +3949,15 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
             const $number = (typia.createAssertStringify as any).number;
             const $tail = (typia.createAssertStringify as any).tail;
             const $join = (typia.createAssertStringify as any).join;
+            const $is_custom = (typia.createAssertStringify as any).is_custom;
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4004,7 +4045,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4039,7 +4081,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4072,7 +4115,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4118,7 +4162,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4161,7 +4206,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4206,7 +4252,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4253,7 +4300,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4292,7 +4340,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4501,7 +4550,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
@@ -4708,6 +4758,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                   : undefined
                           },`
                 }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.deprecated
                         ? ""
                         : `"deprecated":${
@@ -4786,7 +4844,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"boolean"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so2 = (input: any): any =>
                 `{"kind":${(() => {
                     if ("string" === typeof input.kind)
@@ -5000,6 +5058,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                   : undefined
                           },`
                 }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.deprecated
                         ? ""
                         : `"deprecated":${
@@ -5078,7 +5144,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"number"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so20 = (input: any): any =>
                 `{${
                     undefined === input["default"]
@@ -5086,6 +5152,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $string(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -5167,7 +5241,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"string"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so21 = (input: any): any =>
                 `{${
                     undefined === input["default"]
@@ -5175,6 +5249,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? input["default"]
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -5254,7 +5336,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"boolean"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so22 = (input: any): any =>
                 `{${
                     undefined === input.minimum
@@ -5302,6 +5384,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $number(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -5381,7 +5471,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"integer"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so23 = (input: any): any =>
                 `{${
                     undefined === input.minimum
@@ -5429,6 +5519,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $number(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -5508,7 +5606,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"number"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so24 = (input: any): any =>
                 `{${
                     undefined === input.minLength
@@ -5548,6 +5646,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $string(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -5627,7 +5733,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"string"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so25 = (input: any): any =>
                 `{${
                     undefined === input.minItems
@@ -5651,6 +5757,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         : `"x-typia-tuple":${
                               undefined !== input["x-typia-tuple"]
                                   ? $so26(input["x-typia-tuple"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -5730,9 +5844,17 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"array"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so26 = (input: any): any =>
                 `{${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.deprecated
                         ? ""
                         : `"deprecated":${
@@ -5811,7 +5933,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"array"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so27 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
@@ -6203,6 +6325,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                   : undefined
                           },`
                 }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.patternProperties
                         ? ""
                         : `"patternProperties":${
@@ -6272,9 +6402,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"object"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable},"properties":${$so35(
-                    input.properties,
-                )}}`;
+                })()},"properties":${$so35(input.properties)}}`;
             const $so35 = (input: any): any =>
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {

--- a/test/generated/output/createClone/test_createClone_UltimateUnion.ts
+++ b/test/generated/output/createClone/test_createClone_UltimateUnion.ts
@@ -8,13 +8,15 @@ export const test_createClone_UltimateUnion = _test_clone(
     (input: UltimateUnion): typia.Primitive<UltimateUnion> => {
         const $join = (typia.createClone as any).join;
         const $throws = (typia.createClone as any).throws;
+        const $is_custom = (typia.createClone as any).is_custom;
         const $io1 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "boolean" === typeof elem) &&
             (undefined === input["default"] ||
                 "boolean" === typeof input["default"]) &&
             "boolean" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -100,7 +102,8 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input["default"] ||
                 "number" === typeof input["default"]) &&
             "number" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -134,7 +137,8 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input["default"] ||
                 "string" === typeof input["default"]) &&
             "string" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -166,7 +170,8 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input["default"] ||
                 "boolean" === typeof input["default"]) &&
             "boolean" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -211,7 +216,8 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input["default"] ||
                 "number" === typeof input["default"]) &&
             "integer" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -253,7 +259,8 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input["default"] ||
                 "number" === typeof input["default"]) &&
             "number" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -296,7 +303,8 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input["default"] ||
                 "string" === typeof input["default"]) &&
             "string" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -342,7 +350,8 @@ export const test_createClone_UltimateUnion = _test_clone(
                     null !== input["x-typia-tuple"] &&
                     $io26(input["x-typia-tuple"]))) &&
             "array" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -380,7 +389,8 @@ export const test_createClone_UltimateUnion = _test_clone(
                     $iu2(elem),
             ) &&
             "array" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -583,7 +593,8 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor) &&
             "object" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             "object" === typeof input.properties &&
             null !== input.properties &&
             false === Array.isArray(input.properties) &&

--- a/test/generated/output/createIs/test_createIs_UltimateUnion.ts
+++ b/test/generated/output/createIs/test_createIs_UltimateUnion.ts
@@ -6,6 +6,7 @@ export const test_createIs_UltimateUnion = _test_is(
     "UltimateUnion",
     UltimateUnion.generate,
     (input: any): input is UltimateUnion => {
+        const $is_custom = (typia.createIs as any).is_custom;
         const $join = (typia.createIs as any).join;
         const $io0 = (input: any): boolean =>
             Array.isArray(input.schemas) &&
@@ -20,14 +21,21 @@ export const test_createIs_UltimateUnion = _test_is(
             null !== input.components &&
             $io32(input.components) &&
             ("ajv" === input.purpose || "swagger" === input.purpose) &&
-            "string" === typeof input.prefix;
+            "string" === typeof input.prefix &&
+            $is_custom(
+                "deprecated",
+                "string",
+                'Always "#/components/schemas"',
+                input.prefix,
+            );
         const $io1 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "boolean" === typeof elem) &&
             (undefined === input["default"] ||
                 "boolean" === typeof input["default"]) &&
             "boolean" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -139,7 +147,8 @@ export const test_createIs_UltimateUnion = _test_is(
                 ("number" === typeof input["default"] &&
                     Number.isFinite(input["default"]))) &&
             "number" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -173,7 +182,8 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input["default"] ||
                 "string" === typeof input["default"]) &&
             "string" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -205,7 +215,8 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input["default"] ||
                 "boolean" === typeof input["default"]) &&
             "boolean" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -254,7 +265,8 @@ export const test_createIs_UltimateUnion = _test_is(
                 ("number" === typeof input["default"] &&
                     Number.isFinite(input["default"]))) &&
             "integer" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -300,7 +312,8 @@ export const test_createIs_UltimateUnion = _test_is(
                 ("number" === typeof input["default"] &&
                     Number.isFinite(input["default"]))) &&
             "number" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -345,7 +358,8 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input["default"] ||
                 "string" === typeof input["default"]) &&
             "string" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -393,7 +407,8 @@ export const test_createIs_UltimateUnion = _test_is(
                     null !== input["x-typia-tuple"] &&
                     $io26(input["x-typia-tuple"]))) &&
             "array" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -431,7 +446,8 @@ export const test_createIs_UltimateUnion = _test_is(
                     $iu2(elem),
             ) &&
             "array" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -634,7 +650,8 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor) &&
             "object" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             "object" === typeof input.properties &&
             null !== input.properties &&
             false === Array.isArray(input.properties) &&

--- a/test/generated/output/createIsClone/test_createIsClone_UltimateUnion.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_UltimateUnion.ts
@@ -7,6 +7,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
     UltimateUnion.generate,
     (input: any): typia.Primitive<UltimateUnion> | null => {
         const is = (input: any): input is UltimateUnion => {
+            const $is_custom = (typia.createIsClone as any).is_custom;
             const $join = (typia.createIsClone as any).join;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.schemas) &&
@@ -21,14 +22,21 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 null !== input.components &&
                 $io32(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                "string" === typeof input.prefix;
+                "string" === typeof input.prefix &&
+                $is_custom(
+                    "deprecated",
+                    "string",
+                    'Always "#/components/schemas"',
+                    input.prefix,
+                );
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -142,7 +150,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -177,7 +186,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -210,7 +220,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -260,7 +271,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -307,7 +319,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -354,7 +367,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -403,7 +417,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -442,7 +457,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -651,7 +667,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
@@ -849,13 +866,15 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
         ): typia.Primitive<UltimateUnion> => {
             const $join = (typia.createIsClone as any).join;
             const $throws = (typia.createIsClone as any).throws;
+            const $is_custom = (typia.createIsClone as any).is_custom;
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -943,7 +962,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -978,7 +998,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1011,7 +1032,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1057,7 +1079,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1100,7 +1123,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1145,7 +1169,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1192,7 +1217,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1231,7 +1257,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1440,7 +1467,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&

--- a/test/generated/output/createIsParse/test_createIsParse_UltimateUnion.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_UltimateUnion.ts
@@ -7,6 +7,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
     UltimateUnion.generate,
     (input: any): typia.Primitive<UltimateUnion> => {
         const is = (input: any): input is UltimateUnion => {
+            const $is_custom = (typia.createIsParse as any).is_custom;
             const $join = (typia.createIsParse as any).join;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.schemas) &&
@@ -21,14 +22,21 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 null !== input.components &&
                 $io32(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                "string" === typeof input.prefix;
+                "string" === typeof input.prefix &&
+                $is_custom(
+                    "deprecated",
+                    "string",
+                    'Always "#/components/schemas"',
+                    input.prefix,
+                );
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -142,7 +150,8 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -177,7 +186,8 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -210,7 +220,8 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -260,7 +271,8 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -307,7 +319,8 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -354,7 +367,8 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -403,7 +417,8 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -442,7 +457,8 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -651,7 +667,8 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&

--- a/test/generated/output/createIsStringify/test_createIsStringify_UltimateUnion.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_UltimateUnion.ts
@@ -7,6 +7,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
     UltimateUnion.generate,
     (input: UltimateUnion): string | null => {
         const is = (input: any): input is UltimateUnion => {
+            const $is_custom = (typia.createIsStringify as any).is_custom;
             const $join = (typia.createIsStringify as any).join;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.schemas) &&
@@ -21,14 +22,21 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 null !== input.components &&
                 $io32(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                "string" === typeof input.prefix;
+                "string" === typeof input.prefix &&
+                $is_custom(
+                    "deprecated",
+                    "string",
+                    'Always "#/components/schemas"',
+                    input.prefix,
+                );
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -142,7 +150,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -177,7 +186,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -210,7 +220,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -260,7 +271,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -307,7 +319,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -354,7 +367,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -403,7 +417,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -442,7 +457,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -651,7 +667,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
@@ -850,13 +867,15 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
             const $number = (typia.createIsStringify as any).number;
             const $tail = (typia.createIsStringify as any).tail;
             const $join = (typia.createIsStringify as any).join;
+            const $is_custom = (typia.createIsStringify as any).is_custom;
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -944,7 +963,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -979,7 +999,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1012,7 +1033,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1058,7 +1080,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1101,7 +1124,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1146,7 +1170,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1193,7 +1218,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1232,7 +1258,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -1441,7 +1468,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
@@ -1648,6 +1676,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                                   : undefined
                           },`
                 }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.deprecated
                         ? ""
                         : `"deprecated":${
@@ -1726,7 +1762,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"boolean"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so2 = (input: any): any =>
                 `{"kind":${(() => {
                     if ("string" === typeof input.kind)
@@ -1940,6 +1976,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                                   : undefined
                           },`
                 }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.deprecated
                         ? ""
                         : `"deprecated":${
@@ -2018,7 +2062,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"number"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so20 = (input: any): any =>
                 `{${
                     undefined === input["default"]
@@ -2026,6 +2070,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $string(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -2107,7 +2159,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"string"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so21 = (input: any): any =>
                 `{${
                     undefined === input["default"]
@@ -2115,6 +2167,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? input["default"]
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -2194,7 +2254,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"boolean"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so22 = (input: any): any =>
                 `{${
                     undefined === input.minimum
@@ -2242,6 +2302,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $number(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -2321,7 +2389,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"integer"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so23 = (input: any): any =>
                 `{${
                     undefined === input.minimum
@@ -2369,6 +2437,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $number(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -2448,7 +2524,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"number"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so24 = (input: any): any =>
                 `{${
                     undefined === input.minLength
@@ -2488,6 +2564,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $string(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -2567,7 +2651,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"string"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so25 = (input: any): any =>
                 `{${
                     undefined === input.minItems
@@ -2591,6 +2675,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         : `"x-typia-tuple":${
                               undefined !== input["x-typia-tuple"]
                                   ? $so26(input["x-typia-tuple"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -2670,9 +2762,17 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"array"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so26 = (input: any): any =>
                 `{${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.deprecated
                         ? ""
                         : `"deprecated":${
@@ -2751,7 +2851,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"array"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so27 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
@@ -3143,6 +3243,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                                   : undefined
                           },`
                 }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.patternProperties
                         ? ""
                         : `"patternProperties":${
@@ -3212,9 +3320,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"object"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable},"properties":${$so35(
-                    input.properties,
-                )}}`;
+                })()},"properties":${$so35(input.properties)}}`;
             const $so35 = (input: any): any =>
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {

--- a/test/generated/output/createRandom/test_createRandom_UltimateUnion.ts
+++ b/test/generated/output/createRandom/test_createRandom_UltimateUnion.ts
@@ -34,8 +34,12 @@ export const test_createRandom_UltimateUnion = _test_random(
             components: $ro32(_recursive, _recursive ? 1 + _depth : _depth),
             purpose: $pick([() => "ajv", () => "swagger"])(),
             prefix:
-                (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                (generator?.string ?? $generator.string)(),
+                (generator?.customs ?? $generator.customs)?.string?.([
+                    {
+                        name: "deprecated",
+                        value: 'Always "#/components/schemas"',
+                    },
+                ]) ?? (generator?.string ?? $generator.string)(),
         });
         const $ro1 = (
             _recursive: boolean = false,
@@ -49,7 +53,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
             type: "boolean",
-            nullable: (generator?.boolean ?? $generator.boolean)(),
+            nullable: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -350,7 +357,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                     (generator?.number ?? $generator.number)(0, 100),
             ])(),
             type: "number",
-            nullable: (generator?.boolean ?? $generator.boolean)(),
+            nullable: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -486,7 +496,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                     (generator?.string ?? $generator.string)(),
             ])(),
             type: "string",
-            nullable: (generator?.boolean ?? $generator.boolean)(),
+            nullable: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -615,7 +628,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
             type: "boolean",
-            nullable: (generator?.boolean ?? $generator.boolean)(),
+            nullable: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -784,7 +800,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                     (generator?.number ?? $generator.number)(0, 100),
             ])(),
             type: "integer",
-            nullable: (generator?.boolean ?? $generator.boolean)(),
+            nullable: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -941,7 +960,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                     (generator?.number ?? $generator.number)(0, 100),
             ])(),
             type: "number",
-            nullable: (generator?.boolean ?? $generator.boolean)(),
+            nullable: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -1104,7 +1126,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                     (generator?.string ?? $generator.string)(),
             ])(),
             type: "string",
-            nullable: (generator?.boolean ?? $generator.boolean)(),
+            nullable: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -1269,7 +1294,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => $ro26(true, _recursive ? 1 + _depth : _depth),
             ])(),
             type: "array",
-            nullable: (generator?.boolean ?? $generator.boolean)(),
+            nullable: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -1433,7 +1461,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                           ])(),
                       ),
             type: "array",
-            nullable: (generator?.boolean ?? $generator.boolean)(),
+            nullable: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -2256,7 +2287,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
             type: "object",
-            nullable: (generator?.boolean ?? $generator.boolean)(),
+            nullable: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
             properties: $ro35(_recursive, _recursive ? 1 + _depth : _depth),
             patternProperties: $pick([
                 () => undefined,
@@ -2374,6 +2408,7 @@ export const test_createRandom_UltimateUnion = _test_random(
     },
     (input: any): typia.Primitive<UltimateUnion> => {
         const $guard = (typia.createAssert as any).guard;
+        const $is_custom = (typia.createAssert as any).is_custom;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<UltimateUnion> => {
             const $io0 = (input: any): boolean =>
@@ -2389,14 +2424,21 @@ export const test_createRandom_UltimateUnion = _test_random(
                 null !== input.components &&
                 $io32(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                "string" === typeof input.prefix;
+                "string" === typeof input.prefix &&
+                $is_custom(
+                    "deprecated",
+                    "string",
+                    'Always "#/components/schemas"',
+                    input.prefix,
+                );
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2510,7 +2552,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2545,7 +2588,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2578,7 +2622,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2628,7 +2673,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2675,7 +2721,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2722,7 +2769,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2771,7 +2819,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2810,7 +2859,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -3019,7 +3069,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
@@ -3266,7 +3317,19 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '("ajv" | "swagger")',
                             value: input.purpose,
                         })) &&
-                    ("string" === typeof input.prefix ||
+                    (("string" === typeof input.prefix &&
+                        ($is_custom(
+                            "deprecated",
+                            "string",
+                            'Always "#/components/schemas"',
+                            input.prefix,
+                        ) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".prefix",
+                                expected:
+                                    'string (@deprecated Always "#/components/schemas")',
+                                value: input.prefix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".prefix",
                             expected: "string",
@@ -3305,10 +3368,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '"boolean"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -3778,10 +3842,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '"number"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -3919,10 +3984,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '"string"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4045,10 +4111,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '"boolean"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4228,10 +4295,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '"integer"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4393,10 +4461,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '"number"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4573,10 +4642,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '"string"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4759,10 +4829,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '"array"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4902,10 +4973,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '"array"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -5668,10 +5740,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: '"object"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (("object" === typeof input.properties &&

--- a/test/generated/output/createStringify/test_createStringify_UltimateUnion.ts
+++ b/test/generated/output/createStringify/test_createStringify_UltimateUnion.ts
@@ -11,13 +11,15 @@ export const test_createStringify_UltimateUnion = _test_stringify(
         const $number = (typia.createStringify as any).number;
         const $tail = (typia.createStringify as any).tail;
         const $join = (typia.createStringify as any).join;
+        const $is_custom = (typia.createStringify as any).is_custom;
         const $io1 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "boolean" === typeof elem) &&
             (undefined === input["default"] ||
                 "boolean" === typeof input["default"]) &&
             "boolean" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -103,7 +105,8 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input["default"] ||
                 "number" === typeof input["default"]) &&
             "number" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -137,7 +140,8 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input["default"] ||
                 "string" === typeof input["default"]) &&
             "string" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -169,7 +173,8 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input["default"] ||
                 "boolean" === typeof input["default"]) &&
             "boolean" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -214,7 +219,8 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input["default"] ||
                 "number" === typeof input["default"]) &&
             "integer" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -256,7 +262,8 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input["default"] ||
                 "number" === typeof input["default"]) &&
             "number" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -299,7 +306,8 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input["default"] ||
                 "string" === typeof input["default"]) &&
             "string" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -345,7 +353,8 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     null !== input["x-typia-tuple"] &&
                     $io26(input["x-typia-tuple"]))) &&
             "array" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -383,7 +392,8 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     $iu2(elem),
             ) &&
             "array" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
             (undefined === input.title || "string" === typeof input.title) &&
@@ -586,7 +596,8 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor) &&
             "object" === input.type &&
-            "boolean" === typeof input.nullable &&
+            (undefined === input.nullable ||
+                "boolean" === typeof input.nullable) &&
             "object" === typeof input.properties &&
             null !== input.properties &&
             false === Array.isArray(input.properties) &&
@@ -790,6 +801,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                               : undefined
                       },`
             }${
+                undefined === input.nullable
+                    ? ""
+                    : `"nullable":${
+                          undefined !== input.nullable
+                              ? input.nullable
+                              : undefined
+                      },`
+            }${
                 undefined === input.deprecated
                     ? ""
                     : `"deprecated":${
@@ -867,7 +886,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"boolean"',
                     value: input.type,
                 });
-            })()},"nullable":${input.nullable}}`;
+            })()}}`;
         const $so2 = (input: any): any =>
             `{"kind":${(() => {
                 if ("string" === typeof input.kind) return $string(input.kind);
@@ -1064,6 +1083,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                               : undefined
                       },`
             }${
+                undefined === input.nullable
+                    ? ""
+                    : `"nullable":${
+                          undefined !== input.nullable
+                              ? input.nullable
+                              : undefined
+                      },`
+            }${
                 undefined === input.deprecated
                     ? ""
                     : `"deprecated":${
@@ -1141,7 +1168,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"number"',
                     value: input.type,
                 });
-            })()},"nullable":${input.nullable}}`;
+            })()}}`;
         const $so20 = (input: any): any =>
             `{${
                 undefined === input["default"]
@@ -1149,6 +1176,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     : `"default":${
                           undefined !== input["default"]
                               ? $string(input["default"])
+                              : undefined
+                      },`
+            }${
+                undefined === input.nullable
+                    ? ""
+                    : `"nullable":${
+                          undefined !== input.nullable
+                              ? input.nullable
                               : undefined
                       },`
             }${
@@ -1229,7 +1264,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"string"',
                     value: input.type,
                 });
-            })()},"nullable":${input.nullable}}`;
+            })()}}`;
         const $so21 = (input: any): any =>
             `{${
                 undefined === input["default"]
@@ -1237,6 +1272,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     : `"default":${
                           undefined !== input["default"]
                               ? input["default"]
+                              : undefined
+                      },`
+            }${
+                undefined === input.nullable
+                    ? ""
+                    : `"nullable":${
+                          undefined !== input.nullable
+                              ? input.nullable
                               : undefined
                       },`
             }${
@@ -1315,7 +1358,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"boolean"',
                     value: input.type,
                 });
-            })()},"nullable":${input.nullable}}`;
+            })()}}`;
         const $so22 = (input: any): any =>
             `{${
                 undefined === input.minimum
@@ -1363,6 +1406,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     : `"default":${
                           undefined !== input["default"]
                               ? $number(input["default"])
+                              : undefined
+                      },`
+            }${
+                undefined === input.nullable
+                    ? ""
+                    : `"nullable":${
+                          undefined !== input.nullable
+                              ? input.nullable
                               : undefined
                       },`
             }${
@@ -1441,7 +1492,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"integer"',
                     value: input.type,
                 });
-            })()},"nullable":${input.nullable}}`;
+            })()}}`;
         const $so23 = (input: any): any =>
             `{${
                 undefined === input.minimum
@@ -1489,6 +1540,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     : `"default":${
                           undefined !== input["default"]
                               ? $number(input["default"])
+                              : undefined
+                      },`
+            }${
+                undefined === input.nullable
+                    ? ""
+                    : `"nullable":${
+                          undefined !== input.nullable
+                              ? input.nullable
                               : undefined
                       },`
             }${
@@ -1567,7 +1626,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"number"',
                     value: input.type,
                 });
-            })()},"nullable":${input.nullable}}`;
+            })()}}`;
         const $so24 = (input: any): any =>
             `{${
                 undefined === input.minLength
@@ -1607,6 +1666,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     : `"default":${
                           undefined !== input["default"]
                               ? $string(input["default"])
+                              : undefined
+                      },`
+            }${
+                undefined === input.nullable
+                    ? ""
+                    : `"nullable":${
+                          undefined !== input.nullable
+                              ? input.nullable
                               : undefined
                       },`
             }${
@@ -1685,7 +1752,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"string"',
                     value: input.type,
                 });
-            })()},"nullable":${input.nullable}}`;
+            })()}}`;
         const $so25 = (input: any): any =>
             `{${
                 undefined === input.minItems
@@ -1709,6 +1776,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     : `"x-typia-tuple":${
                           undefined !== input["x-typia-tuple"]
                               ? $so26(input["x-typia-tuple"])
+                              : undefined
+                      },`
+            }${
+                undefined === input.nullable
+                    ? ""
+                    : `"nullable":${
+                          undefined !== input.nullable
+                              ? input.nullable
                               : undefined
                       },`
             }${
@@ -1787,9 +1862,17 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"array"',
                     value: input.type,
                 });
-            })()},"nullable":${input.nullable}}`;
+            })()}}`;
         const $so26 = (input: any): any =>
             `{${
+                undefined === input.nullable
+                    ? ""
+                    : `"nullable":${
+                          undefined !== input.nullable
+                              ? input.nullable
+                              : undefined
+                      },`
+            }${
                 undefined === input.deprecated
                     ? ""
                     : `"deprecated":${
@@ -1867,7 +1950,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"array"',
                     value: input.type,
                 });
-            })()},"nullable":${input.nullable}}`;
+            })()}}`;
         const $so27 = (input: any): any =>
             `{${
                 undefined === input.deprecated
@@ -2258,6 +2341,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                               : undefined
                       },`
             }${
+                undefined === input.nullable
+                    ? ""
+                    : `"nullable":${
+                          undefined !== input.nullable
+                              ? input.nullable
+                              : undefined
+                      },`
+            }${
                 undefined === input.patternProperties
                     ? ""
                     : `"patternProperties":${
@@ -2325,9 +2416,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"object"',
                     value: input.type,
                 });
-            })()},"nullable":${input.nullable},"properties":${$so35(
-                input.properties,
-            )}}`;
+            })()},"properties":${$so35(input.properties)}}`;
         const $so35 = (input: any): any =>
             `{${Object.entries(input)
                 .map(([key, value]: [string, any]) => {

--- a/test/generated/output/createValidate/test_createValidate_UltimateUnion.ts
+++ b/test/generated/output/createValidate/test_createValidate_UltimateUnion.ts
@@ -20,14 +20,21 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 null !== input.components &&
                 $io32(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                "string" === typeof input.prefix;
+                "string" === typeof input.prefix &&
+                $is_custom(
+                    "deprecated",
+                    "string",
+                    'Always "#/components/schemas"',
+                    input.prefix,
+                );
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -141,7 +148,8 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -176,7 +184,8 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -209,7 +218,8 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -259,7 +269,8 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -306,7 +317,8 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -353,7 +365,8 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -402,7 +415,8 @@ export const test_createValidate_UltimateUnion = _test_validate(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -441,7 +455,8 @@ export const test_createValidate_UltimateUnion = _test_validate(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -650,7 +665,8 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
@@ -845,6 +861,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
         };
         const errors = [] as any[];
         const $report = (typia.createValidate as any).report(errors);
+        const $is_custom = (typia.createValidate as any).is_custom;
         const $join = (typia.createValidate as any).join;
         if (false === __is(input))
             ((
@@ -931,7 +948,19 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '("ajv" | "swagger")',
                                 value: input.purpose,
                             }),
-                        "string" === typeof input.prefix ||
+                        ("string" === typeof input.prefix &&
+                            ($is_custom(
+                                "deprecated",
+                                "string",
+                                'Always "#/components/schemas"',
+                                input.prefix,
+                            ) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".prefix",
+                                    expected:
+                                        'string (@deprecated Always "#/components/schemas")',
+                                    value: input.prefix,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected: "string",
@@ -983,10 +1012,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '"boolean"',
                                 value: input.type,
                             }),
-                        "boolean" === typeof input.nullable ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             }),
                         undefined === input.deprecated ||
@@ -1559,10 +1589,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '"number"',
                                 value: input.type,
                             }),
-                        "boolean" === typeof input.nullable ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             }),
                         undefined === input.deprecated ||
@@ -1748,10 +1779,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '"string"',
                                 value: input.type,
                             }),
-                        "boolean" === typeof input.nullable ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             }),
                         undefined === input.deprecated ||
@@ -1911,10 +1943,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '"boolean"',
                                 value: input.type,
                             }),
-                        "boolean" === typeof input.nullable ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             }),
                         undefined === input.deprecated ||
@@ -2132,10 +2165,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '"integer"',
                                 value: input.type,
                             }),
-                        "boolean" === typeof input.nullable ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             }),
                         undefined === input.deprecated ||
@@ -2334,10 +2368,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '"number"',
                                 value: input.type,
                             }),
-                        "boolean" === typeof input.nullable ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             }),
                         undefined === input.deprecated ||
@@ -2553,10 +2588,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '"string"',
                                 value: input.type,
                             }),
-                        "boolean" === typeof input.nullable ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             }),
                         undefined === input.deprecated ||
@@ -2788,10 +2824,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '"array"',
                                 value: input.type,
                             }),
-                        "boolean" === typeof input.nullable ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             }),
                         undefined === input.deprecated ||
@@ -2993,10 +3030,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '"array"',
                                 value: input.type,
                             }),
-                        "boolean" === typeof input.nullable ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             }),
                         undefined === input.deprecated ||
@@ -4026,10 +4064,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: '"object"',
                                 value: input.type,
                             }),
-                        "boolean" === typeof input.nullable ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
                                 path: _path + ".nullable",
-                                expected: "boolean",
+                                expected: "(boolean | undefined)",
                                 value: input.nullable,
                             }),
                         ((("object" === typeof input.properties &&

--- a/test/generated/output/createValidateClone/test_createValidateClone_UltimateUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_UltimateUnion.ts
@@ -21,7 +21,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     null !== input.components &&
                     $io32(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                    "string" === typeof input.prefix;
+                    "string" === typeof input.prefix &&
+                    $is_custom(
+                        "deprecated",
+                        "string",
+                        'Always "#/components/schemas"',
+                        input.prefix,
+                    );
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -30,7 +36,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -144,7 +151,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -181,7 +189,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -214,7 +223,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -264,7 +274,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -311,7 +322,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -358,7 +370,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -407,7 +420,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -446,7 +460,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -656,7 +671,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -862,6 +878,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
             };
             const errors = [] as any[];
             const $report = (typia.createValidateClone as any).report(errors);
+            const $is_custom = (typia.createValidateClone as any).is_custom;
             const $join = (typia.createValidateClone as any).join;
             if (false === __is(input))
                 ((
@@ -949,7 +966,19 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '("ajv" | "swagger")',
                                     value: input.purpose,
                                 }),
-                            "string" === typeof input.prefix ||
+                            ("string" === typeof input.prefix &&
+                                ($is_custom(
+                                    "deprecated",
+                                    "string",
+                                    'Always "#/components/schemas"',
+                                    input.prefix,
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".prefix",
+                                        expected:
+                                            'string (@deprecated Always "#/components/schemas")',
+                                        value: input.prefix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".prefix",
                                     expected: "string",
@@ -1001,10 +1030,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '"boolean"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -1582,10 +1612,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '"number"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -1775,10 +1806,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '"string"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -1942,10 +1974,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '"boolean"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2169,10 +2202,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '"integer"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2375,10 +2409,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '"number"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2598,10 +2633,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '"string"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2840,10 +2876,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '"array"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -3050,10 +3087,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '"array"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -4109,10 +4147,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: '"object"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             ((("object" === typeof input.properties &&
@@ -4784,13 +4823,15 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
         ): typia.Primitive<UltimateUnion> => {
             const $join = (typia.createValidateClone as any).join;
             const $throws = (typia.createValidateClone as any).throws;
+            const $is_custom = (typia.createValidateClone as any).is_custom;
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4878,7 +4919,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4913,7 +4955,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4946,7 +4989,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -4992,7 +5036,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -5035,7 +5080,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -5080,7 +5126,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -5127,7 +5174,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -5166,7 +5214,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -5375,7 +5424,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&

--- a/test/generated/output/createValidateParse/test_createValidateParse_UltimateUnion.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_UltimateUnion.ts
@@ -21,7 +21,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     null !== input.components &&
                     $io32(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                    "string" === typeof input.prefix;
+                    "string" === typeof input.prefix &&
+                    $is_custom(
+                        "deprecated",
+                        "string",
+                        'Always "#/components/schemas"',
+                        input.prefix,
+                    );
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -30,7 +36,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -144,7 +151,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -181,7 +189,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -214,7 +223,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -264,7 +274,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -311,7 +322,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -358,7 +370,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -407,7 +420,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -446,7 +460,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -656,7 +671,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -862,6 +878,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
             };
             const errors = [] as any[];
             const $report = (typia.createValidateParse as any).report(errors);
+            const $is_custom = (typia.createValidateParse as any).is_custom;
             const $join = (typia.createValidateParse as any).join;
             if (false === __is(input))
                 ((
@@ -949,7 +966,19 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '("ajv" | "swagger")',
                                     value: input.purpose,
                                 }),
-                            "string" === typeof input.prefix ||
+                            ("string" === typeof input.prefix &&
+                                ($is_custom(
+                                    "deprecated",
+                                    "string",
+                                    'Always "#/components/schemas"',
+                                    input.prefix,
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".prefix",
+                                        expected:
+                                            'string (@deprecated Always "#/components/schemas")',
+                                        value: input.prefix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".prefix",
                                     expected: "string",
@@ -1001,10 +1030,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '"boolean"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -1582,10 +1612,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '"number"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -1775,10 +1806,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '"string"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -1942,10 +1974,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '"boolean"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2169,10 +2202,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '"integer"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2375,10 +2409,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '"number"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2598,10 +2633,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '"string"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2840,10 +2876,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '"array"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -3050,10 +3087,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '"array"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -4109,10 +4147,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: '"object"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             ((("object" === typeof input.properties &&

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_UltimateUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_UltimateUnion.ts
@@ -23,7 +23,13 @@ export const test_createValidateStringify_UltimateUnion =
                         $io32(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose) &&
-                        "string" === typeof input.prefix;
+                        "string" === typeof input.prefix &&
+                        $is_custom(
+                            "deprecated",
+                            "string",
+                            'Always "#/components/schemas"',
+                            input.prefix,
+                        );
                     const $io1 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
@@ -32,7 +38,8 @@ export const test_createValidateStringify_UltimateUnion =
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -148,7 +155,8 @@ export const test_createValidateStringify_UltimateUnion =
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -185,7 +193,8 @@ export const test_createValidateStringify_UltimateUnion =
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -218,7 +227,8 @@ export const test_createValidateStringify_UltimateUnion =
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -269,7 +279,8 @@ export const test_createValidateStringify_UltimateUnion =
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "integer" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -316,7 +327,8 @@ export const test_createValidateStringify_UltimateUnion =
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -363,7 +375,8 @@ export const test_createValidateStringify_UltimateUnion =
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -412,7 +425,8 @@ export const test_createValidateStringify_UltimateUnion =
                                 null !== input["x-typia-tuple"] &&
                                 $io26(input["x-typia-tuple"]))) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -451,7 +465,8 @@ export const test_createValidateStringify_UltimateUnion =
                                 $iu2(elem),
                         ) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -661,7 +676,8 @@ export const test_createValidateStringify_UltimateUnion =
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
@@ -871,6 +887,8 @@ export const test_createValidateStringify_UltimateUnion =
                 const $report = (typia.createValidateStringify as any).report(
                     errors,
                 );
+                const $is_custom = (typia.createValidateStringify as any)
+                    .is_custom;
                 const $join = (typia.createValidateStringify as any).join;
                 if (false === __is(input))
                     ((
@@ -958,7 +976,19 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '("ajv" | "swagger")',
                                         value: input.purpose,
                                     }),
-                                "string" === typeof input.prefix ||
+                                ("string" === typeof input.prefix &&
+                                    ($is_custom(
+                                        "deprecated",
+                                        "string",
+                                        'Always "#/components/schemas"',
+                                        input.prefix,
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".prefix",
+                                            expected:
+                                                'string (@deprecated Always "#/components/schemas")',
+                                            value: input.prefix,
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".prefix",
                                         expected: "string",
@@ -1010,10 +1040,11 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '"boolean"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -1614,10 +1645,11 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '"number"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -1825,10 +1857,11 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '"string"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2010,10 +2043,11 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '"boolean"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2257,10 +2291,11 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '"integer"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2483,10 +2518,11 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '"number"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2724,10 +2760,11 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '"string"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2985,10 +3022,11 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '"array"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -3213,10 +3251,11 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '"array"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -4389,10 +4428,11 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: '"object"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 ((("object" === typeof input.properties &&
@@ -5179,6 +5219,8 @@ export const test_createValidateStringify_UltimateUnion =
                 const $number = (typia.createValidateStringify as any).number;
                 const $tail = (typia.createValidateStringify as any).tail;
                 const $join = (typia.createValidateStringify as any).join;
+                const $is_custom = (typia.createValidateStringify as any)
+                    .is_custom;
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -5187,7 +5229,8 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5282,7 +5325,8 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5319,7 +5363,8 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5352,7 +5397,8 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5398,7 +5444,8 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5441,7 +5488,8 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5486,7 +5534,8 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5533,7 +5582,8 @@ export const test_createValidateStringify_UltimateUnion =
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5572,7 +5622,8 @@ export const test_createValidateStringify_UltimateUnion =
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5782,7 +5833,8 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -5998,6 +6050,14 @@ export const test_createValidateStringify_UltimateUnion =
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -6076,7 +6136,7 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"boolean"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so2 = (input: any): any =>
                     `{"kind":${(() => {
                         if ("string" === typeof input.kind)
@@ -6290,6 +6350,14 @@ export const test_createValidateStringify_UltimateUnion =
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -6368,7 +6436,7 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"number"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so20 = (input: any): any =>
                     `{${
                         undefined === input["default"]
@@ -6376,6 +6444,14 @@ export const test_createValidateStringify_UltimateUnion =
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $string(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -6457,7 +6533,7 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"string"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so21 = (input: any): any =>
                     `{${
                         undefined === input["default"]
@@ -6465,6 +6541,14 @@ export const test_createValidateStringify_UltimateUnion =
                             : `"default":${
                                   undefined !== input["default"]
                                       ? input["default"]
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -6544,7 +6628,7 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"boolean"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so22 = (input: any): any =>
                     `{${
                         undefined === input.minimum
@@ -6592,6 +6676,14 @@ export const test_createValidateStringify_UltimateUnion =
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $number(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -6671,7 +6763,7 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"integer"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so23 = (input: any): any =>
                     `{${
                         undefined === input.minimum
@@ -6719,6 +6811,14 @@ export const test_createValidateStringify_UltimateUnion =
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $number(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -6798,7 +6898,7 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"number"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so24 = (input: any): any =>
                     `{${
                         undefined === input.minLength
@@ -6838,6 +6938,14 @@ export const test_createValidateStringify_UltimateUnion =
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $string(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -6917,7 +7025,7 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"string"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so25 = (input: any): any =>
                     `{${
                         undefined === input.minItems
@@ -6941,6 +7049,14 @@ export const test_createValidateStringify_UltimateUnion =
                             : `"x-typia-tuple":${
                                   undefined !== input["x-typia-tuple"]
                                       ? $so26(input["x-typia-tuple"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -7020,9 +7136,17 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"array"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so26 = (input: any): any =>
                     `{${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -7101,7 +7225,7 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"array"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so27 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
@@ -7493,6 +7617,14 @@ export const test_createValidateStringify_UltimateUnion =
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.patternProperties
                             ? ""
                             : `"patternProperties":${
@@ -7569,9 +7701,7 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"object"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable},"properties":${$so35(
-                        input.properties,
-                    )}}`;
+                    })()},"properties":${$so35(input.properties)}}`;
                 const $so35 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {

--- a/test/generated/output/is/test_is_UltimateUnion.ts
+++ b/test/generated/output/is/test_is_UltimateUnion.ts
@@ -7,6 +7,7 @@ export const test_is_UltimateUnion = _test_is(
     UltimateUnion.generate,
     (input) =>
         ((input: any): input is Array<typia.IJsonApplication> => {
+            const $is_custom = (typia.is as any).is_custom;
             const $join = (typia.is as any).join;
             const $io0 = (input: any): boolean =>
                 Array.isArray(input.schemas) &&
@@ -21,14 +22,21 @@ export const test_is_UltimateUnion = _test_is(
                 null !== input.components &&
                 $io32(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                "string" === typeof input.prefix;
+                "string" === typeof input.prefix &&
+                $is_custom(
+                    "deprecated",
+                    "string",
+                    'Always "#/components/schemas"',
+                    input.prefix,
+                );
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -142,7 +150,8 @@ export const test_is_UltimateUnion = _test_is(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -177,7 +186,8 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -210,7 +220,8 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -260,7 +271,8 @@ export const test_is_UltimateUnion = _test_is(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -307,7 +319,8 @@ export const test_is_UltimateUnion = _test_is(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -354,7 +367,8 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -403,7 +417,8 @@ export const test_is_UltimateUnion = _test_is(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -442,7 +457,8 @@ export const test_is_UltimateUnion = _test_is(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -651,7 +667,8 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&

--- a/test/generated/output/isClone/test_isClone_UltimateUnion.ts
+++ b/test/generated/output/isClone/test_isClone_UltimateUnion.ts
@@ -10,6 +10,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
             input: any,
         ): typia.Primitive<Array<typia.IJsonApplication>> | null => {
             const is = (input: any): input is Array<typia.IJsonApplication> => {
+                const $is_custom = (typia.isClone as any).is_custom;
                 const $join = (typia.isClone as any).join;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.schemas) &&
@@ -24,7 +25,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     null !== input.components &&
                     $io32(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                    "string" === typeof input.prefix;
+                    "string" === typeof input.prefix &&
+                    $is_custom(
+                        "deprecated",
+                        "string",
+                        'Always "#/components/schemas"',
+                        input.prefix,
+                    );
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -33,7 +40,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -147,7 +155,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -184,7 +193,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -217,7 +227,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -267,7 +278,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -314,7 +326,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -361,7 +374,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -410,7 +424,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -449,7 +464,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -659,7 +675,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -868,6 +885,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
             ): typia.Primitive<Array<typia.IJsonApplication>> => {
                 const $join = (typia.isClone as any).join;
                 const $throws = (typia.isClone as any).throws;
+                const $is_custom = (typia.isClone as any).is_custom;
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -876,7 +894,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -971,7 +990,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1008,7 +1028,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1041,7 +1062,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1087,7 +1109,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1130,7 +1153,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1175,7 +1199,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1222,7 +1247,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1261,7 +1287,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1471,7 +1498,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&

--- a/test/generated/output/isParse/test_isParse_UltimateUnion.ts
+++ b/test/generated/output/isParse/test_isParse_UltimateUnion.ts
@@ -8,6 +8,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
     (input) =>
         ((input: any): typia.Primitive<UltimateUnion> => {
             const is = (input: any): input is UltimateUnion => {
+                const $is_custom = (typia.isParse as any).is_custom;
                 const $join = (typia.isParse as any).join;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.schemas) &&
@@ -22,7 +23,13 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     null !== input.components &&
                     $io32(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                    "string" === typeof input.prefix;
+                    "string" === typeof input.prefix &&
+                    $is_custom(
+                        "deprecated",
+                        "string",
+                        'Always "#/components/schemas"',
+                        input.prefix,
+                    );
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -31,7 +38,8 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -145,7 +153,8 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -182,7 +191,8 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -215,7 +225,8 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -265,7 +276,8 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -312,7 +324,8 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -359,7 +372,8 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -408,7 +422,8 @@ export const test_isParse_UltimateUnion = _test_isParse(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -447,7 +462,8 @@ export const test_isParse_UltimateUnion = _test_isParse(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -657,7 +673,8 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&

--- a/test/generated/output/isStringify/test_isStringify_UltimateUnion.ts
+++ b/test/generated/output/isStringify/test_isStringify_UltimateUnion.ts
@@ -8,6 +8,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
     (input) =>
         ((input: Array<typia.IJsonApplication>): string | null => {
             const is = (input: any): input is Array<typia.IJsonApplication> => {
+                const $is_custom = (typia.isStringify as any).is_custom;
                 const $join = (typia.isStringify as any).join;
                 const $io0 = (input: any): boolean =>
                     Array.isArray(input.schemas) &&
@@ -22,7 +23,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     null !== input.components &&
                     $io32(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                    "string" === typeof input.prefix;
+                    "string" === typeof input.prefix &&
+                    $is_custom(
+                        "deprecated",
+                        "string",
+                        'Always "#/components/schemas"',
+                        input.prefix,
+                    );
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -31,7 +38,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -145,7 +153,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -182,7 +191,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -215,7 +225,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -265,7 +276,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -312,7 +324,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -359,7 +372,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -408,7 +422,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -447,7 +462,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -657,7 +673,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -869,6 +886,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                 const $number = (typia.isStringify as any).number;
                 const $tail = (typia.isStringify as any).tail;
                 const $join = (typia.isStringify as any).join;
+                const $is_custom = (typia.isStringify as any).is_custom;
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -877,7 +895,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -972,7 +991,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1009,7 +1029,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1042,7 +1063,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1088,7 +1110,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1131,7 +1154,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1176,7 +1200,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1223,7 +1248,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1262,7 +1288,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -1472,7 +1499,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -1688,6 +1716,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -1766,7 +1802,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"boolean"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so2 = (input: any): any =>
                     `{"kind":${(() => {
                         if ("string" === typeof input.kind)
@@ -1980,6 +2016,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -2058,7 +2102,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"number"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so20 = (input: any): any =>
                     `{${
                         undefined === input["default"]
@@ -2066,6 +2110,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $string(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -2147,7 +2199,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"string"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so21 = (input: any): any =>
                     `{${
                         undefined === input["default"]
@@ -2155,6 +2207,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? input["default"]
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -2234,7 +2294,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"boolean"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so22 = (input: any): any =>
                     `{${
                         undefined === input.minimum
@@ -2282,6 +2342,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $number(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -2361,7 +2429,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"integer"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so23 = (input: any): any =>
                     `{${
                         undefined === input.minimum
@@ -2409,6 +2477,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $number(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -2488,7 +2564,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"number"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so24 = (input: any): any =>
                     `{${
                         undefined === input.minLength
@@ -2528,6 +2604,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $string(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -2607,7 +2691,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"string"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so25 = (input: any): any =>
                     `{${
                         undefined === input.minItems
@@ -2631,6 +2715,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             : `"x-typia-tuple":${
                                   undefined !== input["x-typia-tuple"]
                                       ? $so26(input["x-typia-tuple"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -2710,9 +2802,17 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"array"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so26 = (input: any): any =>
                     `{${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -2791,7 +2891,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"array"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so27 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
@@ -3183,6 +3283,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.patternProperties
                             ? ""
                             : `"patternProperties":${
@@ -3259,9 +3367,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"object"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable},"properties":${$so35(
-                        input.properties,
-                    )}}`;
+                    })()},"properties":${$so35(input.properties)}}`;
                 const $so35 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {

--- a/test/generated/output/random/test_random_UltimateUnion.ts
+++ b/test/generated/output/random/test_random_UltimateUnion.ts
@@ -49,8 +49,12 @@ export const test_random_UltimateUnion = _test_random(
                 components: $ro32(_recursive, _recursive ? 1 + _depth : _depth),
                 purpose: $pick([() => "ajv", () => "swagger"])(),
                 prefix:
-                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                    (generator?.string ?? $generator.string)(),
+                    (generator?.customs ?? $generator.customs)?.string?.([
+                        {
+                            name: "deprecated",
+                            value: 'Always "#/components/schemas"',
+                        },
+                    ]) ?? (generator?.string ?? $generator.string)(),
             });
             const $ro1 = (
                 _recursive: boolean = false,
@@ -64,7 +68,10 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
                 type: "boolean",
-                nullable: (generator?.boolean ?? $generator.boolean)(),
+                nullable: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -369,7 +376,10 @@ export const test_random_UltimateUnion = _test_random(
                         ) ?? (generator?.number ?? $generator.number)(0, 100),
                 ])(),
                 type: "number",
-                nullable: (generator?.boolean ?? $generator.boolean)(),
+                nullable: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -509,7 +519,10 @@ export const test_random_UltimateUnion = _test_random(
                         ) ?? (generator?.string ?? $generator.string)(),
                 ])(),
                 type: "string",
-                nullable: (generator?.boolean ?? $generator.boolean)(),
+                nullable: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -640,7 +653,10 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
                 type: "boolean",
-                nullable: (generator?.boolean ?? $generator.boolean)(),
+                nullable: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -815,7 +831,10 @@ export const test_random_UltimateUnion = _test_random(
                         ) ?? (generator?.number ?? $generator.number)(0, 100),
                 ])(),
                 type: "integer",
-                nullable: (generator?.boolean ?? $generator.boolean)(),
+                nullable: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -978,7 +997,10 @@ export const test_random_UltimateUnion = _test_random(
                         ) ?? (generator?.number ?? $generator.number)(0, 100),
                 ])(),
                 type: "number",
-                nullable: (generator?.boolean ?? $generator.boolean)(),
+                nullable: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -1146,7 +1168,10 @@ export const test_random_UltimateUnion = _test_random(
                         ) ?? (generator?.string ?? $generator.string)(),
                 ])(),
                 type: "string",
-                nullable: (generator?.boolean ?? $generator.boolean)(),
+                nullable: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -1313,7 +1338,10 @@ export const test_random_UltimateUnion = _test_random(
                     () => $ro26(true, _recursive ? 1 + _depth : _depth),
                 ])(),
                 type: "array",
-                nullable: (generator?.boolean ?? $generator.boolean)(),
+                nullable: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -1521,7 +1549,10 @@ export const test_random_UltimateUnion = _test_random(
                               ])(),
                           ),
                 type: "array",
-                nullable: (generator?.boolean ?? $generator.boolean)(),
+                nullable: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -2402,7 +2433,10 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
                 type: "object",
-                nullable: (generator?.boolean ?? $generator.boolean)(),
+                nullable: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
                 properties: $ro35(_recursive, _recursive ? 1 + _depth : _depth),
                 patternProperties: $pick([
                     () => undefined,
@@ -2564,6 +2598,7 @@ export const test_random_UltimateUnion = _test_random(
         })(),
     (input: any): typia.Primitive<UltimateUnion> => {
         const $guard = (typia.createAssert as any).guard;
+        const $is_custom = (typia.createAssert as any).is_custom;
         const $join = (typia.createAssert as any).join;
         const __is = (input: any): input is typia.Primitive<UltimateUnion> => {
             const $io0 = (input: any): boolean =>
@@ -2579,14 +2614,21 @@ export const test_random_UltimateUnion = _test_random(
                 null !== input.components &&
                 $io32(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                "string" === typeof input.prefix;
+                "string" === typeof input.prefix &&
+                $is_custom(
+                    "deprecated",
+                    "string",
+                    'Always "#/components/schemas"',
+                    input.prefix,
+                );
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2700,7 +2742,8 @@ export const test_random_UltimateUnion = _test_random(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2735,7 +2778,8 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2768,7 +2812,8 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2818,7 +2863,8 @@ export const test_random_UltimateUnion = _test_random(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2865,7 +2911,8 @@ export const test_random_UltimateUnion = _test_random(
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2912,7 +2959,8 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -2961,7 +3009,8 @@ export const test_random_UltimateUnion = _test_random(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -3000,7 +3049,8 @@ export const test_random_UltimateUnion = _test_random(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -3209,7 +3259,8 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
@@ -3456,7 +3507,19 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '("ajv" | "swagger")',
                             value: input.purpose,
                         })) &&
-                    ("string" === typeof input.prefix ||
+                    (("string" === typeof input.prefix &&
+                        ($is_custom(
+                            "deprecated",
+                            "string",
+                            'Always "#/components/schemas"',
+                            input.prefix,
+                        ) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".prefix",
+                                expected:
+                                    'string (@deprecated Always "#/components/schemas")',
+                                value: input.prefix,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".prefix",
                             expected: "string",
@@ -3495,10 +3558,11 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '"boolean"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -3968,10 +4032,11 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '"number"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4109,10 +4174,11 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '"string"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4235,10 +4301,11 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '"boolean"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4418,10 +4485,11 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '"integer"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4583,10 +4651,11 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '"number"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4763,10 +4832,11 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '"string"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4949,10 +5019,11 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '"array"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -5092,10 +5163,11 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '"array"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (undefined === input.deprecated ||
@@ -5858,10 +5930,11 @@ export const test_random_UltimateUnion = _test_random(
                             expected: '"object"',
                             value: input.type,
                         })) &&
-                    ("boolean" === typeof input.nullable ||
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
                         $guard(_exceptionable, {
                             path: _path + ".nullable",
-                            expected: "boolean",
+                            expected: "(boolean | undefined)",
                             value: input.nullable,
                         })) &&
                     (("object" === typeof input.properties &&

--- a/test/generated/output/stringify/test_stringify_UltimateUnion.ts
+++ b/test/generated/output/stringify/test_stringify_UltimateUnion.ts
@@ -12,13 +12,15 @@ export const test_stringify_UltimateUnion = _test_stringify(
             const $number = (typia.stringify as any).number;
             const $tail = (typia.stringify as any).tail;
             const $join = (typia.stringify as any).join;
+            const $is_custom = (typia.stringify as any).is_custom;
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -106,7 +108,8 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -141,7 +144,8 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -174,7 +178,8 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -220,7 +225,8 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -263,7 +269,8 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "number" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -308,7 +315,8 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input["default"] ||
                     "string" === typeof input["default"]) &&
                 "string" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -355,7 +363,8 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         null !== input["x-typia-tuple"] &&
                         $io26(input["x-typia-tuple"]))) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -394,7 +403,8 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         $iu2(elem),
                 ) &&
                 "array" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
                 (undefined === input.title ||
@@ -603,7 +613,8 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
-                "boolean" === typeof input.nullable &&
+                (undefined === input.nullable ||
+                    "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
@@ -810,6 +821,14 @@ export const test_stringify_UltimateUnion = _test_stringify(
                                   : undefined
                           },`
                 }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.deprecated
                         ? ""
                         : `"deprecated":${
@@ -888,7 +907,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"boolean"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so2 = (input: any): any =>
                 `{"kind":${(() => {
                     if ("string" === typeof input.kind)
@@ -1102,6 +1121,14 @@ export const test_stringify_UltimateUnion = _test_stringify(
                                   : undefined
                           },`
                 }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.deprecated
                         ? ""
                         : `"deprecated":${
@@ -1180,7 +1207,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"number"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so20 = (input: any): any =>
                 `{${
                     undefined === input["default"]
@@ -1188,6 +1215,14 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $string(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -1269,7 +1304,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"string"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so21 = (input: any): any =>
                 `{${
                     undefined === input["default"]
@@ -1277,6 +1312,14 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? input["default"]
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -1356,7 +1399,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"boolean"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so22 = (input: any): any =>
                 `{${
                     undefined === input.minimum
@@ -1404,6 +1447,14 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $number(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -1483,7 +1534,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"integer"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so23 = (input: any): any =>
                 `{${
                     undefined === input.minimum
@@ -1531,6 +1582,14 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $number(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -1610,7 +1669,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"number"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so24 = (input: any): any =>
                 `{${
                     undefined === input.minLength
@@ -1650,6 +1709,14 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         : `"default":${
                               undefined !== input["default"]
                                   ? $string(input["default"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -1729,7 +1796,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"string"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so25 = (input: any): any =>
                 `{${
                     undefined === input.minItems
@@ -1753,6 +1820,14 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         : `"x-typia-tuple":${
                               undefined !== input["x-typia-tuple"]
                                   ? $so26(input["x-typia-tuple"])
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
                                   : undefined
                           },`
                 }${
@@ -1832,9 +1907,17 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"array"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so26 = (input: any): any =>
                 `{${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.deprecated
                         ? ""
                         : `"deprecated":${
@@ -1913,7 +1996,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"array"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable}}`;
+                })()}}`;
             const $so27 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
@@ -2305,6 +2388,14 @@ export const test_stringify_UltimateUnion = _test_stringify(
                                   : undefined
                           },`
                 }${
+                    undefined === input.nullable
+                        ? ""
+                        : `"nullable":${
+                              undefined !== input.nullable
+                                  ? input.nullable
+                                  : undefined
+                          },`
+                }${
                     undefined === input.patternProperties
                         ? ""
                         : `"patternProperties":${
@@ -2374,9 +2465,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"object"',
                         value: input.type,
                     });
-                })()},"nullable":${input.nullable},"properties":${$so35(
-                    input.properties,
-                )}}`;
+                })()},"properties":${$so35(input.properties)}}`;
             const $so35 = (input: any): any =>
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {

--- a/test/generated/output/validate/test_validate_UltimateUnion.ts
+++ b/test/generated/output/validate/test_validate_UltimateUnion.ts
@@ -23,7 +23,13 @@ export const test_validate_UltimateUnion = _test_validate(
                     null !== input.components &&
                     $io32(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose) &&
-                    "string" === typeof input.prefix;
+                    "string" === typeof input.prefix &&
+                    $is_custom(
+                        "deprecated",
+                        "string",
+                        'Always "#/components/schemas"',
+                        input.prefix,
+                    );
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -32,7 +38,8 @@ export const test_validate_UltimateUnion = _test_validate(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -146,7 +153,8 @@ export const test_validate_UltimateUnion = _test_validate(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -183,7 +191,8 @@ export const test_validate_UltimateUnion = _test_validate(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -216,7 +225,8 @@ export const test_validate_UltimateUnion = _test_validate(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -266,7 +276,8 @@ export const test_validate_UltimateUnion = _test_validate(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -313,7 +324,8 @@ export const test_validate_UltimateUnion = _test_validate(
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -360,7 +372,8 @@ export const test_validate_UltimateUnion = _test_validate(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -409,7 +422,8 @@ export const test_validate_UltimateUnion = _test_validate(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -448,7 +462,8 @@ export const test_validate_UltimateUnion = _test_validate(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -658,7 +673,8 @@ export const test_validate_UltimateUnion = _test_validate(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -864,6 +880,7 @@ export const test_validate_UltimateUnion = _test_validate(
             };
             const errors = [] as any[];
             const $report = (typia.validate as any).report(errors);
+            const $is_custom = (typia.validate as any).is_custom;
             const $join = (typia.validate as any).join;
             if (false === __is(input))
                 ((
@@ -951,7 +968,19 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '("ajv" | "swagger")',
                                     value: input.purpose,
                                 }),
-                            "string" === typeof input.prefix ||
+                            ("string" === typeof input.prefix &&
+                                ($is_custom(
+                                    "deprecated",
+                                    "string",
+                                    'Always "#/components/schemas"',
+                                    input.prefix,
+                                ) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".prefix",
+                                        expected:
+                                            'string (@deprecated Always "#/components/schemas")',
+                                        value: input.prefix,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".prefix",
                                     expected: "string",
@@ -1003,10 +1032,11 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '"boolean"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -1584,10 +1614,11 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '"number"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -1777,10 +1808,11 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '"string"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -1944,10 +1976,11 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '"boolean"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2171,10 +2204,11 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '"integer"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2377,10 +2411,11 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '"number"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2600,10 +2635,11 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '"string"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -2842,10 +2878,11 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '"array"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -3052,10 +3089,11 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '"array"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             undefined === input.deprecated ||
@@ -4111,10 +4149,11 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: '"object"',
                                     value: input.type,
                                 }),
-                            "boolean" === typeof input.nullable ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
                                     path: _path + ".nullable",
-                                    expected: "boolean",
+                                    expected: "(boolean | undefined)",
                                     value: input.nullable,
                                 }),
                             ((("object" === typeof input.properties &&

--- a/test/generated/output/validateClone/test_validateClone_UltimateUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_UltimateUnion.ts
@@ -31,7 +31,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         $io32(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose) &&
-                        "string" === typeof input.prefix;
+                        "string" === typeof input.prefix &&
+                        $is_custom(
+                            "deprecated",
+                            "string",
+                            'Always "#/components/schemas"',
+                            input.prefix,
+                        );
                     const $io1 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
@@ -40,7 +46,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -156,7 +163,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -193,7 +201,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -226,7 +235,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -277,7 +287,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "integer" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -324,7 +335,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -371,7 +383,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -420,7 +433,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 null !== input["x-typia-tuple"] &&
                                 $io26(input["x-typia-tuple"]))) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -459,7 +473,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 $iu2(elem),
                         ) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -669,7 +684,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
@@ -877,6 +893,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                 };
                 const errors = [] as any[];
                 const $report = (typia.validateClone as any).report(errors);
+                const $is_custom = (typia.validateClone as any).is_custom;
                 const $join = (typia.validateClone as any).join;
                 if (false === __is(input))
                     ((
@@ -964,7 +981,19 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '("ajv" | "swagger")',
                                         value: input.purpose,
                                     }),
-                                "string" === typeof input.prefix ||
+                                ("string" === typeof input.prefix &&
+                                    ($is_custom(
+                                        "deprecated",
+                                        "string",
+                                        'Always "#/components/schemas"',
+                                        input.prefix,
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".prefix",
+                                            expected:
+                                                'string (@deprecated Always "#/components/schemas")',
+                                            value: input.prefix,
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".prefix",
                                         expected: "string",
@@ -1016,10 +1045,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '"boolean"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -1620,10 +1650,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '"number"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -1831,10 +1862,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '"string"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2016,10 +2048,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '"boolean"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2263,10 +2296,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '"integer"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2489,10 +2523,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '"number"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2730,10 +2765,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '"string"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2991,10 +3027,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '"array"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -3219,10 +3256,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '"array"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -4395,10 +4433,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: '"object"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 ((("object" === typeof input.properties &&
@@ -5184,6 +5223,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
             ): typia.Primitive<Array<typia.IJsonApplication>> => {
                 const $join = (typia.validateClone as any).join;
                 const $throws = (typia.validateClone as any).throws;
+                const $is_custom = (typia.validateClone as any).is_custom;
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -5192,7 +5232,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5287,7 +5328,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5324,7 +5366,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5357,7 +5400,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5403,7 +5447,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5446,7 +5491,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5491,7 +5537,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5538,7 +5585,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5577,7 +5625,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5787,7 +5836,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&

--- a/test/generated/output/validateParse/test_validateParse_UltimateUnion.ts
+++ b/test/generated/output/validateParse/test_validateParse_UltimateUnion.ts
@@ -23,7 +23,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         $io32(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose) &&
-                        "string" === typeof input.prefix;
+                        "string" === typeof input.prefix &&
+                        $is_custom(
+                            "deprecated",
+                            "string",
+                            'Always "#/components/schemas"',
+                            input.prefix,
+                        );
                     const $io1 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
@@ -32,7 +38,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -148,7 +155,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -185,7 +193,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -218,7 +227,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -269,7 +279,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "integer" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -316,7 +327,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -363,7 +375,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -412,7 +425,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                 null !== input["x-typia-tuple"] &&
                                 $io26(input["x-typia-tuple"]))) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -451,7 +465,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                 $iu2(elem),
                         ) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -661,7 +676,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
@@ -869,6 +885,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                 };
                 const errors = [] as any[];
                 const $report = (typia.validateParse as any).report(errors);
+                const $is_custom = (typia.validateParse as any).is_custom;
                 const $join = (typia.validateParse as any).join;
                 if (false === __is(input))
                     ((
@@ -956,7 +973,19 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '("ajv" | "swagger")',
                                         value: input.purpose,
                                     }),
-                                "string" === typeof input.prefix ||
+                                ("string" === typeof input.prefix &&
+                                    ($is_custom(
+                                        "deprecated",
+                                        "string",
+                                        'Always "#/components/schemas"',
+                                        input.prefix,
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".prefix",
+                                            expected:
+                                                'string (@deprecated Always "#/components/schemas")',
+                                            value: input.prefix,
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".prefix",
                                         expected: "string",
@@ -1008,10 +1037,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '"boolean"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -1612,10 +1642,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '"number"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -1823,10 +1854,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '"string"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2008,10 +2040,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '"boolean"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2255,10 +2288,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '"integer"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2481,10 +2515,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '"number"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2722,10 +2757,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '"string"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2983,10 +3019,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '"array"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -3211,10 +3248,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '"array"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -4387,10 +4425,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: '"object"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 ((("object" === typeof input.properties &&

--- a/test/generated/output/validateStringify/test_validateStringify_UltimateUnion.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_UltimateUnion.ts
@@ -27,7 +27,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         $io32(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose) &&
-                        "string" === typeof input.prefix;
+                        "string" === typeof input.prefix &&
+                        $is_custom(
+                            "deprecated",
+                            "string",
+                            'Always "#/components/schemas"',
+                            input.prefix,
+                        );
                     const $io1 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
@@ -36,7 +42,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -152,7 +159,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -189,7 +197,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -222,7 +231,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -273,7 +283,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "integer" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -320,7 +331,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
                         "number" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -367,7 +379,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         (undefined === input["default"] ||
                             "string" === typeof input["default"]) &&
                         "string" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -416,7 +429,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 null !== input["x-typia-tuple"] &&
                                 $io26(input["x-typia-tuple"]))) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -455,7 +469,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 $iu2(elem),
                         ) &&
                         "array" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
                         (undefined === input.title ||
@@ -665,7 +680,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
-                        "boolean" === typeof input.nullable &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
@@ -873,6 +889,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                 };
                 const errors = [] as any[];
                 const $report = (typia.validateStringify as any).report(errors);
+                const $is_custom = (typia.validateStringify as any).is_custom;
                 const $join = (typia.validateStringify as any).join;
                 if (false === __is(input))
                     ((
@@ -960,7 +977,19 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '("ajv" | "swagger")',
                                         value: input.purpose,
                                     }),
-                                "string" === typeof input.prefix ||
+                                ("string" === typeof input.prefix &&
+                                    ($is_custom(
+                                        "deprecated",
+                                        "string",
+                                        'Always "#/components/schemas"',
+                                        input.prefix,
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".prefix",
+                                            expected:
+                                                'string (@deprecated Always "#/components/schemas")',
+                                            value: input.prefix,
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".prefix",
                                         expected: "string",
@@ -1012,10 +1041,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '"boolean"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -1616,10 +1646,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '"number"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -1827,10 +1858,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '"string"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2012,10 +2044,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '"boolean"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2259,10 +2292,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '"integer"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2485,10 +2519,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '"number"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2726,10 +2761,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '"string"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -2987,10 +3023,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '"array"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -3215,10 +3252,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '"array"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 undefined === input.deprecated ||
@@ -4391,10 +4429,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: '"object"',
                                         value: input.type,
                                     }),
-                                "boolean" === typeof input.nullable ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
                                         path: _path + ".nullable",
-                                        expected: "boolean",
+                                        expected: "(boolean | undefined)",
                                         value: input.nullable,
                                     }),
                                 ((("object" === typeof input.properties &&
@@ -5183,6 +5222,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                 const $number = (typia.validateStringify as any).number;
                 const $tail = (typia.validateStringify as any).tail;
                 const $join = (typia.validateStringify as any).join;
+                const $is_custom = (typia.validateStringify as any).is_custom;
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
@@ -5191,7 +5231,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5286,7 +5327,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5323,7 +5365,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5356,7 +5399,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5402,7 +5446,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5445,7 +5490,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "number" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5490,7 +5536,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input["default"] ||
                         "string" === typeof input["default"]) &&
                     "string" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5537,7 +5584,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             null !== input["x-typia-tuple"] &&
                             $io26(input["x-typia-tuple"]))) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5576,7 +5624,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             $iu2(elem),
                     ) &&
                     "array" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
                     (undefined === input.title ||
@@ -5786,7 +5835,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
-                    "boolean" === typeof input.nullable &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
@@ -6002,6 +6052,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -6080,7 +6138,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"boolean"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so2 = (input: any): any =>
                     `{"kind":${(() => {
                         if ("string" === typeof input.kind)
@@ -6294,6 +6352,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -6372,7 +6438,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"number"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so20 = (input: any): any =>
                     `{${
                         undefined === input["default"]
@@ -6380,6 +6446,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $string(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -6461,7 +6535,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"string"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so21 = (input: any): any =>
                     `{${
                         undefined === input["default"]
@@ -6469,6 +6543,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? input["default"]
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -6548,7 +6630,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"boolean"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so22 = (input: any): any =>
                     `{${
                         undefined === input.minimum
@@ -6596,6 +6678,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $number(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -6675,7 +6765,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"integer"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so23 = (input: any): any =>
                     `{${
                         undefined === input.minimum
@@ -6723,6 +6813,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $number(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -6802,7 +6900,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"number"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so24 = (input: any): any =>
                     `{${
                         undefined === input.minLength
@@ -6842,6 +6940,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             : `"default":${
                                   undefined !== input["default"]
                                       ? $string(input["default"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -6921,7 +7027,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"string"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so25 = (input: any): any =>
                     `{${
                         undefined === input.minItems
@@ -6945,6 +7051,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             : `"x-typia-tuple":${
                                   undefined !== input["x-typia-tuple"]
                                       ? $so26(input["x-typia-tuple"])
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
                                       : undefined
                               },`
                     }${
@@ -7024,9 +7138,17 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"array"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so26 = (input: any): any =>
                     `{${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.deprecated
                             ? ""
                             : `"deprecated":${
@@ -7105,7 +7227,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"array"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable}}`;
+                    })()}}`;
                 const $so27 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
@@ -7497,6 +7619,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                       : undefined
                               },`
                     }${
+                        undefined === input.nullable
+                            ? ""
+                            : `"nullable":${
+                                  undefined !== input.nullable
+                                      ? input.nullable
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.patternProperties
                             ? ""
                             : `"patternProperties":${
@@ -7573,9 +7703,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"object"',
                             value: input.type,
                         });
-                    })()},"nullable":${input.nullable},"properties":${$so35(
-                        input.properties,
-                    )}}`;
+                    })()},"properties":${$so35(input.properties)}}`;
                 const $so35 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {

--- a/test/issues/json-schema.ts
+++ b/test/issues/json-schema.ts
@@ -1,0 +1,27 @@
+import ajv from "ajv";
+import fast from "fast-json-stringify";
+import typia from "typia";
+
+import { ObjectSimple } from "../structures/ObjectSimple";
+
+type ObjectArray = Array<ObjectSimple | null>;
+const data: ObjectArray = [
+    null,
+    ObjectSimple.generate(),
+    ObjectSimple.generate(),
+    ObjectSimple.generate(),
+];
+const app = typia.application<[ObjectArray], "swagger">();
+const stringify = fast({
+    ...app.schemas[0],
+    ...app,
+});
+console.log(stringify(data));
+
+console.log(
+    new ajv().compile(typia.application<[ObjectArray], "ajv">())([...data, {}]),
+    new ajv().compile(typia.application<[ObjectArray], "swagger">())([
+        ...data,
+        {},
+    ]),
+);

--- a/test/schemas/json/ajv/ArrayAny.json
+++ b/test/schemas/json/ajv/ArrayAny.json
@@ -1,125 +1,180 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ArrayAny"
+      "$ref": "#/components/schemas/ArrayAny"
     }
   ],
   "components": {
     "schemas": {
       "ArrayAny": {
-        "$id": "components#/schemas/ArrayAny",
+        "$id": "#/components/schemas/ArrayAny",
         "type": "object",
         "properties": {
           "anys": {
-            "type": "array",
-            "items": {
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "undefindable1": {
-            "type": "array",
-            "items": {
-              "description": "",
-              "x-typia-required": false,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": false
-          },
-          "undefindable2": {
-            "type": "array",
-            "items": {
-              "description": "",
-              "x-typia-required": false,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": false
-          },
-          "nullables1": {
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": true,
+            }
+          },
+          "undefindable1": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": false,
+              "x-typia-optional": false
+            }
+          },
+          "undefindable2": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": false,
+              "x-typia-optional": false
+            }
+          },
+          "nullables1": {
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "array",
+                "items": {
+                  "description": "",
+                  "x-typia-required": true,
+                  "x-typia-optional": false
+                }
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "nullables2": {
-            "type": "array",
-            "items": {
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "array",
+                "items": {
+                  "description": "",
+                  "x-typia-required": true,
+                  "x-typia-optional": false
+                }
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "both1": {
-            "type": "array",
-            "items": {
-              "description": "",
-              "x-typia-required": false,
-              "x-typia-optional": false
-            },
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": false,
+                "type": "array",
+                "items": {
+                  "description": "",
+                  "x-typia-required": false,
+                  "x-typia-optional": false
+                }
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "both2": {
-            "type": "array",
-            "items": {
-              "description": "",
-              "x-typia-required": false,
-              "x-typia-optional": false
-            },
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": false,
+                "type": "array",
+                "items": {
+                  "description": "",
+                  "x-typia-required": false,
+                  "x-typia-optional": false
+                }
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "both3": {
-            "type": "array",
-            "items": {
-              "description": "",
-              "x-typia-required": false,
-              "x-typia-optional": false
-            },
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": false,
+                "type": "array",
+                "items": {
+                  "description": "",
+                  "x-typia-required": false,
+                  "x-typia-optional": false
+                }
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": false
           },
           "union": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "anys",
           "nullables1",
@@ -131,5 +186,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ArrayAtomicAlias.json
+++ b/test/schemas/json/ajv/ArrayAtomicAlias.json
@@ -4,50 +4,43 @@
       "type": "array",
       "items": [
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
+          }
         },
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
+          }
         },
         {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "nullable": false,
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
           "x-typia-rest": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "array",
+          "items": {
+            "x-typia-rest": false,
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          }
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ArrayAtomicSimple.json
+++ b/test/schemas/json/ajv/ArrayAtomicSimple.json
@@ -4,50 +4,43 @@
       "type": "array",
       "items": [
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
+          }
         },
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
+          }
         },
         {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "nullable": false,
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
           "x-typia-rest": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "array",
+          "items": {
+            "x-typia-rest": false,
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          }
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ArrayHierarchical.json
+++ b/test/schemas/json/ajv/ArrayHierarchical.json
@@ -3,59 +3,53 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/ArrayHierarchical.ICompany"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/ArrayHierarchical.ICompany"
+      }
     }
   ],
   "components": {
     "schemas": {
       "ArrayHierarchical.ICompany": {
-        "$id": "components#/schemas/ArrayHierarchical.ICompany",
+        "$id": "#/components/schemas/ArrayHierarchical.ICompany",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "serial": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "established_at": {
-            "$ref": "components#/schemas/ArrayHierarchical.ITimestamp",
+            "$ref": "#/components/schemas/ArrayHierarchical.ITimestamp",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "departments": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ArrayHierarchical.IDepartment",
+              "$ref": "#/components/schemas/ArrayHierarchical.IDepartment",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "serial",
@@ -66,25 +60,22 @@
         "x-typia-jsDocTags": []
       },
       "ArrayHierarchical.ITimestamp": {
-        "$id": "components#/schemas/ArrayHierarchical.ITimestamp",
+        "$id": "#/components/schemas/ArrayHierarchical.ITimestamp",
         "type": "object",
         "properties": {
           "time": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "zone": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "time",
           "zone"
@@ -92,51 +83,46 @@
         "x-typia-jsDocTags": []
       },
       "ArrayHierarchical.IDepartment": {
-        "$id": "components#/schemas/ArrayHierarchical.IDepartment",
+        "$id": "#/components/schemas/ArrayHierarchical.IDepartment",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sales": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
-            "$ref": "components#/schemas/ArrayHierarchical.ITimestamp",
+            "$ref": "#/components/schemas/ArrayHierarchical.ITimestamp",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "employees": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ArrayHierarchical.IEmployee",
+              "$ref": "#/components/schemas/ArrayHierarchical.IEmployee",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "code",
@@ -147,45 +133,40 @@
         "x-typia-jsDocTags": []
       },
       "ArrayHierarchical.IEmployee": {
-        "$id": "components#/schemas/ArrayHierarchical.IEmployee",
+        "$id": "#/components/schemas/ArrayHierarchical.IEmployee",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "age": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "grade": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "employeed_at": {
-            "$ref": "components#/schemas/ArrayHierarchical.ITimestamp",
+            "$ref": "#/components/schemas/ArrayHierarchical.ITimestamp",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -198,5 +179,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ArrayMatrix.json
+++ b/test/schemas/json/ajv/ArrayMatrix.json
@@ -7,19 +7,15 @@
         "items": {
           "type": "array",
           "items": {
-            "type": "number",
-            "nullable": false
-          },
-          "nullable": false
-        },
-        "nullable": false
-      },
-      "nullable": false
+            "type": "number"
+          }
+        }
+      }
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ArrayRecursive.json
+++ b/test/schemas/json/ajv/ArrayRecursive.json
@@ -1,58 +1,53 @@
 {
   "schemas": [
     {
-      "$recursiveRef": "components#/schemas/ArrayRecursive.ICategory"
+      "$recursiveRef": "#/components/schemas/ArrayRecursive.ICategory"
     }
   ],
   "components": {
     "schemas": {
       "ArrayRecursive.ICategory": {
-        "$id": "components#/schemas/ArrayRecursive.ICategory",
+        "$id": "#/components/schemas/ArrayRecursive.ICategory",
         "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "children": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$recursiveRef": "components#/schemas/ArrayRecursive.ICategory",
+              "$recursiveRef": "#/components/schemas/ArrayRecursive.ICategory",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
-            "$ref": "components#/schemas/ArrayRecursive.ITimestamp",
+            "$ref": "#/components/schemas/ArrayRecursive.ITimestamp",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "children",
           "id",
@@ -63,25 +58,22 @@
         "x-typia-jsDocTags": []
       },
       "ArrayRecursive.ITimestamp": {
-        "$id": "components#/schemas/ArrayRecursive.ITimestamp",
+        "$id": "#/components/schemas/ArrayRecursive.ITimestamp",
         "type": "object",
         "properties": {
           "time": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "zone": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "time",
           "zone"
@@ -91,5 +83,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ArrayRecursiveUnionExplicit.json
+++ b/test/schemas/json/ajv/ArrayRecursiveUnionExplicit.json
@@ -5,83 +5,82 @@
       "items": {
         "oneOf": [
           {
-            "$recursiveRef": "components#/schemas/ArrayRecursiveUnionExplicit.IDirectory"
+            "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionExplicit.IDirectory"
           },
           {
-            "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.IImageFile"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IImageFile"
           },
           {
-            "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.ITextFile"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.ITextFile"
           },
           {
-            "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.IZipFile"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IZipFile"
           },
           {
-            "$recursiveRef": "components#/schemas/ArrayRecursiveUnionExplicit.IShortcut"
+            "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionExplicit.IShortcut"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "ArrayRecursiveUnionExplicit.IDirectory": {
-        "$id": "components#/schemas/ArrayRecursiveUnionExplicit.IDirectory",
+        "$id": "#/components/schemas/ArrayRecursiveUnionExplicit.IDirectory",
         "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "children": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$recursiveRef": "components#/schemas/ArrayRecursiveUnionExplicit.IDirectory",
+                  "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionExplicit.IDirectory",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.IImageFile",
+                  "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IImageFile",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.ITextFile",
+                  "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.ITextFile",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.IZipFile",
+                  "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IZipFile",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/ArrayRecursiveUnionExplicit.IShortcut",
+                  "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionExplicit.IShortcut",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
@@ -90,24 +89,18 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "directory"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -118,80 +111,70 @@
         "x-typia-jsDocTags": []
       },
       "ArrayRecursiveUnionExplicit.IImageFile": {
-        "$id": "components#/schemas/ArrayRecursiveUnionExplicit.IImageFile",
+        "$id": "#/components/schemas/ArrayRecursiveUnionExplicit.IImageFile",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "width": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "height": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "url": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "file"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "extension": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "jpg"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -206,66 +189,58 @@
         "x-typia-jsDocTags": []
       },
       "ArrayRecursiveUnionExplicit.ITextFile": {
-        "$id": "components#/schemas/ArrayRecursiveUnionExplicit.ITextFile",
+        "$id": "#/components/schemas/ArrayRecursiveUnionExplicit.ITextFile",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "content": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "file"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "extension": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "txt"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -278,66 +253,58 @@
         "x-typia-jsDocTags": []
       },
       "ArrayRecursiveUnionExplicit.IZipFile": {
-        "$id": "components#/schemas/ArrayRecursiveUnionExplicit.IZipFile",
+        "$id": "#/components/schemas/ArrayRecursiveUnionExplicit.IZipFile",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "count": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "file"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "extension": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "zip"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -350,59 +317,56 @@
         "x-typia-jsDocTags": []
       },
       "ArrayRecursiveUnionExplicit.IShortcut": {
-        "$id": "components#/schemas/ArrayRecursiveUnionExplicit.IShortcut",
+        "$id": "#/components/schemas/ArrayRecursiveUnionExplicit.IShortcut",
         "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "target": {
             "oneOf": [
               {
-                "$recursiveRef": "components#/schemas/ArrayRecursiveUnionExplicit.IDirectory",
+                "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionExplicit.IDirectory",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.IImageFile",
+                "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IImageFile",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.ITextFile",
+                "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.ITextFile",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ArrayRecursiveUnionExplicit.IZipFile",
+                "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IZipFile",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$recursiveRef": "components#/schemas/ArrayRecursiveUnionExplicit.IShortcut",
+                "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionExplicit.IShortcut",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
@@ -413,27 +377,24 @@
             "x-typia-optional": false
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "file"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "extension": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "lnk"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -447,5 +408,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ArrayRecursiveUnionImplicit.json
+++ b/test/schemas/json/ajv/ArrayRecursiveUnionImplicit.json
@@ -5,92 +5,91 @@
       "items": {
         "oneOf": [
           {
-            "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IDirectory"
+            "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory"
           },
           {
-            "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory"
+            "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory"
           },
           {
-            "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IImageFile"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IImageFile"
           },
           {
-            "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.ITextFile"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ITextFile"
           },
           {
-            "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IZipFile"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IZipFile"
           },
           {
-            "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IShortcut"
+            "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "ArrayRecursiveUnionImplicit.IDirectory": {
-        "$id": "components#/schemas/ArrayRecursiveUnionImplicit.IDirectory",
+        "$id": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory",
         "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "children": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IDirectory",
+                  "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
+                  "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IImageFile",
+                  "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IImageFile",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.ITextFile",
+                  "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ITextFile",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IZipFile",
+                  "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IZipFile",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IShortcut",
+                  "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
@@ -99,14 +98,9 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -116,78 +110,77 @@
         "x-typia-jsDocTags": []
       },
       "ArrayRecursiveUnionImplicit.ISharedDirectory": {
-        "$id": "components#/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
+        "$id": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
         "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "access": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "read",
               "write"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "children": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IDirectory",
+                  "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
+                  "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IImageFile",
+                  "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IImageFile",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.ITextFile",
+                  "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ITextFile",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IZipFile",
+                  "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IZipFile",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IShortcut",
+                  "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
@@ -196,14 +189,9 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "access",
           "id",
@@ -214,60 +202,52 @@
         "x-typia-jsDocTags": []
       },
       "ArrayRecursiveUnionImplicit.IImageFile": {
-        "$id": "components#/schemas/ArrayRecursiveUnionImplicit.IImageFile",
+        "$id": "#/components/schemas/ArrayRecursiveUnionImplicit.IImageFile",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "width": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "height": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "url": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -280,46 +260,40 @@
         "x-typia-jsDocTags": []
       },
       "ArrayRecursiveUnionImplicit.ITextFile": {
-        "$id": "components#/schemas/ArrayRecursiveUnionImplicit.ITextFile",
+        "$id": "#/components/schemas/ArrayRecursiveUnionImplicit.ITextFile",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "content": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -330,46 +304,40 @@
         "x-typia-jsDocTags": []
       },
       "ArrayRecursiveUnionImplicit.IZipFile": {
-        "$id": "components#/schemas/ArrayRecursiveUnionImplicit.IZipFile",
+        "$id": "#/components/schemas/ArrayRecursiveUnionImplicit.IZipFile",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "count": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -380,65 +348,62 @@
         "x-typia-jsDocTags": []
       },
       "ArrayRecursiveUnionImplicit.IShortcut": {
-        "$id": "components#/schemas/ArrayRecursiveUnionImplicit.IShortcut",
+        "$id": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut",
         "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "target": {
             "oneOf": [
               {
-                "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IDirectory",
+                "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
+                "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IImageFile",
+                "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IImageFile",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.ITextFile",
+                "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ITextFile",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ArrayRecursiveUnionImplicit.IZipFile",
+                "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IZipFile",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$recursiveRef": "components#/schemas/ArrayRecursiveUnionImplicit.IShortcut",
+                "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
@@ -449,7 +414,6 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -461,5 +425,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ArraySimple.json
+++ b/test/schemas/json/ajv/ArraySimple.json
@@ -3,46 +3,41 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/ArraySimple.IPerson"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/ArraySimple.IPerson"
+      }
     }
   ],
   "components": {
     "schemas": {
       "ArraySimple.IPerson": {
-        "$id": "components#/schemas/ArraySimple.IPerson",
+        "$id": "#/components/schemas/ArraySimple.IPerson",
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "hobbies": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ArraySimple.IHobby",
+              "$ref": "#/components/schemas/ArraySimple.IHobby",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "name",
           "email",
@@ -51,32 +46,28 @@
         "x-typia-jsDocTags": []
       },
       "ArraySimple.IHobby": {
-        "$id": "components#/schemas/ArraySimple.IHobby",
+        "$id": "#/components/schemas/ArraySimple.IHobby",
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "body": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "rank": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "name",
           "body",
@@ -87,5 +78,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ArrayUnion.json
+++ b/test/schemas/json/ajv/ArrayUnion.json
@@ -7,35 +7,28 @@
           {
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "string"
+            }
           },
           {
             "type": "array",
             "items": {
-              "type": "number",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "number"
+            }
           },
           {
             "type": "array",
             "items": {
-              "type": "boolean",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "boolean"
+            }
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/AtomicAlias.json
+++ b/test/schemas/json/ajv/AtomicAlias.json
@@ -4,31 +4,27 @@
       "type": "array",
       "items": [
         {
-          "type": "boolean",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "boolean"
         },
         {
-          "type": "number",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         },
         {
-          "type": "string",
-          "nullable": false,
           "x-typia-rest": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "string"
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/AtomicClass.json
+++ b/test/schemas/json/ajv/AtomicClass.json
@@ -4,67 +4,57 @@
       "type": "array",
       "items": [
         {
-          "type": "boolean",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "boolean"
         },
         {
-          "type": "boolean",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "boolean"
         },
         {
-          "type": "boolean",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "boolean"
         },
         {
-          "type": "number",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         },
         {
-          "type": "number",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         },
         {
-          "type": "number",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         },
         {
-          "type": "string",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "string"
         },
         {
-          "type": "string",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "string"
         },
         {
-          "type": "string",
-          "nullable": false,
           "x-typia-rest": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "string"
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/AtomicSimple.json
+++ b/test/schemas/json/ajv/AtomicSimple.json
@@ -4,31 +4,27 @@
       "type": "array",
       "items": [
         {
-          "type": "boolean",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "boolean"
         },
         {
-          "type": "number",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         },
         {
-          "type": "string",
-          "nullable": false,
           "x-typia-rest": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "string"
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/AtomicUnion.json
+++ b/test/schemas/json/ajv/AtomicUnion.json
@@ -5,25 +5,24 @@
       "items": {
         "oneOf": [
           {
-            "type": "string",
-            "nullable": true
+            "type": "null"
           },
           {
-            "type": "number",
-            "nullable": true
+            "type": "string"
           },
           {
-            "type": "boolean",
-            "nullable": true
+            "type": "number"
+          },
+          {
+            "type": "boolean"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ClassGetter.json
+++ b/test/schemas/json/ajv/ClassGetter.json
@@ -1,38 +1,47 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ClassGetter.Person"
+      "$ref": "#/components/schemas/ClassGetter.Person"
     }
   ],
   "components": {
     "schemas": {
       "ClassGetter.Person": {
-        "$id": "components#/schemas/ClassGetter.Person",
+        "$id": "#/components/schemas/ClassGetter.Person",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "dead": {
-            "type": "boolean",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "boolean"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -43,5 +52,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ClassMethod.json
+++ b/test/schemas/json/ajv/ClassMethod.json
@@ -1,31 +1,28 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ClassMethod.Animal"
+      "$ref": "#/components/schemas/ClassMethod.Animal"
     }
   ],
   "components": {
     "schemas": {
       "ClassMethod.Animal": {
-        "$id": "components#/schemas/ClassMethod.Animal",
+        "$id": "#/components/schemas/ClassMethod.Animal",
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "age": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "name",
           "age"
@@ -35,5 +32,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ClassPropertyAssignment.json
+++ b/test/schemas/json/ajv/ClassPropertyAssignment.json
@@ -1,58 +1,52 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ClassPropertyAssignment"
+      "$ref": "#/components/schemas/ClassPropertyAssignment"
     }
   ],
   "components": {
     "schemas": {
       "ClassPropertyAssignment": {
-        "$id": "components#/schemas/ClassPropertyAssignment",
+        "$id": "#/components/schemas/ClassPropertyAssignment",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "note": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "assignment"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "editable": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "boolean",
             "enum": [
               false
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "incremental": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -65,5 +59,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ConstantAtomicSimple.json
+++ b/test/schemas/json/ajv/ConstantAtomicSimple.json
@@ -4,49 +4,44 @@
       "type": "array",
       "items": [
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "boolean",
           "enum": [
             false
-          ],
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+          ]
         },
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "boolean",
           "enum": [
             true
-          ],
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+          ]
         },
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "number",
           "enum": [
             2
-          ],
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+          ]
         },
         {
+          "x-typia-rest": false,
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "string",
           "enum": [
             "three"
-          ],
-          "nullable": false,
-          "x-typia-rest": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+          ]
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ConstantAtomicUnion.json
+++ b/test/schemas/json/ajv/ConstantAtomicUnion.json
@@ -8,51 +8,45 @@
             "type": "boolean",
             "enum": [
               false
-            ],
-            "nullable": false
+            ]
           },
           {
             "type": "number",
             "enum": [
               2,
               1
-            ],
-            "nullable": false
+            ]
           },
           {
             "type": "string",
             "enum": [
               "three",
               "four"
-            ],
-            "nullable": false
+            ]
           },
           {
-            "$ref": "components#/schemas/__type"
+            "$ref": "#/components/schemas/__type"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "__type": {
-        "$id": "components#/schemas/__type",
+        "$id": "#/components/schemas/__type",
         "type": "object",
         "properties": {
           "key": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "key"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "key"
         ],
@@ -61,5 +55,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ConstantAtomicWrapper.json
+++ b/test/schemas/json/ajv/ConstantAtomicWrapper.json
@@ -4,76 +4,69 @@
       "type": "array",
       "items": [
         {
-          "$ref": "components#/schemas/ConstantAtomicWrapper.IPointer_lt_boolean_gt_",
+          "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_boolean_gt_",
           "x-typia-required": true,
           "x-typia-optional": false
         },
         {
-          "$ref": "components#/schemas/ConstantAtomicWrapper.IPointer_lt_number_gt_",
+          "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_number_gt_",
           "x-typia-required": true,
           "x-typia-optional": false
         },
         {
-          "$ref": "components#/schemas/ConstantAtomicWrapper.IPointer_lt_string_gt_",
+          "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_string_gt_",
           "x-typia-rest": false,
           "x-typia-required": true,
           "x-typia-optional": false
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {
       "ConstantAtomicWrapper.IPointer_lt_boolean_gt_": {
-        "$id": "components#/schemas/ConstantAtomicWrapper.IPointer_lt_boolean_gt_",
+        "$id": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_boolean_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ConstantAtomicWrapper.IPointer_lt_number_gt_": {
-        "$id": "components#/schemas/ConstantAtomicWrapper.IPointer_lt_number_gt_",
+        "$id": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_number_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ConstantAtomicWrapper.IPointer_lt_string_gt_": {
-        "$id": "components#/schemas/ConstantAtomicWrapper.IPointer_lt_string_gt_",
+        "$id": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_string_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
@@ -82,5 +75,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ConstantConstEnumeration.json
+++ b/test/schemas/json/ajv/ConstantConstEnumeration.json
@@ -10,25 +10,22 @@
               0,
               1,
               2
-            ],
-            "nullable": false
+            ]
           },
           {
             "type": "string",
             "enum": [
               "Three",
               "Four"
-            ],
-            "nullable": false
+            ]
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ConstantEnumeration.json
+++ b/test/schemas/json/ajv/ConstantEnumeration.json
@@ -10,25 +10,22 @@
               0,
               1,
               2
-            ],
-            "nullable": false
+            ]
           },
           {
             "type": "string",
             "enum": [
               "Three",
               "Four"
-            ],
-            "nullable": false
+            ]
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/DynamicArray.json
+++ b/test/schemas/json/ajv/DynamicArray.json
@@ -1,34 +1,31 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/DynamicArray"
+      "$ref": "#/components/schemas/DynamicArray"
     }
   ],
   "components": {
     "schemas": {
       "DynamicArray": {
-        "$id": "components#/schemas/DynamicArray",
+        "$id": "#/components/schemas/DynamicArray",
         "type": "object",
         "properties": {},
-        "nullable": false,
         "x-typia-jsDocTags": [],
         "additionalProperties": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
           "description": "",
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "array",
+          "items": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          }
         }
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/DynamicComposite.json
+++ b/test/schemas/json/ajv/DynamicComposite.json
@@ -1,31 +1,28 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/DynamicComposite"
+      "$ref": "#/components/schemas/DynamicComposite"
     }
   ],
   "components": {
     "schemas": {
       "DynamicComposite": {
-        "$id": "components#/schemas/DynamicComposite",
+        "$id": "#/components/schemas/DynamicComposite",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name"
@@ -33,48 +30,42 @@
         "x-typia-jsDocTags": [],
         "patternProperties": {
           "^-?\\d+\\.?\\d*$": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "^(prefix_(.*))": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "((.*)_postfix)$": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "^(value_-?\\d+\\.?\\d*)$": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "string"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "number"
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -82,16 +73,15 @@
             "x-typia-optional": false
           },
           "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         }
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/DynamicConstant.json
+++ b/test/schemas/json/ajv/DynamicConstant.json
@@ -1,45 +1,40 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/DynamicConstant"
+      "$ref": "#/components/schemas/DynamicConstant"
     }
   ],
   "components": {
     "schemas": {
       "DynamicConstant": {
-        "$id": "components#/schemas/DynamicConstant",
+        "$id": "#/components/schemas/DynamicConstant",
         "type": "object",
         "properties": {
           "a": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "b": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "c": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "d": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "a",
           "b",
@@ -51,5 +46,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/DynamicEnumeration.json
+++ b/test/schemas/json/ajv/DynamicEnumeration.json
@@ -1,91 +1,80 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/DynamicEnumeration"
+      "$ref": "#/components/schemas/DynamicEnumeration"
     }
   ],
   "components": {
     "schemas": {
       "DynamicEnumeration": {
-        "$id": "components#/schemas/DynamicEnumeration",
+        "$id": "#/components/schemas/DynamicEnumeration",
         "type": "object",
         "properties": {
           "ar": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "zh-Hans": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "zh-Hant": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "en": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "fr": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "de": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "ja": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "ko": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "pt": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "ru": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "x-typia-jsDocTags": []
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/DynamicNever.json
+++ b/test/schemas/json/ajv/DynamicNever.json
@@ -1,20 +1,19 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/DynamicNever"
+      "$ref": "#/components/schemas/DynamicNever"
     }
   ],
   "components": {
     "schemas": {
       "DynamicNever": {
-        "$id": "components#/schemas/DynamicNever",
+        "$id": "#/components/schemas/DynamicNever",
         "type": "object",
         "properties": {},
-        "nullable": false,
         "x-typia-jsDocTags": []
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/DynamicSimple.json
+++ b/test/schemas/json/ajv/DynamicSimple.json
@@ -1,27 +1,25 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/DynamicSimple"
+      "$ref": "#/components/schemas/DynamicSimple"
     }
   ],
   "components": {
     "schemas": {
       "DynamicSimple": {
-        "$id": "components#/schemas/DynamicSimple",
+        "$id": "#/components/schemas/DynamicSimple",
         "type": "object",
         "properties": {},
-        "nullable": false,
         "x-typia-jsDocTags": [],
         "additionalProperties": {
-          "type": "number",
-          "nullable": false,
           "description": "",
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         }
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/DynamicTemplate.json
+++ b/test/schemas/json/ajv/DynamicTemplate.json
@@ -1,50 +1,45 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/DynamicTemplate"
+      "$ref": "#/components/schemas/DynamicTemplate"
     }
   ],
   "components": {
     "schemas": {
       "DynamicTemplate": {
-        "$id": "components#/schemas/DynamicTemplate",
+        "$id": "#/components/schemas/DynamicTemplate",
         "type": "object",
         "properties": {},
-        "nullable": false,
         "x-typia-jsDocTags": [],
         "patternProperties": {
           "^(prefix_(.*))": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "((.*)_postfix)$": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "^(value_-?\\d+\\.?\\d*)$": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         }
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/DynamicTree.json
+++ b/test/schemas/json/ajv/DynamicTree.json
@@ -1,37 +1,34 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/DynamicTree"
+      "$ref": "#/components/schemas/DynamicTree"
     }
   ],
   "components": {
     "schemas": {
       "DynamicTree": {
-        "$id": "components#/schemas/DynamicTree",
+        "$id": "#/components/schemas/DynamicTree",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "children": {
-            "$ref": "components#/schemas/Record_lt_string_comma__space_DynamicTree_gt_",
+            "$ref": "#/components/schemas/Record_lt_string_comma__space_DynamicTree_gt_",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "sequence",
@@ -40,13 +37,12 @@
         "x-typia-jsDocTags": []
       },
       "Record_lt_string_comma__space_DynamicTree_gt_": {
-        "$id": "components#/schemas/Record_lt_string_comma__space_DynamicTree_gt_",
+        "$id": "#/components/schemas/Record_lt_string_comma__space_DynamicTree_gt_",
         "type": "object",
         "properties": {},
-        "nullable": false,
         "x-typia-jsDocTags": [],
         "additionalProperties": {
-          "$ref": "components#/schemas/DynamicTree",
+          "$ref": "#/components/schemas/DynamicTree",
           "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
@@ -55,5 +51,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/DynamicUndefined.json
+++ b/test/schemas/json/ajv/DynamicUndefined.json
@@ -1,20 +1,19 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/DynamicUndefined"
+      "$ref": "#/components/schemas/DynamicUndefined"
     }
   ],
   "components": {
     "schemas": {
       "DynamicUndefined": {
-        "$id": "components#/schemas/DynamicUndefined",
+        "$id": "#/components/schemas/DynamicUndefined",
         "type": "object",
         "properties": {},
-        "nullable": false,
         "x-typia-jsDocTags": []
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/DynamicUnion.json
+++ b/test/schemas/json/ajv/DynamicUnion.json
@@ -1,50 +1,45 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/DynamicUnion"
+      "$ref": "#/components/schemas/DynamicUnion"
     }
   ],
   "components": {
     "schemas": {
       "DynamicUnion": {
-        "$id": "components#/schemas/DynamicUnion",
+        "$id": "#/components/schemas/DynamicUnion",
         "type": "object",
         "properties": {},
-        "nullable": false,
         "x-typia-jsDocTags": [],
         "patternProperties": {
           "^-?\\d+\\.?\\d*$": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "^(prefix_(.*))": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "((.*)_postfix)$": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "^(value_between_-?\\d+\\.?\\d*_and_-?\\d+\\.?\\d*)$": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         }
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/MapAlias.json
+++ b/test/schemas/json/ajv/MapAlias.json
@@ -1,47 +1,46 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/MapAlias"
+      "$ref": "#/components/schemas/MapAlias"
     }
   ],
   "components": {
     "schemas": {
       "MapAlias": {
-        "$id": "components#/schemas/MapAlias",
+        "$id": "#/components/schemas/MapAlias",
         "type": "object",
         "properties": {
           "boolean": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "number": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "strings": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "arrays": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "objects": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           }
         },
-        "nullable": false,
         "required": [
           "boolean",
           "number",
@@ -53,12 +52,11 @@
       },
       "Map": {
         "type": "object",
-        "$id": "components#/schemas/Map",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Map",
+        "properties": {}
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/MapSimple.json
+++ b/test/schemas/json/ajv/MapSimple.json
@@ -1,47 +1,46 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/MapSimple"
+      "$ref": "#/components/schemas/MapSimple"
     }
   ],
   "components": {
     "schemas": {
       "MapSimple": {
-        "$id": "components#/schemas/MapSimple",
+        "$id": "#/components/schemas/MapSimple",
         "type": "object",
         "properties": {
           "boolean": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "number": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "strings": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "arrays": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "objects": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           }
         },
-        "nullable": false,
         "required": [
           "boolean",
           "number",
@@ -53,12 +52,11 @@
       },
       "Map": {
         "type": "object",
-        "$id": "components#/schemas/Map",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Map",
+        "properties": {}
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/MapUnion.json
+++ b/test/schemas/json/ajv/MapUnion.json
@@ -4,20 +4,18 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/Map"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "Map": {
         "type": "object",
-        "$id": "components#/schemas/Map",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Map",
+        "properties": {}
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/NativeAlias.json
+++ b/test/schemas/json/ajv/NativeAlias.json
@@ -1,126 +1,124 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/NativeAlias"
+      "$ref": "#/components/schemas/NativeAlias"
     }
   ],
   "components": {
     "schemas": {
       "NativeAlias": {
-        "$id": "components#/schemas/NativeAlias",
+        "$id": "#/components/schemas/NativeAlias",
         "type": "object",
         "properties": {
           "date": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "uint8Array": {
-            "$ref": "#/components/schemas/Uint8Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint8Array"
           },
           "uint8ClampedArray": {
-            "$ref": "#/components/schemas/Uint8ClampedArray",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint8ClampedArray"
           },
           "uint16Array": {
-            "$ref": "#/components/schemas/Uint16Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint16Array"
           },
           "uint32Array": {
-            "$ref": "#/components/schemas/Uint32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint32Array"
           },
           "bigUint64Array": {
-            "$ref": "#/components/schemas/BigUint64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/BigUint64Array"
           },
           "int8Array": {
-            "$ref": "#/components/schemas/Int8Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int8Array"
           },
           "int16Array": {
-            "$ref": "#/components/schemas/Int16Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int16Array"
           },
           "int32Array": {
-            "$ref": "#/components/schemas/Int32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int32Array"
           },
           "bigInt64Array": {
-            "$ref": "#/components/schemas/BigInt64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/BigInt64Array"
           },
           "float32Array": {
-            "$ref": "#/components/schemas/Float32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Float32Array"
           },
           "float64Array": {
-            "$ref": "#/components/schemas/Float64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Float64Array"
           },
           "buffer": {
-            "$ref": "components#/schemas/__type",
+            "$ref": "#/components/schemas/__type",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrayBuffer": {
-            "$ref": "#/components/schemas/ArrayBuffer",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/ArrayBuffer"
           },
           "sharedArrayBuffer": {
-            "$ref": "#/components/schemas/SharedArrayBuffer",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/SharedArrayBuffer"
           },
           "dataView": {
-            "$ref": "#/components/schemas/DataView",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/DataView"
           },
           "weakSet": {
-            "$ref": "#/components/schemas/WeakSet",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/WeakSet"
           },
           "weakMap": {
-            "$ref": "#/components/schemas/WeakMap",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/WeakMap"
           }
         },
-        "nullable": false,
         "required": [
           "date",
           "uint8Array",
@@ -145,100 +143,85 @@
       },
       "Uint8Array": {
         "type": "object",
-        "$id": "components#/schemas/Uint8Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint8Array",
+        "properties": {}
       },
       "Uint8ClampedArray": {
         "type": "object",
-        "$id": "components#/schemas/Uint8ClampedArray",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint8ClampedArray",
+        "properties": {}
       },
       "Uint16Array": {
         "type": "object",
-        "$id": "components#/schemas/Uint16Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint16Array",
+        "properties": {}
       },
       "Uint32Array": {
         "type": "object",
-        "$id": "components#/schemas/Uint32Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint32Array",
+        "properties": {}
       },
       "BigUint64Array": {
         "type": "object",
-        "$id": "components#/schemas/BigUint64Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/BigUint64Array",
+        "properties": {}
       },
       "Int8Array": {
         "type": "object",
-        "$id": "components#/schemas/Int8Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Int8Array",
+        "properties": {}
       },
       "Int16Array": {
         "type": "object",
-        "$id": "components#/schemas/Int16Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Int16Array",
+        "properties": {}
       },
       "Int32Array": {
         "type": "object",
-        "$id": "components#/schemas/Int32Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Int32Array",
+        "properties": {}
       },
       "BigInt64Array": {
         "type": "object",
-        "$id": "components#/schemas/BigInt64Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/BigInt64Array",
+        "properties": {}
       },
       "Float32Array": {
         "type": "object",
-        "$id": "components#/schemas/Float32Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Float32Array",
+        "properties": {}
       },
       "Float64Array": {
         "type": "object",
-        "$id": "components#/schemas/Float64Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Float64Array",
+        "properties": {}
       },
       "__type": {
-        "$id": "components#/schemas/__type",
+        "$id": "#/components/schemas/__type",
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "Buffer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "data": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
           }
         },
-        "nullable": false,
         "required": [
           "type",
           "data"
@@ -247,36 +230,31 @@
       },
       "ArrayBuffer": {
         "type": "object",
-        "$id": "components#/schemas/ArrayBuffer",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/ArrayBuffer",
+        "properties": {}
       },
       "SharedArrayBuffer": {
         "type": "object",
-        "$id": "components#/schemas/SharedArrayBuffer",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/SharedArrayBuffer",
+        "properties": {}
       },
       "DataView": {
         "type": "object",
-        "$id": "components#/schemas/DataView",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/DataView",
+        "properties": {}
       },
       "WeakSet": {
         "type": "object",
-        "$id": "components#/schemas/WeakSet",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/WeakSet",
+        "properties": {}
       },
       "WeakMap": {
         "type": "object",
-        "$id": "components#/schemas/WeakMap",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/WeakMap",
+        "properties": {}
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/NativeSimple.json
+++ b/test/schemas/json/ajv/NativeSimple.json
@@ -1,126 +1,124 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/NativeSimple"
+      "$ref": "#/components/schemas/NativeSimple"
     }
   ],
   "components": {
     "schemas": {
       "NativeSimple": {
-        "$id": "components#/schemas/NativeSimple",
+        "$id": "#/components/schemas/NativeSimple",
         "type": "object",
         "properties": {
           "date": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "uint8Array": {
-            "$ref": "#/components/schemas/Uint8Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint8Array"
           },
           "uint8ClampedArray": {
-            "$ref": "#/components/schemas/Uint8ClampedArray",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint8ClampedArray"
           },
           "uint16Array": {
-            "$ref": "#/components/schemas/Uint16Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint16Array"
           },
           "uint32Array": {
-            "$ref": "#/components/schemas/Uint32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint32Array"
           },
           "bigUint64Array": {
-            "$ref": "#/components/schemas/BigUint64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/BigUint64Array"
           },
           "int8Array": {
-            "$ref": "#/components/schemas/Int8Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int8Array"
           },
           "int16Array": {
-            "$ref": "#/components/schemas/Int16Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int16Array"
           },
           "int32Array": {
-            "$ref": "#/components/schemas/Int32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int32Array"
           },
           "bigInt64Array": {
-            "$ref": "#/components/schemas/BigInt64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/BigInt64Array"
           },
           "float32Array": {
-            "$ref": "#/components/schemas/Float32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Float32Array"
           },
           "float64Array": {
-            "$ref": "#/components/schemas/Float64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Float64Array"
           },
           "buffer": {
-            "$ref": "components#/schemas/__type",
+            "$ref": "#/components/schemas/__type",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "arrayBuffer": {
-            "$ref": "#/components/schemas/ArrayBuffer",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/ArrayBuffer"
           },
           "sharedArrayBuffer": {
-            "$ref": "#/components/schemas/SharedArrayBuffer",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/SharedArrayBuffer"
           },
           "dataView": {
-            "$ref": "#/components/schemas/DataView",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/DataView"
           },
           "weakSet": {
-            "$ref": "#/components/schemas/WeakSet",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/WeakSet"
           },
           "weakMap": {
-            "$ref": "#/components/schemas/WeakMap",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/WeakMap"
           }
         },
-        "nullable": false,
         "required": [
           "date",
           "uint8Array",
@@ -145,100 +143,85 @@
       },
       "Uint8Array": {
         "type": "object",
-        "$id": "components#/schemas/Uint8Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint8Array",
+        "properties": {}
       },
       "Uint8ClampedArray": {
         "type": "object",
-        "$id": "components#/schemas/Uint8ClampedArray",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint8ClampedArray",
+        "properties": {}
       },
       "Uint16Array": {
         "type": "object",
-        "$id": "components#/schemas/Uint16Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint16Array",
+        "properties": {}
       },
       "Uint32Array": {
         "type": "object",
-        "$id": "components#/schemas/Uint32Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint32Array",
+        "properties": {}
       },
       "BigUint64Array": {
         "type": "object",
-        "$id": "components#/schemas/BigUint64Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/BigUint64Array",
+        "properties": {}
       },
       "Int8Array": {
         "type": "object",
-        "$id": "components#/schemas/Int8Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Int8Array",
+        "properties": {}
       },
       "Int16Array": {
         "type": "object",
-        "$id": "components#/schemas/Int16Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Int16Array",
+        "properties": {}
       },
       "Int32Array": {
         "type": "object",
-        "$id": "components#/schemas/Int32Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Int32Array",
+        "properties": {}
       },
       "BigInt64Array": {
         "type": "object",
-        "$id": "components#/schemas/BigInt64Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/BigInt64Array",
+        "properties": {}
       },
       "Float32Array": {
         "type": "object",
-        "$id": "components#/schemas/Float32Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Float32Array",
+        "properties": {}
       },
       "Float64Array": {
         "type": "object",
-        "$id": "components#/schemas/Float64Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Float64Array",
+        "properties": {}
       },
       "__type": {
-        "$id": "components#/schemas/__type",
+        "$id": "#/components/schemas/__type",
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "Buffer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "data": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
           }
         },
-        "nullable": false,
         "required": [
           "type",
           "data"
@@ -247,36 +230,31 @@
       },
       "ArrayBuffer": {
         "type": "object",
-        "$id": "components#/schemas/ArrayBuffer",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/ArrayBuffer",
+        "properties": {}
       },
       "SharedArrayBuffer": {
         "type": "object",
-        "$id": "components#/schemas/SharedArrayBuffer",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/SharedArrayBuffer",
+        "properties": {}
       },
       "DataView": {
         "type": "object",
-        "$id": "components#/schemas/DataView",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/DataView",
+        "properties": {}
       },
       "WeakSet": {
         "type": "object",
-        "$id": "components#/schemas/WeakSet",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/WeakSet",
+        "properties": {}
       },
       "WeakMap": {
         "type": "object",
-        "$id": "components#/schemas/WeakMap",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/WeakMap",
+        "properties": {}
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/NativeUnion.json
+++ b/test/schemas/json/ajv/NativeUnion.json
@@ -3,20 +3,31 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/NativeUnion.Union"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/NativeUnion.Union"
+      }
     }
   ],
   "components": {
     "schemas": {
       "NativeUnion.Union": {
-        "$id": "components#/schemas/NativeUnion.Union",
+        "$id": "#/components/schemas/NativeUnion.Union",
         "type": "object",
         "properties": {
           "date": {
-            "type": "string",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "string"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
@@ -24,34 +35,34 @@
           "unsigned": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/Uint8Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Uint8Array"
               },
               {
-                "$ref": "#/components/schemas/Uint8ClampedArray",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Uint8ClampedArray"
               },
               {
-                "$ref": "#/components/schemas/Uint16Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Uint16Array"
               },
               {
-                "$ref": "#/components/schemas/Uint32Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Uint32Array"
               },
               {
-                "$ref": "#/components/schemas/BigUint64Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/BigUint64Array"
               }
             ],
             "description": "",
@@ -61,28 +72,28 @@
           "signed": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/Int8Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Int8Array"
               },
               {
-                "$ref": "#/components/schemas/Int16Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Int16Array"
               },
               {
-                "$ref": "#/components/schemas/Int32Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Int32Array"
               },
               {
-                "$ref": "#/components/schemas/BigInt64Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/BigInt64Array"
               }
             ],
             "description": "",
@@ -92,16 +103,16 @@
           "float": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/Float32Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Float32Array"
               },
               {
-                "$ref": "#/components/schemas/Float64Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Float64Array"
               }
             ],
             "description": "",
@@ -111,25 +122,25 @@
           "buffer": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/ArrayBuffer",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/ArrayBuffer"
               },
               {
-                "$ref": "#/components/schemas/SharedArrayBuffer",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/SharedArrayBuffer"
               },
               {
-                "$ref": "#/components/schemas/DataView",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/DataView"
               },
               {
-                "$ref": "components#/schemas/__type",
+                "$ref": "#/components/schemas/__type",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
@@ -142,16 +153,16 @@
           "weak": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/WeakSet",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/WeakSet"
               },
               {
-                "$ref": "#/components/schemas/WeakMap",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/WeakMap"
               }
             ],
             "description": "",
@@ -159,7 +170,6 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "date",
           "unsigned",
@@ -172,118 +182,100 @@
       },
       "Uint8Array": {
         "type": "object",
-        "$id": "components#/schemas/Uint8Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint8Array",
+        "properties": {}
       },
       "Uint8ClampedArray": {
         "type": "object",
-        "$id": "components#/schemas/Uint8ClampedArray",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint8ClampedArray",
+        "properties": {}
       },
       "Uint16Array": {
         "type": "object",
-        "$id": "components#/schemas/Uint16Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint16Array",
+        "properties": {}
       },
       "Uint32Array": {
         "type": "object",
-        "$id": "components#/schemas/Uint32Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Uint32Array",
+        "properties": {}
       },
       "BigUint64Array": {
         "type": "object",
-        "$id": "components#/schemas/BigUint64Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/BigUint64Array",
+        "properties": {}
       },
       "Int8Array": {
         "type": "object",
-        "$id": "components#/schemas/Int8Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Int8Array",
+        "properties": {}
       },
       "Int16Array": {
         "type": "object",
-        "$id": "components#/schemas/Int16Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Int16Array",
+        "properties": {}
       },
       "Int32Array": {
         "type": "object",
-        "$id": "components#/schemas/Int32Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Int32Array",
+        "properties": {}
       },
       "BigInt64Array": {
         "type": "object",
-        "$id": "components#/schemas/BigInt64Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/BigInt64Array",
+        "properties": {}
       },
       "Float32Array": {
         "type": "object",
-        "$id": "components#/schemas/Float32Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Float32Array",
+        "properties": {}
       },
       "Float64Array": {
         "type": "object",
-        "$id": "components#/schemas/Float64Array",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Float64Array",
+        "properties": {}
       },
       "ArrayBuffer": {
         "type": "object",
-        "$id": "components#/schemas/ArrayBuffer",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/ArrayBuffer",
+        "properties": {}
       },
       "SharedArrayBuffer": {
         "type": "object",
-        "$id": "components#/schemas/SharedArrayBuffer",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/SharedArrayBuffer",
+        "properties": {}
       },
       "DataView": {
         "type": "object",
-        "$id": "components#/schemas/DataView",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/DataView",
+        "properties": {}
       },
       "__type": {
-        "$id": "components#/schemas/__type",
+        "$id": "#/components/schemas/__type",
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "Buffer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "data": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
           }
         },
-        "nullable": false,
         "required": [
           "type",
           "data"
@@ -292,18 +284,16 @@
       },
       "WeakSet": {
         "type": "object",
-        "$id": "components#/schemas/WeakSet",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/WeakSet",
+        "properties": {}
       },
       "WeakMap": {
         "type": "object",
-        "$id": "components#/schemas/WeakMap",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/WeakMap",
+        "properties": {}
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectAlias.json
+++ b/test/schemas/json/ajv/ObjectAlias.json
@@ -3,61 +3,74 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/ObjectAlias.IMember"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/ObjectAlias.IMember"
+      }
     }
   ],
   "components": {
     "schemas": {
       "ObjectAlias.IMember": {
-        "$id": "components#/schemas/ObjectAlias.IMember",
+        "$id": "#/components/schemas/ObjectAlias.IMember",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "string"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sex": {
             "oneOf": [
               {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "number",
                 "enum": [
                   2,
                   1
-                ],
-                "nullable": true,
-                "description": "",
-                "x-typia-required": true,
-                "x-typia-optional": false
+                ]
               },
               {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "string",
                 "enum": [
                   "male",
                   "female"
-                ],
-                "nullable": true,
-                "description": "",
-                "x-typia-required": true,
-                "x-typia-optional": false
+                ]
               }
             ],
             "description": "",
@@ -65,21 +78,44 @@
             "x-typia-optional": false
           },
           "age": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "dead": {
-            "type": "boolean",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "boolean"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "email",
@@ -93,5 +129,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectDynamic.json
+++ b/test/schemas/json/ajv/ObjectDynamic.json
@@ -1,39 +1,35 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectDynamic"
+      "$ref": "#/components/schemas/ObjectDynamic"
     }
   ],
   "components": {
     "schemas": {
       "ObjectDynamic": {
-        "$id": "components#/schemas/ObjectDynamic",
+        "$id": "#/components/schemas/ObjectDynamic",
         "type": "object",
         "properties": {},
-        "nullable": false,
         "x-typia-jsDocTags": [],
         "additionalProperties": {
           "oneOf": [
             {
-              "type": "string",
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "string"
             },
             {
-              "type": "number",
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "number"
             },
             {
-              "type": "boolean",
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "boolean"
             }
           ],
           "description": "",
@@ -44,5 +40,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectGeneric.json
+++ b/test/schemas/json/ajv/ObjectGeneric.json
@@ -4,59 +4,55 @@
       "type": "array",
       "items": [
         {
-          "$ref": "components#/schemas/ObjectGeneric.ISomething_lt_boolean_gt_",
+          "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_boolean_gt_",
           "x-typia-required": true,
           "x-typia-optional": false
         },
         {
-          "$ref": "components#/schemas/ObjectGeneric.ISomething_lt_number_gt_",
+          "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_number_gt_",
           "x-typia-required": true,
           "x-typia-optional": false
         },
         {
-          "$ref": "components#/schemas/ObjectGeneric.ISomething_lt_string_gt_",
+          "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_string_gt_",
           "x-typia-rest": false,
           "x-typia-required": true,
           "x-typia-optional": false
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {
       "ObjectGeneric.ISomething_lt_boolean_gt_": {
-        "$id": "components#/schemas/ObjectGeneric.ISomething_lt_boolean_gt_",
+        "$id": "#/components/schemas/ObjectGeneric.ISomething_lt_boolean_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           "child": {
-            "$ref": "components#/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
+            "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "elements": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
+              "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "value",
           "child",
@@ -65,25 +61,22 @@
         "x-typia-jsDocTags": []
       },
       "ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_": {
-        "$id": "components#/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
+        "$id": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
         "type": "object",
         "properties": {
           "child_value": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           "child_next": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "child_value",
           "child_next"
@@ -91,37 +84,34 @@
         "x-typia-jsDocTags": []
       },
       "ObjectGeneric.ISomething_lt_number_gt_": {
-        "$id": "components#/schemas/ObjectGeneric.ISomething_lt_number_gt_",
+        "$id": "#/components/schemas/ObjectGeneric.ISomething_lt_number_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "child": {
-            "$ref": "components#/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
+            "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "elements": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
+              "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "value",
           "child",
@@ -130,25 +120,22 @@
         "x-typia-jsDocTags": []
       },
       "ObjectGeneric.IChild_lt_number_comma__space_number_gt_": {
-        "$id": "components#/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
+        "$id": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
         "type": "object",
         "properties": {
           "child_value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "child_next": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "child_value",
           "child_next"
@@ -156,37 +143,34 @@
         "x-typia-jsDocTags": []
       },
       "ObjectGeneric.ISomething_lt_string_gt_": {
-        "$id": "components#/schemas/ObjectGeneric.ISomething_lt_string_gt_",
+        "$id": "#/components/schemas/ObjectGeneric.ISomething_lt_string_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "child": {
-            "$ref": "components#/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
+            "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "elements": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
+              "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "value",
           "child",
@@ -195,25 +179,22 @@
         "x-typia-jsDocTags": []
       },
       "ObjectGeneric.IChild_lt_string_comma__space_string_gt_": {
-        "$id": "components#/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
+        "$id": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
         "type": "object",
         "properties": {
           "child_value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "child_next": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "child_value",
           "child_next"
@@ -223,5 +204,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectGenericAlias.json
+++ b/test/schemas/json/ajv/ObjectGenericAlias.json
@@ -1,24 +1,22 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectGenericAlias.Alias"
+      "$ref": "#/components/schemas/ObjectGenericAlias.Alias"
     }
   ],
   "components": {
     "schemas": {
       "ObjectGenericAlias.Alias": {
-        "$id": "components#/schemas/ObjectGenericAlias.Alias",
+        "$id": "#/components/schemas/ObjectGenericAlias.Alias",
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
@@ -27,5 +25,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectGenericArray.json
+++ b/test/schemas/json/ajv/ObjectGenericArray.json
@@ -1,36 +1,34 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectGenericArray"
+      "$ref": "#/components/schemas/ObjectGenericArray"
     }
   ],
   "components": {
     "schemas": {
       "ObjectGenericArray": {
-        "$id": "components#/schemas/ObjectGenericArray",
+        "$id": "#/components/schemas/ObjectGenericArray",
         "type": "object",
         "properties": {
           "pagination": {
-            "$ref": "components#/schemas/ObjectGenericArray.IPagination",
+            "$ref": "#/components/schemas/ObjectGenericArray.IPagination",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "data": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectGenericArray.IPerson",
+              "$ref": "#/components/schemas/ObjectGenericArray.IPerson",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "pagination",
           "data"
@@ -38,39 +36,34 @@
         "x-typia-jsDocTags": []
       },
       "ObjectGenericArray.IPagination": {
-        "$id": "components#/schemas/ObjectGenericArray.IPagination",
+        "$id": "#/components/schemas/ObjectGenericArray.IPagination",
         "type": "object",
         "properties": {
           "page": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "limit": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "total_count": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "total_pages": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "page",
           "limit",
@@ -80,25 +73,22 @@
         "x-typia-jsDocTags": []
       },
       "ObjectGenericArray.IPerson": {
-        "$id": "components#/schemas/ObjectGenericArray.IPerson",
+        "$id": "#/components/schemas/ObjectGenericArray.IPerson",
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "age": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "name",
           "age"
@@ -108,5 +98,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectGenericUnion.json
+++ b/test/schemas/json/ajv/ObjectGenericUnion.json
@@ -3,10 +3,10 @@
     {
       "oneOf": [
         {
-          "$ref": "components#/schemas/ObjectGenericUnion.ISaleQuestion"
+          "$ref": "#/components/schemas/ObjectGenericUnion.ISaleQuestion"
         },
         {
-          "$ref": "components#/schemas/ObjectGenericUnion.ISaleReview"
+          "$ref": "#/components/schemas/ObjectGenericUnion.ISaleReview"
         }
       ]
     }
@@ -14,58 +14,65 @@
   "components": {
     "schemas": {
       "ObjectGenericUnion.ISaleQuestion": {
-        "$id": "components#/schemas/ObjectGenericUnion.ISaleQuestion",
+        "$id": "#/components/schemas/ObjectGenericUnion.ISaleQuestion",
         "type": "object",
         "properties": {
           "writer": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "answer": {
-            "$ref": "components#/schemas/ObjectGenericUnion.ISaleAnswer.Nullable",
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectGenericUnion.ISaleAnswer",
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "hit": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "contents": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectGenericUnion.ISaleArticle.IContent",
+              "$ref": "#/components/schemas/ObjectGenericUnion.ISaleArticle.IContent",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "writer",
           "answer",
@@ -76,46 +83,41 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGenericUnion.ISaleAnswer.Nullable": {
-        "$id": "components#/schemas/ObjectGenericUnion.ISaleAnswer.Nullable",
+      "ObjectGenericUnion.ISaleAnswer": {
+        "$id": "#/components/schemas/ObjectGenericUnion.ISaleAnswer",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "hit": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "contents": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectGenericUnion.ISaleArticle.IContent",
+              "$ref": "#/components/schemas/ObjectGenericUnion.ISaleArticle.IContent",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": true,
         "required": [
           "id",
           "hit",
@@ -125,52 +127,46 @@
         "x-typia-jsDocTags": []
       },
       "ObjectGenericUnion.ISaleArticle.IContent": {
-        "$id": "components#/schemas/ObjectGenericUnion.ISaleArticle.IContent",
+        "$id": "#/components/schemas/ObjectGenericUnion.ISaleArticle.IContent",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "body": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "files": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
+              "$ref": "#/components/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "created_at",
@@ -181,32 +177,41 @@
         "x-typia-jsDocTags": []
       },
       "Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_": {
-        "$id": "components#/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
+        "$id": "#/components/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
         "type": "object",
         "properties": {
           "url": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "extension": {
-            "type": "string",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "string"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "url",
           "name",
@@ -215,58 +220,65 @@
         "x-typia-jsDocTags": []
       },
       "ObjectGenericUnion.ISaleReview": {
-        "$id": "components#/schemas/ObjectGenericUnion.ISaleReview",
+        "$id": "#/components/schemas/ObjectGenericUnion.ISaleReview",
         "type": "object",
         "properties": {
           "writer": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "answer": {
-            "$ref": "components#/schemas/ObjectGenericUnion.ISaleAnswer.Nullable",
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectGenericUnion.ISaleAnswer",
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "hit": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "contents": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectGenericUnion.ISaleReview.IContent",
+              "$ref": "#/components/schemas/ObjectGenericUnion.ISaleReview.IContent",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "writer",
           "answer",
@@ -278,59 +290,52 @@
         "x-typia-jsDocTags": []
       },
       "ObjectGenericUnion.ISaleReview.IContent": {
-        "$id": "components#/schemas/ObjectGenericUnion.ISaleReview.IContent",
+        "$id": "#/components/schemas/ObjectGenericUnion.ISaleReview.IContent",
         "type": "object",
         "properties": {
           "score": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "body": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "files": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
+              "$ref": "#/components/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "score",
           "id",
@@ -344,5 +349,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectHierarchical.json
+++ b/test/schemas/json/ajv/ObjectHierarchical.json
@@ -1,100 +1,117 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectHierarchical.ICustomer"
+      "$ref": "#/components/schemas/ObjectHierarchical.ICustomer"
     }
   ],
   "components": {
     "schemas": {
       "ObjectHierarchical.ICustomer": {
-        "$id": "components#/schemas/ObjectHierarchical.ICustomer",
+        "$id": "#/components/schemas/ObjectHierarchical.ICustomer",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "channel": {
-            "$ref": "components#/schemas/ObjectHierarchical.IChannel",
+            "$ref": "#/components/schemas/ObjectHierarchical.IChannel",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "member": {
-            "$ref": "components#/schemas/ObjectHierarchical.IMember.Nullable",
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectHierarchical.IMember",
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "account": {
-            "$ref": "components#/schemas/ObjectHierarchical.IAccount.Nullable",
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectHierarchical.IAccount",
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "href": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "referrer": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "ip": {
             "type": "array",
             "items": [
               {
-                "type": "number",
-                "nullable": false,
-                "description": "",
-                "x-typia-required": true,
-                "x-typia-optional": false
-              },
-              {
-                "type": "number",
-                "nullable": false,
-                "description": "",
-                "x-typia-required": true,
-                "x-typia-optional": false
-              },
-              {
-                "type": "number",
-                "nullable": false,
-                "description": "",
-                "x-typia-required": true,
-                "x-typia-optional": false
-              },
-              {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "x-typia-rest": false
+                "type": "number"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "number"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "number"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "x-typia-rest": false,
+                "type": "number"
               }
             ],
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "created_at": {
-            "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "channel",
@@ -108,59 +125,52 @@
         "x-typia-jsDocTags": []
       },
       "ObjectHierarchical.IChannel": {
-        "$id": "components#/schemas/ObjectHierarchical.IChannel",
+        "$id": "#/components/schemas/ObjectHierarchical.IChannel",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "exclusive": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           "priority": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
-            "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "code",
@@ -173,83 +183,88 @@
         "x-typia-jsDocTags": []
       },
       "ObjectHierarchical.ITimestamp": {
-        "$id": "components#/schemas/ObjectHierarchical.ITimestamp",
+        "$id": "#/components/schemas/ObjectHierarchical.ITimestamp",
         "type": "object",
         "properties": {
           "time": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "zone": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "time",
           "zone"
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectHierarchical.IMember.Nullable": {
-        "$id": "components#/schemas/ObjectHierarchical.IMember.Nullable",
+      "ObjectHierarchical.IMember": {
+        "$id": "#/components/schemas/ObjectHierarchical.IMember",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "account": {
-            "$ref": "components#/schemas/ObjectHierarchical.IAccount",
+            "$ref": "#/components/schemas/ObjectHierarchical.IAccount",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "enterprise": {
-            "$ref": "components#/schemas/ObjectHierarchical.IEnterprise.Nullable",
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectHierarchical.IEnterprise",
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "emails": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
           },
           "created_at": {
-            "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "authorized": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
-        "nullable": true,
         "required": [
           "id",
           "account",
@@ -261,31 +276,28 @@
         "x-typia-jsDocTags": []
       },
       "ObjectHierarchical.IAccount": {
-        "$id": "components#/schemas/ObjectHierarchical.IAccount",
+        "$id": "#/components/schemas/ObjectHierarchical.IAccount",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "created_at": {
-            "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "code",
@@ -293,45 +305,41 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectHierarchical.IEnterprise.Nullable": {
-        "$id": "components#/schemas/ObjectHierarchical.IEnterprise.Nullable",
+      "ObjectHierarchical.IEnterprise": {
+        "$id": "#/components/schemas/ObjectHierarchical.IEnterprise",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "account": {
-            "$ref": "components#/schemas/ObjectHierarchical.IAccount",
+            "$ref": "#/components/schemas/ObjectHierarchical.IAccount",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "grade": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
-            "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
+            "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": true,
         "required": [
           "id",
           "account",
@@ -340,42 +348,9 @@
           "created_at"
         ],
         "x-typia-jsDocTags": []
-      },
-      "ObjectHierarchical.IAccount.Nullable": {
-        "$id": "components#/schemas/ObjectHierarchical.IAccount.Nullable",
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "number",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "code": {
-            "type": "string",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "created_at": {
-            "$ref": "components#/schemas/ObjectHierarchical.ITimestamp",
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          }
-        },
-        "nullable": true,
-        "required": [
-          "id",
-          "code",
-          "created_at"
-        ],
-        "x-typia-jsDocTags": []
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectInternal.json
+++ b/test/schemas/json/ajv/ObjectInternal.json
@@ -1,31 +1,28 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectInternal"
+      "$ref": "#/components/schemas/ObjectInternal"
     }
   ],
   "components": {
     "schemas": {
       "ObjectInternal": {
-        "$id": "components#/schemas/ObjectInternal",
+        "$id": "#/components/schemas/ObjectInternal",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name"
@@ -35,5 +32,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectIntersection.json
+++ b/test/schemas/json/ajv/ObjectIntersection.json
@@ -1,38 +1,34 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectIntersection"
+      "$ref": "#/components/schemas/ObjectIntersection"
     }
   ],
   "components": {
     "schemas": {
       "ObjectIntersection": {
-        "$id": "components#/schemas/ObjectIntersection",
+        "$id": "#/components/schemas/ObjectIntersection",
         "type": "object",
         "properties": {
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "vulnerable": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "email",
           "name",
@@ -43,5 +39,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectJsonTag.json
+++ b/test/schemas/json/ajv/ObjectJsonTag.json
@@ -1,18 +1,16 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectJsonTag"
+      "$ref": "#/components/schemas/ObjectJsonTag"
     }
   ],
   "components": {
     "schemas": {
       "ObjectJsonTag": {
-        "$id": "components#/schemas/ObjectJsonTag",
+        "$id": "#/components/schemas/ObjectJsonTag",
         "type": "object",
         "properties": {
           "vulnerable": {
-            "type": "string",
-            "nullable": false,
             "deprecated": true,
             "description": "",
             "x-typia-jsDocTags": [
@@ -21,18 +19,16 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "Descripted property.",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "title": "something",
             "description": "Titled property.",
             "x-typia-jsDocTags": [
@@ -47,11 +43,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "complicate_title": {
-            "type": "string",
-            "nullable": false,
             "title": "something weirdo with {@link something } tag",
             "description": "Complicate title.",
             "x-typia-jsDocTags": [
@@ -82,10 +77,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "vulnerable",
           "description",
@@ -97,5 +92,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectLiteralProperty.json
+++ b/test/schemas/json/ajv/ObjectLiteralProperty.json
@@ -1,31 +1,28 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectLiteralProperty.ISomething"
+      "$ref": "#/components/schemas/ObjectLiteralProperty.ISomething"
     }
   ],
   "components": {
     "schemas": {
       "ObjectLiteralProperty.ISomething": {
-        "$id": "components#/schemas/ObjectLiteralProperty.ISomething",
+        "$id": "#/components/schemas/ObjectLiteralProperty.ISomething",
         "type": "object",
         "properties": {
           "something-interesting-do-you-want?": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "or-something-crazy-do-you-want?": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "something-interesting-do-you-want?",
           "or-something-crazy-do-you-want?"
@@ -35,5 +32,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectLiteralType.json
+++ b/test/schemas/json/ajv/ObjectLiteralType.json
@@ -1,38 +1,34 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/__object"
+      "$ref": "#/components/schemas/__object"
     }
   ],
   "components": {
     "schemas": {
       "__object": {
-        "$id": "components#/schemas/__object",
+        "$id": "#/components/schemas/__object",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "age": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -43,5 +39,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectNullable.json
+++ b/test/schemas/json/ajv/ObjectNullable.json
@@ -4,46 +4,57 @@
       "type": "array",
       "items": [
         {
-          "$ref": "components#/schemas/ObjectNullable.IProduct",
+          "$ref": "#/components/schemas/ObjectNullable.IProduct",
           "x-typia-required": true,
           "x-typia-optional": false
         },
         {
-          "$ref": "components#/schemas/ObjectNullable.IProduct",
+          "$ref": "#/components/schemas/ObjectNullable.IProduct",
           "x-typia-required": true,
           "x-typia-optional": false
         },
         {
-          "$ref": "components#/schemas/ObjectNullable.IProduct",
+          "$ref": "#/components/schemas/ObjectNullable.IProduct",
           "x-typia-rest": false,
           "x-typia-required": true,
           "x-typia-optional": false
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {
       "ObjectNullable.IProduct": {
-        "$id": "components#/schemas/ObjectNullable.IProduct",
+        "$id": "#/components/schemas/ObjectNullable.IProduct",
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "manufacturer": {
-            "$ref": "components#/schemas/ObjectNullable.IManufacturer",
+            "$ref": "#/components/schemas/ObjectNullable.IManufacturer",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "brand": {
-            "$ref": "components#/schemas/ObjectNullable.IBrand.Nullable",
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectNullable.IBrand",
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
@@ -51,13 +62,19 @@
           "similar": {
             "oneOf": [
               {
-                "$ref": "components#/schemas/ObjectNullable.IManufacturer.Nullable",
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectNullable.IManufacturer",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ObjectNullable.IBrand.Nullable",
+                "$ref": "#/components/schemas/ObjectNullable.IBrand",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
@@ -68,7 +85,6 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "name",
           "manufacturer",
@@ -78,86 +94,51 @@
         "x-typia-jsDocTags": []
       },
       "ObjectNullable.IManufacturer": {
-        "$id": "components#/schemas/ObjectNullable.IManufacturer",
+        "$id": "#/components/schemas/ObjectNullable.IManufacturer",
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "manufacturer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "type",
           "name"
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectNullable.IBrand.Nullable": {
-        "$id": "components#/schemas/ObjectNullable.IBrand.Nullable",
+      "ObjectNullable.IBrand": {
+        "$id": "#/components/schemas/ObjectNullable.IBrand",
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "brand"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": true,
-        "required": [
-          "type",
-          "name"
-        ],
-        "x-typia-jsDocTags": []
-      },
-      "ObjectNullable.IManufacturer.Nullable": {
-        "$id": "components#/schemas/ObjectNullable.IManufacturer.Nullable",
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "manufacturer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "name": {
-            "type": "string",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          }
-        },
-        "nullable": true,
         "required": [
           "type",
           "name"
@@ -167,5 +148,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectOptional.json
+++ b/test/schemas/json/ajv/ObjectOptional.json
@@ -1,49 +1,44 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectOptional"
+      "$ref": "#/components/schemas/ObjectOptional"
     }
   ],
   "components": {
     "schemas": {
       "ObjectOptional": {
-        "$id": "components#/schemas/ObjectOptional",
+        "$id": "#/components/schemas/ObjectOptional",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           }
         },
-        "nullable": false,
         "x-typia-jsDocTags": []
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectPrimitive.json
+++ b/test/schemas/json/ajv/ObjectPrimitive.json
@@ -1,77 +1,69 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectPrimitive.IArticle"
+      "$ref": "#/components/schemas/ObjectPrimitive.IArticle"
     }
   ],
   "components": {
     "schemas": {
       "ObjectPrimitive.IArticle": {
-        "$id": "components#/schemas/ObjectPrimitive.IArticle",
+        "$id": "#/components/schemas/ObjectPrimitive.IArticle",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "extension": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "txt",
               "md",
               "html"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "body": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "files": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectPrimitive.IFile",
+              "$ref": "#/components/schemas/ObjectPrimitive.IFile",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "secret": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "extension",
@@ -84,46 +76,40 @@
         "x-typia-jsDocTags": []
       },
       "ObjectPrimitive.IFile": {
-        "$id": "components#/schemas/ObjectPrimitive.IFile",
+        "$id": "#/components/schemas/ObjectPrimitive.IFile",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "extension": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "url": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name",
@@ -136,5 +122,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectPropertyNullable.json
+++ b/test/schemas/json/ajv/ObjectPropertyNullable.json
@@ -4,169 +4,242 @@
       "type": "array",
       "items": [
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "$ref": "components#/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_",
+            "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_",
             "x-typia-required": true,
             "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+          }
         },
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "$ref": "components#/schemas/ObjectPropertyNullable.IPointer_lt_number_gt_",
+            "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_number_gt_",
             "x-typia-required": true,
             "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+          }
         },
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "$ref": "components#/schemas/ObjectPropertyNullable.IPointer_lt_string_gt_",
+            "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_string_gt_",
             "x-typia-required": true,
             "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+          }
         },
         {
+          "x-typia-rest": false,
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "$ref": "components#/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_",
+            "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_",
             "x-typia-rest": false,
             "x-typia-required": true,
             "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-rest": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+          }
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {
       "ObjectPropertyNullable.IPointer_lt_boolean_gt_": {
-        "$id": "components#/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_",
+        "$id": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "boolean",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "boolean"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectPropertyNullable.IPointer_lt_number_gt_": {
-        "$id": "components#/schemas/ObjectPropertyNullable.IPointer_lt_number_gt_",
+        "$id": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_number_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectPropertyNullable.IPointer_lt_string_gt_": {
-        "$id": "components#/schemas/ObjectPropertyNullable.IPointer_lt_string_gt_",
+        "$id": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_string_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "string"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_": {
-        "$id": "components#/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_",
+        "$id": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/ObjectPropertyNullable.IMember.Nullable",
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectPropertyNullable.IMember",
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectPropertyNullable.IMember.Nullable": {
-        "$id": "components#/schemas/ObjectPropertyNullable.IMember.Nullable",
+      "ObjectPropertyNullable.IMember": {
+        "$id": "#/components/schemas/ObjectPropertyNullable.IMember",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "string"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "grade": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "serial": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "activated": {
-            "type": "boolean",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "boolean"
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": true,
         "required": [
           "id",
           "name",
@@ -177,5 +250,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectRecursive.json
+++ b/test/schemas/json/ajv/ObjectRecursive.json
@@ -1,115 +1,66 @@
 {
   "schemas": [
     {
-      "$recursiveRef": "components#/schemas/ObjectRecursive.IDepartment"
+      "$recursiveRef": "#/components/schemas/ObjectRecursive.IDepartment"
     }
   ],
   "components": {
     "schemas": {
       "ObjectRecursive.IDepartment": {
-        "$id": "components#/schemas/ObjectRecursive.IDepartment",
+        "$id": "#/components/schemas/ObjectRecursive.IDepartment",
         "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "parent": {
-            "$recursiveRef": "components#/schemas/ObjectRecursive.IDepartment.Nullable",
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$recursiveRef": "#/components/schemas/ObjectRecursive.IDepartment",
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false
+              }
+            ],
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
-            "$ref": "components#/schemas/ObjectRecursive.ITimestamp",
+            "$ref": "#/components/schemas/ObjectRecursive.ITimestamp",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
-        "required": [
-          "parent",
-          "id",
-          "code",
-          "name",
-          "sequence",
-          "created_at"
-        ],
-        "x-typia-jsDocTags": []
-      },
-      "ObjectRecursive.IDepartment.Nullable": {
-        "$id": "components#/schemas/ObjectRecursive.IDepartment.Nullable",
-        "$recursiveAnchor": true,
-        "type": "object",
-        "properties": {
-          "parent": {
-            "$recursiveRef": "components#/schemas/ObjectRecursive.IDepartment.Nullable",
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "id": {
-            "type": "number",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "code": {
-            "type": "string",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "name": {
-            "type": "string",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "sequence": {
-            "type": "number",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "created_at": {
-            "$ref": "components#/schemas/ObjectRecursive.ITimestamp",
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          }
-        },
-        "nullable": true,
         "required": [
           "parent",
           "id",
@@ -121,25 +72,22 @@
         "x-typia-jsDocTags": []
       },
       "ObjectRecursive.ITimestamp": {
-        "$id": "components#/schemas/ObjectRecursive.ITimestamp",
+        "$id": "#/components/schemas/ObjectRecursive.ITimestamp",
         "type": "object",
         "properties": {
           "time": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "zone": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "time",
           "zone"
@@ -149,5 +97,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectSimple.json
+++ b/test/schemas/json/ajv/ObjectSimple.json
@@ -1,41 +1,40 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ObjectSimple.IBox3D"
+      "$ref": "#/components/schemas/ObjectSimple.IBox3D"
     }
   ],
   "components": {
     "schemas": {
       "ObjectSimple.IBox3D": {
-        "$id": "components#/schemas/ObjectSimple.IBox3D",
+        "$id": "#/components/schemas/ObjectSimple.IBox3D",
         "type": "object",
         "properties": {
           "scale": {
-            "$ref": "components#/schemas/ObjectSimple.IPoint3D",
+            "$ref": "#/components/schemas/ObjectSimple.IPoint3D",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "position": {
-            "$ref": "components#/schemas/ObjectSimple.IPoint3D",
+            "$ref": "#/components/schemas/ObjectSimple.IPoint3D",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "rotate": {
-            "$ref": "components#/schemas/ObjectSimple.IPoint3D",
+            "$ref": "#/components/schemas/ObjectSimple.IPoint3D",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "pivot": {
-            "$ref": "components#/schemas/ObjectSimple.IPoint3D",
+            "$ref": "#/components/schemas/ObjectSimple.IPoint3D",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "scale",
           "position",
@@ -45,32 +44,28 @@
         "x-typia-jsDocTags": []
       },
       "ObjectSimple.IPoint3D": {
-        "$id": "components#/schemas/ObjectSimple.IPoint3D",
+        "$id": "#/components/schemas/ObjectSimple.IPoint3D",
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "z": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "x",
           "y",
@@ -81,5 +76,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectTuple.json
+++ b/test/schemas/json/ajv/ObjectTuple.json
@@ -4,49 +4,44 @@
       "type": "array",
       "items": [
         {
-          "$ref": "components#/schemas/ObjectTuple.ISection",
+          "$ref": "#/components/schemas/ObjectTuple.ISection",
           "x-typia-required": true,
           "x-typia-optional": false
         },
         {
-          "$ref": "components#/schemas/ObjectTuple.ICitizen",
+          "$ref": "#/components/schemas/ObjectTuple.ICitizen",
           "x-typia-rest": false,
           "x-typia-required": true,
           "x-typia-optional": false
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {
       "ObjectTuple.ISection": {
-        "$id": "components#/schemas/ObjectTuple.ISection",
+        "$id": "#/components/schemas/ObjectTuple.ISection",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "code",
@@ -55,32 +50,28 @@
         "x-typia-jsDocTags": []
       },
       "ObjectTuple.ICitizen": {
-        "$id": "components#/schemas/ObjectTuple.ICitizen",
+        "$id": "#/components/schemas/ObjectTuple.ICitizen",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "mobile": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "mobile",
@@ -91,5 +82,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectUndefined.json
+++ b/test/schemas/json/ajv/ObjectUndefined.json
@@ -3,39 +3,35 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/ObjectUndefined.ILecture"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/ObjectUndefined.ILecture"
+      }
     }
   ],
   "components": {
     "schemas": {
       "ObjectUndefined.ILecture": {
-        "$id": "components#/schemas/ObjectUndefined.ILecture",
+        "$id": "#/components/schemas/ObjectUndefined.ILecture",
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "professor": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": false,
-                "x-typia-optional": true
+                "x-typia-optional": true,
+                "type": "string"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": false,
-                "x-typia-optional": true
+                "x-typia-optional": true,
+                "type": "number"
               }
             ],
             "description": "",
@@ -43,17 +39,16 @@
             "x-typia-optional": true
           },
           "classroom": {
-            "$ref": "components#/schemas/ObjectUndefined.IClassroom",
+            "$ref": "#/components/schemas/ObjectUndefined.IClassroom",
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "grade": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "unknown": {
             "description": "",
@@ -61,7 +56,6 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "name",
           "unknown"
@@ -69,25 +63,22 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUndefined.IClassroom": {
-        "$id": "components#/schemas/ObjectUndefined.IClassroom",
+        "$id": "#/components/schemas/ObjectUndefined.IClassroom",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "name"
@@ -97,5 +88,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectUnionComposite.json
+++ b/test/schemas/json/ajv/ObjectUnionComposite.json
@@ -5,56 +5,52 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint"
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionComposite.ILine"
+            "$ref": "#/components/schemas/ObjectUnionComposite.ILine"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionComposite.ITriangle"
+            "$ref": "#/components/schemas/ObjectUnionComposite.ITriangle"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionComposite.IRectangle"
+            "$ref": "#/components/schemas/ObjectUnionComposite.IRectangle"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPolyline"
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPolyline"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPolygon"
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPolygon"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPointedShape"
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPointedShape"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionComposite.ICircle"
+            "$ref": "#/components/schemas/ObjectUnionComposite.ICircle"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "ObjectUnionComposite.IPoint": {
-        "$id": "components#/schemas/ObjectUnionComposite.IPoint",
+        "$id": "#/components/schemas/ObjectUnionComposite.IPoint",
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "x",
           "y"
@@ -62,23 +58,22 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionComposite.ILine": {
-        "$id": "components#/schemas/ObjectUnionComposite.ILine",
+        "$id": "#/components/schemas/ObjectUnionComposite.ILine",
         "type": "object",
         "properties": {
           "p1": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "p1",
           "p2"
@@ -86,29 +81,28 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionComposite.ITriangle": {
-        "$id": "components#/schemas/ObjectUnionComposite.ITriangle",
+        "$id": "#/components/schemas/ObjectUnionComposite.ITriangle",
         "type": "object",
         "properties": {
           "p1": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "p1",
           "p2",
@@ -117,35 +111,34 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionComposite.IRectangle": {
-        "$id": "components#/schemas/ObjectUnionComposite.IRectangle",
+        "$id": "#/components/schemas/ObjectUnionComposite.IRectangle",
         "type": "object",
         "properties": {
           "p1": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p4": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "p1",
           "p2",
@@ -155,54 +148,50 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionComposite.IPolyline": {
-        "$id": "components#/schemas/ObjectUnionComposite.IPolyline",
+        "$id": "#/components/schemas/ObjectUnionComposite.IPolyline",
         "type": "object",
         "properties": {
           "points": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+              "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "points"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionComposite.IPolygon": {
-        "$id": "components#/schemas/ObjectUnionComposite.IPolygon",
+        "$id": "#/components/schemas/ObjectUnionComposite.IPolygon",
         "type": "object",
         "properties": {
           "outer": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPolyline",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPolyline",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "inner": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectUnionComposite.IPolyline",
+              "$ref": "#/components/schemas/ObjectUnionComposite.IPolyline",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "outer",
           "inner"
@@ -210,30 +199,28 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionComposite.IPointedShape": {
-        "$id": "components#/schemas/ObjectUnionComposite.IPointedShape",
+        "$id": "#/components/schemas/ObjectUnionComposite.IPointedShape",
         "type": "object",
         "properties": {
           "outer": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+              "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "inner": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "outer",
           "inner"
@@ -241,24 +228,22 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionComposite.ICircle": {
-        "$id": "components#/schemas/ObjectUnionComposite.ICircle",
+        "$id": "#/components/schemas/ObjectUnionComposite.ICircle",
         "type": "object",
         "properties": {
           "centroid": {
-            "$ref": "components#/schemas/ObjectUnionComposite.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "radius": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "centroid",
           "radius"
@@ -268,5 +253,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectUnionDouble.json
+++ b/test/schemas/json/ajv/ObjectUnionDouble.json
@@ -5,24 +5,23 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "components#/schemas/ObjectUnionDouble.IA"
+            "$ref": "#/components/schemas/ObjectUnionDouble.IA"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionDouble.IB"
+            "$ref": "#/components/schemas/ObjectUnionDouble.IB"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "ObjectUnionDouble.IA": {
-        "$id": "components#/schemas/ObjectUnionDouble.IA",
+        "$id": "#/components/schemas/ObjectUnionDouble.IA",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/__type",
+            "$ref": "#/components/schemas/__type",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
@@ -30,13 +29,13 @@
           "child": {
             "oneOf": [
               {
-                "$ref": "components#/schemas/ObjectUnionDouble.IAA",
+                "$ref": "#/components/schemas/ObjectUnionDouble.IAA",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ObjectUnionDouble.IAB",
+                "$ref": "#/components/schemas/ObjectUnionDouble.IAB",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
@@ -47,7 +46,6 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value",
           "child"
@@ -55,99 +53,91 @@
         "x-typia-jsDocTags": []
       },
       "__type": {
-        "$id": "components#/schemas/__type",
+        "$id": "#/components/schemas/__type",
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "x"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionDouble.IAA": {
-        "$id": "components#/schemas/ObjectUnionDouble.IAA",
+        "$id": "#/components/schemas/ObjectUnionDouble.IAA",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/__type.o1",
+            "$ref": "#/components/schemas/__type.o1",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "__type.o1": {
-        "$id": "components#/schemas/__type.o1",
+        "$id": "#/components/schemas/__type.o1",
         "type": "object",
         "properties": {
           "y": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "y"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionDouble.IAB": {
-        "$id": "components#/schemas/ObjectUnionDouble.IAB",
+        "$id": "#/components/schemas/ObjectUnionDouble.IAB",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/__type.o2",
+            "$ref": "#/components/schemas/__type.o2",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "__type.o2": {
-        "$id": "components#/schemas/__type.o2",
+        "$id": "#/components/schemas/__type.o2",
         "type": "object",
         "properties": {
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "y"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionDouble.IB": {
-        "$id": "components#/schemas/ObjectUnionDouble.IB",
+        "$id": "#/components/schemas/ObjectUnionDouble.IB",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/__type.o3",
+            "$ref": "#/components/schemas/__type.o3",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
@@ -155,13 +145,13 @@
           "child": {
             "oneOf": [
               {
-                "$ref": "components#/schemas/ObjectUnionDouble.IBA",
+                "$ref": "#/components/schemas/ObjectUnionDouble.IBA",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ObjectUnionDouble.IBB",
+                "$ref": "#/components/schemas/ObjectUnionDouble.IBB",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
@@ -172,7 +162,6 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value",
           "child"
@@ -180,95 +169,86 @@
         "x-typia-jsDocTags": []
       },
       "__type.o3": {
-        "$id": "components#/schemas/__type.o3",
+        "$id": "#/components/schemas/__type.o3",
         "type": "object",
         "properties": {
           "x": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "x"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionDouble.IBA": {
-        "$id": "components#/schemas/ObjectUnionDouble.IBA",
+        "$id": "#/components/schemas/ObjectUnionDouble.IBA",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/__type.o4",
+            "$ref": "#/components/schemas/__type.o4",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "__type.o4": {
-        "$id": "components#/schemas/__type.o4",
+        "$id": "#/components/schemas/__type.o4",
         "type": "object",
         "properties": {
           "y": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "y"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionDouble.IBB": {
-        "$id": "components#/schemas/ObjectUnionDouble.IBB",
+        "$id": "#/components/schemas/ObjectUnionDouble.IBB",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/__type.o5",
+            "$ref": "#/components/schemas/__type.o5",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "__type.o5": {
-        "$id": "components#/schemas/__type.o5",
+        "$id": "#/components/schemas/__type.o5",
         "type": "object",
         "properties": {
           "y": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
           }
         },
-        "nullable": false,
         "required": [
           "y"
         ],
@@ -277,5 +257,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectUnionExplicit.json
+++ b/test/schemas/json/ajv/ObjectUnionExplicit.json
@@ -5,63 +5,58 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicit.IPoint_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicit.IPoint_gt_"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicit.ILine_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicit.ILine_gt_"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicit.ITriangle_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicit.ITriangle_gt_"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicit.IRectangle_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicit.IRectangle_gt_"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicit.IPolyline_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicit.IPolyline_gt_"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicit.IPolygon_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicit.IPolygon_gt_"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "ObjectUnionExplicit.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicit.IPoint_gt_": {
-        "$id": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicit.IPoint_gt_",
+        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicit.IPoint_gt_",
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "point"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "x",
           "y",
@@ -70,33 +65,31 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionExplicit.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicit.ILine_gt_": {
-        "$id": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicit.ILine_gt_",
+        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicit.ILine_gt_",
         "type": "object",
         "properties": {
           "p1": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "line"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "p1",
           "p2",
@@ -105,25 +98,22 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionExplicit.IPoint": {
-        "$id": "components#/schemas/ObjectUnionExplicit.IPoint",
+        "$id": "#/components/schemas/ObjectUnionExplicit.IPoint",
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "x",
           "y"
@@ -131,39 +121,37 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionExplicit.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicit.ITriangle_gt_": {
-        "$id": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicit.ITriangle_gt_",
+        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicit.ITriangle_gt_",
         "type": "object",
         "properties": {
           "p1": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "triangle"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "p1",
           "p2",
@@ -173,45 +161,43 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionExplicit.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicit.IRectangle_gt_": {
-        "$id": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicit.IRectangle_gt_",
+        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicit.IRectangle_gt_",
         "type": "object",
         "properties": {
           "p1": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p4": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "rectangle"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "p1",
           "p2",
@@ -222,34 +208,31 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionExplicit.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicit.IPolyline_gt_": {
-        "$id": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicit.IPolyline_gt_",
+        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicit.IPolyline_gt_",
         "type": "object",
         "properties": {
           "points": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+              "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "polyline"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "points",
           "type"
@@ -257,40 +240,37 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionExplicit.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicit.IPolygon_gt_": {
-        "$id": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicit.IPolygon_gt_",
+        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicit.IPolygon_gt_",
         "type": "object",
         "properties": {
           "outer": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPolyline",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPolyline",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "inner": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectUnionExplicit.IPolyline",
+              "$ref": "#/components/schemas/ObjectUnionExplicit.IPolyline",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "polygon"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "outer",
           "inner",
@@ -299,58 +279,53 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionExplicit.IPolyline": {
-        "$id": "components#/schemas/ObjectUnionExplicit.IPolyline",
+        "$id": "#/components/schemas/ObjectUnionExplicit.IPolyline",
         "type": "object",
         "properties": {
           "points": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+              "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "points"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_": {
-        "$id": "components#/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_",
+        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_",
         "type": "object",
         "properties": {
           "centroid": {
-            "$ref": "components#/schemas/ObjectUnionExplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "radius": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "circle"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "centroid",
           "radius",
@@ -361,5 +336,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectUnionImplicit.json
+++ b/test/schemas/json/ajv/ObjectUnionImplicit.json
@@ -5,60 +5,68 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint"
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionImplicit.ILine"
+            "$ref": "#/components/schemas/ObjectUnionImplicit.ILine"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionImplicit.ITriangle"
+            "$ref": "#/components/schemas/ObjectUnionImplicit.ITriangle"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IRectangle"
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IRectangle"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPolyline"
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPolyline"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPolygon"
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPolygon"
           },
           {
-            "$ref": "components#/schemas/ObjectUnionImplicit.ICircle"
+            "$ref": "#/components/schemas/ObjectUnionImplicit.ICircle"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "ObjectUnionImplicit.IPoint": {
-        "$id": "components#/schemas/ObjectUnionImplicit.IPoint",
+        "$id": "#/components/schemas/ObjectUnionImplicit.IPoint",
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "slope": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
         },
-        "nullable": false,
         "required": [
           "x",
           "y"
@@ -66,37 +74,60 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionImplicit.ILine": {
-        "$id": "components#/schemas/ObjectUnionImplicit.ILine",
+        "$id": "#/components/schemas/ObjectUnionImplicit.ILine",
         "type": "object",
         "properties": {
           "p1": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "distance": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
         },
-        "nullable": false,
         "required": [
           "p1",
           "p2"
@@ -104,50 +135,85 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionImplicit.ITriangle": {
-        "$id": "components#/schemas/ObjectUnionImplicit.ITriangle",
+        "$id": "#/components/schemas/ObjectUnionImplicit.ITriangle",
         "type": "object",
         "properties": {
           "p1": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "height": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "area": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
         },
-        "nullable": false,
         "required": [
           "p1",
           "p2",
@@ -156,56 +222,91 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionImplicit.IRectangle": {
-        "$id": "components#/schemas/ObjectUnionImplicit.IRectangle",
+        "$id": "#/components/schemas/ObjectUnionImplicit.IRectangle",
         "type": "object",
         "properties": {
           "p1": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p2": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p3": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "p4": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "width": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "height": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "area": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
         },
-        "nullable": false,
         "required": [
           "p1",
           "p2",
@@ -215,99 +316,129 @@
         "x-typia-jsDocTags": []
       },
       "ObjectUnionImplicit.IPolyline": {
-        "$id": "components#/schemas/ObjectUnionImplicit.IPolyline",
+        "$id": "#/components/schemas/ObjectUnionImplicit.IPolyline",
         "type": "object",
         "properties": {
           "points": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+              "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "length": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
         },
-        "nullable": false,
         "required": [
           "points"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionImplicit.IPolygon": {
-        "$id": "components#/schemas/ObjectUnionImplicit.IPolygon",
+        "$id": "#/components/schemas/ObjectUnionImplicit.IPolygon",
         "type": "object",
         "properties": {
           "outer": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPolyline",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPolyline",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "inner": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/ObjectUnionImplicit.IPolyline",
+              "$ref": "#/components/schemas/ObjectUnionImplicit.IPolyline",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "area": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
         },
-        "nullable": false,
         "required": [
           "outer"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionImplicit.ICircle": {
-        "$id": "components#/schemas/ObjectUnionImplicit.ICircle",
+        "$id": "#/components/schemas/ObjectUnionImplicit.ICircle",
         "type": "object",
         "properties": {
           "centroid": {
-            "$ref": "components#/schemas/ObjectUnionImplicit.IPoint",
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "radius": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "area": {
-            "type": "number",
-            "nullable": true,
+            "oneOf": [
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "description": "",
+                "x-typia-required": false,
+                "x-typia-optional": true,
+                "type": "number"
+              }
+            ],
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           }
         },
-        "nullable": false,
         "required": [
           "radius"
         ],
@@ -316,5 +447,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ObjectUnionNonPredictable.json
+++ b/test/schemas/json/ajv/ObjectUnionNonPredictable.json
@@ -3,50 +3,48 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_"
+      }
     }
   ],
   "components": {
     "schemas": {
       "ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_": {
-        "$id": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_",
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_",
+            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionNonPredictable.IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_": {
-        "$id": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_",
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_",
         "type": "object",
         "properties": {
           "value": {
             "oneOf": [
               {
-                "$ref": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_",
+                "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_number_gt_",
+                "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_number_gt_",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_string_gt_",
+                "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_string_gt_",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
@@ -57,112 +55,102 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_": {
-        "$id": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_",
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_boolean_gt_",
+            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_boolean_gt_",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionNonPredictable.IPointer_lt_boolean_gt_": {
-        "$id": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_boolean_gt_",
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_boolean_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionNonPredictable.IWrapper_lt_number_gt_": {
-        "$id": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_number_gt_",
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_number_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_number_gt_",
+            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_number_gt_",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionNonPredictable.IPointer_lt_number_gt_": {
-        "$id": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_number_gt_",
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_number_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionNonPredictable.IWrapper_lt_string_gt_": {
-        "$id": "components#/schemas/ObjectUnionNonPredictable.IWrapper_lt_string_gt_",
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_string_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_string_gt_",
+            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_string_gt_",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "ObjectUnionNonPredictable.IPointer_lt_string_gt_": {
-        "$id": "components#/schemas/ObjectUnionNonPredictable.IPointer_lt_string_gt_",
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IPointer_lt_string_gt_",
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
@@ -171,5 +159,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/SetAlias.json
+++ b/test/schemas/json/ajv/SetAlias.json
@@ -1,47 +1,46 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/SetAlias"
+      "$ref": "#/components/schemas/SetAlias"
     }
   ],
   "components": {
     "schemas": {
       "SetAlias": {
-        "$id": "components#/schemas/SetAlias",
+        "$id": "#/components/schemas/SetAlias",
         "type": "object",
         "properties": {
           "booleans": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "numbers": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "strings": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "arrays": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "objects": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           }
         },
-        "nullable": false,
         "required": [
           "booleans",
           "numbers",
@@ -53,12 +52,11 @@
       },
       "Set": {
         "type": "object",
-        "$id": "components#/schemas/Set",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Set",
+        "properties": {}
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/SetSimple.json
+++ b/test/schemas/json/ajv/SetSimple.json
@@ -1,47 +1,46 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/SetSimple"
+      "$ref": "#/components/schemas/SetSimple"
     }
   ],
   "components": {
     "schemas": {
       "SetSimple": {
-        "$id": "components#/schemas/SetSimple",
+        "$id": "#/components/schemas/SetSimple",
         "type": "object",
         "properties": {
           "booleans": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "numbers": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "strings": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "arrays": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "objects": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           }
         },
-        "nullable": false,
         "required": [
           "booleans",
           "numbers",
@@ -53,12 +52,11 @@
       },
       "Set": {
         "type": "object",
-        "$id": "components#/schemas/Set",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Set",
+        "properties": {}
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/SetUnion.json
+++ b/test/schemas/json/ajv/SetUnion.json
@@ -4,20 +4,18 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/Set"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "Set": {
         "type": "object",
-        "$id": "components#/schemas/Set",
-        "properties": {},
-        "nullable": false
+        "$id": "#/components/schemas/Set",
+        "properties": {}
       }
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagArray.json
+++ b/test/schemas/json/ajv/TagArray.json
@@ -3,22 +3,52 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/TagArray.Type"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/TagArray.Type"
+      }
     }
   ],
   "components": {
     "schemas": {
       "TagArray.Type": {
-        "$id": "components#/schemas/TagArray.Type",
+        "$id": "#/components/schemas/TagArray.Type",
         "type": "object",
         "properties": {
           "items": {
+            "description": "",
+            "x-typia-metaTags": [
+              {
+                "kind": "items",
+                "value": 3
+              },
+              {
+                "kind": "format",
+                "value": "uuid"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "items",
+                "text": [
+                  {
+                    "text": "3",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "format",
+                "text": [
+                  {
+                    "text": "uuid",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false,
               "description": "",
               "x-typia-metaTags": [
                 {
@@ -52,84 +82,11 @@
               ],
               "x-typia-required": true,
               "x-typia-optional": false,
+              "type": "string",
               "format": "uuid"
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-metaTags": [
-              {
-                "kind": "items",
-                "value": 3
-              },
-              {
-                "kind": "format",
-                "value": "uuid"
-              }
-            ],
-            "x-typia-jsDocTags": [
-              {
-                "name": "items",
-                "text": [
-                  {
-                    "text": "3",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "format",
-                "text": [
-                  {
-                    "text": "uuid",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ],
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "minItems": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-metaTags": [
-                {
-                  "kind": "minItems",
-                  "value": 3
-                },
-                {
-                  "kind": "minimum",
-                  "value": 3
-                }
-              ],
-              "x-typia-jsDocTags": [
-                {
-                  "name": "minItems",
-                  "text": [
-                    {
-                      "text": "3",
-                      "kind": "text"
-                    }
-                  ]
-                },
-                {
-                  "name": "minimum",
-                  "text": [
-                    {
-                      "text": "3",
-                      "kind": "text"
-                    }
-                  ]
-                }
-              ],
-              "x-typia-required": true,
-              "x-typia-optional": false,
-              "minimum": 3
-            },
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -163,15 +120,97 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-metaTags": [
+                {
+                  "kind": "minItems",
+                  "value": 3
+                },
+                {
+                  "kind": "minimum",
+                  "value": 3
+                }
+              ],
+              "x-typia-jsDocTags": [
+                {
+                  "name": "minItems",
+                  "text": [
+                    {
+                      "text": "3",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "minimum",
+                  "text": [
+                    {
+                      "text": "3",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number",
+              "minimum": 3
+            },
             "minItems": 3
           },
           "maxItems": {
+            "description": "",
+            "x-typia-metaTags": [
+              {
+                "kind": "maxItems",
+                "value": 7
+              },
+              {
+                "kind": "maxLength",
+                "value": 7
+              },
+              {
+                "kind": "maximum",
+                "value": 7
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "maxItems",
+                "text": [
+                  {
+                    "text": "7",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maxLength",
+                "text": [
+                  {
+                    "text": "7",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maximum",
+                "text": [
+                  {
+                    "text": "7",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "type": "string",
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -218,11 +257,10 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
+                  "type": "string",
                   "maxLength": 7
                 },
                 {
-                  "type": "number",
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -269,6 +307,7 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
+                  "type": "number",
                   "maximum": 7
                 }
               ],
@@ -319,109 +358,9 @@
               "x-typia-required": true,
               "x-typia-optional": false
             },
-            "nullable": false,
-            "description": "",
-            "x-typia-metaTags": [
-              {
-                "kind": "maxItems",
-                "value": 7
-              },
-              {
-                "kind": "maxLength",
-                "value": 7
-              },
-              {
-                "kind": "maximum",
-                "value": 7
-              }
-            ],
-            "x-typia-jsDocTags": [
-              {
-                "name": "maxItems",
-                "text": [
-                  {
-                    "text": "7",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "maxLength",
-                "text": [
-                  {
-                    "text": "7",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "maximum",
-                "text": [
-                  {
-                    "text": "7",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ],
-            "x-typia-required": true,
-            "x-typia-optional": false,
             "maxItems": 7
           },
           "both": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "description": "",
-              "x-typia-metaTags": [
-                {
-                  "kind": "minItems",
-                  "value": 3
-                },
-                {
-                  "kind": "maxItems",
-                  "value": 7
-                },
-                {
-                  "kind": "format",
-                  "value": "uuid"
-                }
-              ],
-              "x-typia-jsDocTags": [
-                {
-                  "name": "minItems",
-                  "text": [
-                    {
-                      "text": "3",
-                      "kind": "text"
-                    }
-                  ]
-                },
-                {
-                  "name": "maxItems",
-                  "text": [
-                    {
-                      "text": "7",
-                      "kind": "text"
-                    }
-                  ]
-                },
-                {
-                  "name": "format",
-                  "text": [
-                    {
-                      "text": "uuid",
-                      "kind": "text"
-                    }
-                  ]
-                }
-              ],
-              "x-typia-required": true,
-              "x-typia-optional": false,
-              "format": "uuid"
-            },
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -468,11 +407,61 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-metaTags": [
+                {
+                  "kind": "minItems",
+                  "value": 3
+                },
+                {
+                  "kind": "maxItems",
+                  "value": 7
+                },
+                {
+                  "kind": "format",
+                  "value": "uuid"
+                }
+              ],
+              "x-typia-jsDocTags": [
+                {
+                  "name": "minItems",
+                  "text": [
+                    {
+                      "text": "3",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "maxItems",
+                  "text": [
+                    {
+                      "text": "7",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "format",
+                  "text": [
+                    {
+                      "text": "uuid",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string",
+              "format": "uuid"
+            },
             "minItems": 3,
             "maxItems": 7
           }
         },
-        "nullable": false,
         "required": [
           "items",
           "minItems",
@@ -484,5 +473,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagAtomicUnion.json
+++ b/test/schemas/json/ajv/TagAtomicUnion.json
@@ -3,22 +3,19 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/TagAtomicUnion.Type"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/TagAtomicUnion.Type"
+      }
     }
   ],
   "components": {
     "schemas": {
       "TagAtomicUnion.Type": {
-        "$id": "components#/schemas/TagAtomicUnion.Type",
+        "$id": "#/components/schemas/TagAtomicUnion.Type",
         "type": "object",
         "properties": {
           "value": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-metaTags": [
                   {
@@ -65,12 +62,11 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "string",
                 "minLength": 3,
                 "maxLength": 7
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-metaTags": [
                   {
@@ -117,6 +113,7 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "number",
                 "minimum": 3
               }
             ],
@@ -168,7 +165,6 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
@@ -177,5 +173,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagCustom.json
+++ b/test/schemas/json/ajv/TagCustom.json
@@ -1,18 +1,16 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/TagCustom"
+      "$ref": "#/components/schemas/TagCustom"
     }
   ],
   "components": {
     "schemas": {
       "TagCustom": {
-        "$id": "components#/schemas/TagCustom",
+        "$id": "#/components/schemas/TagCustom",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "Regular feature supported by typia",
             "x-typia-metaTags": [
               {
@@ -33,11 +31,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "uuid"
           },
           "dollar": {
-            "type": "string",
-            "nullable": false,
             "description": "Custom feature composed with \"$\" + number",
             "x-typia-jsDocTags": [
               {
@@ -45,11 +42,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "postfix": {
-            "type": "string",
-            "nullable": false,
             "description": "Custom feature composed with string + \"abcd\"",
             "x-typia-jsDocTags": [
               {
@@ -63,11 +59,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "log": {
-            "type": "number",
-            "nullable": false,
             "description": "Custom feature meaning x^y",
             "x-typia-jsDocTags": [
               {
@@ -81,10 +76,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "dollar",
@@ -96,5 +91,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagDefault.json
+++ b/test/schemas/json/ajv/TagDefault.json
@@ -1,18 +1,16 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/TagDefault"
+      "$ref": "#/components/schemas/TagDefault"
     }
   ],
   "components": {
     "schemas": {
       "TagDefault": {
-        "$id": "components#/schemas/TagDefault",
+        "$id": "#/components/schemas/TagDefault",
         "type": "object",
         "properties": {
           "boolean": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -27,11 +25,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
-            "default": true
+            "default": true,
+            "type": "boolean"
           },
           "number": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -46,11 +43,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "default": 1
           },
           "string": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -65,11 +61,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "default": "two"
           },
           "text": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -84,11 +79,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "default": "Very long text, can you understand it?"
           },
           "template": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -109,8 +104,6 @@
           "boolean_and_number_and_string": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -143,11 +136,10 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "string",
                 "default": "two"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -180,11 +172,10 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "number",
                 "default": 1
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -217,7 +208,8 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "default": true
+                "default": true,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -256,44 +248,6 @@
           "union_but_boolean": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
-                "description": "",
-                "x-typia-jsDocTags": [
-                  {
-                    "name": "default",
-                    "text": [
-                      {
-                        "text": "false",
-                        "kind": "text"
-                      }
-                    ]
-                  }
-                ],
-                "x-typia-required": true,
-                "x-typia-optional": false
-              },
-              {
-                "type": "number",
-                "nullable": false,
-                "description": "",
-                "x-typia-jsDocTags": [
-                  {
-                    "name": "default",
-                    "text": [
-                      {
-                        "text": "false",
-                        "kind": "text"
-                      }
-                    ]
-                  }
-                ],
-                "x-typia-required": true,
-                "x-typia-optional": false
-              },
-              {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -308,7 +262,42 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "default": true
+                "type": "string"
+              },
+              {
+                "description": "",
+                "x-typia-jsDocTags": [
+                  {
+                    "name": "default",
+                    "text": [
+                      {
+                        "text": "false",
+                        "kind": "text"
+                      }
+                    ]
+                  }
+                ],
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "number"
+              },
+              {
+                "description": "",
+                "x-typia-jsDocTags": [
+                  {
+                    "name": "default",
+                    "text": [
+                      {
+                        "text": "false",
+                        "kind": "text"
+                      }
+                    ]
+                  }
+                ],
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "default": true,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -329,26 +318,6 @@
           "union_but_number": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
-                "description": "",
-                "x-typia-jsDocTags": [
-                  {
-                    "name": "default",
-                    "text": [
-                      {
-                        "text": "1",
-                        "kind": "text"
-                      }
-                    ]
-                  }
-                ],
-                "x-typia-required": true,
-                "x-typia-optional": false
-              },
-              {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -363,11 +332,9 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "default": 1
+                "type": "string"
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -381,7 +348,26 @@
                   }
                 ],
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "number",
+                "default": 1
+              },
+              {
+                "description": "",
+                "x-typia-jsDocTags": [
+                  {
+                    "name": "default",
+                    "text": [
+                      {
+                        "text": "1",
+                        "kind": "text"
+                      }
+                    ]
+                  }
+                ],
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -402,8 +388,6 @@
           "union_but_string": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -418,11 +402,10 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "string",
                 "default": "two"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -436,11 +419,10 @@
                   }
                 ],
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "number"
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -454,7 +436,8 @@
                   }
                 ],
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -473,8 +456,6 @@
             "x-typia-optional": false
           },
           "vulnerable_range": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -517,12 +498,12 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "maximum": 5
           },
           "vulnerable_template": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -543,7 +524,6 @@
             "oneOf": [
               {
                 "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -580,8 +560,6 @@
                 "default": "prefix_B"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -614,11 +592,10 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "number",
                 "default": 1
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -651,7 +628,8 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "default": true
+                "default": true,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -688,7 +666,6 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "boolean",
           "number",
@@ -708,5 +685,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagFormat.json
+++ b/test/schemas/json/ajv/TagFormat.json
@@ -1,18 +1,16 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/TagFormat"
+      "$ref": "#/components/schemas/TagFormat"
     }
   ],
   "components": {
     "schemas": {
       "TagFormat": {
-        "$id": "components#/schemas/TagFormat",
+        "$id": "#/components/schemas/TagFormat",
         "type": "object",
         "properties": {
           "uuid": {
-            "type": "string",
-            "nullable": false,
             "description": "Universally Unique Identifier.",
             "x-typia-metaTags": [
               {
@@ -33,11 +31,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "uuid"
           },
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "Email address",
             "x-typia-metaTags": [
               {
@@ -58,11 +55,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "email"
           },
           "url": {
-            "type": "string",
-            "nullable": false,
             "description": "URL address.",
             "x-typia-metaTags": [
               {
@@ -83,11 +79,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "url"
           },
           "ipv4": {
-            "type": "string",
-            "nullable": false,
             "description": "IPv4 address.",
             "x-typia-metaTags": [
               {
@@ -108,11 +103,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "ipv4"
           },
           "ipv6": {
-            "type": "string",
-            "nullable": false,
             "description": "IPv6 address.",
             "x-typia-metaTags": [
               {
@@ -133,11 +127,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "ipv6"
           },
           "date": {
-            "type": "string",
-            "nullable": false,
             "description": "Date only.",
             "x-typia-metaTags": [
               {
@@ -158,11 +151,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "date"
           },
           "date_time": {
-            "type": "string",
-            "nullable": false,
             "description": "Date and time.",
             "x-typia-metaTags": [
               {
@@ -183,11 +175,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "date-time"
           },
           "datetime": {
-            "type": "string",
-            "nullable": false,
             "description": "Date and time with only lowercase characters.",
             "x-typia-metaTags": [
               {
@@ -208,11 +199,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "date-time"
           },
           "dateTime": {
-            "type": "string",
-            "nullable": false,
             "description": "Date and time with camelCase.",
             "x-typia-metaTags": [
               {
@@ -233,11 +223,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "date-time"
           },
           "custom": {
-            "type": "string",
-            "nullable": false,
             "description": "A custom format string.",
             "x-typia-jsDocTags": [
               {
@@ -252,10 +241,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "my-custom-format"
           }
         },
-        "nullable": false,
         "required": [
           "uuid",
           "email",
@@ -273,5 +262,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagLength.json
+++ b/test/schemas/json/ajv/TagLength.json
@@ -3,20 +3,17 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/TagLength.Type"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/TagLength.Type"
+      }
     }
   ],
   "components": {
     "schemas": {
       "TagLength.Type": {
-        "$id": "components#/schemas/TagLength.Type",
+        "$id": "#/components/schemas/TagLength.Type",
         "type": "object",
         "properties": {
           "fixed": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -36,11 +33,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "minimum": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -61,11 +57,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "minLength": 3
           },
           "maximum": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -86,11 +81,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "maxLength": 7
           },
           "minimum_and_maximum": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -124,11 +118,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "minLength": 3,
             "maxLength": 7
           }
         },
-        "nullable": false,
         "required": [
           "fixed",
           "minimum",
@@ -140,5 +134,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagMatrix.json
+++ b/test/schemas/json/ajv/TagMatrix.json
@@ -1,22 +1,86 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/TagMatrix"
+      "$ref": "#/components/schemas/TagMatrix"
     }
   ],
   "components": {
     "schemas": {
       "TagMatrix": {
-        "$id": "components#/schemas/TagMatrix",
+        "$id": "#/components/schemas/TagMatrix",
         "type": "object",
         "properties": {
           "matrix": {
+            "description": "Doubled array.",
+            "x-typia-metaTags": [
+              {
+                "kind": "items",
+                "value": 3
+              },
+              {
+                "kind": "format",
+                "value": "uuid"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "items",
+                "text": [
+                  {
+                    "text": "3",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "format",
+                "text": [
+                  {
+                    "text": "uuid",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
+              "description": "Doubled array.",
+              "x-typia-metaTags": [
+                {
+                  "kind": "items",
+                  "value": 3
+                },
+                {
+                  "kind": "format",
+                  "value": "uuid"
+                }
+              ],
+              "x-typia-jsDocTags": [
+                {
+                  "name": "items",
+                  "text": [
+                    {
+                      "text": "3",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "format",
+                  "text": [
+                    {
+                      "text": "uuid",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "array",
               "items": {
-                "type": "string",
-                "nullable": false,
                 "description": "Doubled array.",
                 "x-typia-metaTags": [
                   {
@@ -50,80 +114,12 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "string",
                 "format": "uuid"
-              },
-              "nullable": false,
-              "description": "Doubled array.",
-              "x-typia-metaTags": [
-                {
-                  "kind": "items",
-                  "value": 3
-                },
-                {
-                  "kind": "format",
-                  "value": "uuid"
-                }
-              ],
-              "x-typia-jsDocTags": [
-                {
-                  "name": "items",
-                  "text": [
-                    {
-                      "text": "3",
-                      "kind": "text"
-                    }
-                  ]
-                },
-                {
-                  "name": "format",
-                  "text": [
-                    {
-                      "text": "uuid",
-                      "kind": "text"
-                    }
-                  ]
-                }
-              ],
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "Doubled array.",
-            "x-typia-metaTags": [
-              {
-                "kind": "items",
-                "value": 3
-              },
-              {
-                "kind": "format",
-                "value": "uuid"
               }
-            ],
-            "x-typia-jsDocTags": [
-              {
-                "name": "items",
-                "text": [
-                  {
-                    "text": "3",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "format",
-                "text": [
-                  {
-                    "text": "uuid",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ],
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
-        "nullable": false,
         "required": [
           "matrix"
         ],
@@ -132,5 +128,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagObjectUnion.json
+++ b/test/schemas/json/ajv/TagObjectUnion.json
@@ -5,25 +5,22 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "components#/schemas/TagObjectUnion.Numeric"
+            "$ref": "#/components/schemas/TagObjectUnion.Numeric"
           },
           {
-            "$ref": "components#/schemas/TagObjectUnion.Literal"
+            "$ref": "#/components/schemas/TagObjectUnion.Literal"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "TagObjectUnion.Numeric": {
-        "$id": "components#/schemas/TagObjectUnion.Numeric",
+        "$id": "#/components/schemas/TagObjectUnion.Numeric",
         "type": "object",
         "properties": {
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -44,22 +41,20 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
         "x-typia-jsDocTags": []
       },
       "TagObjectUnion.Literal": {
-        "$id": "components#/schemas/TagObjectUnion.Literal",
+        "$id": "#/components/schemas/TagObjectUnion.Literal",
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -93,11 +88,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "minLength": 3,
             "maxLength": 7
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
@@ -106,5 +101,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagPattern.json
+++ b/test/schemas/json/ajv/TagPattern.json
@@ -1,18 +1,16 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/TagPattern"
+      "$ref": "#/components/schemas/TagPattern"
     }
   ],
   "components": {
     "schemas": {
       "TagPattern": {
-        "$id": "components#/schemas/TagPattern",
+        "$id": "#/components/schemas/TagPattern",
         "type": "object",
         "properties": {
           "uuid": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -33,11 +31,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "pattern": "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$"
           },
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -58,11 +55,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "pattern": "^(([^<>()[\\]\\.,;:\\s@\\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\\"]+)*)|(\\\".+\\\"))@(([^<>()[\\]\\.,;:\\s@\\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\\"]{2,})$"
           },
           "ipv4": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -83,11 +79,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "pattern": "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
           },
           "ipv6": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -108,10 +103,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "pattern": "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$"
           }
         },
-        "nullable": false,
         "required": [
           "uuid",
           "email",
@@ -123,5 +118,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagRange.json
+++ b/test/schemas/json/ajv/TagRange.json
@@ -3,20 +3,17 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/TagRange.Type"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/TagRange.Type"
+      }
     }
   ],
   "components": {
     "schemas": {
       "TagRange.Type": {
-        "$id": "components#/schemas/TagRange.Type",
+        "$id": "#/components/schemas/TagRange.Type",
         "type": "object",
         "properties": {
           "greater": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -37,12 +34,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "exclusiveMinimum": true
           },
           "greater_equal": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -63,11 +59,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3
           },
           "less": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -88,12 +83,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "maximum": 7,
             "exclusiveMaximum": true
           },
           "less_equal": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -114,11 +108,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "maximum": 7
           },
           "greater_less": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -152,14 +145,13 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "exclusiveMinimum": true,
             "maximum": 7,
             "exclusiveMaximum": true
           },
           "greater_equal_less": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -193,13 +185,12 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "maximum": 7,
             "exclusiveMaximum": true
           },
           "greater_less_equal": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -233,13 +224,12 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "exclusiveMinimum": true,
             "maximum": 7
           },
           "greater_equal_less_equal": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -273,11 +263,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "maximum": 7
           }
         },
-        "nullable": false,
         "required": [
           "greater",
           "greater_equal",
@@ -293,5 +283,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagStep.json
+++ b/test/schemas/json/ajv/TagStep.json
@@ -3,20 +3,17 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/TagStep.Type"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/TagStep.Type"
+      }
     }
   ],
   "components": {
     "schemas": {
       "TagStep.Type": {
-        "$id": "components#/schemas/TagStep.Type",
+        "$id": "#/components/schemas/TagStep.Type",
         "type": "object",
         "properties": {
           "exclusiveMinimum": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -50,12 +47,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "exclusiveMinimum": true
           },
           "minimum": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -89,11 +85,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3
           },
           "range": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -140,14 +135,13 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 0,
             "exclusiveMinimum": true,
             "maximum": 100,
             "exclusiveMaximum": true
           },
           "multipleOf": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -194,12 +188,12 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "multipleOf": 5,
             "minimum": 3,
             "maximum": 99
           }
         },
-        "nullable": false,
         "required": [
           "exclusiveMinimum",
           "minimum",
@@ -211,5 +205,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagTuple.json
+++ b/test/schemas/json/ajv/TagTuple.json
@@ -1,21 +1,19 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/TagTuple"
+      "$ref": "#/components/schemas/TagTuple"
     }
   ],
   "components": {
     "schemas": {
       "TagTuple": {
-        "$id": "components#/schemas/TagTuple",
+        "$id": "#/components/schemas/TagTuple",
         "type": "object",
         "properties": {
           "tuple": {
             "type": "array",
             "items": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-metaTags": [
                   {
@@ -101,12 +99,11 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "string",
                 "minLength": 3,
                 "maxLength": 7
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-metaTags": [
                   {
@@ -192,103 +189,11 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "number",
                 "minimum": 3,
                 "maximum": 7
               },
               {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "nullable": false,
-                  "description": "",
-                  "x-typia-metaTags": [
-                    {
-                      "kind": "minItems",
-                      "value": 3
-                    },
-                    {
-                      "kind": "maxItems",
-                      "value": 7
-                    },
-                    {
-                      "kind": "minimum",
-                      "value": 3
-                    },
-                    {
-                      "kind": "maximum",
-                      "value": 7
-                    },
-                    {
-                      "kind": "minLength",
-                      "value": 3
-                    },
-                    {
-                      "kind": "maxLength",
-                      "value": 7
-                    }
-                  ],
-                  "x-typia-jsDocTags": [
-                    {
-                      "name": "minItems",
-                      "text": [
-                        {
-                          "text": "3",
-                          "kind": "text"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "maxItems",
-                      "text": [
-                        {
-                          "text": "7",
-                          "kind": "text"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "minimum",
-                      "text": [
-                        {
-                          "text": "3",
-                          "kind": "text"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "maximum",
-                      "text": [
-                        {
-                          "text": "7",
-                          "kind": "text"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "minLength",
-                      "text": [
-                        {
-                          "text": "3",
-                          "kind": "text"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "maxLength",
-                      "text": [
-                        {
-                          "text": "7",
-                          "kind": "text"
-                        }
-                      ]
-                    }
-                  ],
-                  "x-typia-required": true,
-                  "x-typia-optional": false,
-                  "minLength": 3,
-                  "maxLength": 7
-                },
-                "nullable": false,
                 "description": "",
                 "x-typia-metaTags": [
                   {
@@ -374,14 +279,8 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "minItems": 3,
-                "maxItems": 7
-              },
-              {
                 "type": "array",
                 "items": {
-                  "type": "number",
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -467,11 +366,14 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
-                  "x-typia-rest": false,
-                  "minimum": 3,
-                  "maximum": 7
+                  "type": "string",
+                  "minLength": 3,
+                  "maxLength": 7
                 },
-                "nullable": false,
+                "minItems": 3,
+                "maxItems": 7
+              },
+              {
                 "description": "",
                 "x-typia-metaTags": [
                   {
@@ -558,11 +460,102 @@
                 "x-typia-required": true,
                 "x-typia-optional": false,
                 "x-typia-rest": false,
+                "type": "array",
+                "items": {
+                  "description": "",
+                  "x-typia-metaTags": [
+                    {
+                      "kind": "minItems",
+                      "value": 3
+                    },
+                    {
+                      "kind": "maxItems",
+                      "value": 7
+                    },
+                    {
+                      "kind": "minimum",
+                      "value": 3
+                    },
+                    {
+                      "kind": "maximum",
+                      "value": 7
+                    },
+                    {
+                      "kind": "minLength",
+                      "value": 3
+                    },
+                    {
+                      "kind": "maxLength",
+                      "value": 7
+                    }
+                  ],
+                  "x-typia-jsDocTags": [
+                    {
+                      "name": "minItems",
+                      "text": [
+                        {
+                          "text": "3",
+                          "kind": "text"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "maxItems",
+                      "text": [
+                        {
+                          "text": "7",
+                          "kind": "text"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "minimum",
+                      "text": [
+                        {
+                          "text": "3",
+                          "kind": "text"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "maximum",
+                      "text": [
+                        {
+                          "text": "7",
+                          "kind": "text"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "minLength",
+                      "text": [
+                        {
+                          "text": "3",
+                          "kind": "text"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "maxLength",
+                      "text": [
+                        {
+                          "text": "7",
+                          "kind": "text"
+                        }
+                      ]
+                    }
+                  ],
+                  "x-typia-required": true,
+                  "x-typia-optional": false,
+                  "x-typia-rest": false,
+                  "type": "number",
+                  "minimum": 3,
+                  "maximum": 7
+                },
                 "minItems": 3,
                 "maxItems": 7
               }
             ],
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -650,7 +643,6 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "tuple"
         ],
@@ -659,5 +651,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TagType.json
+++ b/test/schemas/json/ajv/TagType.json
@@ -3,20 +3,17 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/TagType.Type"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/TagType.Type"
+      }
     }
   ],
   "components": {
     "schemas": {
       "TagType.Type": {
-        "$id": "components#/schemas/TagType.Type",
+        "$id": "#/components/schemas/TagType.Type",
         "type": "object",
         "properties": {
           "int": {
-            "type": "integer",
-            "nullable": false,
             "description": "Integer value.",
             "x-typia-metaTags": [
               {
@@ -36,11 +33,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "integer"
           },
           "uint": {
-            "type": "integer",
-            "nullable": false,
             "description": "Unsigned integer value.",
             "x-typia-metaTags": [
               {
@@ -61,10 +57,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "integer",
             "minimum": 0
           }
         },
-        "nullable": false,
         "required": [
           "int",
           "uint"
@@ -74,5 +70,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TemplateAtomic.json
+++ b/test/schemas/json/ajv/TemplateAtomic.json
@@ -1,18 +1,17 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/TemplateAtomic"
+      "$ref": "#/components/schemas/TemplateAtomic"
     }
   ],
   "components": {
     "schemas": {
       "TemplateAtomic": {
-        "$id": "components#/schemas/TemplateAtomic",
+        "$id": "#/components/schemas/TemplateAtomic",
         "type": "object",
         "properties": {
           "prefix": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -20,7 +19,6 @@
           },
           "postfix": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -28,7 +26,6 @@
           },
           "middle_string": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -36,7 +33,6 @@
           },
           "middle_string_empty": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -44,26 +40,23 @@
           },
           "middle_numeric": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(the_-?\\d+\\.?\\d*_value)$"
           },
           "middle_boolean": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "the_false_value",
               "the_true_value"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "ipv4": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -71,14 +64,12 @@
           },
           "email": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "((.*)@(.*)\\.(.*))"
           }
         },
-        "nullable": false,
         "required": [
           "prefix",
           "postfix",
@@ -94,5 +85,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TemplateConstant.json
+++ b/test/schemas/json/ajv/TemplateConstant.json
@@ -3,42 +3,42 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/TemplateConstant.Type"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/TemplateConstant.Type"
+      }
     }
   ],
   "components": {
     "schemas": {
       "TemplateConstant.Type": {
-        "$id": "components#/schemas/TemplateConstant.Type",
+        "$id": "#/components/schemas/TemplateConstant.Type",
         "type": "object",
         "properties": {
           "prefix": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "prefix_A",
               "prefix_B",
               "prefix_C"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "postfix": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "2_postfix",
               "3_postfix",
               "1_postfix"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "combined": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "the_2_value_with_label_A",
@@ -50,14 +50,9 @@
               "the_1_value_with_label_A",
               "the_1_value_with_label_B",
               "the_1_value_with_label_C"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "prefix",
           "postfix",
@@ -68,5 +63,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TemplateUnion.json
+++ b/test/schemas/json/ajv/TemplateUnion.json
@@ -3,20 +3,18 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/TemplateUnion.Type"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/TemplateUnion.Type"
+      }
     }
   ],
   "components": {
     "schemas": {
       "TemplateUnion.Type": {
-        "$id": "components#/schemas/TemplateUnion.Type",
+        "$id": "#/components/schemas/TemplateUnion.Type",
         "type": "object",
         "properties": {
           "prefix": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -24,7 +22,6 @@
           },
           "postfix": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -32,7 +29,6 @@
           },
           "middle": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -42,28 +38,25 @@
             "oneOf": [
               {
                 "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false,
                 "pattern": "^(the_A_value|the_B_value|-?\\d+\\.?\\d*|true|false|(the_-?\\d+\\.?\\d*_value))$"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "number"
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "boolean"
               },
               {
-                "$ref": "components#/schemas/__type",
+                "$ref": "#/components/schemas/__type",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
@@ -74,7 +67,6 @@
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "prefix",
           "postfix",
@@ -84,18 +76,16 @@
         "x-typia-jsDocTags": []
       },
       "__type": {
-        "$id": "components#/schemas/__type",
+        "$id": "#/components/schemas/__type",
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "name"
         ],
@@ -104,5 +94,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ToJsonArray.json
+++ b/test/schemas/json/ajv/ToJsonArray.json
@@ -4,73 +4,63 @@
       "type": "array",
       "items": [
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
+          }
         },
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
+          }
         },
         {
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "type": "string",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
+          }
         },
         {
+          "x-typia-rest": false,
+          "x-typia-required": true,
+          "x-typia-optional": false,
           "type": "array",
           "items": {
-            "$ref": "components#/schemas/ToJsonArray.IObject",
+            "$ref": "#/components/schemas/ToJsonArray.IObject",
             "x-typia-rest": false,
             "x-typia-required": true,
             "x-typia-optional": false
-          },
-          "nullable": false,
-          "x-typia-rest": false,
-          "x-typia-required": true,
-          "x-typia-optional": false
+          }
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {
       "ToJsonArray.IObject": {
-        "$id": "components#/schemas/ToJsonArray.IObject",
+        "$id": "#/components/schemas/ToJsonArray.IObject",
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "id"
         ],
@@ -79,5 +69,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ToJsonAtomicSimple.json
+++ b/test/schemas/json/ajv/ToJsonAtomicSimple.json
@@ -4,31 +4,27 @@
       "type": "array",
       "items": [
         {
-          "type": "boolean",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "boolean"
         },
         {
-          "type": "number",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         },
         {
-          "type": "string",
-          "nullable": false,
           "x-typia-rest": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "string"
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ToJsonAtomicUnion.json
+++ b/test/schemas/json/ajv/ToJsonAtomicUnion.json
@@ -5,25 +5,24 @@
       "items": {
         "oneOf": [
           {
-            "type": "string",
-            "nullable": true
+            "type": "null"
           },
           {
-            "type": "number",
-            "nullable": true
+            "type": "string"
           },
           {
-            "type": "boolean",
-            "nullable": true
+            "type": "number"
+          },
+          {
+            "type": "boolean"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ToJsonDouble.json
+++ b/test/schemas/json/ajv/ToJsonDouble.json
@@ -1,31 +1,28 @@
 {
   "schemas": [
     {
-      "$ref": "components#/schemas/ToJsonDouble.Child"
+      "$ref": "#/components/schemas/ToJsonDouble.Child"
     }
   ],
   "components": {
     "schemas": {
       "ToJsonDouble.Child": {
-        "$id": "components#/schemas/ToJsonDouble.Child",
+        "$id": "#/components/schemas/ToJsonDouble.Child",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "flag": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "flag"
@@ -35,5 +32,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ToJsonNull.json
+++ b/test/schemas/json/ajv/ToJsonNull.json
@@ -8,5 +8,5 @@
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ToJsonTuple.json
+++ b/test/schemas/json/ajv/ToJsonTuple.json
@@ -4,55 +4,48 @@
       "type": "array",
       "items": [
         {
-          "type": "string",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "string"
         },
         {
-          "type": "number",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         },
         {
-          "type": "boolean",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "boolean"
         },
         {
-          "$ref": "components#/schemas/ToJsonTuple.IHobby",
+          "$ref": "#/components/schemas/ToJsonTuple.IHobby",
           "x-typia-rest": false,
           "x-typia-required": true,
           "x-typia-optional": false
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {
       "ToJsonTuple.IHobby": {
-        "$id": "components#/schemas/ToJsonTuple.IHobby",
+        "$id": "#/components/schemas/ToJsonTuple.IHobby",
         "type": "object",
         "properties": {
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "code",
           "name"
@@ -62,5 +55,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/ToJsonUnion.json
+++ b/test/schemas/json/ajv/ToJsonUnion.json
@@ -6,57 +6,49 @@
         "oneOf": [
           {},
           {
-            "type": "string",
-            "nullable": false
+            "type": "string"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "$ref": "components#/schemas/ToJsonUnion.ICitizen"
+            "$ref": "#/components/schemas/ToJsonUnion.ICitizen"
           },
           {
-            "$ref": "components#/schemas/ToJsonUnion.IProduct"
+            "$ref": "#/components/schemas/ToJsonUnion.IProduct"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
     "schemas": {
       "ToJsonUnion.ICitizen": {
-        "$id": "components#/schemas/ToJsonUnion.ICitizen",
+        "$id": "#/components/schemas/ToJsonUnion.ICitizen",
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "mobile": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "id",
           "mobile",
@@ -65,32 +57,28 @@
         "x-typia-jsDocTags": []
       },
       "ToJsonUnion.IProduct": {
-        "$id": "components#/schemas/ToJsonUnion.IProduct",
+        "$id": "#/components/schemas/ToJsonUnion.IProduct",
         "type": "object",
         "properties": {
           "manufacturer": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "brand": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "manufacturer",
           "brand",
@@ -101,5 +89,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TupleHierarchical.json
+++ b/test/schemas/json/ajv/TupleHierarchical.json
@@ -4,10 +4,9 @@
       "type": "array",
       "items": [
         {
-          "type": "boolean",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "boolean"
         },
         {
           "type": "null",
@@ -15,19 +14,17 @@
           "x-typia-optional": false
         },
         {
-          "type": "number",
-          "nullable": false,
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         },
         {
           "type": "array",
           "items": [
             {
-              "type": "boolean",
-              "nullable": false,
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "boolean"
             },
             {
               "type": "null",
@@ -38,41 +35,35 @@
               "type": "array",
               "items": [
                 {
-                  "type": "number",
-                  "nullable": false,
                   "x-typia-required": true,
-                  "x-typia-optional": false
+                  "x-typia-optional": false,
+                  "type": "number"
                 },
                 {
                   "type": "array",
                   "items": [
                     {
-                      "type": "boolean",
-                      "nullable": false,
                       "x-typia-required": true,
-                      "x-typia-optional": false
+                      "x-typia-optional": false,
+                      "type": "boolean"
                     },
                     {
-                      "type": "string",
-                      "nullable": false,
                       "x-typia-rest": false,
                       "x-typia-required": true,
-                      "x-typia-optional": false
+                      "x-typia-optional": false,
+                      "type": "string"
                     }
                   ],
-                  "nullable": false,
                   "x-typia-rest": false,
                   "x-typia-required": true,
                   "x-typia-optional": false
                 }
               ],
-              "nullable": false,
               "x-typia-rest": false,
               "x-typia-required": true,
               "x-typia-optional": false
             }
           ],
-          "nullable": false,
           "x-typia-required": true,
           "x-typia-optional": false
         },
@@ -80,102 +71,88 @@
           "type": "array",
           "items": [
             {
-              "type": "number",
-              "nullable": false,
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "number"
             },
             {
+              "x-typia-rest": false,
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "array",
               "items": {
                 "type": "array",
                 "items": [
                   {
-                    "type": "string",
-                    "nullable": false,
                     "x-typia-required": true,
-                    "x-typia-optional": false
+                    "x-typia-optional": false,
+                    "type": "string"
                   },
                   {
-                    "type": "boolean",
-                    "nullable": false,
                     "x-typia-required": true,
-                    "x-typia-optional": false
+                    "x-typia-optional": false,
+                    "type": "boolean"
                   },
                   {
+                    "x-typia-rest": false,
+                    "x-typia-required": true,
+                    "x-typia-optional": false,
                     "type": "array",
                     "items": {
                       "type": "array",
                       "items": [
                         {
-                          "type": "number",
-                          "nullable": false,
                           "x-typia-required": true,
-                          "x-typia-optional": false
+                          "x-typia-optional": false,
+                          "type": "number"
                         },
                         {
-                          "type": "number",
-                          "nullable": false,
                           "x-typia-required": true,
-                          "x-typia-optional": false
+                          "x-typia-optional": false,
+                          "type": "number"
                         },
                         {
                           "type": "array",
                           "items": [
                             {
-                              "type": "boolean",
-                              "nullable": false,
                               "x-typia-required": true,
-                              "x-typia-optional": false
+                              "x-typia-optional": false,
+                              "type": "boolean"
                             },
                             {
-                              "type": "string",
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
-                              "x-typia-optional": false
+                              "x-typia-optional": false,
+                              "type": "string"
                             }
                           ],
-                          "nullable": false,
                           "x-typia-rest": false,
                           "x-typia-required": true,
                           "x-typia-optional": false
                         }
                       ],
-                      "nullable": false,
                       "x-typia-rest": false,
                       "x-typia-required": true,
                       "x-typia-optional": false
-                    },
-                    "nullable": false,
-                    "x-typia-rest": false,
-                    "x-typia-required": true,
-                    "x-typia-optional": false
+                    }
                   }
                 ],
-                "nullable": false,
                 "x-typia-rest": false,
                 "x-typia-required": true,
                 "x-typia-optional": false
-              },
-              "nullable": false,
-              "x-typia-rest": false,
-              "x-typia-required": true,
-              "x-typia-optional": false
+              }
             }
           ],
-          "nullable": false,
           "x-typia-rest": false,
           "x-typia-required": true,
           "x-typia-optional": false
         }
-      ],
-      "nullable": false
+      ]
     }
   ],
   "components": {
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TupleRestArray.json
+++ b/test/schemas/json/ajv/TupleRestArray.json
@@ -5,59 +5,48 @@
       "items": {
         "oneOf": [
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
             "type": "array",
             "items": {
               "type": "array",
               "items": {
-                "type": "string",
-                "nullable": false
-              },
-              "nullable": false
-            },
-            "nullable": false
+                "type": "string"
+              }
+            }
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "x-typia-rest": true,
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "x-typia-rest": true,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-rest": true,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
@@ -65,5 +54,5 @@
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TupleRestAtomic.json
+++ b/test/schemas/json/ajv/TupleRestAtomic.json
@@ -5,48 +5,39 @@
       "items": {
         "oneOf": [
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "string"
+            }
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "string",
-            "nullable": false,
             "x-typia-rest": true,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
@@ -54,5 +45,5 @@
     "schemas": {}
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/TupleRestObject.json
+++ b/test/schemas/json/ajv/TupleRestObject.json
@@ -5,64 +5,55 @@
       "items": {
         "oneOf": [
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/TupleRestObject.IObject"
-            },
-            "nullable": false
+              "$ref": "#/components/schemas/TupleRestObject.IObject"
+            }
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "$ref": "components#/schemas/TupleRestObject.IObject",
+            "$ref": "#/components/schemas/TupleRestObject.IObject",
             "x-typia-rest": true,
             "x-typia-required": true,
             "x-typia-optional": false
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
   "components": {
     "schemas": {
       "TupleRestObject.IObject": {
-        "$id": "components#/schemas/TupleRestObject.IObject",
+        "$id": "#/components/schemas/TupleRestObject.IObject",
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "value"
         ],
@@ -71,5 +62,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/ajv/UltimateUnion.json
+++ b/test/schemas/json/ajv/UltimateUnion.json
@@ -3,101 +3,103 @@
     {
       "type": "array",
       "items": {
-        "$ref": "components#/schemas/IJsonApplication"
-      },
-      "nullable": false
+        "$ref": "#/components/schemas/IJsonApplication"
+      }
     }
   ],
   "components": {
     "schemas": {
       "IJsonApplication": {
-        "$id": "components#/schemas/IJsonApplication",
+        "$id": "#/components/schemas/IJsonApplication",
         "type": "object",
         "properties": {
           "schemas": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                  "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                  "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                  "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                  "$ref": "#/components/schemas/IJsonSchema.IBoolean",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IInteger",
+                  "$ref": "#/components/schemas/IJsonSchema.IInteger",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.INumber",
+                  "$ref": "#/components/schemas/IJsonSchema.INumber",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IString",
+                  "$ref": "#/components/schemas/IJsonSchema.IString",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                  "$recursiveRef": "#/components/schemas/IJsonSchema.IArray",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                  "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                  "$recursiveRef": "#/components/schemas/IJsonSchema.IOneOf",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IReference",
+                  "$ref": "#/components/schemas/IJsonSchema.IReference",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                  "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                  "$ref": "#/components/schemas/IJsonSchema.INullOnly",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                  "$ref": "#/components/schemas/IJsonSchema.IUnknown",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
@@ -106,38 +108,43 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "components": {
-            "$ref": "components#/schemas/IJsonComponents",
+            "$ref": "#/components/schemas/IJsonComponents",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "purpose": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "swagger",
               "ajv"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "prefix": {
-            "type": "string",
-            "nullable": false,
+            "deprecated": true,
             "description": "",
+            "x-typia-jsDocTags": [
+              {
+                "name": "deprecated",
+                "text": [
+                  {
+                    "text": "Always \"#/components/schemas\"",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "schemas",
           "components",
@@ -147,158 +154,153 @@
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_": {
-        "$id": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+        "$id": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
         "type": "object",
         "properties": {
           "enum": {
-            "type": "array",
-            "items": {
-              "type": "boolean",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "boolean"
+            }
           },
           "default": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "boolean"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -307,82 +309,69 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "enum",
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IType": {
-        "$id": "components#/schemas/IMetadataTag.IType",
+        "$id": "#/components/schemas/IMetadataTag.IType",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "type"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "int",
               "uint"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -390,28 +379,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IMinimum": {
-        "$id": "components#/schemas/IMetadataTag.IMinimum",
+        "$id": "#/components/schemas/IMetadataTag.IMinimum",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "minimum"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -419,28 +405,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IMaximum": {
-        "$id": "components#/schemas/IMetadataTag.IMaximum",
+        "$id": "#/components/schemas/IMetadataTag.IMaximum",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "maximum"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -448,28 +431,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IExclusiveMinimum": {
-        "$id": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+        "$id": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "exclusiveMinimum"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -477,28 +457,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IExclusiveMaximum": {
-        "$id": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+        "$id": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "exclusiveMaximum"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -506,28 +483,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IMultipleOf": {
-        "$id": "components#/schemas/IMetadataTag.IMultipleOf",
+        "$id": "#/components/schemas/IMetadataTag.IMultipleOf",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "multipleOf"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -535,28 +509,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IStep": {
-        "$id": "components#/schemas/IMetadataTag.IStep",
+        "$id": "#/components/schemas/IMetadataTag.IStep",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "step"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -564,20 +535,22 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IFormat": {
-        "$id": "components#/schemas/IMetadataTag.IFormat",
+        "$id": "#/components/schemas/IMetadataTag.IFormat",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "format"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "uuid",
@@ -587,14 +560,9 @@
               "ipv6",
               "date",
               "datetime"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -602,28 +570,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IPattern": {
-        "$id": "components#/schemas/IMetadataTag.IPattern",
+        "$id": "#/components/schemas/IMetadataTag.IPattern",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "pattern"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -631,28 +596,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.ILength": {
-        "$id": "components#/schemas/IMetadataTag.ILength",
+        "$id": "#/components/schemas/IMetadataTag.ILength",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "length"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -660,28 +622,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IMinLength": {
-        "$id": "components#/schemas/IMetadataTag.IMinLength",
+        "$id": "#/components/schemas/IMetadataTag.IMinLength",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "minLength"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -689,28 +648,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IMaxLength": {
-        "$id": "components#/schemas/IMetadataTag.IMaxLength",
+        "$id": "#/components/schemas/IMetadataTag.IMaxLength",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "maxLength"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -718,28 +674,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IItems": {
-        "$id": "components#/schemas/IMetadataTag.IItems",
+        "$id": "#/components/schemas/IMetadataTag.IItems",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "items"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -747,28 +700,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IMinItems": {
-        "$id": "components#/schemas/IMetadataTag.IMinItems",
+        "$id": "#/components/schemas/IMetadataTag.IMinItems",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "minItems"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -776,28 +726,25 @@
         "x-typia-jsDocTags": []
       },
       "IMetadataTag.IMaxItems": {
-        "$id": "components#/schemas/IMetadataTag.IMaxItems",
+        "$id": "#/components/schemas/IMetadataTag.IMaxItems",
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "maxItems"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
-        "nullable": false,
         "required": [
           "kind",
           "value"
@@ -805,56 +752,50 @@
         "x-typia-jsDocTags": []
       },
       "IJsDocTagInfo": {
-        "$id": "components#/schemas/IJsDocTagInfo",
+        "$id": "#/components/schemas/IJsDocTagInfo",
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "text": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo.IText",
+              "$ref": "#/components/schemas/IJsDocTagInfo.IText",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           }
         },
-        "nullable": false,
         "required": [
           "name"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsDocTagInfo.IText": {
-        "$id": "components#/schemas/IJsDocTagInfo.IText",
+        "$id": "#/components/schemas/IJsDocTagInfo.IText",
         "type": "object",
         "properties": {
           "text": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "kind": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
-        "nullable": false,
         "required": [
           "text",
           "kind"
@@ -862,158 +803,153 @@
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_": {
-        "$id": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+        "$id": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
         "type": "object",
         "properties": {
           "enum": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
           },
           "default": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "number"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -1022,208 +958,193 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "enum",
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_": {
-        "$id": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+        "$id": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
         "type": "object",
         "properties": {
           "enum": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
           },
           "default": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "string"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -1232,194 +1153,181 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "enum",
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IBoolean": {
-        "$id": "components#/schemas/IJsonSchema.IBoolean",
+        "$id": "#/components/schemas/IJsonSchema.IBoolean",
         "type": "object",
         "properties": {
           "default": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "boolean"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -1428,61 +1336,49 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IInteger": {
-        "$id": "components#/schemas/IJsonSchema.IInteger",
+        "$id": "#/components/schemas/IJsonSchema.IInteger",
         "type": "object",
         "properties": {
           "minimum": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -1502,11 +1398,10 @@
               }
             ],
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "integer"
           },
           "maximum": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -1526,25 +1421,22 @@
               }
             ],
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "integer"
           },
           "exclusiveMinimum": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "exclusiveMaximum": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "multipleOf": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -1564,143 +1456,141 @@
               }
             ],
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "integer"
           },
           "default": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "integer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -1709,228 +1599,210 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.INumber": {
-        "$id": "components#/schemas/IJsonSchema.INumber",
+        "$id": "#/components/schemas/IJsonSchema.INumber",
         "type": "object",
         "properties": {
           "minimum": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "maximum": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "exclusiveMinimum": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "exclusiveMaximum": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "multipleOf": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "default": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "number"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -1939,61 +1811,49 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IString": {
-        "$id": "components#/schemas/IJsonSchema.IString",
+        "$id": "#/components/schemas/IJsonSchema.IString",
         "type": "object",
         "properties": {
           "minLength": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -2014,11 +1874,10 @@
             ],
             "x-typia-required": false,
             "x-typia-optional": true,
+            "type": "integer",
             "minimum": 0
           },
           "maxLength": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -2039,157 +1898,153 @@
             ],
             "x-typia-required": false,
             "x-typia-optional": true,
+            "type": "integer",
             "minimum": 0
           },
           "pattern": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "format": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "default": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "string"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -2198,141 +2053,131 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IArray": {
-        "$id": "components#/schemas/IJsonSchema.IArray",
+        "$id": "#/components/schemas/IJsonSchema.IArray",
         "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "items": {
             "oneOf": [
               {
-                "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                "$ref": "#/components/schemas/IJsonSchema.IBoolean",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IInteger",
+                "$ref": "#/components/schemas/IJsonSchema.IInteger",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.INumber",
+                "$ref": "#/components/schemas/IJsonSchema.INumber",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IString",
+                "$ref": "#/components/schemas/IJsonSchema.IString",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                "$recursiveRef": "#/components/schemas/IJsonSchema.IArray",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                "$recursiveRef": "#/components/schemas/IJsonSchema.IOneOf",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IReference",
+                "$ref": "#/components/schemas/IJsonSchema.IReference",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                "$ref": "#/components/schemas/IJsonSchema.INullOnly",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                "$ref": "#/components/schemas/IJsonSchema.IUnknown",
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false
@@ -2343,8 +2188,6 @@
             "x-typia-optional": false
           },
           "minItems": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -2365,11 +2208,10 @@
             ],
             "x-typia-required": false,
             "x-typia-optional": true,
+            "type": "integer",
             "minimum": 0
           },
           "maxItems": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -2390,142 +2232,141 @@
             ],
             "x-typia-required": false,
             "x-typia-optional": true,
+            "type": "integer",
             "minimum": 0
           },
           "x-typia-tuple": {
-            "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+            "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple",
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "array"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -2534,144 +2375,137 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "items",
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.ITuple": {
-        "$id": "components#/schemas/IJsonSchema.ITuple",
+        "$id": "#/components/schemas/IJsonSchema.ITuple",
         "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "items": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                  "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                  "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                  "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                  "$ref": "#/components/schemas/IJsonSchema.IBoolean",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IInteger",
+                  "$ref": "#/components/schemas/IJsonSchema.IInteger",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.INumber",
+                  "$ref": "#/components/schemas/IJsonSchema.INumber",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IString",
+                  "$ref": "#/components/schemas/IJsonSchema.IString",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                  "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                  "$recursiveRef": "#/components/schemas/IJsonSchema.IArray",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                  "$recursiveRef": "#/components/schemas/IJsonSchema.IOneOf",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IReference",
+                  "$ref": "#/components/schemas/IJsonSchema.IReference",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                  "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                  "$ref": "#/components/schemas/IJsonSchema.INullOnly",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                  "$ref": "#/components/schemas/IJsonSchema.IUnknown",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
@@ -2680,140 +2514,134 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "array"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -2822,144 +2650,137 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "items",
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IOneOf": {
-        "$id": "components#/schemas/IJsonSchema.IOneOf",
+        "$id": "#/components/schemas/IJsonSchema.IOneOf",
         "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "oneOf": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                  "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                  "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                  "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                  "$ref": "#/components/schemas/IJsonSchema.IBoolean",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IInteger",
+                  "$ref": "#/components/schemas/IJsonSchema.IInteger",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.INumber",
+                  "$ref": "#/components/schemas/IJsonSchema.INumber",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IString",
+                  "$ref": "#/components/schemas/IJsonSchema.IString",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                  "$recursiveRef": "#/components/schemas/IJsonSchema.IOneOf",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                  "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                  "$recursiveRef": "#/components/schemas/IJsonSchema.IArray",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IReference",
+                  "$ref": "#/components/schemas/IJsonSchema.IReference",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                  "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                  "$ref": "#/components/schemas/IJsonSchema.INullOnly",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
                 },
                 {
-                  "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                  "$ref": "#/components/schemas/IJsonSchema.IUnknown",
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false
@@ -2968,123 +2789,119 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -3093,175 +2910,165 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "oneOf"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IReference": {
-        "$id": "components#/schemas/IJsonSchema.IReference",
+        "$id": "#/components/schemas/IJsonSchema.IReference",
         "type": "object",
         "properties": {
           "$ref": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -3270,175 +3077,165 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "$ref"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IRecursiveReference": {
-        "$id": "components#/schemas/IJsonSchema.IRecursiveReference",
+        "$id": "#/components/schemas/IJsonSchema.IRecursiveReference",
         "type": "object",
         "properties": {
           "$recursiveRef": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -3447,178 +3244,168 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "$recursiveRef"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.INullOnly": {
-        "$id": "components#/schemas/IJsonSchema.INullOnly",
+        "$id": "#/components/schemas/IJsonSchema.INullOnly",
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "null"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -3627,168 +3414,159 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "required": [
           "type"
         ],
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IUnknown": {
-        "$id": "components#/schemas/IJsonSchema.IUnknown",
+        "$id": "#/components/schemas/IJsonSchema.IUnknown",
         "type": "object",
         "properties": {
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IType",
+                  "$ref": "#/components/schemas/IMetadataTag.IType",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMinimum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMinimum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IExclusiveMaximum",
+                  "$ref": "#/components/schemas/IMetadataTag.IExclusiveMaximum",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMultipleOf",
+                  "$ref": "#/components/schemas/IMetadataTag.IMultipleOf",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IStep",
+                  "$ref": "#/components/schemas/IMetadataTag.IStep",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IFormat",
+                  "$ref": "#/components/schemas/IMetadataTag.IFormat",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IPattern",
+                  "$ref": "#/components/schemas/IMetadataTag.IPattern",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.ILength",
+                  "$ref": "#/components/schemas/IMetadataTag.ILength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxLength",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxLength",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMinItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMinItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
                 },
                 {
-                  "$ref": "components#/schemas/IMetadataTag.IMaxItems",
+                  "$ref": "#/components/schemas/IMetadataTag.IMaxItems",
                   "description": "",
                   "x-typia-required": false,
                   "x-typia-optional": true
@@ -3797,123 +3575,108 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
-        "nullable": false,
         "x-typia-jsDocTags": []
       },
       "IJsonComponents": {
-        "$id": "components#/schemas/IJsonComponents",
+        "$id": "#/components/schemas/IJsonComponents",
         "type": "object",
         "properties": {
           "schemas": {
-            "$ref": "components#/schemas/Record_lt_string_comma__space_IJsonComponents.IObject_gt_",
+            "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonComponents.IObject_gt_",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           }
         },
-        "nullable": false,
         "required": [
           "schemas"
         ],
         "x-typia-jsDocTags": []
       },
       "Record_lt_string_comma__space_IJsonComponents.IObject_gt_": {
-        "$id": "components#/schemas/Record_lt_string_comma__space_IJsonComponents.IObject_gt_",
+        "$id": "#/components/schemas/Record_lt_string_comma__space_IJsonComponents.IObject_gt_",
         "type": "object",
         "properties": {},
-        "nullable": false,
         "x-typia-jsDocTags": [],
         "additionalProperties": {
-          "$ref": "components#/schemas/IJsonComponents.IObject",
+          "$ref": "#/components/schemas/IJsonComponents.IObject",
           "description": "",
           "x-typia-required": true,
           "x-typia-optional": false
         }
       },
       "IJsonComponents.IObject": {
-        "$id": "components#/schemas/IJsonComponents.IObject",
+        "$id": "#/components/schemas/IJsonComponents.IObject",
         "type": "object",
         "properties": {
           "$id": {
-            "type": "string",
-            "nullable": false,
-            "description": "",
+            "description": "Used only when ajv mode.",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "$recursiveAnchor": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "object"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "properties": {
-            "$ref": "components#/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+            "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false
           },
           "patternProperties": {
-            "$ref": "components#/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+            "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
@@ -3921,85 +3684,85 @@
           "additionalProperties": {
             "oneOf": [
               {
-                "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                "$ref": "#/components/schemas/IJsonSchema.IBoolean",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IInteger",
+                "$ref": "#/components/schemas/IJsonSchema.IInteger",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.INumber",
+                "$ref": "#/components/schemas/IJsonSchema.INumber",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IString",
+                "$ref": "#/components/schemas/IJsonSchema.IString",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                "$recursiveRef": "#/components/schemas/IJsonSchema.IArray",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                "$recursiveRef": "#/components/schemas/IJsonSchema.IOneOf",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IReference",
+                "$ref": "#/components/schemas/IJsonSchema.IReference",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                "$ref": "#/components/schemas/IJsonSchema.INullOnly",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                "$ref": "#/components/schemas/IJsonSchema.IUnknown",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
@@ -4010,41 +3773,37 @@
             "x-typia-optional": true
           },
           "required": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": false,
-              "x-typia-optional": true
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": false,
+              "x-typia-optional": true,
+              "type": "string"
+            }
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "$ref": "components#/schemas/IJsDocTagInfo",
+              "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-patternProperties": {
-            "$ref": "components#/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+            "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
             "description": "",
             "x-typia-required": false,
             "x-typia-optional": true
@@ -4052,85 +3811,85 @@
           "x-typia-additionalProperties": {
             "oneOf": [
               {
-                "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IBoolean",
+                "$ref": "#/components/schemas/IJsonSchema.IBoolean",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IInteger",
+                "$ref": "#/components/schemas/IJsonSchema.IInteger",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.INumber",
+                "$ref": "#/components/schemas/IJsonSchema.INumber",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IString",
+                "$ref": "#/components/schemas/IJsonSchema.IString",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+                "$recursiveRef": "#/components/schemas/IJsonSchema.IArray",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+                "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+                "$recursiveRef": "#/components/schemas/IJsonSchema.IOneOf",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IReference",
+                "$ref": "#/components/schemas/IJsonSchema.IReference",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+                "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.INullOnly",
+                "$ref": "#/components/schemas/IJsonSchema.INullOnly",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
               },
               {
-                "$ref": "components#/schemas/IJsonSchema.IUnknown",
+                "$ref": "#/components/schemas/IJsonSchema.IUnknown",
                 "description": "",
                 "x-typia-required": false,
                 "x-typia-optional": true
@@ -4141,102 +3900,99 @@
             "x-typia-optional": true
           }
         },
-        "nullable": false,
         "required": [
           "type",
-          "nullable",
           "properties"
         ],
         "x-typia-jsDocTags": []
       },
       "Record_lt_string_comma__space_IJsonSchema_gt_": {
-        "$id": "components#/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+        "$id": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
         "type": "object",
         "properties": {},
-        "nullable": false,
         "x-typia-jsDocTags": [],
         "additionalProperties": {
           "oneOf": [
             {
-              "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+              "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+              "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$ref": "components#/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+              "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$ref": "components#/schemas/IJsonSchema.IBoolean",
+              "$ref": "#/components/schemas/IJsonSchema.IBoolean",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$ref": "components#/schemas/IJsonSchema.IInteger",
+              "$ref": "#/components/schemas/IJsonSchema.IInteger",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$ref": "components#/schemas/IJsonSchema.INumber",
+              "$ref": "#/components/schemas/IJsonSchema.INumber",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$ref": "components#/schemas/IJsonSchema.IString",
+              "$ref": "#/components/schemas/IJsonSchema.IString",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$recursiveRef": "components#/schemas/IJsonSchema.IArray",
+              "$recursiveRef": "#/components/schemas/IJsonSchema.IArray",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$recursiveRef": "components#/schemas/IJsonSchema.ITuple",
+              "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$recursiveRef": "components#/schemas/IJsonSchema.IOneOf",
+              "$recursiveRef": "#/components/schemas/IJsonSchema.IOneOf",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$ref": "components#/schemas/IJsonSchema.IReference",
+              "$ref": "#/components/schemas/IJsonSchema.IReference",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$ref": "components#/schemas/IJsonSchema.IRecursiveReference",
+              "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$ref": "components#/schemas/IJsonSchema.INullOnly",
+              "$ref": "#/components/schemas/IJsonSchema.INullOnly",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
             {
-              "$ref": "components#/schemas/IJsonSchema.IUnknown",
+              "$ref": "#/components/schemas/IJsonSchema.IUnknown",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
@@ -4250,5 +4006,5 @@
     }
   },
   "purpose": "ajv",
-  "prefix": "components#/schemas"
+  "prefix": "#/components/schemas"
 }

--- a/test/schemas/json/swagger/ArrayAny.json
+++ b/test/schemas/json/swagger/ArrayAny.json
@@ -10,112 +10,108 @@
         "type": "object",
         "properties": {
           "anys": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "undefindable1": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": false
+            }
           },
           "undefindable2": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": false
+            }
           },
           "nullables1": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
-            "nullable": true,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "nullable": true
           },
           "nullables2": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
             },
-            "nullable": true,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "nullable": true
           },
           "both1": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
-            "nullable": true,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": false
+            "nullable": true
           },
           "both2": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
-            "nullable": true,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": false
+            "nullable": true
           },
           "both3": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": false
             },
-            "nullable": true,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": false
+            "nullable": true
           },
           "union": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ArrayAtomicAlias.json
+++ b/test/schemas/json/swagger/ArrayAtomicAlias.json
@@ -7,73 +7,59 @@
           {
             "type": "array",
             "items": {
-              "type": "boolean",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "boolean"
+            }
           },
           {
             "type": "array",
             "items": {
-              "type": "number",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "number"
+            }
           },
           {
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "string"
+            }
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "boolean",
-              "nullable": false,
               "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "boolean"
+            }
           },
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "number",
-              "nullable": false,
               "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "number"
+            }
           },
           {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "x-typia-rest": false,
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "x-typia-rest": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-rest": false,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],

--- a/test/schemas/json/swagger/ArrayAtomicSimple.json
+++ b/test/schemas/json/swagger/ArrayAtomicSimple.json
@@ -7,73 +7,59 @@
           {
             "type": "array",
             "items": {
-              "type": "boolean",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "boolean"
+            }
           },
           {
             "type": "array",
             "items": {
-              "type": "number",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "number"
+            }
           },
           {
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "string"
+            }
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "boolean",
-              "nullable": false,
               "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "boolean"
+            }
           },
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "number",
-              "nullable": false,
               "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "number"
+            }
           },
           {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "x-typia-rest": false,
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "x-typia-rest": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-rest": false,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],

--- a/test/schemas/json/swagger/ArrayHierarchical.json
+++ b/test/schemas/json/swagger/ArrayHierarchical.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/ArrayHierarchical.ICompany"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,25 +13,22 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "serial": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "established_at": {
             "$ref": "#/components/schemas/ArrayHierarchical.ITimestamp",
@@ -41,17 +37,16 @@
             "x-typia-optional": false
           },
           "departments": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ArrayHierarchical.IDepartment",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -68,18 +63,16 @@
         "type": "object",
         "properties": {
           "time": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "zone": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -93,25 +86,22 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sales": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
             "$ref": "#/components/schemas/ArrayHierarchical.ITimestamp",
@@ -120,17 +110,16 @@
             "x-typia-optional": false
           },
           "employees": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ArrayHierarchical.IEmployee",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -147,32 +136,28 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "age": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "grade": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "employeed_at": {
             "$ref": "#/components/schemas/ArrayHierarchical.ITimestamp",

--- a/test/schemas/json/swagger/ArrayMatrix.json
+++ b/test/schemas/json/swagger/ArrayMatrix.json
@@ -7,14 +7,10 @@
         "items": {
           "type": "array",
           "items": {
-            "type": "number",
-            "nullable": false
-          },
-          "nullable": false
-        },
-        "nullable": false
-      },
-      "nullable": false
+            "type": "number"
+          }
+        }
+      }
     }
   ],
   "components": {

--- a/test/schemas/json/swagger/ArrayRecursive.json
+++ b/test/schemas/json/swagger/ArrayRecursive.json
@@ -10,38 +10,34 @@
         "type": "object",
         "properties": {
           "children": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ArrayRecursive.ICategory",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
             "$ref": "#/components/schemas/ArrayRecursive.ITimestamp",
@@ -64,18 +60,16 @@
         "type": "object",
         "properties": {
           "time": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "zone": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ArrayRecursiveUnionExplicit.json
+++ b/test/schemas/json/swagger/ArrayRecursiveUnionExplicit.json
@@ -20,8 +20,7 @@
             "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IShortcut"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -30,27 +29,27 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "children": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
@@ -88,21 +87,16 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "directory"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -119,73 +113,64 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "width": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "height": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "url": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "file"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "extension": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "jpg"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -206,59 +191,52 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "content": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "file"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "extension": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "txt"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -277,59 +255,52 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "count": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "file"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "extension": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "zip"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -348,25 +319,22 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "target": {
             "oneOf": [
@@ -406,24 +374,22 @@
             "x-typia-optional": false
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "file"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "extension": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "lnk"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ArrayRecursiveUnionImplicit.json
+++ b/test/schemas/json/swagger/ArrayRecursiveUnionImplicit.json
@@ -23,8 +23,7 @@
             "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -33,27 +32,27 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "children": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
@@ -97,11 +96,7 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -117,38 +112,37 @@
         "type": "object",
         "properties": {
           "access": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "read",
               "write"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "children": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
@@ -192,11 +186,7 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -213,53 +203,46 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "width": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "height": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "url": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -278,39 +261,34 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "content": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -327,39 +305,34 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "size": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "count": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -376,25 +349,22 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "target": {
             "oneOf": [

--- a/test/schemas/json/swagger/ArraySimple.json
+++ b/test/schemas/json/swagger/ArraySimple.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/ArraySimple.IPerson"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,31 +13,28 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "hobbies": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ArraySimple.IHobby",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -53,25 +49,22 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "body": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "rank": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ArrayUnion.json
+++ b/test/schemas/json/swagger/ArrayUnion.json
@@ -7,30 +7,23 @@
           {
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "string"
+            }
           },
           {
             "type": "array",
             "items": {
-              "type": "number",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "number"
+            }
           },
           {
             "type": "array",
             "items": {
-              "type": "boolean",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "boolean"
+            }
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {

--- a/test/schemas/json/swagger/AtomicAlias.json
+++ b/test/schemas/json/swagger/AtomicAlias.json
@@ -5,44 +5,36 @@
       "items": {
         "oneOf": [
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
-            "type": "string",
-            "nullable": false
+            "type": "string"
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "string",
-            "nullable": false,
             "x-typia-rest": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],

--- a/test/schemas/json/swagger/AtomicClass.json
+++ b/test/schemas/json/swagger/AtomicClass.json
@@ -5,80 +5,66 @@
       "items": {
         "oneOf": [
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
-            "type": "string",
-            "nullable": false
+            "type": "string"
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "string",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           {
-            "type": "string",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           {
-            "type": "string",
-            "nullable": false,
             "x-typia-rest": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],

--- a/test/schemas/json/swagger/AtomicSimple.json
+++ b/test/schemas/json/swagger/AtomicSimple.json
@@ -5,44 +5,36 @@
       "items": {
         "oneOf": [
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
-            "type": "string",
-            "nullable": false
+            "type": "string"
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "string",
-            "nullable": false,
             "x-typia-rest": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],

--- a/test/schemas/json/swagger/AtomicUnion.json
+++ b/test/schemas/json/swagger/AtomicUnion.json
@@ -17,8 +17,7 @@
             "nullable": true
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {

--- a/test/schemas/json/swagger/ClassGetter.json
+++ b/test/schemas/json/swagger/ClassGetter.json
@@ -10,25 +10,23 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "dead": {
-            "type": "boolean",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean",
+            "nullable": true
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ClassMethod.json
+++ b/test/schemas/json/swagger/ClassMethod.json
@@ -10,18 +10,16 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "age": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ClassPropertyAssignment.json
+++ b/test/schemas/json/swagger/ClassPropertyAssignment.json
@@ -10,45 +10,40 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "note": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "assignment"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "editable": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "boolean",
             "enum": [
               false
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "incremental": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ConstantAtomicSimple.json
+++ b/test/schemas/json/swagger/ConstantAtomicSimple.json
@@ -9,69 +9,60 @@
             "enum": [
               false,
               true
-            ],
-            "nullable": false
+            ]
           },
           {
             "type": "number",
             "enum": [
               2
-            ],
-            "nullable": false
+            ]
           },
           {
             "type": "string",
             "enum": [
               "three"
-            ],
-            "nullable": false
+            ]
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "boolean",
             "enum": [
               false,
               true
-            ],
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "boolean",
             "enum": [
               true
-            ],
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "number",
             "enum": [
               2
-            ],
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           {
+            "x-typia-rest": false,
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "three"
-            ],
-            "nullable": false,
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],

--- a/test/schemas/json/swagger/ConstantAtomicUnion.json
+++ b/test/schemas/json/swagger/ConstantAtomicUnion.json
@@ -8,31 +8,27 @@
             "type": "boolean",
             "enum": [
               false
-            ],
-            "nullable": false
+            ]
           },
           {
             "type": "number",
             "enum": [
               2,
               1
-            ],
-            "nullable": false
+            ]
           },
           {
             "type": "string",
             "enum": [
               "three",
               "four"
-            ],
-            "nullable": false
+            ]
           },
           {
             "$ref": "#/components/schemas/__type"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -41,14 +37,13 @@
         "type": "object",
         "properties": {
           "key": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "key"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ConstantAtomicWrapper.json
+++ b/test/schemas/json/swagger/ConstantAtomicWrapper.json
@@ -15,7 +15,6 @@
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
@@ -35,8 +34,7 @@
             "x-typia-required": true,
             "x-typia-optional": false
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
@@ -46,11 +44,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
         "nullable": false,
@@ -63,11 +60,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -80,11 +76,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ConstantConstEnumeration.json
+++ b/test/schemas/json/swagger/ConstantConstEnumeration.json
@@ -10,20 +10,17 @@
               0,
               1,
               2
-            ],
-            "nullable": false
+            ]
           },
           {
             "type": "string",
             "enum": [
               "Three",
               "Four"
-            ],
-            "nullable": false
+            ]
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {

--- a/test/schemas/json/swagger/ConstantEnumeration.json
+++ b/test/schemas/json/swagger/ConstantEnumeration.json
@@ -10,20 +10,17 @@
               0,
               1,
               2
-            ],
-            "nullable": false
+            ]
           },
           {
             "type": "string",
             "enum": [
               "Three",
               "Four"
-            ],
-            "nullable": false
+            ]
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {

--- a/test/schemas/json/swagger/DynamicArray.json
+++ b/test/schemas/json/swagger/DynamicArray.json
@@ -12,32 +12,28 @@
         "nullable": false,
         "x-typia-jsDocTags": [],
         "x-typia-additionalProperties": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
           "description": "",
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "array",
+          "items": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          }
         },
         "additionalProperties": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
-          },
-          "nullable": false,
           "description": "",
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "array",
+          "items": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          }
         }
       }
     }

--- a/test/schemas/json/swagger/DynamicComposite.json
+++ b/test/schemas/json/swagger/DynamicComposite.json
@@ -10,18 +10,16 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -32,48 +30,42 @@
         "x-typia-jsDocTags": [],
         "x-typia-patternProperties": {
           "^-?\\d+\\.?\\d*$": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "^(prefix_(.*))": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "((.*)_postfix)$": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "^(value_-?\\d+\\.?\\d*)$": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "string"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "number"
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -81,29 +73,25 @@
             "x-typia-optional": false
           },
           "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
         "additionalProperties": {
           "oneOf": [
             {
-              "type": "number",
-              "nullable": false,
-              "x-typia-required": false
+              "x-typia-required": false,
+              "type": "number"
             },
             {
-              "type": "string",
-              "nullable": false,
-              "x-typia-required": false
+              "x-typia-required": false,
+              "type": "string"
             },
             {
-              "type": "boolean",
-              "nullable": false,
-              "x-typia-required": false
+              "x-typia-required": false,
+              "type": "boolean"
             }
           ],
           "x-typia-required": false

--- a/test/schemas/json/swagger/DynamicConstant.json
+++ b/test/schemas/json/swagger/DynamicConstant.json
@@ -10,32 +10,28 @@
         "type": "object",
         "properties": {
           "a": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "b": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "c": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "d": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/DynamicEnumeration.json
+++ b/test/schemas/json/swagger/DynamicEnumeration.json
@@ -10,74 +10,64 @@
         "type": "object",
         "properties": {
           "ar": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "zh-Hans": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "zh-Hant": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "en": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "fr": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "de": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "ja": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "ko": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "pt": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "ru": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/DynamicSimple.json
+++ b/test/schemas/json/swagger/DynamicSimple.json
@@ -12,18 +12,16 @@
         "nullable": false,
         "x-typia-jsDocTags": [],
         "x-typia-additionalProperties": {
-          "type": "number",
-          "nullable": false,
           "description": "",
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         },
         "additionalProperties": {
-          "type": "number",
-          "nullable": false,
           "description": "",
           "x-typia-required": true,
-          "x-typia-optional": false
+          "x-typia-optional": false,
+          "type": "number"
         }
       }
     }

--- a/test/schemas/json/swagger/DynamicTemplate.json
+++ b/test/schemas/json/swagger/DynamicTemplate.json
@@ -13,50 +13,43 @@
         "x-typia-jsDocTags": [],
         "x-typia-patternProperties": {
           "^(prefix_(.*))": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "((.*)_postfix)$": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "^(value_-?\\d+\\.?\\d*)$": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
         "additionalProperties": {
           "oneOf": [
             {
-              "type": "string",
-              "nullable": false,
-              "x-typia-required": false
+              "x-typia-required": false,
+              "type": "string"
             },
             {
-              "type": "number",
-              "nullable": false,
-              "x-typia-required": false
+              "x-typia-required": false,
+              "type": "number"
             },
             {
-              "type": "boolean",
-              "nullable": false,
-              "x-typia-required": false
+              "x-typia-required": false,
+              "type": "boolean"
             }
           ],
           "x-typia-required": false

--- a/test/schemas/json/swagger/DynamicTree.json
+++ b/test/schemas/json/swagger/DynamicTree.json
@@ -10,18 +10,16 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "children": {
             "$ref": "#/components/schemas/Record_lt_string_comma__space_DynamicTree_gt_",

--- a/test/schemas/json/swagger/DynamicUnion.json
+++ b/test/schemas/json/swagger/DynamicUnion.json
@@ -13,45 +13,39 @@
         "x-typia-jsDocTags": [],
         "x-typia-patternProperties": {
           "^-?\\d+\\.?\\d*$": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "^(prefix_(.*))": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "((.*)_postfix)$": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "^(value_between_-?\\d+\\.?\\d*_and_-?\\d+\\.?\\d*)$": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "additionalProperties": {
           "oneOf": [
             {
-              "type": "string",
-              "nullable": false,
-              "x-typia-required": false
+              "x-typia-required": false,
+              "type": "string"
             },
             {
-              "type": "number",
-              "nullable": false,
-              "x-typia-required": false
+              "x-typia-required": false,
+              "type": "number"
             }
           ],
           "x-typia-required": false

--- a/test/schemas/json/swagger/MapAlias.json
+++ b/test/schemas/json/swagger/MapAlias.json
@@ -10,34 +10,34 @@
         "type": "object",
         "properties": {
           "boolean": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "number": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "strings": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "arrays": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "objects": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/MapSimple.json
+++ b/test/schemas/json/swagger/MapSimple.json
@@ -10,34 +10,34 @@
         "type": "object",
         "properties": {
           "boolean": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "number": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "strings": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "arrays": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           },
           "objects": {
-            "$ref": "#/components/schemas/Map",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Map"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/MapUnion.json
+++ b/test/schemas/json/swagger/MapUnion.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/Map"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {

--- a/test/schemas/json/swagger/NativeAlias.json
+++ b/test/schemas/json/swagger/NativeAlias.json
@@ -10,77 +10,76 @@
         "type": "object",
         "properties": {
           "date": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "uint8Array": {
-            "$ref": "#/components/schemas/Uint8Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint8Array"
           },
           "uint8ClampedArray": {
-            "$ref": "#/components/schemas/Uint8ClampedArray",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint8ClampedArray"
           },
           "uint16Array": {
-            "$ref": "#/components/schemas/Uint16Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint16Array"
           },
           "uint32Array": {
-            "$ref": "#/components/schemas/Uint32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint32Array"
           },
           "bigUint64Array": {
-            "$ref": "#/components/schemas/BigUint64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/BigUint64Array"
           },
           "int8Array": {
-            "$ref": "#/components/schemas/Int8Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int8Array"
           },
           "int16Array": {
-            "$ref": "#/components/schemas/Int16Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int16Array"
           },
           "int32Array": {
-            "$ref": "#/components/schemas/Int32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int32Array"
           },
           "bigInt64Array": {
-            "$ref": "#/components/schemas/BigInt64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/BigInt64Array"
           },
           "float32Array": {
-            "$ref": "#/components/schemas/Float32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Float32Array"
           },
           "float64Array": {
-            "$ref": "#/components/schemas/Float64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Float64Array"
           },
           "buffer": {
             "$ref": "#/components/schemas/__type",
@@ -89,34 +88,34 @@
             "x-typia-optional": false
           },
           "arrayBuffer": {
-            "$ref": "#/components/schemas/ArrayBuffer",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/ArrayBuffer"
           },
           "sharedArrayBuffer": {
-            "$ref": "#/components/schemas/SharedArrayBuffer",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/SharedArrayBuffer"
           },
           "dataView": {
-            "$ref": "#/components/schemas/DataView",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/DataView"
           },
           "weakSet": {
-            "$ref": "#/components/schemas/WeakSet",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/WeakSet"
           },
           "weakMap": {
-            "$ref": "#/components/schemas/WeakMap",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/WeakMap"
           }
         },
         "nullable": false,
@@ -201,28 +200,25 @@
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "Buffer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "data": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/NativeSimple.json
+++ b/test/schemas/json/swagger/NativeSimple.json
@@ -10,77 +10,76 @@
         "type": "object",
         "properties": {
           "date": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "uint8Array": {
-            "$ref": "#/components/schemas/Uint8Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint8Array"
           },
           "uint8ClampedArray": {
-            "$ref": "#/components/schemas/Uint8ClampedArray",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint8ClampedArray"
           },
           "uint16Array": {
-            "$ref": "#/components/schemas/Uint16Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint16Array"
           },
           "uint32Array": {
-            "$ref": "#/components/schemas/Uint32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Uint32Array"
           },
           "bigUint64Array": {
-            "$ref": "#/components/schemas/BigUint64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/BigUint64Array"
           },
           "int8Array": {
-            "$ref": "#/components/schemas/Int8Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int8Array"
           },
           "int16Array": {
-            "$ref": "#/components/schemas/Int16Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int16Array"
           },
           "int32Array": {
-            "$ref": "#/components/schemas/Int32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Int32Array"
           },
           "bigInt64Array": {
-            "$ref": "#/components/schemas/BigInt64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/BigInt64Array"
           },
           "float32Array": {
-            "$ref": "#/components/schemas/Float32Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Float32Array"
           },
           "float64Array": {
-            "$ref": "#/components/schemas/Float64Array",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Float64Array"
           },
           "buffer": {
             "$ref": "#/components/schemas/__type",
@@ -89,34 +88,34 @@
             "x-typia-optional": false
           },
           "arrayBuffer": {
-            "$ref": "#/components/schemas/ArrayBuffer",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/ArrayBuffer"
           },
           "sharedArrayBuffer": {
-            "$ref": "#/components/schemas/SharedArrayBuffer",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/SharedArrayBuffer"
           },
           "dataView": {
-            "$ref": "#/components/schemas/DataView",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/DataView"
           },
           "weakSet": {
-            "$ref": "#/components/schemas/WeakSet",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/WeakSet"
           },
           "weakMap": {
-            "$ref": "#/components/schemas/WeakMap",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/WeakMap"
           }
         },
         "nullable": false,
@@ -201,28 +200,25 @@
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "Buffer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "data": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/NativeUnion.json
+++ b/test/schemas/json/swagger/NativeUnion.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/NativeUnion.Union"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,43 +13,43 @@
         "type": "object",
         "properties": {
           "date": {
-            "type": "string",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string",
+            "nullable": true
           },
           "unsigned": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/Uint8Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Uint8Array"
               },
               {
-                "$ref": "#/components/schemas/Uint8ClampedArray",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Uint8ClampedArray"
               },
               {
-                "$ref": "#/components/schemas/Uint16Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Uint16Array"
               },
               {
-                "$ref": "#/components/schemas/Uint32Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Uint32Array"
               },
               {
-                "$ref": "#/components/schemas/BigUint64Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/BigUint64Array"
               }
             ],
             "description": "",
@@ -60,28 +59,28 @@
           "signed": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/Int8Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Int8Array"
               },
               {
-                "$ref": "#/components/schemas/Int16Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Int16Array"
               },
               {
-                "$ref": "#/components/schemas/Int32Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Int32Array"
               },
               {
-                "$ref": "#/components/schemas/BigInt64Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/BigInt64Array"
               }
             ],
             "description": "",
@@ -91,16 +90,16 @@
           "float": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/Float32Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Float32Array"
               },
               {
-                "$ref": "#/components/schemas/Float64Array",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/Float64Array"
               }
             ],
             "description": "",
@@ -110,22 +109,22 @@
           "buffer": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/ArrayBuffer",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/ArrayBuffer"
               },
               {
-                "$ref": "#/components/schemas/SharedArrayBuffer",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/SharedArrayBuffer"
               },
               {
-                "$ref": "#/components/schemas/DataView",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/DataView"
               },
               {
                 "$ref": "#/components/schemas/__type",
@@ -141,16 +140,16 @@
           "weak": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/WeakSet",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/WeakSet"
               },
               {
-                "$ref": "#/components/schemas/WeakMap",
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "$ref": "#/components/schemas/WeakMap"
               }
             ],
             "description": "",
@@ -243,28 +242,25 @@
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "Buffer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "data": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectAlias.json
+++ b/test/schemas/json/swagger/ObjectAlias.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/ObjectAlias.IMember"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,49 +13,47 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string",
+            "nullable": true
           },
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sex": {
             "oneOf": [
               {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "number",
                 "enum": [
                   2,
                   1
                 ],
-                "nullable": true,
-                "description": "",
-                "x-typia-required": true,
-                "x-typia-optional": false
+                "nullable": true
               },
               {
+                "description": "",
+                "x-typia-required": true,
+                "x-typia-optional": false,
                 "type": "string",
                 "enum": [
                   "male",
                   "female"
                 ],
-                "nullable": true,
-                "description": "",
-                "x-typia-required": true,
-                "x-typia-optional": false
+                "nullable": true
               }
             ],
             "description": "",
@@ -64,18 +61,18 @@
             "x-typia-optional": false
           },
           "age": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number",
+            "nullable": true
           },
           "dead": {
-            "type": "boolean",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean",
+            "nullable": true
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectDynamic.json
+++ b/test/schemas/json/swagger/ObjectDynamic.json
@@ -14,25 +14,22 @@
         "x-typia-additionalProperties": {
           "oneOf": [
             {
-              "type": "string",
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "string"
             },
             {
-              "type": "number",
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "number"
             },
             {
-              "type": "boolean",
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "boolean"
             }
           ],
           "description": "",
@@ -42,25 +39,22 @@
         "additionalProperties": {
           "oneOf": [
             {
-              "type": "string",
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "string"
             },
             {
-              "type": "number",
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "number"
             },
             {
-              "type": "boolean",
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "boolean"
             }
           ],
           "description": "",

--- a/test/schemas/json/swagger/ObjectGeneric.json
+++ b/test/schemas/json/swagger/ObjectGeneric.json
@@ -15,7 +15,6 @@
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
@@ -35,8 +34,7 @@
             "x-typia-required": true,
             "x-typia-optional": false
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
@@ -46,11 +44,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           "child": {
             "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
@@ -59,17 +56,16 @@
             "x-typia-optional": false
           },
           "elements": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -84,18 +80,16 @@
         "type": "object",
         "properties": {
           "child_value": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           "child_next": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
         "nullable": false,
@@ -109,11 +103,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "child": {
             "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
@@ -122,17 +115,16 @@
             "x-typia-optional": false
           },
           "elements": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -147,18 +139,16 @@
         "type": "object",
         "properties": {
           "child_value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "child_next": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -172,11 +162,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "child": {
             "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
@@ -185,17 +174,16 @@
             "x-typia-optional": false
           },
           "elements": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -210,18 +198,16 @@
         "type": "object",
         "properties": {
           "child_value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "child_next": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectGenericAlias.json
+++ b/test/schemas/json/swagger/ObjectGenericAlias.json
@@ -10,11 +10,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectGenericArray.json
+++ b/test/schemas/json/swagger/ObjectGenericArray.json
@@ -16,17 +16,16 @@
             "x-typia-optional": false
           },
           "data": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGenericArray.IPerson",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -40,32 +39,28 @@
         "type": "object",
         "properties": {
           "page": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "limit": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "total_count": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "total_pages": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -81,18 +76,16 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "age": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectGenericUnion.json
+++ b/test/schemas/json/swagger/ObjectGenericUnion.json
@@ -17,11 +17,10 @@
         "type": "object",
         "properties": {
           "writer": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "answer": {
             "$ref": "#/components/schemas/ObjectGenericUnion.ISaleAnswer.Nullable",
@@ -30,38 +29,34 @@
             "x-typia-optional": false
           },
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "hit": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "contents": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGenericUnion.ISaleArticle.IContent",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -79,38 +74,34 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "hit": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "contents": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGenericUnion.ISaleArticle.IContent",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": true,
@@ -126,45 +117,40 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "body": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "files": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -181,25 +167,23 @@
         "type": "object",
         "properties": {
           "url": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "extension": {
-            "type": "string",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string",
+            "nullable": true
           }
         },
         "nullable": false,
@@ -214,11 +198,10 @@
         "type": "object",
         "properties": {
           "writer": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "answer": {
             "$ref": "#/components/schemas/ObjectGenericUnion.ISaleAnswer.Nullable",
@@ -227,38 +210,34 @@
             "x-typia-optional": false
           },
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "hit": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "contents": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectGenericUnion.ISaleReview.IContent",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -276,52 +255,46 @@
         "type": "object",
         "properties": {
           "score": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "body": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "files": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Omit_lt_ObjectGenericUnion.IAttachmentFile_comma__space__doublequote_id_doublequote__gt_",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectHierarchical.json
+++ b/test/schemas/json/swagger/ObjectHierarchical.json
@@ -10,11 +10,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "channel": {
             "$ref": "#/components/schemas/ObjectHierarchical.IChannel",
@@ -35,70 +34,61 @@
             "x-typia-optional": false
           },
           "href": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "referrer": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "ip": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "number",
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "number"
             },
-            "nullable": false,
             "x-typia-tuple": {
               "type": "array",
               "items": [
                 {
-                  "type": "number",
-                  "nullable": false,
-                  "description": "",
-                  "x-typia-required": true,
-                  "x-typia-optional": false
-                },
-                {
-                  "type": "number",
-                  "nullable": false,
-                  "description": "",
-                  "x-typia-required": true,
-                  "x-typia-optional": false
-                },
-                {
-                  "type": "number",
-                  "nullable": false,
-                  "description": "",
-                  "x-typia-required": true,
-                  "x-typia-optional": false
-                },
-                {
-                  "type": "number",
-                  "nullable": false,
                   "description": "",
                   "x-typia-required": true,
                   "x-typia-optional": false,
-                  "x-typia-rest": false
+                  "type": "number"
+                },
+                {
+                  "description": "",
+                  "x-typia-required": true,
+                  "x-typia-optional": false,
+                  "type": "number"
+                },
+                {
+                  "description": "",
+                  "x-typia-required": true,
+                  "x-typia-optional": false,
+                  "type": "number"
+                },
+                {
+                  "description": "",
+                  "x-typia-required": true,
+                  "x-typia-optional": false,
+                  "x-typia-rest": false,
+                  "type": "number"
                 }
               ],
-              "nullable": false,
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
@@ -124,46 +114,40 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "exclusive": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           "priority": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
@@ -188,18 +172,16 @@
         "type": "object",
         "properties": {
           "time": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "zone": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -213,11 +195,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "account": {
             "$ref": "#/components/schemas/ObjectHierarchical.IAccount",
@@ -232,18 +213,16 @@
             "x-typia-optional": false
           },
           "emails": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
@@ -252,11 +231,10 @@
             "x-typia-optional": false
           },
           "authorized": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
         "nullable": true,
@@ -274,18 +252,16 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
@@ -306,11 +282,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "account": {
             "$ref": "#/components/schemas/ObjectHierarchical.IAccount",
@@ -319,18 +294,16 @@
             "x-typia-optional": false
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "grade": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",
@@ -353,18 +326,16 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp",

--- a/test/schemas/json/swagger/ObjectInternal.json
+++ b/test/schemas/json/swagger/ObjectInternal.json
@@ -10,18 +10,16 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectIntersection.json
+++ b/test/schemas/json/swagger/ObjectIntersection.json
@@ -10,25 +10,22 @@
         "type": "object",
         "properties": {
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "vulnerable": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectJsonTag.json
+++ b/test/schemas/json/swagger/ObjectJsonTag.json
@@ -10,8 +10,6 @@
         "type": "object",
         "properties": {
           "vulnerable": {
-            "type": "string",
-            "nullable": false,
             "deprecated": true,
             "description": "",
             "x-typia-jsDocTags": [
@@ -20,18 +18,16 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "Descripted property.",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "title": "something",
             "description": "Titled property.",
             "x-typia-jsDocTags": [
@@ -46,11 +42,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "complicate_title": {
-            "type": "string",
-            "nullable": false,
             "title": "something weirdo with {@link something } tag",
             "description": "Complicate title.",
             "x-typia-jsDocTags": [
@@ -81,7 +76,8 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectLiteralProperty.json
+++ b/test/schemas/json/swagger/ObjectLiteralProperty.json
@@ -10,18 +10,16 @@
         "type": "object",
         "properties": {
           "something-interesting-do-you-want?": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "or-something-crazy-do-you-want?": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectLiteralType.json
+++ b/test/schemas/json/swagger/ObjectLiteralType.json
@@ -10,25 +10,22 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "age": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectNullable.json
+++ b/test/schemas/json/swagger/ObjectNullable.json
@@ -5,7 +5,6 @@
       "items": {
         "$ref": "#/components/schemas/ObjectNullable.IProduct"
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
@@ -25,8 +24,7 @@
             "x-typia-required": true,
             "x-typia-optional": false
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
@@ -36,11 +34,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "manufacturer": {
             "$ref": "#/components/schemas/ObjectNullable.IManufacturer",
@@ -87,21 +84,19 @@
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "manufacturer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -115,21 +110,19 @@
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "brand"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": true,
@@ -143,21 +136,19 @@
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "manufacturer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": true,

--- a/test/schemas/json/swagger/ObjectOptional.json
+++ b/test/schemas/json/swagger/ObjectOptional.json
@@ -10,32 +10,28 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectPrimitive.json
+++ b/test/schemas/json/swagger/ObjectPrimitive.json
@@ -10,64 +10,57 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "extension": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "txt",
               "md",
               "html"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "body": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "files": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectPrimitive.IFile",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "secret": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -86,39 +79,34 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "extension": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "url": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "created_at": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectPropertyNullable.json
+++ b/test/schemas/json/swagger/ObjectPropertyNullable.json
@@ -8,84 +8,74 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_"
-            },
-            "nullable": false
+            }
           },
           {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_number_gt_"
-            },
-            "nullable": false
+            }
           },
           {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_string_gt_"
-            },
-            "nullable": false
+            }
           },
           {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_"
-            },
-            "nullable": false
+            }
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_number_gt_",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_string_gt_",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           {
+            "x-typia-rest": false,
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_",
               "x-typia-rest": false,
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
@@ -95,11 +85,11 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "boolean",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean",
+            "nullable": true
           }
         },
         "nullable": false,
@@ -112,11 +102,11 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number",
+            "nullable": true
           }
         },
         "nullable": false,
@@ -129,11 +119,11 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string",
+            "nullable": true
           }
         },
         "nullable": false,
@@ -162,39 +152,37 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string",
+            "nullable": true
           },
           "grade": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "serial": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           },
           "activated": {
-            "type": "boolean",
-            "nullable": true,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean",
+            "nullable": true
           }
         },
         "nullable": true,

--- a/test/schemas/json/swagger/ObjectRecursive.json
+++ b/test/schemas/json/swagger/ObjectRecursive.json
@@ -16,32 +16,28 @@
             "x-typia-optional": false
           },
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectRecursive.ITimestamp",
@@ -71,32 +67,28 @@
             "x-typia-optional": false
           },
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "sequence": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectRecursive.ITimestamp",
@@ -120,18 +112,16 @@
         "type": "object",
         "properties": {
           "time": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "zone": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectSimple.json
+++ b/test/schemas/json/swagger/ObjectSimple.json
@@ -47,25 +47,22 @@
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "z": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectTuple.json
+++ b/test/schemas/json/swagger/ObjectTuple.json
@@ -12,7 +12,6 @@
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
@@ -27,8 +26,7 @@
             "x-typia-required": true,
             "x-typia-optional": false
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
@@ -38,25 +36,22 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -71,25 +66,22 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "mobile": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectUndefined.json
+++ b/test/schemas/json/swagger/ObjectUndefined.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/ObjectUndefined.ILecture"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,27 +13,24 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "professor": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": false,
-                "x-typia-optional": true
+                "x-typia-optional": true,
+                "type": "string"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": false,
-                "x-typia-optional": true
+                "x-typia-optional": true,
+                "type": "number"
               }
             ],
             "description": "",
@@ -48,11 +44,10 @@
             "x-typia-optional": true
           },
           "grade": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "unknown": {
             "description": "",
@@ -71,18 +66,16 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectUnionComposite.json
+++ b/test/schemas/json/swagger/ObjectUnionComposite.json
@@ -29,8 +29,7 @@
             "$ref": "#/components/schemas/ObjectUnionComposite.ICircle"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -39,18 +38,16 @@
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -154,17 +151,16 @@
         "type": "object",
         "properties": {
           "points": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -183,17 +179,16 @@
             "x-typia-optional": false
           },
           "inner": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionComposite.IPolyline",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -207,17 +202,16 @@
         "type": "object",
         "properties": {
           "outer": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "inner": {
             "$ref": "#/components/schemas/ObjectUnionComposite.IPoint",
@@ -243,11 +237,10 @@
             "x-typia-optional": false
           },
           "radius": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectUnionDouble.json
+++ b/test/schemas/json/swagger/ObjectUnionDouble.json
@@ -11,8 +11,7 @@
             "$ref": "#/components/schemas/ObjectUnionDouble.IB"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -57,11 +56,10 @@
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -90,11 +88,10 @@
         "type": "object",
         "properties": {
           "y": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
         "nullable": false,
@@ -123,11 +120,10 @@
         "type": "object",
         "properties": {
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -176,11 +172,10 @@
         "type": "object",
         "properties": {
           "x": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -209,11 +204,10 @@
         "type": "object",
         "properties": {
           "y": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -242,18 +236,16 @@
         "type": "object",
         "properties": {
           "y": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectUnionExplicit.json
+++ b/test/schemas/json/swagger/ObjectUnionExplicit.json
@@ -26,8 +26,7 @@
             "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -36,28 +35,25 @@
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "point"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -84,14 +80,13 @@
             "x-typia-optional": false
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "line"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -106,18 +101,16 @@
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -149,14 +142,13 @@
             "x-typia-optional": false
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "triangle"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -196,14 +188,13 @@
             "x-typia-optional": false
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "rectangle"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -220,27 +211,25 @@
         "type": "object",
         "properties": {
           "points": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "polyline"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -260,27 +249,25 @@
             "x-typia-optional": false
           },
           "inner": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionExplicit.IPolyline",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "polygon"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -295,17 +282,16 @@
         "type": "object",
         "properties": {
           "points": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionExplicit.IPoint",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,
@@ -324,21 +310,19 @@
             "x-typia-optional": false
           },
           "radius": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "circle"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectUnionImplicit.json
+++ b/test/schemas/json/swagger/ObjectUnionImplicit.json
@@ -26,8 +26,7 @@
             "$ref": "#/components/schemas/ObjectUnionImplicit.ICircle"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -36,25 +35,23 @@
         "type": "object",
         "properties": {
           "x": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "y": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "slope": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           }
         },
         "nullable": false,
@@ -80,18 +77,18 @@
             "x-typia-optional": false
           },
           "width": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           },
           "distance": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           }
         },
         "nullable": false,
@@ -123,25 +120,25 @@
             "x-typia-optional": false
           },
           "width": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           },
           "height": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           },
           "area": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           }
         },
         "nullable": false,
@@ -180,25 +177,25 @@
             "x-typia-optional": false
           },
           "width": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           },
           "height": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           },
           "area": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           }
         },
         "nullable": false,
@@ -214,24 +211,23 @@
         "type": "object",
         "properties": {
           "points": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint",
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "length": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           }
         },
         "nullable": false,
@@ -250,24 +246,23 @@
             "x-typia-optional": false
           },
           "inner": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectUnionImplicit.IPolyline",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "area": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           }
         },
         "nullable": false,
@@ -286,18 +281,17 @@
             "x-typia-optional": true
           },
           "radius": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "area": {
-            "type": "number",
-            "nullable": true,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number",
+            "nullable": true
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ObjectUnionNonPredictable.json
+++ b/test/schemas/json/swagger/ObjectUnionNonPredictable.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -81,11 +80,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
         "nullable": false,
@@ -114,11 +112,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -147,11 +144,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/SetAlias.json
+++ b/test/schemas/json/swagger/SetAlias.json
@@ -10,34 +10,34 @@
         "type": "object",
         "properties": {
           "booleans": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "numbers": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "strings": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "arrays": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "objects": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/SetSimple.json
+++ b/test/schemas/json/swagger/SetSimple.json
@@ -10,34 +10,34 @@
         "type": "object",
         "properties": {
           "booleans": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "numbers": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "strings": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "arrays": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           },
           "objects": {
-            "$ref": "#/components/schemas/Set",
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "$ref": "#/components/schemas/Set"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/SetUnion.json
+++ b/test/schemas/json/swagger/SetUnion.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/Set"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {

--- a/test/schemas/json/swagger/TagArray.json
+++ b/test/schemas/json/swagger/TagArray.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/TagArray.Type"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,10 +13,41 @@
         "type": "object",
         "properties": {
           "items": {
+            "description": "",
+            "x-typia-metaTags": [
+              {
+                "kind": "items",
+                "value": 3
+              },
+              {
+                "kind": "format",
+                "value": "uuid"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "items",
+                "text": [
+                  {
+                    "text": "3",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "format",
+                "text": [
+                  {
+                    "text": "uuid",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false,
               "description": "",
               "x-typia-metaTags": [
                 {
@@ -51,84 +81,11 @@
               ],
               "x-typia-required": true,
               "x-typia-optional": false,
+              "type": "string",
               "format": "uuid"
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-metaTags": [
-              {
-                "kind": "items",
-                "value": 3
-              },
-              {
-                "kind": "format",
-                "value": "uuid"
-              }
-            ],
-            "x-typia-jsDocTags": [
-              {
-                "name": "items",
-                "text": [
-                  {
-                    "text": "3",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "format",
-                "text": [
-                  {
-                    "text": "uuid",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ],
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "minItems": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-metaTags": [
-                {
-                  "kind": "minItems",
-                  "value": 3
-                },
-                {
-                  "kind": "minimum",
-                  "value": 3
-                }
-              ],
-              "x-typia-jsDocTags": [
-                {
-                  "name": "minItems",
-                  "text": [
-                    {
-                      "text": "3",
-                      "kind": "text"
-                    }
-                  ]
-                },
-                {
-                  "name": "minimum",
-                  "text": [
-                    {
-                      "text": "3",
-                      "kind": "text"
-                    }
-                  ]
-                }
-              ],
-              "x-typia-required": true,
-              "x-typia-optional": false,
-              "minimum": 3
-            },
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -162,15 +119,97 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-metaTags": [
+                {
+                  "kind": "minItems",
+                  "value": 3
+                },
+                {
+                  "kind": "minimum",
+                  "value": 3
+                }
+              ],
+              "x-typia-jsDocTags": [
+                {
+                  "name": "minItems",
+                  "text": [
+                    {
+                      "text": "3",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "minimum",
+                  "text": [
+                    {
+                      "text": "3",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number",
+              "minimum": 3
+            },
             "minItems": 3
           },
           "maxItems": {
+            "description": "",
+            "x-typia-metaTags": [
+              {
+                "kind": "maxItems",
+                "value": 7
+              },
+              {
+                "kind": "maxLength",
+                "value": 7
+              },
+              {
+                "kind": "maximum",
+                "value": 7
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "maxItems",
+                "text": [
+                  {
+                    "text": "7",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maxLength",
+                "text": [
+                  {
+                    "text": "7",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maximum",
+                "text": [
+                  {
+                    "text": "7",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "type": "string",
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -217,11 +256,10 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
+                  "type": "string",
                   "maxLength": 7
                 },
                 {
-                  "type": "number",
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -268,6 +306,7 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
+                  "type": "number",
                   "maximum": 7
                 }
               ],
@@ -318,109 +357,9 @@
               "x-typia-required": true,
               "x-typia-optional": false
             },
-            "nullable": false,
-            "description": "",
-            "x-typia-metaTags": [
-              {
-                "kind": "maxItems",
-                "value": 7
-              },
-              {
-                "kind": "maxLength",
-                "value": 7
-              },
-              {
-                "kind": "maximum",
-                "value": 7
-              }
-            ],
-            "x-typia-jsDocTags": [
-              {
-                "name": "maxItems",
-                "text": [
-                  {
-                    "text": "7",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "maxLength",
-                "text": [
-                  {
-                    "text": "7",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "maximum",
-                "text": [
-                  {
-                    "text": "7",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ],
-            "x-typia-required": true,
-            "x-typia-optional": false,
             "maxItems": 7
           },
           "both": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "description": "",
-              "x-typia-metaTags": [
-                {
-                  "kind": "minItems",
-                  "value": 3
-                },
-                {
-                  "kind": "maxItems",
-                  "value": 7
-                },
-                {
-                  "kind": "format",
-                  "value": "uuid"
-                }
-              ],
-              "x-typia-jsDocTags": [
-                {
-                  "name": "minItems",
-                  "text": [
-                    {
-                      "text": "3",
-                      "kind": "text"
-                    }
-                  ]
-                },
-                {
-                  "name": "maxItems",
-                  "text": [
-                    {
-                      "text": "7",
-                      "kind": "text"
-                    }
-                  ]
-                },
-                {
-                  "name": "format",
-                  "text": [
-                    {
-                      "text": "uuid",
-                      "kind": "text"
-                    }
-                  ]
-                }
-              ],
-              "x-typia-required": true,
-              "x-typia-optional": false,
-              "format": "uuid"
-            },
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -467,6 +406,57 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-metaTags": [
+                {
+                  "kind": "minItems",
+                  "value": 3
+                },
+                {
+                  "kind": "maxItems",
+                  "value": 7
+                },
+                {
+                  "kind": "format",
+                  "value": "uuid"
+                }
+              ],
+              "x-typia-jsDocTags": [
+                {
+                  "name": "minItems",
+                  "text": [
+                    {
+                      "text": "3",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "maxItems",
+                  "text": [
+                    {
+                      "text": "7",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "format",
+                  "text": [
+                    {
+                      "text": "uuid",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string",
+              "format": "uuid"
+            },
             "minItems": 3,
             "maxItems": 7
           }

--- a/test/schemas/json/swagger/TagAtomicUnion.json
+++ b/test/schemas/json/swagger/TagAtomicUnion.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/TagAtomicUnion.Type"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -16,8 +15,6 @@
           "value": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-metaTags": [
                   {
@@ -64,12 +61,11 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "string",
                 "minLength": 3,
                 "maxLength": 7
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-metaTags": [
                   {
@@ -116,6 +112,7 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "number",
                 "minimum": 3
               }
             ],

--- a/test/schemas/json/swagger/TagCustom.json
+++ b/test/schemas/json/swagger/TagCustom.json
@@ -10,8 +10,6 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "Regular feature supported by typia",
             "x-typia-metaTags": [
               {
@@ -32,11 +30,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "uuid"
           },
           "dollar": {
-            "type": "string",
-            "nullable": false,
             "description": "Custom feature composed with \"$\" + number",
             "x-typia-jsDocTags": [
               {
@@ -44,11 +41,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "postfix": {
-            "type": "string",
-            "nullable": false,
             "description": "Custom feature composed with string + \"abcd\"",
             "x-typia-jsDocTags": [
               {
@@ -62,11 +58,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "log": {
-            "type": "number",
-            "nullable": false,
             "description": "Custom feature meaning x^y",
             "x-typia-jsDocTags": [
               {
@@ -80,7 +75,8 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/TagDefault.json
+++ b/test/schemas/json/swagger/TagDefault.json
@@ -10,8 +10,6 @@
         "type": "object",
         "properties": {
           "boolean": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -26,11 +24,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
-            "default": true
+            "default": true,
+            "type": "boolean"
           },
           "number": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -45,11 +42,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "default": 1
           },
           "string": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -64,11 +60,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "default": "two"
           },
           "text": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -83,11 +78,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "default": "Very long text, can you understand it?"
           },
           "template": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -108,8 +103,6 @@
           "boolean_and_number_and_string": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -142,11 +135,10 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "string",
                 "default": "two"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -179,11 +171,10 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "number",
                 "default": 1
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -216,7 +207,8 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "default": true
+                "default": true,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -255,44 +247,6 @@
           "union_but_boolean": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
-                "description": "",
-                "x-typia-jsDocTags": [
-                  {
-                    "name": "default",
-                    "text": [
-                      {
-                        "text": "false",
-                        "kind": "text"
-                      }
-                    ]
-                  }
-                ],
-                "x-typia-required": true,
-                "x-typia-optional": false
-              },
-              {
-                "type": "number",
-                "nullable": false,
-                "description": "",
-                "x-typia-jsDocTags": [
-                  {
-                    "name": "default",
-                    "text": [
-                      {
-                        "text": "false",
-                        "kind": "text"
-                      }
-                    ]
-                  }
-                ],
-                "x-typia-required": true,
-                "x-typia-optional": false
-              },
-              {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -307,7 +261,42 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "default": true
+                "type": "string"
+              },
+              {
+                "description": "",
+                "x-typia-jsDocTags": [
+                  {
+                    "name": "default",
+                    "text": [
+                      {
+                        "text": "false",
+                        "kind": "text"
+                      }
+                    ]
+                  }
+                ],
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "number"
+              },
+              {
+                "description": "",
+                "x-typia-jsDocTags": [
+                  {
+                    "name": "default",
+                    "text": [
+                      {
+                        "text": "false",
+                        "kind": "text"
+                      }
+                    ]
+                  }
+                ],
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "default": true,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -328,26 +317,6 @@
           "union_but_number": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
-                "description": "",
-                "x-typia-jsDocTags": [
-                  {
-                    "name": "default",
-                    "text": [
-                      {
-                        "text": "1",
-                        "kind": "text"
-                      }
-                    ]
-                  }
-                ],
-                "x-typia-required": true,
-                "x-typia-optional": false
-              },
-              {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -362,11 +331,9 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "default": 1
+                "type": "string"
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -380,7 +347,26 @@
                   }
                 ],
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "number",
+                "default": 1
+              },
+              {
+                "description": "",
+                "x-typia-jsDocTags": [
+                  {
+                    "name": "default",
+                    "text": [
+                      {
+                        "text": "1",
+                        "kind": "text"
+                      }
+                    ]
+                  }
+                ],
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -401,8 +387,6 @@
           "union_but_string": {
             "oneOf": [
               {
-                "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -417,11 +401,10 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "string",
                 "default": "two"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -435,11 +418,10 @@
                   }
                 ],
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "number"
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -453,7 +435,8 @@
                   }
                 ],
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "boolean"
               }
             ],
             "description": "",
@@ -472,8 +455,6 @@
             "x-typia-optional": false
           },
           "vulnerable_range": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -516,12 +497,12 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "maximum": 5
           },
           "vulnerable_template": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-jsDocTags": [
               {
@@ -542,7 +523,6 @@
             "oneOf": [
               {
                 "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -579,8 +559,6 @@
                 "default": "prefix_B"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -613,11 +591,10 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "number",
                 "default": 1
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-jsDocTags": [
                   {
@@ -650,7 +627,8 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "default": true
+                "default": true,
+                "type": "boolean"
               }
             ],
             "description": "",

--- a/test/schemas/json/swagger/TagFormat.json
+++ b/test/schemas/json/swagger/TagFormat.json
@@ -10,8 +10,6 @@
         "type": "object",
         "properties": {
           "uuid": {
-            "type": "string",
-            "nullable": false,
             "description": "Universally Unique Identifier.",
             "x-typia-metaTags": [
               {
@@ -32,11 +30,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "uuid"
           },
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "Email address",
             "x-typia-metaTags": [
               {
@@ -57,11 +54,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "email"
           },
           "url": {
-            "type": "string",
-            "nullable": false,
             "description": "URL address.",
             "x-typia-metaTags": [
               {
@@ -82,11 +78,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "url"
           },
           "ipv4": {
-            "type": "string",
-            "nullable": false,
             "description": "IPv4 address.",
             "x-typia-metaTags": [
               {
@@ -107,11 +102,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "ipv4"
           },
           "ipv6": {
-            "type": "string",
-            "nullable": false,
             "description": "IPv6 address.",
             "x-typia-metaTags": [
               {
@@ -132,11 +126,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "ipv6"
           },
           "date": {
-            "type": "string",
-            "nullable": false,
             "description": "Date only.",
             "x-typia-metaTags": [
               {
@@ -157,11 +150,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "date"
           },
           "date_time": {
-            "type": "string",
-            "nullable": false,
             "description": "Date and time.",
             "x-typia-metaTags": [
               {
@@ -182,11 +174,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "date-time"
           },
           "datetime": {
-            "type": "string",
-            "nullable": false,
             "description": "Date and time with only lowercase characters.",
             "x-typia-metaTags": [
               {
@@ -207,11 +198,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "date-time"
           },
           "dateTime": {
-            "type": "string",
-            "nullable": false,
             "description": "Date and time with camelCase.",
             "x-typia-metaTags": [
               {
@@ -232,11 +222,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "date-time"
           },
           "custom": {
-            "type": "string",
-            "nullable": false,
             "description": "A custom format string.",
             "x-typia-jsDocTags": [
               {
@@ -251,6 +240,7 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "format": "my-custom-format"
           }
         },

--- a/test/schemas/json/swagger/TagLength.json
+++ b/test/schemas/json/swagger/TagLength.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/TagLength.Type"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,8 +13,6 @@
         "type": "object",
         "properties": {
           "fixed": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -35,11 +32,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "minimum": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -60,11 +56,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "minLength": 3
           },
           "maximum": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -85,11 +80,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "maxLength": 7
           },
           "minimum_and_maximum": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -123,6 +117,7 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "minLength": 3,
             "maxLength": 7
           }

--- a/test/schemas/json/swagger/TagMatrix.json
+++ b/test/schemas/json/swagger/TagMatrix.json
@@ -10,12 +10,76 @@
         "type": "object",
         "properties": {
           "matrix": {
+            "description": "Doubled array.",
+            "x-typia-metaTags": [
+              {
+                "kind": "items",
+                "value": 3
+              },
+              {
+                "kind": "format",
+                "value": "uuid"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "items",
+                "text": [
+                  {
+                    "text": "3",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "format",
+                "text": [
+                  {
+                    "text": "uuid",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
+              "description": "Doubled array.",
+              "x-typia-metaTags": [
+                {
+                  "kind": "items",
+                  "value": 3
+                },
+                {
+                  "kind": "format",
+                  "value": "uuid"
+                }
+              ],
+              "x-typia-jsDocTags": [
+                {
+                  "name": "items",
+                  "text": [
+                    {
+                      "text": "3",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "format",
+                  "text": [
+                    {
+                      "text": "uuid",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": true,
+              "x-typia-optional": false,
               "type": "array",
               "items": {
-                "type": "string",
-                "nullable": false,
                 "description": "Doubled array.",
                 "x-typia-metaTags": [
                   {
@@ -49,77 +113,10 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
+                "type": "string",
                 "format": "uuid"
-              },
-              "nullable": false,
-              "description": "Doubled array.",
-              "x-typia-metaTags": [
-                {
-                  "kind": "items",
-                  "value": 3
-                },
-                {
-                  "kind": "format",
-                  "value": "uuid"
-                }
-              ],
-              "x-typia-jsDocTags": [
-                {
-                  "name": "items",
-                  "text": [
-                    {
-                      "text": "3",
-                      "kind": "text"
-                    }
-                  ]
-                },
-                {
-                  "name": "format",
-                  "text": [
-                    {
-                      "text": "uuid",
-                      "kind": "text"
-                    }
-                  ]
-                }
-              ],
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "Doubled array.",
-            "x-typia-metaTags": [
-              {
-                "kind": "items",
-                "value": 3
-              },
-              {
-                "kind": "format",
-                "value": "uuid"
               }
-            ],
-            "x-typia-jsDocTags": [
-              {
-                "name": "items",
-                "text": [
-                  {
-                    "text": "3",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "format",
-                "text": [
-                  {
-                    "text": "uuid",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ],
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/TagObjectUnion.json
+++ b/test/schemas/json/swagger/TagObjectUnion.json
@@ -11,8 +11,7 @@
             "$ref": "#/components/schemas/TagObjectUnion.Literal"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -21,8 +20,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -43,6 +40,7 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3
           }
         },
@@ -56,8 +54,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -91,6 +87,7 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "minLength": 3,
             "maxLength": 7
           }

--- a/test/schemas/json/swagger/TagPattern.json
+++ b/test/schemas/json/swagger/TagPattern.json
@@ -10,8 +10,6 @@
         "type": "object",
         "properties": {
           "uuid": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -32,11 +30,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "pattern": "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[4][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$"
           },
           "email": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -57,11 +54,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "pattern": "^(([^<>()[\\]\\.,;:\\s@\\\"]+(\\.[^<>()[\\]\\.,;:\\s@\\\"]+)*)|(\\\".+\\\"))@(([^<>()[\\]\\.,;:\\s@\\\"]+\\.)+[^<>()[\\]\\.,;:\\s@\\\"]{2,})$"
           },
           "ipv4": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -82,11 +78,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "pattern": "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
           },
           "ipv6": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -107,6 +102,7 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "string",
             "pattern": "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$"
           }
         },

--- a/test/schemas/json/swagger/TagRange.json
+++ b/test/schemas/json/swagger/TagRange.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/TagRange.Type"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,8 +13,6 @@
         "type": "object",
         "properties": {
           "greater": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -36,12 +33,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "exclusiveMinimum": true
           },
           "greater_equal": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -62,11 +58,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3
           },
           "less": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -87,12 +82,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "maximum": 7,
             "exclusiveMaximum": true
           },
           "less_equal": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -113,11 +107,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "maximum": 7
           },
           "greater_less": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -151,14 +144,13 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "exclusiveMinimum": true,
             "maximum": 7,
             "exclusiveMaximum": true
           },
           "greater_equal_less": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -192,13 +184,12 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "maximum": 7,
             "exclusiveMaximum": true
           },
           "greater_less_equal": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -232,13 +223,12 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "exclusiveMinimum": true,
             "maximum": 7
           },
           "greater_equal_less_equal": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -272,6 +262,7 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "maximum": 7
           }

--- a/test/schemas/json/swagger/TagStep.json
+++ b/test/schemas/json/swagger/TagStep.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/TagStep.Type"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,8 +13,6 @@
         "type": "object",
         "properties": {
           "exclusiveMinimum": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -49,12 +46,11 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3,
             "exclusiveMinimum": true
           },
           "minimum": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -88,11 +84,10 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 3
           },
           "range": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -139,14 +134,13 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "minimum": 0,
             "exclusiveMinimum": true,
             "maximum": 100,
             "exclusiveMaximum": true
           },
           "multipleOf": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -193,6 +187,7 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "number",
             "multipleOf": 5,
             "minimum": 3,
             "maximum": 99

--- a/test/schemas/json/swagger/TagTuple.json
+++ b/test/schemas/json/swagger/TagTuple.json
@@ -10,12 +10,95 @@
         "type": "object",
         "properties": {
           "tuple": {
+            "description": "",
+            "x-typia-metaTags": [
+              {
+                "kind": "minItems",
+                "value": 3
+              },
+              {
+                "kind": "maxItems",
+                "value": 7
+              },
+              {
+                "kind": "minimum",
+                "value": 3
+              },
+              {
+                "kind": "maximum",
+                "value": 7
+              },
+              {
+                "kind": "minLength",
+                "value": 3
+              },
+              {
+                "kind": "maxLength",
+                "value": 7
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "minItems",
+                "text": [
+                  {
+                    "text": "3",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maxItems",
+                "text": [
+                  {
+                    "text": "7",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "minimum",
+                "text": [
+                  {
+                    "text": "3",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maximum",
+                "text": [
+                  {
+                    "text": "7",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "minLength",
+                "text": [
+                  {
+                    "text": "3",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maxLength",
+                "text": [
+                  {
+                    "text": "7",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "type": "string",
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -101,12 +184,11 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
+                  "type": "string",
                   "minLength": 3,
                   "maxLength": 7
                 },
                 {
-                  "type": "number",
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -192,103 +274,11 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
+                  "type": "number",
                   "minimum": 3,
                   "maximum": 7
                 },
                 {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "nullable": false,
-                    "description": "",
-                    "x-typia-metaTags": [
-                      {
-                        "kind": "minItems",
-                        "value": 3
-                      },
-                      {
-                        "kind": "maxItems",
-                        "value": 7
-                      },
-                      {
-                        "kind": "minimum",
-                        "value": 3
-                      },
-                      {
-                        "kind": "maximum",
-                        "value": 7
-                      },
-                      {
-                        "kind": "minLength",
-                        "value": 3
-                      },
-                      {
-                        "kind": "maxLength",
-                        "value": 7
-                      }
-                    ],
-                    "x-typia-jsDocTags": [
-                      {
-                        "name": "minItems",
-                        "text": [
-                          {
-                            "text": "3",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "maxItems",
-                        "text": [
-                          {
-                            "text": "7",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "minimum",
-                        "text": [
-                          {
-                            "text": "3",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "maximum",
-                        "text": [
-                          {
-                            "text": "7",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "minLength",
-                        "text": [
-                          {
-                            "text": "3",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "maxLength",
-                        "text": [
-                          {
-                            "text": "7",
-                            "kind": "text"
-                          }
-                        ]
-                      }
-                    ],
-                    "x-typia-required": true,
-                    "x-typia-optional": false,
-                    "minLength": 3,
-                    "maxLength": 7
-                  },
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -374,103 +364,101 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
+                  "type": "array",
+                  "items": {
+                    "description": "",
+                    "x-typia-metaTags": [
+                      {
+                        "kind": "minItems",
+                        "value": 3
+                      },
+                      {
+                        "kind": "maxItems",
+                        "value": 7
+                      },
+                      {
+                        "kind": "minimum",
+                        "value": 3
+                      },
+                      {
+                        "kind": "maximum",
+                        "value": 7
+                      },
+                      {
+                        "kind": "minLength",
+                        "value": 3
+                      },
+                      {
+                        "kind": "maxLength",
+                        "value": 7
+                      }
+                    ],
+                    "x-typia-jsDocTags": [
+                      {
+                        "name": "minItems",
+                        "text": [
+                          {
+                            "text": "3",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "maxItems",
+                        "text": [
+                          {
+                            "text": "7",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "minimum",
+                        "text": [
+                          {
+                            "text": "3",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "maximum",
+                        "text": [
+                          {
+                            "text": "7",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "minLength",
+                        "text": [
+                          {
+                            "text": "3",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "maxLength",
+                        "text": [
+                          {
+                            "text": "7",
+                            "kind": "text"
+                          }
+                        ]
+                      }
+                    ],
+                    "x-typia-required": true,
+                    "x-typia-optional": false,
+                    "type": "string",
+                    "minLength": 3,
+                    "maxLength": 7
+                  },
                   "minItems": 3,
                   "maxItems": 7
                 },
                 {
-                  "type": "array",
-                  "items": {
-                    "type": "number",
-                    "nullable": false,
-                    "description": "",
-                    "x-typia-metaTags": [
-                      {
-                        "kind": "minItems",
-                        "value": 3
-                      },
-                      {
-                        "kind": "maxItems",
-                        "value": 7
-                      },
-                      {
-                        "kind": "minimum",
-                        "value": 3
-                      },
-                      {
-                        "kind": "maximum",
-                        "value": 7
-                      },
-                      {
-                        "kind": "minLength",
-                        "value": 3
-                      },
-                      {
-                        "kind": "maxLength",
-                        "value": 7
-                      }
-                    ],
-                    "x-typia-jsDocTags": [
-                      {
-                        "name": "minItems",
-                        "text": [
-                          {
-                            "text": "3",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "maxItems",
-                        "text": [
-                          {
-                            "text": "7",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "minimum",
-                        "text": [
-                          {
-                            "text": "3",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "maximum",
-                        "text": [
-                          {
-                            "text": "7",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "minLength",
-                        "text": [
-                          {
-                            "text": "3",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "maxLength",
-                        "text": [
-                          {
-                            "text": "7",
-                            "kind": "text"
-                          }
-                        ]
-                      }
-                    ],
-                    "x-typia-required": true,
-                    "x-typia-optional": false,
-                    "minimum": 3,
-                    "maximum": 7
-                  },
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -556,6 +544,97 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
+                  "type": "array",
+                  "items": {
+                    "description": "",
+                    "x-typia-metaTags": [
+                      {
+                        "kind": "minItems",
+                        "value": 3
+                      },
+                      {
+                        "kind": "maxItems",
+                        "value": 7
+                      },
+                      {
+                        "kind": "minimum",
+                        "value": 3
+                      },
+                      {
+                        "kind": "maximum",
+                        "value": 7
+                      },
+                      {
+                        "kind": "minLength",
+                        "value": 3
+                      },
+                      {
+                        "kind": "maxLength",
+                        "value": 7
+                      }
+                    ],
+                    "x-typia-jsDocTags": [
+                      {
+                        "name": "minItems",
+                        "text": [
+                          {
+                            "text": "3",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "maxItems",
+                        "text": [
+                          {
+                            "text": "7",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "minimum",
+                        "text": [
+                          {
+                            "text": "3",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "maximum",
+                        "text": [
+                          {
+                            "text": "7",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "minLength",
+                        "text": [
+                          {
+                            "text": "3",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "maxLength",
+                        "text": [
+                          {
+                            "text": "7",
+                            "kind": "text"
+                          }
+                        ]
+                      }
+                    ],
+                    "x-typia-required": true,
+                    "x-typia-optional": false,
+                    "type": "number",
+                    "minimum": 3,
+                    "maximum": 7
+                  },
                   "minItems": 3,
                   "maxItems": 7
                 }
@@ -646,13 +725,10 @@
               "x-typia-required": true,
               "x-typia-optional": false
             },
-            "nullable": false,
             "x-typia-tuple": {
               "type": "array",
               "items": [
                 {
-                  "type": "string",
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -738,12 +814,11 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
+                  "type": "string",
                   "minLength": 3,
                   "maxLength": 7
                 },
                 {
-                  "type": "number",
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -829,103 +904,11 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
+                  "type": "number",
                   "minimum": 3,
                   "maximum": 7
                 },
                 {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "nullable": false,
-                    "description": "",
-                    "x-typia-metaTags": [
-                      {
-                        "kind": "minItems",
-                        "value": 3
-                      },
-                      {
-                        "kind": "maxItems",
-                        "value": 7
-                      },
-                      {
-                        "kind": "minimum",
-                        "value": 3
-                      },
-                      {
-                        "kind": "maximum",
-                        "value": 7
-                      },
-                      {
-                        "kind": "minLength",
-                        "value": 3
-                      },
-                      {
-                        "kind": "maxLength",
-                        "value": 7
-                      }
-                    ],
-                    "x-typia-jsDocTags": [
-                      {
-                        "name": "minItems",
-                        "text": [
-                          {
-                            "text": "3",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "maxItems",
-                        "text": [
-                          {
-                            "text": "7",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "minimum",
-                        "text": [
-                          {
-                            "text": "3",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "maximum",
-                        "text": [
-                          {
-                            "text": "7",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "minLength",
-                        "text": [
-                          {
-                            "text": "3",
-                            "kind": "text"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "maxLength",
-                        "text": [
-                          {
-                            "text": "7",
-                            "kind": "text"
-                          }
-                        ]
-                      }
-                    ],
-                    "x-typia-required": true,
-                    "x-typia-optional": false,
-                    "minLength": 3,
-                    "maxLength": 7
-                  },
-                  "nullable": false,
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -1011,14 +994,8 @@
                   ],
                   "x-typia-required": true,
                   "x-typia-optional": false,
-                  "minItems": 3,
-                  "maxItems": 7
-                },
-                {
                   "type": "array",
                   "items": {
-                    "type": "number",
-                    "nullable": false,
                     "description": "",
                     "x-typia-metaTags": [
                       {
@@ -1104,11 +1081,14 @@
                     ],
                     "x-typia-required": true,
                     "x-typia-optional": false,
-                    "x-typia-rest": false,
-                    "minimum": 3,
-                    "maximum": 7
+                    "type": "string",
+                    "minLength": 3,
+                    "maxLength": 7
                   },
-                  "nullable": false,
+                  "minItems": 3,
+                  "maxItems": 7
+                },
+                {
                   "description": "",
                   "x-typia-metaTags": [
                     {
@@ -1195,11 +1175,102 @@
                   "x-typia-required": true,
                   "x-typia-optional": false,
                   "x-typia-rest": false,
+                  "type": "array",
+                  "items": {
+                    "description": "",
+                    "x-typia-metaTags": [
+                      {
+                        "kind": "minItems",
+                        "value": 3
+                      },
+                      {
+                        "kind": "maxItems",
+                        "value": 7
+                      },
+                      {
+                        "kind": "minimum",
+                        "value": 3
+                      },
+                      {
+                        "kind": "maximum",
+                        "value": 7
+                      },
+                      {
+                        "kind": "minLength",
+                        "value": 3
+                      },
+                      {
+                        "kind": "maxLength",
+                        "value": 7
+                      }
+                    ],
+                    "x-typia-jsDocTags": [
+                      {
+                        "name": "minItems",
+                        "text": [
+                          {
+                            "text": "3",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "maxItems",
+                        "text": [
+                          {
+                            "text": "7",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "minimum",
+                        "text": [
+                          {
+                            "text": "3",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "maximum",
+                        "text": [
+                          {
+                            "text": "7",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "minLength",
+                        "text": [
+                          {
+                            "text": "3",
+                            "kind": "text"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "maxLength",
+                        "text": [
+                          {
+                            "text": "7",
+                            "kind": "text"
+                          }
+                        ]
+                      }
+                    ],
+                    "x-typia-required": true,
+                    "x-typia-optional": false,
+                    "x-typia-rest": false,
+                    "type": "number",
+                    "minimum": 3,
+                    "maximum": 7
+                  },
                   "minItems": 3,
                   "maxItems": 7
                 }
               ],
-              "nullable": false,
               "description": "",
               "x-typia-metaTags": [
                 {
@@ -1286,91 +1357,6 @@
               "x-typia-required": true,
               "x-typia-optional": false
             },
-            "description": "",
-            "x-typia-metaTags": [
-              {
-                "kind": "minItems",
-                "value": 3
-              },
-              {
-                "kind": "maxItems",
-                "value": 7
-              },
-              {
-                "kind": "minimum",
-                "value": 3
-              },
-              {
-                "kind": "maximum",
-                "value": 7
-              },
-              {
-                "kind": "minLength",
-                "value": 3
-              },
-              {
-                "kind": "maxLength",
-                "value": 7
-              }
-            ],
-            "x-typia-jsDocTags": [
-              {
-                "name": "minItems",
-                "text": [
-                  {
-                    "text": "3",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "maxItems",
-                "text": [
-                  {
-                    "text": "7",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "minimum",
-                "text": [
-                  {
-                    "text": "3",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "maximum",
-                "text": [
-                  {
-                    "text": "7",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "minLength",
-                "text": [
-                  {
-                    "text": "3",
-                    "kind": "text"
-                  }
-                ]
-              },
-              {
-                "name": "maxLength",
-                "text": [
-                  {
-                    "text": "7",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ],
-            "x-typia-required": true,
-            "x-typia-optional": false,
             "minItems": 3,
             "maxItems": 7
           }

--- a/test/schemas/json/swagger/TagType.json
+++ b/test/schemas/json/swagger/TagType.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/TagType.Type"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,8 +13,6 @@
         "type": "object",
         "properties": {
           "int": {
-            "type": "integer",
-            "nullable": false,
             "description": "Integer value.",
             "x-typia-metaTags": [
               {
@@ -35,11 +32,10 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "integer"
           },
           "uint": {
-            "type": "integer",
-            "nullable": false,
             "description": "Unsigned integer value.",
             "x-typia-metaTags": [
               {
@@ -60,6 +56,7 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "type": "integer",
             "minimum": 0
           }
         },

--- a/test/schemas/json/swagger/TemplateAtomic.json
+++ b/test/schemas/json/swagger/TemplateAtomic.json
@@ -11,7 +11,6 @@
         "properties": {
           "prefix": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -19,7 +18,6 @@
           },
           "postfix": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -27,7 +25,6 @@
           },
           "middle_string": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -35,7 +32,6 @@
           },
           "middle_string_empty": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -43,26 +39,23 @@
           },
           "middle_numeric": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
             "pattern": "^(the_-?\\d+\\.?\\d*_value)$"
           },
           "middle_boolean": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "the_false_value",
               "the_true_value"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "ipv4": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -70,7 +63,6 @@
           },
           "email": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,

--- a/test/schemas/json/swagger/TemplateConstant.json
+++ b/test/schemas/json/swagger/TemplateConstant.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/TemplateConstant.Type"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,30 +13,31 @@
         "type": "object",
         "properties": {
           "prefix": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "prefix_A",
               "prefix_B",
               "prefix_C"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "postfix": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "2_postfix",
               "3_postfix",
               "1_postfix"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "combined": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "the_2_value_with_label_A",
@@ -49,11 +49,7 @@
               "the_1_value_with_label_A",
               "the_1_value_with_label_B",
               "the_1_value_with_label_C"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/TemplateUnion.json
+++ b/test/schemas/json/swagger/TemplateUnion.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/TemplateUnion.Type"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -15,7 +14,6 @@
         "properties": {
           "prefix": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -23,7 +21,6 @@
           },
           "postfix": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -31,7 +28,6 @@
           },
           "middle": {
             "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -41,25 +37,22 @@
             "oneOf": [
               {
                 "type": "string",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
                 "x-typia-optional": false,
                 "pattern": "^(the_A_value|the_B_value|-?\\d+\\.?\\d*|true|false|(the_-?\\d+\\.?\\d*_value))$"
               },
               {
-                "type": "number",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "number"
               },
               {
-                "type": "boolean",
-                "nullable": false,
                 "description": "",
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "type": "boolean"
               },
               {
                 "$ref": "#/components/schemas/__type",
@@ -86,11 +79,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ToJsonArray.json
+++ b/test/schemas/json/swagger/ToJsonArray.json
@@ -7,91 +7,75 @@
           {
             "type": "array",
             "items": {
-              "type": "boolean",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "boolean"
+            }
           },
           {
             "type": "array",
             "items": {
-              "type": "number",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "number"
+            }
           },
           {
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "string"
+            }
           },
           {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ToJsonArray.IObject"
-            },
-            "nullable": false
+            }
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "boolean",
-              "nullable": false,
               "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "boolean"
+            }
           },
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "number",
-              "nullable": false,
               "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "number"
+            }
           },
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false,
               "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "string"
+            }
           },
           {
+            "x-typia-rest": false,
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ToJsonArray.IObject",
               "x-typia-rest": false,
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
@@ -101,11 +85,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ToJsonAtomicSimple.json
+++ b/test/schemas/json/swagger/ToJsonAtomicSimple.json
@@ -5,44 +5,36 @@
       "items": {
         "oneOf": [
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
-            "type": "string",
-            "nullable": false
+            "type": "string"
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "string",
-            "nullable": false,
             "x-typia-rest": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],

--- a/test/schemas/json/swagger/ToJsonAtomicUnion.json
+++ b/test/schemas/json/swagger/ToJsonAtomicUnion.json
@@ -17,8 +17,7 @@
             "nullable": true
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {

--- a/test/schemas/json/swagger/ToJsonDouble.json
+++ b/test/schemas/json/swagger/ToJsonDouble.json
@@ -10,18 +10,16 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "flag": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ToJsonTuple.json
+++ b/test/schemas/json/swagger/ToJsonTuple.json
@@ -5,43 +5,36 @@
       "items": {
         "oneOf": [
           {
-            "type": "string",
-            "nullable": false
+            "type": "string"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
             "$ref": "#/components/schemas/ToJsonTuple.IHobby"
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "string",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
             "$ref": "#/components/schemas/ToJsonTuple.IHobby",
@@ -49,8 +42,7 @@
             "x-typia-required": true,
             "x-typia-optional": false
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
@@ -60,18 +52,16 @@
         "type": "object",
         "properties": {
           "code": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/ToJsonUnion.json
+++ b/test/schemas/json/swagger/ToJsonUnion.json
@@ -6,16 +6,13 @@
         "oneOf": [
           {},
           {
-            "type": "string",
-            "nullable": false
+            "type": "string"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
             "$ref": "#/components/schemas/ToJsonUnion.ICitizen"
@@ -24,8 +21,7 @@
             "$ref": "#/components/schemas/ToJsonUnion.IProduct"
           }
         ]
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -34,25 +30,22 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           "mobile": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -67,25 +60,22 @@
         "type": "object",
         "properties": {
           "manufacturer": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "brand": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/TupleHierarchical.json
+++ b/test/schemas/json/swagger/TupleHierarchical.json
@@ -14,15 +14,13 @@
           }
         ]
       },
-      "nullable": true,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
             "type": "null",
@@ -30,28 +28,27 @@
             "x-typia-optional": false
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
-              "type": "boolean",
-              "nullable": true,
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "type": "boolean",
+              "nullable": true
             },
-            "nullable": true,
             "x-typia-tuple": {
               "type": "array",
               "items": [
                 {
-                  "type": "boolean",
-                  "nullable": false,
                   "x-typia-required": true,
-                  "x-typia-optional": false
+                  "x-typia-optional": false,
+                  "type": "boolean"
                 },
                 {
                   "type": "null",
@@ -59,610 +56,530 @@
                   "x-typia-optional": false
                 },
                 {
+                  "x-typia-rest": false,
+                  "x-typia-required": true,
+                  "x-typia-optional": false,
                   "type": "array",
                   "items": {
-                    "type": "number",
-                    "nullable": false,
                     "x-typia-rest": false,
                     "x-typia-required": true,
-                    "x-typia-optional": false
+                    "x-typia-optional": false,
+                    "type": "number"
                   },
-                  "nullable": false,
                   "x-typia-tuple": {
                     "type": "array",
                     "items": [
                       {
-                        "type": "number",
-                        "nullable": false,
                         "x-typia-required": true,
-                        "x-typia-optional": false
+                        "x-typia-optional": false,
+                        "type": "number"
                       },
                       {
+                        "x-typia-rest": false,
+                        "x-typia-required": true,
+                        "x-typia-optional": false,
                         "type": "array",
                         "items": {
                           "oneOf": [
                             {
-                              "type": "boolean",
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
-                              "x-typia-optional": false
+                              "x-typia-optional": false,
+                              "type": "boolean"
                             },
                             {
-                              "type": "string",
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
-                              "x-typia-optional": false
+                              "x-typia-optional": false,
+                              "type": "string"
                             }
                           ],
                           "x-typia-rest": false,
                           "x-typia-required": true,
                           "x-typia-optional": false
                         },
-                        "nullable": false,
                         "x-typia-tuple": {
                           "type": "array",
                           "items": [
                             {
-                              "type": "boolean",
-                              "nullable": false,
                               "x-typia-required": true,
-                              "x-typia-optional": false
+                              "x-typia-optional": false,
+                              "type": "boolean"
                             },
                             {
-                              "type": "string",
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
-                              "x-typia-optional": false
+                              "x-typia-optional": false,
+                              "type": "string"
                             }
                           ],
-                          "nullable": false,
                           "x-typia-rest": false,
                           "x-typia-required": true,
                           "x-typia-optional": false
-                        },
-                        "x-typia-rest": false,
-                        "x-typia-required": true,
-                        "x-typia-optional": false
+                        }
                       }
                     ],
-                    "nullable": false,
                     "x-typia-rest": false,
                     "x-typia-required": true,
                     "x-typia-optional": false
-                  },
-                  "x-typia-rest": false,
-                  "x-typia-required": true,
-                  "x-typia-optional": false
+                  }
                 }
               ],
-              "nullable": false,
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           {
+            "x-typia-rest": false,
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
                 {
-                  "type": "number",
-                  "nullable": false,
                   "x-typia-rest": false,
                   "x-typia-required": true,
-                  "x-typia-optional": false
+                  "x-typia-optional": false,
+                  "type": "number"
                 },
                 {
+                  "x-typia-rest": false,
+                  "x-typia-required": true,
+                  "x-typia-optional": false,
                   "type": "array",
                   "items": {
+                    "x-typia-rest": false,
+                    "x-typia-required": true,
+                    "x-typia-optional": false,
                     "type": "array",
                     "items": {
                       "oneOf": [
                         {
-                          "type": "string",
-                          "nullable": false,
                           "x-typia-rest": false,
                           "x-typia-required": true,
-                          "x-typia-optional": false
+                          "x-typia-optional": false,
+                          "type": "string"
                         },
                         {
-                          "type": "boolean",
-                          "nullable": false,
                           "x-typia-rest": false,
                           "x-typia-required": true,
-                          "x-typia-optional": false
+                          "x-typia-optional": false,
+                          "type": "boolean"
                         },
                         {
+                          "x-typia-rest": false,
+                          "x-typia-required": true,
+                          "x-typia-optional": false,
                           "type": "array",
                           "items": {
+                            "x-typia-rest": false,
+                            "x-typia-required": true,
+                            "x-typia-optional": false,
                             "type": "array",
                             "items": {
-                              "type": "number",
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
-                              "x-typia-optional": false
+                              "x-typia-optional": false,
+                              "type": "number"
                             },
-                            "nullable": false,
                             "x-typia-tuple": {
                               "type": "array",
                               "items": [
                                 {
-                                  "type": "number",
-                                  "nullable": false,
                                   "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  "x-typia-optional": false,
+                                  "type": "number"
                                 },
                                 {
-                                  "type": "number",
-                                  "nullable": false,
                                   "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  "x-typia-optional": false,
+                                  "type": "number"
                                 },
                                 {
+                                  "x-typia-rest": false,
+                                  "x-typia-required": true,
+                                  "x-typia-optional": false,
                                   "type": "array",
                                   "items": {
                                     "oneOf": [
                                       {
-                                        "type": "boolean",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "boolean"
                                       },
                                       {
-                                        "type": "string",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "string"
                                       }
                                     ],
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false
                                   },
-                                  "nullable": false,
                                   "x-typia-tuple": {
                                     "type": "array",
                                     "items": [
                                       {
-                                        "type": "boolean",
-                                        "nullable": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "boolean"
                                       },
                                       {
-                                        "type": "string",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "string"
                                       }
                                     ],
-                                    "nullable": false,
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false
-                                  },
-                                  "x-typia-rest": false,
-                                  "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  }
                                 }
                               ],
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false
-                            },
-                            "x-typia-rest": false,
-                            "x-typia-required": true,
-                            "x-typia-optional": false
-                          },
-                          "nullable": false,
-                          "x-typia-rest": false,
-                          "x-typia-required": true,
-                          "x-typia-optional": false
+                            }
+                          }
                         }
                       ],
                       "x-typia-rest": false,
                       "x-typia-required": true,
                       "x-typia-optional": false
                     },
-                    "nullable": false,
                     "x-typia-tuple": {
                       "type": "array",
                       "items": [
                         {
-                          "type": "string",
-                          "nullable": false,
                           "x-typia-required": true,
-                          "x-typia-optional": false
+                          "x-typia-optional": false,
+                          "type": "string"
                         },
                         {
-                          "type": "boolean",
-                          "nullable": false,
                           "x-typia-required": true,
-                          "x-typia-optional": false
+                          "x-typia-optional": false,
+                          "type": "boolean"
                         },
                         {
+                          "x-typia-rest": false,
+                          "x-typia-required": true,
+                          "x-typia-optional": false,
                           "type": "array",
                           "items": {
+                            "x-typia-rest": false,
+                            "x-typia-required": true,
+                            "x-typia-optional": false,
                             "type": "array",
                             "items": {
-                              "type": "number",
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
-                              "x-typia-optional": false
+                              "x-typia-optional": false,
+                              "type": "number"
                             },
-                            "nullable": false,
                             "x-typia-tuple": {
                               "type": "array",
                               "items": [
                                 {
-                                  "type": "number",
-                                  "nullable": false,
                                   "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  "x-typia-optional": false,
+                                  "type": "number"
                                 },
                                 {
-                                  "type": "number",
-                                  "nullable": false,
                                   "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  "x-typia-optional": false,
+                                  "type": "number"
                                 },
                                 {
+                                  "x-typia-rest": false,
+                                  "x-typia-required": true,
+                                  "x-typia-optional": false,
                                   "type": "array",
                                   "items": {
                                     "oneOf": [
                                       {
-                                        "type": "boolean",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "boolean"
                                       },
                                       {
-                                        "type": "string",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "string"
                                       }
                                     ],
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false
                                   },
-                                  "nullable": false,
                                   "x-typia-tuple": {
                                     "type": "array",
                                     "items": [
                                       {
-                                        "type": "boolean",
-                                        "nullable": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "boolean"
                                       },
                                       {
-                                        "type": "string",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "string"
                                       }
                                     ],
-                                    "nullable": false,
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false
-                                  },
-                                  "x-typia-rest": false,
-                                  "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  }
                                 }
                               ],
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false
-                            },
-                            "x-typia-rest": false,
-                            "x-typia-required": true,
-                            "x-typia-optional": false
-                          },
-                          "nullable": false,
-                          "x-typia-rest": false,
-                          "x-typia-required": true,
-                          "x-typia-optional": false
+                            }
+                          }
                         }
                       ],
-                      "nullable": false,
                       "x-typia-rest": false,
                       "x-typia-required": true,
                       "x-typia-optional": false
-                    },
-                    "x-typia-rest": false,
-                    "x-typia-required": true,
-                    "x-typia-optional": false
-                  },
-                  "nullable": false,
-                  "x-typia-rest": false,
-                  "x-typia-required": true,
-                  "x-typia-optional": false
+                    }
+                  }
                 }
               ],
               "x-typia-rest": false,
               "x-typia-required": true,
               "x-typia-optional": false
             },
-            "nullable": false,
             "x-typia-tuple": {
               "type": "array",
               "items": [
                 {
-                  "type": "number",
-                  "nullable": false,
                   "x-typia-required": true,
-                  "x-typia-optional": false
+                  "x-typia-optional": false,
+                  "type": "number"
                 },
                 {
+                  "x-typia-rest": false,
+                  "x-typia-required": true,
+                  "x-typia-optional": false,
                   "type": "array",
                   "items": {
+                    "x-typia-rest": false,
+                    "x-typia-required": true,
+                    "x-typia-optional": false,
                     "type": "array",
                     "items": {
                       "oneOf": [
                         {
-                          "type": "string",
-                          "nullable": false,
                           "x-typia-rest": false,
                           "x-typia-required": true,
-                          "x-typia-optional": false
+                          "x-typia-optional": false,
+                          "type": "string"
                         },
                         {
-                          "type": "boolean",
-                          "nullable": false,
                           "x-typia-rest": false,
                           "x-typia-required": true,
-                          "x-typia-optional": false
+                          "x-typia-optional": false,
+                          "type": "boolean"
                         },
                         {
+                          "x-typia-rest": false,
+                          "x-typia-required": true,
+                          "x-typia-optional": false,
                           "type": "array",
                           "items": {
+                            "x-typia-rest": false,
+                            "x-typia-required": true,
+                            "x-typia-optional": false,
                             "type": "array",
                             "items": {
-                              "type": "number",
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
-                              "x-typia-optional": false
+                              "x-typia-optional": false,
+                              "type": "number"
                             },
-                            "nullable": false,
                             "x-typia-tuple": {
                               "type": "array",
                               "items": [
                                 {
-                                  "type": "number",
-                                  "nullable": false,
                                   "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  "x-typia-optional": false,
+                                  "type": "number"
                                 },
                                 {
-                                  "type": "number",
-                                  "nullable": false,
                                   "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  "x-typia-optional": false,
+                                  "type": "number"
                                 },
                                 {
+                                  "x-typia-rest": false,
+                                  "x-typia-required": true,
+                                  "x-typia-optional": false,
                                   "type": "array",
                                   "items": {
                                     "oneOf": [
                                       {
-                                        "type": "boolean",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "boolean"
                                       },
                                       {
-                                        "type": "string",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "string"
                                       }
                                     ],
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false
                                   },
-                                  "nullable": false,
                                   "x-typia-tuple": {
                                     "type": "array",
                                     "items": [
                                       {
-                                        "type": "boolean",
-                                        "nullable": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "boolean"
                                       },
                                       {
-                                        "type": "string",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "string"
                                       }
                                     ],
-                                    "nullable": false,
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false
-                                  },
-                                  "x-typia-rest": false,
-                                  "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  }
                                 }
                               ],
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false
-                            },
-                            "x-typia-rest": false,
-                            "x-typia-required": true,
-                            "x-typia-optional": false
-                          },
-                          "nullable": false,
-                          "x-typia-rest": false,
-                          "x-typia-required": true,
-                          "x-typia-optional": false
+                            }
+                          }
                         }
                       ],
                       "x-typia-rest": false,
                       "x-typia-required": true,
                       "x-typia-optional": false
                     },
-                    "nullable": false,
                     "x-typia-tuple": {
                       "type": "array",
                       "items": [
                         {
-                          "type": "string",
-                          "nullable": false,
                           "x-typia-required": true,
-                          "x-typia-optional": false
+                          "x-typia-optional": false,
+                          "type": "string"
                         },
                         {
-                          "type": "boolean",
-                          "nullable": false,
                           "x-typia-required": true,
-                          "x-typia-optional": false
+                          "x-typia-optional": false,
+                          "type": "boolean"
                         },
                         {
+                          "x-typia-rest": false,
+                          "x-typia-required": true,
+                          "x-typia-optional": false,
                           "type": "array",
                           "items": {
+                            "x-typia-rest": false,
+                            "x-typia-required": true,
+                            "x-typia-optional": false,
                             "type": "array",
                             "items": {
-                              "type": "number",
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
-                              "x-typia-optional": false
+                              "x-typia-optional": false,
+                              "type": "number"
                             },
-                            "nullable": false,
                             "x-typia-tuple": {
                               "type": "array",
                               "items": [
                                 {
-                                  "type": "number",
-                                  "nullable": false,
                                   "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  "x-typia-optional": false,
+                                  "type": "number"
                                 },
                                 {
-                                  "type": "number",
-                                  "nullable": false,
                                   "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  "x-typia-optional": false,
+                                  "type": "number"
                                 },
                                 {
+                                  "x-typia-rest": false,
+                                  "x-typia-required": true,
+                                  "x-typia-optional": false,
                                   "type": "array",
                                   "items": {
                                     "oneOf": [
                                       {
-                                        "type": "boolean",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "boolean"
                                       },
                                       {
-                                        "type": "string",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "string"
                                       }
                                     ],
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false
                                   },
-                                  "nullable": false,
                                   "x-typia-tuple": {
                                     "type": "array",
                                     "items": [
                                       {
-                                        "type": "boolean",
-                                        "nullable": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "boolean"
                                       },
                                       {
-                                        "type": "string",
-                                        "nullable": false,
                                         "x-typia-rest": false,
                                         "x-typia-required": true,
-                                        "x-typia-optional": false
+                                        "x-typia-optional": false,
+                                        "type": "string"
                                       }
                                     ],
-                                    "nullable": false,
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false
-                                  },
-                                  "x-typia-rest": false,
-                                  "x-typia-required": true,
-                                  "x-typia-optional": false
+                                  }
                                 }
                               ],
-                              "nullable": false,
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false
-                            },
-                            "x-typia-rest": false,
-                            "x-typia-required": true,
-                            "x-typia-optional": false
-                          },
-                          "nullable": false,
-                          "x-typia-rest": false,
-                          "x-typia-required": true,
-                          "x-typia-optional": false
+                            }
+                          }
                         }
                       ],
-                      "nullable": false,
                       "x-typia-rest": false,
                       "x-typia-required": true,
                       "x-typia-optional": false
-                    },
-                    "x-typia-rest": false,
-                    "x-typia-required": true,
-                    "x-typia-optional": false
-                  },
-                  "nullable": false,
-                  "x-typia-rest": false,
-                  "x-typia-required": true,
-                  "x-typia-optional": false
+                    }
+                  }
                 }
               ],
-              "nullable": false,
               "x-typia-rest": false,
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],

--- a/test/schemas/json/swagger/TupleRestArray.json
+++ b/test/schemas/json/swagger/TupleRestArray.json
@@ -5,59 +5,48 @@
       "items": {
         "oneOf": [
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
             "type": "array",
             "items": {
               "type": "array",
               "items": {
-                "type": "string",
-                "nullable": false
-              },
-              "nullable": false
-            },
-            "nullable": false
+                "type": "string"
+              }
+            }
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "x-typia-rest": true,
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "x-typia-rest": true,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-rest": true,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],

--- a/test/schemas/json/swagger/TupleRestAtomic.json
+++ b/test/schemas/json/swagger/TupleRestAtomic.json
@@ -5,48 +5,39 @@
       "items": {
         "oneOf": [
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false
-            },
-            "nullable": false
+              "type": "string"
+            }
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
-            "type": "string",
-            "nullable": false,
             "x-typia-rest": true,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],

--- a/test/schemas/json/swagger/TupleRestObject.json
+++ b/test/schemas/json/swagger/TupleRestObject.json
@@ -5,37 +5,31 @@
       "items": {
         "oneOf": [
           {
-            "type": "boolean",
-            "nullable": false
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false
+            "type": "number"
           },
           {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/TupleRestObject.IObject"
-            },
-            "nullable": false
+            }
           }
         ]
       },
-      "nullable": false,
       "x-typia-tuple": {
         "type": "array",
         "items": [
           {
-            "type": "boolean",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "boolean"
           },
           {
-            "type": "number",
-            "nullable": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           },
           {
             "$ref": "#/components/schemas/TupleRestObject.IObject",
@@ -43,8 +37,7 @@
             "x-typia-required": true,
             "x-typia-optional": false
           }
-        ],
-        "nullable": false
+        ]
       }
     }
   ],
@@ -54,11 +47,10 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger/UltimateUnion.json
+++ b/test/schemas/json/swagger/UltimateUnion.json
@@ -4,8 +4,7 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/IJsonApplication"
-      },
-      "nullable": false
+      }
     }
   ],
   "components": {
@@ -14,6 +13,9 @@
         "type": "object",
         "properties": {
           "schemas": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
@@ -105,11 +107,7 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "components": {
             "$ref": "#/components/schemas/IJsonComponents",
@@ -118,22 +116,32 @@
             "x-typia-optional": false
           },
           "purpose": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "swagger",
               "ajv"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "prefix": {
-            "type": "string",
-            "nullable": false,
+            "deprecated": true,
             "description": "",
+            "x-typia-jsDocTags": [
+              {
+                "name": "deprecated",
+                "text": [
+                  {
+                    "text": "Always \"#/components/schemas\"",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -149,65 +157,60 @@
         "type": "object",
         "properties": {
           "enum": {
-            "type": "array",
-            "items": {
-              "type": "boolean",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "boolean"
+            }
           },
           "default": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "boolean"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -305,52 +308,43 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
         "required": [
           "enum",
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
@@ -358,25 +352,23 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "type"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "int",
               "uint"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -390,21 +382,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "minimum"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -418,21 +408,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "maximum"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -446,21 +434,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "exclusiveMinimum"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -474,21 +460,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "exclusiveMaximum"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -502,21 +486,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "multipleOf"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -530,21 +512,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "step"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -558,16 +538,18 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "format"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "uuid",
@@ -577,11 +559,7 @@
               "ipv6",
               "date",
               "datetime"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           }
         },
         "nullable": false,
@@ -595,21 +573,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "pattern"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -623,21 +599,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "length"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -651,21 +625,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "minLength"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -679,21 +651,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "maxLength"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -707,21 +677,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "items"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -735,21 +703,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "minItems"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -763,21 +729,19 @@
         "type": "object",
         "properties": {
           "kind": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "maxItems"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "value": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "number"
           }
         },
         "nullable": false,
@@ -791,24 +755,22 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "text": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo.IText",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           }
         },
         "nullable": false,
@@ -821,18 +783,16 @@
         "type": "object",
         "properties": {
           "text": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "kind": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           }
         },
         "nullable": false,
@@ -846,65 +806,60 @@
         "type": "object",
         "properties": {
           "enum": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
           },
           "default": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "number"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -1002,52 +957,43 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
         "required": [
           "enum",
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
@@ -1055,65 +1001,60 @@
         "type": "object",
         "properties": {
           "enum": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "nullable": false,
-              "description": "",
-              "x-typia-required": true,
-              "x-typia-optional": false
-            },
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "description": "",
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
           },
           "default": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "string"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -1211,52 +1152,43 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
         "required": [
           "enum",
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
@@ -1264,51 +1196,48 @@
         "type": "object",
         "properties": {
           "default": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "boolean"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -1406,51 +1335,42 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
         "required": [
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
@@ -1458,8 +1378,6 @@
         "type": "object",
         "properties": {
           "minimum": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -1479,11 +1397,10 @@
               }
             ],
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "integer"
           },
           "maximum": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -1503,25 +1420,22 @@
               }
             ],
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "integer"
           },
           "exclusiveMinimum": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "exclusiveMaximum": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "multipleOf": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -1541,54 +1455,52 @@
               }
             ],
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "integer"
           },
           "default": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "integer"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -1686,51 +1598,42 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
         "required": [
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
@@ -1738,86 +1641,78 @@
         "type": "object",
         "properties": {
           "minimum": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "maximum": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "exclusiveMinimum": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "exclusiveMaximum": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "multipleOf": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "default": {
-            "type": "number",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "number"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "number"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -1915,51 +1810,42 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
         "required": [
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
@@ -1967,8 +1853,6 @@
         "type": "object",
         "properties": {
           "minLength": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -1989,11 +1873,10 @@
             ],
             "x-typia-required": false,
             "x-typia-optional": true,
+            "type": "integer",
             "minimum": 0
           },
           "maxLength": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -2014,68 +1897,64 @@
             ],
             "x-typia-required": false,
             "x-typia-optional": true,
+            "type": "integer",
             "minimum": 0
           },
           "pattern": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "format": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "default": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "string"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -2173,51 +2052,42 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
         "required": [
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
@@ -2316,8 +2186,6 @@
             "x-typia-optional": false
           },
           "minItems": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -2338,11 +2206,10 @@
             ],
             "x-typia-required": false,
             "x-typia-optional": true,
+            "type": "integer",
             "minimum": 0
           },
           "maxItems": {
-            "type": "integer",
-            "nullable": false,
             "description": "",
             "x-typia-metaTags": [
               {
@@ -2363,6 +2230,7 @@
             ],
             "x-typia-required": false,
             "x-typia-optional": true,
+            "type": "integer",
             "minimum": 0
           },
           "x-typia-tuple": {
@@ -2372,44 +2240,42 @@
             "x-typia-optional": true
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "array"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -2507,52 +2373,43 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
         "required": [
           "items",
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
@@ -2560,6 +2417,9 @@
         "type": "object",
         "properties": {
           "items": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
@@ -2651,51 +2511,45 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "array"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -2793,52 +2647,43 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
         "required": [
           "items",
-          "type",
-          "nullable"
+          "type"
         ],
         "x-typia-jsDocTags": []
       },
@@ -2846,6 +2691,9 @@
         "type": "object",
         "properties": {
           "oneOf": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "array",
             "items": {
               "oneOf": [
@@ -2937,34 +2785,30 @@
               "description": "",
               "x-typia-required": true,
               "x-typia-optional": false
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            }
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -3062,45 +2906,37 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
@@ -3113,34 +2949,33 @@
         "type": "object",
         "properties": {
           "$ref": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -3238,45 +3073,37 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
@@ -3289,34 +3116,33 @@
         "type": "object",
         "properties": {
           "$recursiveRef": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "type": "string"
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -3414,45 +3240,37 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
@@ -3465,37 +3283,36 @@
         "type": "object",
         "properties": {
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "null"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -3593,45 +3410,37 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
@@ -3644,27 +3453,27 @@
         "type": "object",
         "properties": {
           "deprecated": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-metaTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "oneOf": [
@@ -3762,45 +3571,37 @@
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-required": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-optional": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "x-typia-rest": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           }
         },
         "nullable": false,
@@ -3844,35 +3645,31 @@
         "type": "object",
         "properties": {
           "$id": {
-            "type": "string",
-            "nullable": false,
-            "description": "",
+            "description": "Used only when ajv mode.",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "$recursiveAnchor": {
-            "type": "boolean",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "type": {
+            "description": "",
+            "x-typia-required": true,
+            "x-typia-optional": false,
             "type": "string",
             "enum": [
               "object"
-            ],
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            ]
           },
           "nullable": {
-            "type": "boolean",
-            "nullable": false,
-            "description": "",
-            "x-typia-required": true,
-            "x-typia-optional": false
+            "description": "Only when swagger mode.",
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "boolean"
           },
           "properties": {
             "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
@@ -3978,38 +3775,34 @@
             "x-typia-optional": true
           },
           "required": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
-              "type": "string",
-              "nullable": false,
               "description": "",
               "x-typia-required": false,
-              "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+              "x-typia-optional": true,
+              "type": "string"
+            }
           },
           "description": {
-            "type": "string",
-            "nullable": false,
             "description": "",
             "x-typia-required": false,
-            "x-typia-optional": true
+            "x-typia-optional": true,
+            "type": "string"
           },
           "x-typia-jsDocTags": {
+            "description": "",
+            "x-typia-required": false,
+            "x-typia-optional": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IJsDocTagInfo",
               "description": "",
               "x-typia-required": false,
               "x-typia-optional": true
-            },
-            "nullable": false,
-            "description": "",
-            "x-typia-required": false,
-            "x-typia-optional": true
+            }
           },
           "x-typia-patternProperties": {
             "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
@@ -4112,7 +3905,6 @@
         "nullable": false,
         "required": [
           "type",
-          "nullable",
           "properties"
         ],
         "x-typia-jsDocTags": []

--- a/website/pages/docs/json/schema.mdx
+++ b/website/pages/docs/json/schema.mdx
@@ -14,9 +14,6 @@ import AlertTitle from '@mui/material/AlertTitle';
 export function application<
     Schemas extends unknown[],
     Purpose extends "ajv" | "swagger",
-    Prefix extends string = Purpose extends "ajv"
-        ? "components#/schemas"
-        : "#/components/schemas",
 >(): IJsonApplication;
 ```
     </Tab>
@@ -26,7 +23,6 @@ export interface IJsonApplication {
     schemas: IJsonSchema[];
     components: IJsonComponents;
     purpose: "swagger" | "ajv";
-    prefix: string;
 }
 ```
     </Tab>
@@ -258,7 +254,6 @@ export const MemberSchema = {
         },
     },
     purpose: "ajv",
-    prefix: "components#/schemas",
 };
 ```
     </Tab>
@@ -427,7 +422,6 @@ export const CommentTagSchema = {
         },
     },
     purpose: "ajv",
-    prefix: "components#/schemas",
 };
 ```
     </Tab>

--- a/website/public/sitemap-0.xml
+++ b/website/public/sitemap-0.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://typia.io/</loc><lastmod>2023-05-10T07:57:38.908Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-05-10T07:57:38.909Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/</loc><lastmod>2023-05-11T10:42:24.345Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/</loc><lastmod>2023-05-11T10:42:24.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-05-11T10:42:24.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-05-11T10:42:24.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-05-11T10:42:24.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-05-11T10:42:24.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-05-11T10:42:24.347Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-05-11T10:42:24.347Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-05-11T10:42:24.347Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-05-11T10:42:24.347Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-05-11T10:42:24.347Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-05-11T10:42:24.347Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-05-11T10:42:24.347Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-05-11T10:42:24.347Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-05-11T10:42:24.347Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
Until previous, `typia` had utilized `nullable` property instead of using union `null` type, because `swagger` (`openapi`) had not supported it. However, since `openapi@3.1` update, it would start supporting the union `null` type. It is not formally supported by Swagger Editor (https://editor.swagger.io), but maybe coming soon.

Therefore, use union typed `null` value first at AJV mode's JSON schema first. About the Swagger mode, I'll support it when `openapi@3.1` be uploaded to the Swagger Editor. Also, remove prefix customization feature, and just assign the fixed value `#/components/schemas`.

### AJV Mode
```json
{
    "oneOf": {
        { "type": "null" },
        { "type": "string" },
        { "$ref": "#/components/schemas/SomeObject" }
    }
}
```

### Swagger Mode
```json
{
    "oneOf": [
        { "type": "string", "nullable": true },
        { "$ref": "$ref": "#/components/schemas/ObjectSomething.Nullable" },
    ]
}
```