### PR TITLE
Enforce `strictNullChecks` to be true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.0.3"
+    "typia": "4.0.4"
   },
   "peerDependencies": {
     "typescript": ">= 4.5.2"

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.0.4"
+    "typia": "4.0.5"
   },
   "peerDependencies": {
     "typescript": ">= 4.5.2"

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -6,12 +6,23 @@ import { ITransformOptions } from "./transformers/ITransformOptions";
 export const transform = (
     program: ts.Program,
     options?: ITransformOptions,
-): ts.TransformerFactory<ts.SourceFile> =>
-    FileTransformer.transform({
+): ts.TransformerFactory<ts.SourceFile> => {
+    const compilerOptions: ts.CompilerOptions = program.getCompilerOptions();
+    const strict: boolean =
+        compilerOptions.strictNullChecks !== undefined
+            ? !!compilerOptions.strictNullChecks
+            : !!compilerOptions.strict;
+    if (strict === false)
+        throw new Error(
+            `Error on "tsconfig.json": typia requires \`compilerOptions.strictNullChecks\` to be true.`,
+        );
+
+    return FileTransformer.transform({
         program,
         compilerOptions: program.getCompilerOptions(),
         checker: program.getTypeChecker(),
         printer: ts.createPrinter(),
         options: options || {},
     });
+};
 export default transform;

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -16,10 +16,9 @@ export const transform = (
         throw new Error(
             `Error on "tsconfig.json": typia requires \`compilerOptions.strictNullChecks\` to be true.`,
         );
-
     return FileTransformer.transform({
         program,
-        compilerOptions: program.getCompilerOptions(),
+        compilerOptions,
         checker: program.getTypeChecker(),
         printer: ts.createPrinter(),
         options: options || {},


### PR DESCRIPTION
Too many `typia` users are confusing by legacy projects that had configured `strictNullChecks: false`, and mis-report to my repo saying "typia seems broken".

I think it would better to entirely prohibit `strictNullChecks: false` option in compliation level. Therefore, since v4.0.4 update, `strictNullChecks: false` would be compilation error in every typia utilizing projects.