### PR TITLE
Fix #639 - `Required<T>` problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.0.3",
+  "version": "4.0.3-dev.20230606",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.0.3-dev.20230605",
+  "version": "4.0.3-dev.20230606",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.0.3-dev.20230605"
+    "typia": "4.0.3-dev.20230606"
   },
   "peerDependencies": {
     "typescript": ">= 4.5.2"

--- a/src/Primitive.ts
+++ b/src/Primitive.ts
@@ -58,7 +58,9 @@ type PrimitiveObject<Instance extends object> = Instance extends Array<infer T>
               : PrimitiveMain<Instance[P]>;
       };
 
-type PrimitiveTuple<T extends readonly any[]> = T extends [infer F]
+type PrimitiveTuple<T extends readonly any[]> = T extends []
+    ? []
+    : T extends [infer F]
     ? [PrimitiveMain<F>]
     : T extends [infer F, ...infer Rest extends readonly any[]]
     ? [PrimitiveMain<F>, ...PrimitiveTuple<Rest>]

--- a/src/factories/internal/metadata/emplace_metadata_object.ts
+++ b/src/factories/internal/metadata/emplace_metadata_object.ts
@@ -106,11 +106,9 @@ export const emplace_metadata_object =
                 collection,
             )(type, false);
 
-            // INSERT WITH REQUIRED CONFIGURATION
-            if (node?.questionToken) {
-                Writable(value).required = false;
+            // OPTIONAL, BUT CAN BE RQUIRED BY `Required<T>` TYPE
+            if (node?.questionToken && (value.required === false || value.any))
                 Writable(value).optional = true;
-            }
             insert(key)(value)(() => `${obj.name}.${prop.name}`)(prop);
         }
 

--- a/src/factories/internal/metadata/emplace_metadata_tuple.ts
+++ b/src/factories/internal/metadata/emplace_metadata_tuple.ts
@@ -35,7 +35,10 @@ export const emplace_metadata_tuple =
 
                 // CHECK OPTIONAL
                 const flag: ts.ElementFlags | undefined = flagList[i];
-                if (flag === ts.ElementFlags.Optional)
+                if (
+                    flag === ts.ElementFlags.Optional &&
+                    (child.required === false || child.any === true)
+                )
                     Writable(child).optional = true;
 
                 // REST TYPE

--- a/test/generated/output/createRandom/test_createRandom_TupleUnion.ts
+++ b/test/generated/output/createRandom/test_createRandom_TupleUnion.ts
@@ -59,10 +59,8 @@ export const test_createRandom_TupleUnion = _test_random(
                             Number.isFinite(entire[1]),
                     ],
                     [
-                        (top: any[]): any =>
-                            0 <= top.length && 1 >= top.length && true,
-                        (entire: any[]): any =>
-                            0 <= entire.length && 1 >= entire.length && true,
+                        (top: any[]): any => top.length === 0,
+                        (entire: any[]): any => entire.length === 0,
                     ],
                 ];
                 for (const pred of tuplePredicators)
@@ -152,16 +150,14 @@ export const test_createRandom_TupleUnion = _test_random(
                                     })),
                         ],
                         [
-                            (top: any[]): any =>
-                                0 <= top.length && 1 >= top.length && true,
+                            (top: any[]): any => top.length === 0,
                             (entire: any[]): any =>
-                                ((0 <= entire.length && 1 >= entire.length) ||
-                                    $guard(_exceptionable, {
-                                        path: _path,
-                                        expected: "[any]",
-                                        value: entire,
-                                    })) &&
-                                true,
+                                entire.length === 0 ||
+                                $guard(_exceptionable, {
+                                    path: _path,
+                                    expected: "[]",
+                                    value: entire,
+                                }),
                         ],
                     ];
                     for (const pred of tuplePredicators)
@@ -169,7 +165,7 @@ export const test_createRandom_TupleUnion = _test_random(
                     return $guard(_exceptionable, {
                         path: _path,
                         expected:
-                            "([number, string, boolean] | [boolean, number] | [unknown?])",
+                            "([number, string, boolean] | [boolean, number] | [])",
                         value: input,
                     });
                 };
@@ -177,8 +173,7 @@ export const test_createRandom_TupleUnion = _test_random(
                     ((Array.isArray(input) ||
                         $guard(true, {
                             path: _path + "",
-                            expected:
-                                "Array<[boolean, number] | [number, string, boolean] | [unknown?]>",
+                            expected: "TupleUnion",
                             value: input,
                         })) &&
                         input.every(
@@ -187,7 +182,7 @@ export const test_createRandom_TupleUnion = _test_random(
                                     $guard(true, {
                                         path: _path + "[" + _index1 + "]",
                                         expected:
-                                            "([boolean, number] | [number, string, boolean] | [unknown?])",
+                                            "([] | [boolean, number] | [number, string, boolean])",
                                         value: elem,
                                     })) &&
                                     ($ap0(
@@ -198,20 +193,19 @@ export const test_createRandom_TupleUnion = _test_random(
                                         $guard(_exceptionable, {
                                             path: _path + "[" + _index1 + "]",
                                             expected:
-                                                "[number, string, boolean] | [boolean, number] | [unknown?]",
+                                                "[number, string, boolean] | [boolean, number] | []",
                                             value: elem,
                                         }))) ||
                                 $guard(true, {
                                     path: _path + "[" + _index1 + "]",
                                     expected:
-                                        "([boolean, number] | [number, string, boolean] | [unknown?])",
+                                        "([] | [boolean, number] | [number, string, boolean])",
                                     value: elem,
                                 }),
                         )) ||
                     $guard(true, {
                         path: _path + "",
-                        expected:
-                            "Array<[boolean, number] | [number, string, boolean] | [unknown?]>",
+                        expected: "TupleUnion",
                         value: input,
                     })
                 );

--- a/test/generated/output/random/test_random_TupleUnion.ts
+++ b/test/generated/output/random/test_random_TupleUnion.ts
@@ -63,10 +63,8 @@ export const test_random_TupleUnion = _test_random(
                             Number.isFinite(entire[1]),
                     ],
                     [
-                        (top: any[]): any =>
-                            0 <= top.length && 1 >= top.length && true,
-                        (entire: any[]): any =>
-                            0 <= entire.length && 1 >= entire.length && true,
+                        (top: any[]): any => top.length === 0,
+                        (entire: any[]): any => entire.length === 0,
                     ],
                 ];
                 for (const pred of tuplePredicators)
@@ -156,16 +154,14 @@ export const test_random_TupleUnion = _test_random(
                                     })),
                         ],
                         [
-                            (top: any[]): any =>
-                                0 <= top.length && 1 >= top.length && true,
+                            (top: any[]): any => top.length === 0,
                             (entire: any[]): any =>
-                                ((0 <= entire.length && 1 >= entire.length) ||
-                                    $guard(_exceptionable, {
-                                        path: _path,
-                                        expected: "[any]",
-                                        value: entire,
-                                    })) &&
-                                true,
+                                entire.length === 0 ||
+                                $guard(_exceptionable, {
+                                    path: _path,
+                                    expected: "[]",
+                                    value: entire,
+                                }),
                         ],
                     ];
                     for (const pred of tuplePredicators)
@@ -173,7 +169,7 @@ export const test_random_TupleUnion = _test_random(
                     return $guard(_exceptionable, {
                         path: _path,
                         expected:
-                            "([number, string, boolean] | [boolean, number] | [unknown?])",
+                            "([number, string, boolean] | [boolean, number] | [])",
                         value: input,
                     });
                 };
@@ -181,8 +177,7 @@ export const test_random_TupleUnion = _test_random(
                     ((Array.isArray(input) ||
                         $guard(true, {
                             path: _path + "",
-                            expected:
-                                "Array<[boolean, number] | [number, string, boolean] | [unknown?]>",
+                            expected: "TupleUnion",
                             value: input,
                         })) &&
                         input.every(
@@ -191,7 +186,7 @@ export const test_random_TupleUnion = _test_random(
                                     $guard(true, {
                                         path: _path + "[" + _index1 + "]",
                                         expected:
-                                            "([boolean, number] | [number, string, boolean] | [unknown?])",
+                                            "([] | [boolean, number] | [number, string, boolean])",
                                         value: elem,
                                     })) &&
                                     ($ap0(
@@ -202,20 +197,19 @@ export const test_random_TupleUnion = _test_random(
                                         $guard(_exceptionable, {
                                             path: _path + "[" + _index1 + "]",
                                             expected:
-                                                "[number, string, boolean] | [boolean, number] | [unknown?]",
+                                                "[number, string, boolean] | [boolean, number] | []",
                                             value: elem,
                                         }))) ||
                                 $guard(true, {
                                     path: _path + "[" + _index1 + "]",
                                     expected:
-                                        "([boolean, number] | [number, string, boolean] | [unknown?])",
+                                        "([] | [boolean, number] | [number, string, boolean])",
                                     value: elem,
                                 }),
                         )) ||
                     $guard(true, {
                         path: _path + "",
-                        expected:
-                            "Array<[boolean, number] | [number, string, boolean] | [unknown?]>",
+                        expected: "TupleUnion",
                         value: input,
                     })
                 );

--- a/test/issues/639-2.ts
+++ b/test/issues/639-2.ts
@@ -1,0 +1,12 @@
+import fs from "fs";
+import typia from "typia";
+
+import { TupleUnion } from "../structures/TupleUnion";
+
+type Tuple = [number, boolean, string?, string?];
+console.log(typia.createIs<Tuple>().toString());
+console.log(typia.createIs<Required<Tuple>>().toString());
+console.log(typia.createIs<[unknown?]>().toString());
+
+const factory = typia.createValidate<typia.Primitive<TupleUnion>>();
+fs.writeFileSync(__dirname + "/639-2.out.js", factory.toString(), "utf8");

--- a/test/issues/639.ts
+++ b/test/issues/639.ts
@@ -4,7 +4,7 @@ type MaybeTwoStrings = {
     primary: string;
     secondary?: string;
 };
-type DefinitelyTwoStrings = Required<MaybeTwoStrings>;
+type DefinitelyTwoStrings = MaybeTwoStrings;
 console.log(
     JSON.stringify(typia.application<[DefinitelyTwoStrings]>(), null, 4),
 );


### PR DESCRIPTION
When user uses `Required<T>` type for question token addicted object or tuple type, TypeScript compiler can identify that every properties are required, but cannot change `ts.PropertyDeclaration.questionToken` value by itself.

Therefore, I did it by myself to fix the problem.