### PR TITLE
Fix typo in assert.mdx

### DIFF
--- a/website/pages/docs/validators/assert.mdx
+++ b/website/pages/docs/validators/assert.mdx
@@ -207,7 +207,7 @@ More strict assert function prohibiting superfluous properties.
 
 In the below example case, as `sex` property is not defined in the `IMember` type, such `TypeGuardError` would be thrown:
 
-  - `method: `typia.assertEquals()`
+  - `method`: `typia.assertEquals()`
   - `path`: `input.sex`
   - `value`: `1`,
   ` expected`: `undefined`


### PR DESCRIPTION
Missing grave accent in `assertEquals()` section.

![image](https://github.com/samchon/typia/assets/8156542/81e205be-e113-4796-ba9f-78d80b59a851)

