### PR TITLE
Support JsDoc `type` tag like `@type {int}`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "3.9.0-dev.20230604",
+  "version": "3.9.0-dev.20230604-2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "3.9.0-dev.20230604",
+  "version": "3.9.0-dev.20230604-2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "3.9.0-dev.20230604"
+    "typia": "3.9.0-dev.20230604-2"
   },
   "peerDependencies": {
     "typescript": ">= 4.5.2"

--- a/src/factories/MetadataTagFactory.ts
+++ b/src/factories/MetadataTagFactory.ts
@@ -87,6 +87,8 @@ export namespace MetadataTagFactory {
             return has_atomic(metadata)("number") &&
                 (text === "int" || text === "uint")
                 ? { kind: "type", value: text }
+                : text === "{int}" || text === "{uint}"
+                ? { kind: "type", value: text.slice(1, -1) as "int" | "uint" }
                 : null;
         },
         minimum: (identifier, metadata, text, output) => {

--- a/src/programmers/internal/application_number.ts
+++ b/src/programmers/internal/application_number.ts
@@ -15,7 +15,10 @@ export const application_number = (
         // CHECK TYPE
         if (
             tag.kind === "type" &&
-            (tag.value === "int" || tag.value === "uint")
+            (tag.value === "int" ||
+                tag.value === "uint" ||
+                tag.value === "{int}" ||
+                tag.value === "{uint}")
         )
             output.type = "integer";
         // RANGE TAG

--- a/test/issues/tag.ts
+++ b/test/issues/tag.ts
@@ -1,0 +1,36 @@
+import typia from "typia";
+
+interface Something {
+    /**
+     * @type {int}
+     */
+    int: number;
+
+    /**
+     * @type {uint}
+     */
+    uint: number;
+}
+
+// console.log(
+//     typia
+//         .metadata<[Something]>()
+//         .collection.objects[0].properties.map((p) =>
+//             JSON.stringify([p.tags, p.jsDocTags], null, 4),
+//         ),
+// );
+
+const props = Object.values(
+    typia.application<[Something]>().components.objects?.Something?.properties!,
+);
+console.log(
+    JSON.stringify(
+        props.map((p) => [
+            (p as any).type,
+            p["x-typia-metaTags"],
+            p["x-typia-jsDocTags"],
+        ]),
+        null,
+        4,
+    ),
+);


### PR DESCRIPTION
Support both styles:

```typescript
interface Something {
    /**
     * Standard tyle
     *
     * @type int
     */
    int: number;

    /**
     * JsDoc type tag style
     *
     * @type {uint}
     */
    uint: number;
}
```