### PR TITLE
Fix #654 - support intersection type with `atomic & object`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.0.5",
+  "version": "4.0.6-dev.20230611",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.0.5",
+  "version": "4.0.6-dev.20230611",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.0.5"
+    "typia": "4.0.6-dev.20230611"
   },
   "peerDependencies": {
     "typescript": ">= 4.5.2"

--- a/src/Primitive.ts
+++ b/src/Primitive.ts
@@ -34,7 +34,13 @@ export type Primitive<T> = Equal<T, PrimitiveMain<T>> extends true
 
 type Equal<X, Y> = X extends Y ? (Y extends X ? true : false) : false;
 
-type PrimitiveMain<Instance> = ValueOf<Instance> extends object
+type PrimitiveMain<Instance> = ValueOf<Instance> extends
+    | boolean
+    | number
+    | bigint
+    | string
+    ? ValueOf<Instance>
+    : ValueOf<Instance> extends object
     ? Instance extends object
         ? Instance extends NativeClass
             ? {}

--- a/src/factories/internal/metadata/iterate_metadata.ts
+++ b/src/factories/internal/metadata/iterate_metadata.ts
@@ -10,6 +10,7 @@ import { iterate_metadata_atomic } from "./iterate_metadata_atomic";
 import { iterate_metadata_coalesce } from "./iterate_metadata_coalesce";
 import { iterate_metadata_constant } from "./iterate_metadata_constant";
 import { iterate_metadata_definition } from "./iterate_metadata_definition";
+import { iterate_metadata_intersection } from "./iterate_metadata_intersection";
 import { iterate_metadata_map } from "./iterate_metadata_map";
 import { iterate_metadata_native } from "./iterate_metadata_native";
 import { iterate_metadata_object } from "./iterate_metadata_object";
@@ -40,6 +41,12 @@ export const iterate_metadata =
                     meta,
                     type,
                 )) ||
+            iterate_metadata_intersection(checker)(options)(collection)(
+                meta,
+                type,
+                parentResolved,
+                aliased,
+            ) ||
             iterate_metadata_union(checker)(options)(collection)(
                 meta,
                 type,

--- a/src/factories/internal/metadata/iterate_metadata_intersection.ts
+++ b/src/factories/internal/metadata/iterate_metadata_intersection.ts
@@ -1,0 +1,86 @@
+import ts from "typescript";
+
+import { Metadata } from "../../../metadata/Metadata";
+
+import { MetadataCollection } from "../../MetadataCollection";
+import { MetadataFactory } from "../../MetadataFactory";
+import { explore_metadata } from "./explore_metadata";
+import { iterate_metadata } from "./iterate_metadata";
+import { iterate_metadata_object } from "./iterate_metadata_object";
+
+export const iterate_metadata_intersection =
+    (checker: ts.TypeChecker) =>
+    (options: MetadataFactory.IOptions) =>
+    (collection: MetadataCollection) =>
+    (
+        meta: Metadata,
+        type: ts.Type,
+        resolved: boolean,
+        aliased: boolean,
+    ): boolean => {
+        if (!type.isIntersection()) return false;
+
+        // COSTRUCT FAKE METADATA LIST
+        const fakeCollection: MetadataCollection = new MetadataCollection();
+        const children: Metadata[] = [
+            ...new Map(
+                type.types.map((t) => {
+                    const m: Metadata = explore_metadata(checker)(options)(
+                        fakeCollection,
+                    )(t, resolved);
+                    return [m.getName(), m] as const;
+                }),
+            ).values(),
+        ];
+
+        // ONLY ONE CHILD AFTER REMOVING DUPLICATES
+        if (children.length === 1) {
+            iterate_metadata(checker)(options)(collection)(
+                meta,
+                type.types[0]!,
+                resolved,
+                aliased,
+            );
+            return true;
+        }
+
+        // ONLY OBJECT TYPES -> MERGE
+        const object: boolean = children.every(
+            (c) => c.objects.length && c.objects.length === c.size(),
+        );
+        if (object)
+            return iterate_metadata_object(checker)(options)(collection)(
+                meta,
+                type,
+                resolved,
+                true,
+            );
+
+        // ABSORB TO ATOMIC (OR CONSTANT) TYPE
+        const atomics: Metadata[] = children.filter(
+            (c) =>
+                (c.atomics.length ? 1 : 0 + c.constants.length ? 1 : 0) ===
+                c.bucket(),
+        );
+        const objects: Metadata[] = children.filter(
+            (c) => c.objects.length && c.objects.length === c.size(),
+        );
+        if (
+            atomics.length === 0 ||
+            atomics.length + objects.length !== children.length
+        )
+            throw new Error(message(children));
+
+        const least: Metadata = atomics.reduce((x, y) => {
+            if (Metadata.covers(x, y)) return y;
+            else if (Metadata.covers(y, x)) return x;
+            throw new Error(message(children));
+        });
+        Object.assign(meta, Metadata.merge(meta, least));
+        return true;
+    };
+
+const message = (children: Metadata[]) =>
+    `Error on typia.MetadataFactory.analyze(): nonsensibl intersection type detected - ${children
+        .map((c) => c.getName())
+        .join(" & ")}.`;

--- a/src/metadata/Metadata.ts
+++ b/src/metadata/Metadata.ts
@@ -449,6 +449,7 @@ export namespace Metadata {
 
         // CONSTANTS
         for (const yc of y.constants) {
+            if (x.atomics.some((type) => yc.type === type)) continue;
             const xc: MetadataConstant | undefined = x.constants.find(
                 (elem) => elem.type === yc.type,
             );

--- a/test/features/application/ajv/test_application_ajv_AtomicIntersection.ts
+++ b/test/features/application/ajv/test_application_ajv_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_application } from "../../../internal/_test_application";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_application_ajv_AtomicIntersection = _test_application("ajv")(
+    "AtomicIntersection",
+    typia.application<[AtomicIntersection], "ajv">(),
+);

--- a/test/features/application/ajv/test_application_ajv_ConstantIntersection.ts
+++ b/test/features/application/ajv/test_application_ajv_ConstantIntersection.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+import { _test_application } from "../../../internal/_test_application";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_application_ajv_ConstantIntersection = _test_application(
+    "ajv",
+)("ConstantIntersection", typia.application<[ConstantIntersection], "ajv">());

--- a/test/features/application/swagger/test_application_swagger_AtomicIntersection.ts
+++ b/test/features/application/swagger/test_application_swagger_AtomicIntersection.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+import { _test_application } from "../../../internal/_test_application";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_application_swagger_AtomicIntersection = _test_application(
+    "swagger",
+)("AtomicIntersection", typia.application<[AtomicIntersection], "swagger">());

--- a/test/features/application/swagger/test_application_swagger_ConstantIntersection.ts
+++ b/test/features/application/swagger/test_application_swagger_ConstantIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "typia";
+
+import { _test_application } from "../../../internal/_test_application";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_application_swagger_ConstantIntersection = _test_application(
+    "swagger",
+)(
+    "ConstantIntersection",
+    typia.application<[ConstantIntersection], "swagger">(),
+);

--- a/test/features/assert/test_assert_AtomicIntersection.ts
+++ b/test/features/assert/test_assert_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_assert_AtomicIntersection = _test_assert(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.assert(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/assert/test_assert_ConstantIntersection.ts
+++ b/test/features/assert/test_assert_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_assert_ConstantIntersection = _test_assert(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.assert(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/assertClone/test_assertClone_AtomicIntersection.ts
+++ b/test/features/assertClone/test_assertClone_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertClone } from "../../internal/_test_assertClone";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_assertClone_AtomicIntersection = _test_assertClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.assertClone(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/assertClone/test_assertClone_ConstantIntersection.ts
+++ b/test/features/assertClone/test_assertClone_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertClone } from "../../internal/_test_assertClone";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_assertClone_ConstantIntersection = _test_assertClone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.assertClone(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/assertEquals/test_assertEquals_AtomicIntersection.ts
+++ b/test/features/assertEquals/test_assertEquals_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_assertEquals_AtomicIntersection = _test_assertEquals(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.assertEquals(input),
+);

--- a/test/features/assertEquals/test_assertEquals_ConstantIntersection.ts
+++ b/test/features/assertEquals/test_assertEquals_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_assertEquals_ConstantIntersection = _test_assertEquals(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.assertEquals(input),
+);

--- a/test/features/assertParse/test_assertParse_AtomicIntersection.ts
+++ b/test/features/assertParse/test_assertParse_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertParse } from "../../internal/_test_assertParse";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_assertParse_AtomicIntersection = _test_assertParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.assertParse<AtomicIntersection>(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/assertParse/test_assertParse_ConstantIntersection.ts
+++ b/test/features/assertParse/test_assertParse_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertParse } from "../../internal/_test_assertParse";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_assertParse_ConstantIntersection = _test_assertParse(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.assertParse<ConstantIntersection>(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/assertPrune/test_assertPrune_AtomicIntersection.ts
+++ b/test/features/assertPrune/test_assertPrune_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertPrune } from "../../internal/_test_assertPrune";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_assertPrune_AtomicIntersection = _test_assertPrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.assertPrune(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/assertPrune/test_assertPrune_ConstantIntersection.ts
+++ b/test/features/assertPrune/test_assertPrune_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertPrune } from "../../internal/_test_assertPrune";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_assertPrune_ConstantIntersection = _test_assertPrune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.assertPrune(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/assertStringify/test_assertStringify_AtomicIntersection.ts
+++ b/test/features/assertStringify/test_assertStringify_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertStringify } from "../../internal/_test_assertStringify";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_assertStringify_AtomicIntersection = _test_assertStringify(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.assertStringify(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/assertStringify/test_assertStringify_ConstantIntersection.ts
+++ b/test/features/assertStringify/test_assertStringify_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertStringify } from "../../internal/_test_assertStringify";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_assertStringify_ConstantIntersection = _test_assertStringify(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.assertStringify(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/clone/test_clone_AtomicIntersection.ts
+++ b/test/features/clone/test_clone_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_clone } from "../../internal/_test_clone";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_clone_AtomicIntersection = _test_clone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.clone(input),
+);

--- a/test/features/clone/test_clone_ConstantIntersection.ts
+++ b/test/features/clone/test_clone_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_clone } from "../../internal/_test_clone";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_clone_ConstantIntersection = _test_clone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.clone(input),
+);

--- a/test/features/createAssert/test_createAssert_AtomicIntersection.ts
+++ b/test/features/createAssert/test_createAssert_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createAssert_AtomicIntersection = _test_assert(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createAssert<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createAssert/test_createAssert_ConstantIntersection.ts
+++ b/test/features/createAssert/test_createAssert_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createAssert_ConstantIntersection = _test_assert(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createAssert<ConstantIntersection>(),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/createAssertClone/test_createAssertClone_AtomicIntersection.ts
+++ b/test/features/createAssertClone/test_createAssertClone_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertClone } from "../../internal/_test_assertClone";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createAssertClone_AtomicIntersection = _test_assertClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createAssertClone<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createAssertClone/test_createAssertClone_ConstantIntersection.ts
+++ b/test/features/createAssertClone/test_createAssertClone_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertClone } from "../../internal/_test_assertClone";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createAssertClone_ConstantIntersection = _test_assertClone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createAssertClone<ConstantIntersection>(),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/createAssertEquals/test_createAssertEquals_AtomicIntersection.ts
+++ b/test/features/createAssertEquals/test_createAssertEquals_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createAssertEquals_AtomicIntersection = _test_assertEquals(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createAssertEquals<AtomicIntersection>(),
+);

--- a/test/features/createAssertEquals/test_createAssertEquals_ConstantIntersection.ts
+++ b/test/features/createAssertEquals/test_createAssertEquals_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createAssertEquals_ConstantIntersection = _test_assertEquals(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createAssertEquals<ConstantIntersection>(),
+);

--- a/test/features/createAssertParse/test_createAssertParse_AtomicIntersection.ts
+++ b/test/features/createAssertParse/test_createAssertParse_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertParse } from "../../internal/_test_assertParse";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createAssertParse_AtomicIntersection = _test_assertParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createAssertParse<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createAssertParse/test_createAssertParse_ConstantIntersection.ts
+++ b/test/features/createAssertParse/test_createAssertParse_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertParse } from "../../internal/_test_assertParse";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createAssertParse_ConstantIntersection = _test_assertParse(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createAssertParse<ConstantIntersection>(),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/createAssertPrune/test_createAssertPrune_AtomicIntersection.ts
+++ b/test/features/createAssertPrune/test_createAssertPrune_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertPrune } from "../../internal/_test_assertPrune";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createAssertPrune_AtomicIntersection = _test_assertPrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createAssertPrune<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createAssertPrune/test_createAssertPrune_ConstantIntersection.ts
+++ b/test/features/createAssertPrune/test_createAssertPrune_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_assertPrune } from "../../internal/_test_assertPrune";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createAssertPrune_ConstantIntersection = _test_assertPrune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createAssertPrune<ConstantIntersection>(),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/createAssertStringify/test_createAssertStringify_AtomicIntersection.ts
+++ b/test/features/createAssertStringify/test_createAssertStringify_AtomicIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_assertStringify } from "../../internal/_test_assertStringify";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createAssertStringify_AtomicIntersection =
+    _test_assertStringify(
+        "AtomicIntersection",
+        AtomicIntersection.generate,
+        typia.createAssertStringify<AtomicIntersection>(),
+        AtomicIntersection.SPOILERS,
+    );

--- a/test/features/createAssertStringify/test_createAssertStringify_ConstantIntersection.ts
+++ b/test/features/createAssertStringify/test_createAssertStringify_ConstantIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_assertStringify } from "../../internal/_test_assertStringify";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createAssertStringify_ConstantIntersection =
+    _test_assertStringify(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        typia.createAssertStringify<ConstantIntersection>(),
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/features/createClone/test_createClone_AtomicIntersection.ts
+++ b/test/features/createClone/test_createClone_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_clone } from "../../internal/_test_clone";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createClone_AtomicIntersection = _test_clone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createClone<AtomicIntersection>(),
+);

--- a/test/features/createClone/test_createClone_ConstantIntersection.ts
+++ b/test/features/createClone/test_createClone_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_clone } from "../../internal/_test_clone";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createClone_ConstantIntersection = _test_clone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createClone<ConstantIntersection>(),
+);

--- a/test/features/createEquals/test_createEquals_AtomicIntersection.ts
+++ b/test/features/createEquals/test_createEquals_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createEquals_AtomicIntersection = _test_equals(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createEquals<AtomicIntersection>(),
+);

--- a/test/features/createEquals/test_createEquals_ConstantIntersection.ts
+++ b/test/features/createEquals/test_createEquals_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createEquals_ConstantIntersection = _test_equals(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createEquals<ConstantIntersection>(),
+);

--- a/test/features/createIs/test_createIs_AtomicIntersection.ts
+++ b/test/features/createIs/test_createIs_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createIs_AtomicIntersection = _test_is(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createIs<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createIs/test_createIs_ConstantIntersection.ts
+++ b/test/features/createIs/test_createIs_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createIs_ConstantIntersection = _test_is(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createIs<ConstantIntersection>(),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/createIsClone/test_createIsClone_AtomicIntersection.ts
+++ b/test/features/createIsClone/test_createIsClone_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isClone } from "../../internal/_test_isClone";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createIsClone_AtomicIntersection = _test_isClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createIsClone<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createIsClone/test_createIsClone_ConstantIntersection.ts
+++ b/test/features/createIsClone/test_createIsClone_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isClone } from "../../internal/_test_isClone";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createIsClone_ConstantIntersection = _test_isClone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createIsClone<ConstantIntersection>(),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/createIsParse/test_createIsParse_AtomicIntersection.ts
+++ b/test/features/createIsParse/test_createIsParse_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isParse } from "../../internal/_test_isParse";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createIsParse_AtomicIntersection = _test_isParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createIsParse<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createIsParse/test_createIsParse_ConstantIntersection.ts
+++ b/test/features/createIsParse/test_createIsParse_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isParse } from "../../internal/_test_isParse";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createIsParse_ConstantIntersection = _test_isParse(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createIsParse<ConstantIntersection>(),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/createIsPrune/test_createIsPrune_AtomicIntersection.ts
+++ b/test/features/createIsPrune/test_createIsPrune_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isPrune } from "../../internal/_test_isPrune";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createIsPrune_AtomicIntersection = _test_isPrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createIsPrune<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createIsPrune/test_createIsPrune_ConstantIntersection.ts
+++ b/test/features/createIsPrune/test_createIsPrune_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isPrune } from "../../internal/_test_isPrune";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createIsPrune_ConstantIntersection = _test_isPrune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createIsPrune<ConstantIntersection>(),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/createIsStringify/test_createIsStringify_AtomicIntersection.ts
+++ b/test/features/createIsStringify/test_createIsStringify_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isStringify } from "../../internal/_test_isStringify";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createIsStringify_AtomicIntersection = _test_isStringify(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createIsStringify<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createIsStringify/test_createIsStringify_ConstantIntersection.ts
+++ b/test/features/createIsStringify/test_createIsStringify_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isStringify } from "../../internal/_test_isStringify";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createIsStringify_ConstantIntersection = _test_isStringify(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createIsStringify<ConstantIntersection>(),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/createPrune/test_createPrune_AtomicIntersection.ts
+++ b/test/features/createPrune/test_createPrune_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_prune } from "../../internal/_test_prune";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createPrune_AtomicIntersection = _test_prune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createPrune<AtomicIntersection>(),
+);

--- a/test/features/createPrune/test_createPrune_ConstantIntersection.ts
+++ b/test/features/createPrune/test_createPrune_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_prune } from "../../internal/_test_prune";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createPrune_ConstantIntersection = _test_prune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createPrune<ConstantIntersection>(),
+);

--- a/test/features/createRandom/test_createRandom_AtomicIntersection.ts
+++ b/test/features/createRandom/test_createRandom_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_random } from "../../internal/_test_random";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createRandom_AtomicIntersection = _test_random(
+    "AtomicIntersection",
+    typia.createRandom<AtomicIntersection>(),
+    typia.createAssert<typia.Primitive<AtomicIntersection>>(),
+);

--- a/test/features/createRandom/test_createRandom_ConstantIntersection.ts
+++ b/test/features/createRandom/test_createRandom_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_random } from "../../internal/_test_random";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createRandom_ConstantIntersection = _test_random(
+    "ConstantIntersection",
+    typia.createRandom<ConstantIntersection>(),
+    typia.createAssert<typia.Primitive<ConstantIntersection>>(),
+);

--- a/test/features/createStringify/test_createStringify_AtomicIntersection.ts
+++ b/test/features/createStringify/test_createStringify_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_stringify } from "../../internal/_test_stringify";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createStringify_AtomicIntersection = _test_stringify(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createStringify<AtomicIntersection>(),
+);

--- a/test/features/createStringify/test_createStringify_ConstantIntersection.ts
+++ b/test/features/createStringify/test_createStringify_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_stringify } from "../../internal/_test_stringify";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createStringify_ConstantIntersection = _test_stringify(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createStringify<ConstantIntersection>(),
+);

--- a/test/features/createValidate/test_createValidate_AtomicIntersection.ts
+++ b/test/features/createValidate/test_createValidate_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createValidate_AtomicIntersection = _test_validate(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createValidate<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createValidate/test_createValidate_ConstantIntersection.ts
+++ b/test/features/createValidate/test_createValidate_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createValidate_ConstantIntersection = _test_validate(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    typia.createValidate<ConstantIntersection>(),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/createValidateClone/test_createValidateClone_AtomicIntersection.ts
+++ b/test/features/createValidateClone/test_createValidateClone_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateClone } from "../../internal/_test_validateClone";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createValidateClone_AtomicIntersection = _test_validateClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createValidateClone<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createValidateClone/test_createValidateClone_ConstantIntersection.ts
+++ b/test/features/createValidateClone/test_createValidateClone_ConstantIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_validateClone } from "../../internal/_test_validateClone";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createValidateClone_ConstantIntersection =
+    _test_validateClone(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        typia.createValidateClone<ConstantIntersection>(),
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/features/createValidateEquals/test_createValidateEquals_AtomicIntersection.ts
+++ b/test/features/createValidateEquals/test_createValidateEquals_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createValidateEquals_AtomicIntersection =
+    _test_validateEquals(
+        "AtomicIntersection",
+        AtomicIntersection.generate,
+        typia.createValidateEquals<AtomicIntersection>(),
+    );

--- a/test/features/createValidateEquals/test_createValidateEquals_ConstantIntersection.ts
+++ b/test/features/createValidateEquals/test_createValidateEquals_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createValidateEquals_ConstantIntersection =
+    _test_validateEquals(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        typia.createValidateEquals<ConstantIntersection>(),
+    );

--- a/test/features/createValidateParse/test_createValidateParse_AtomicIntersection.ts
+++ b/test/features/createValidateParse/test_createValidateParse_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateParse } from "../../internal/_test_validateParse";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createValidateParse_AtomicIntersection = _test_validateParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createValidateParse<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createValidateParse/test_createValidateParse_ConstantIntersection.ts
+++ b/test/features/createValidateParse/test_createValidateParse_ConstantIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_validateParse } from "../../internal/_test_validateParse";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createValidateParse_ConstantIntersection =
+    _test_validateParse(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        typia.createValidateParse<ConstantIntersection>(),
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/features/createValidatePrune/test_createValidatePrune_AtomicIntersection.ts
+++ b/test/features/createValidatePrune/test_createValidatePrune_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validatePrune } from "../../internal/_test_validatePrune";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createValidatePrune_AtomicIntersection = _test_validatePrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    typia.createValidatePrune<AtomicIntersection>(),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/createValidatePrune/test_createValidatePrune_ConstantIntersection.ts
+++ b/test/features/createValidatePrune/test_createValidatePrune_ConstantIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_validatePrune } from "../../internal/_test_validatePrune";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createValidatePrune_ConstantIntersection =
+    _test_validatePrune(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        typia.createValidatePrune<ConstantIntersection>(),
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/features/createValidateStringify/test_createValidateStringify_AtomicIntersection.ts
+++ b/test/features/createValidateStringify/test_createValidateStringify_AtomicIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_validateStringify } from "../../internal/_test_validateStringify";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_createValidateStringify_AtomicIntersection =
+    _test_validateStringify(
+        "AtomicIntersection",
+        AtomicIntersection.generate,
+        typia.createValidateStringify<AtomicIntersection>(),
+        AtomicIntersection.SPOILERS,
+    );

--- a/test/features/createValidateStringify/test_createValidateStringify_ConstantIntersection.ts
+++ b/test/features/createValidateStringify/test_createValidateStringify_ConstantIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_validateStringify } from "../../internal/_test_validateStringify";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_createValidateStringify_ConstantIntersection =
+    _test_validateStringify(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        typia.createValidateStringify<ConstantIntersection>(),
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/features/equals/test_equals_AtomicIntersection.ts
+++ b/test/features/equals/test_equals_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_equals_AtomicIntersection = _test_equals(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.equals(input),
+);

--- a/test/features/equals/test_equals_ConstantIntersection.ts
+++ b/test/features/equals/test_equals_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_equals_ConstantIntersection = _test_equals(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.equals(input),
+);

--- a/test/features/is/test_is_AtomicIntersection.ts
+++ b/test/features/is/test_is_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_is_AtomicIntersection = _test_is(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.is(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/is/test_is_ConstantIntersection.ts
+++ b/test/features/is/test_is_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_is_ConstantIntersection = _test_is(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.is(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/isClone/test_isClone_AtomicIntersection.ts
+++ b/test/features/isClone/test_isClone_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isClone } from "../../internal/_test_isClone";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_isClone_AtomicIntersection = _test_isClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.isClone(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/isClone/test_isClone_ConstantIntersection.ts
+++ b/test/features/isClone/test_isClone_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isClone } from "../../internal/_test_isClone";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_isClone_ConstantIntersection = _test_isClone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.isClone(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/isParse/test_isParse_AtomicIntersection.ts
+++ b/test/features/isParse/test_isParse_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isParse } from "../../internal/_test_isParse";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_isParse_AtomicIntersection = _test_isParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.isParse<AtomicIntersection>(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/isParse/test_isParse_ConstantIntersection.ts
+++ b/test/features/isParse/test_isParse_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isParse } from "../../internal/_test_isParse";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_isParse_ConstantIntersection = _test_isParse(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.isParse<ConstantIntersection>(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/isPrune/test_isPrune_AtomicIntersection.ts
+++ b/test/features/isPrune/test_isPrune_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isPrune } from "../../internal/_test_isPrune";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_isPrune_AtomicIntersection = _test_isPrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.isPrune(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/isPrune/test_isPrune_ConstantIntersection.ts
+++ b/test/features/isPrune/test_isPrune_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isPrune } from "../../internal/_test_isPrune";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_isPrune_ConstantIntersection = _test_isPrune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.isPrune(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/isStringify/test_isStringify_AtomicIntersection.ts
+++ b/test/features/isStringify/test_isStringify_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isStringify } from "../../internal/_test_isStringify";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_isStringify_AtomicIntersection = _test_isStringify(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.isStringify(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/isStringify/test_isStringify_ConstantIntersection.ts
+++ b/test/features/isStringify/test_isStringify_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_isStringify } from "../../internal/_test_isStringify";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_isStringify_ConstantIntersection = _test_isStringify(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.isStringify(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/prune/test_prune_AtomicIntersection.ts
+++ b/test/features/prune/test_prune_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_prune } from "../../internal/_test_prune";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_prune_AtomicIntersection = _test_prune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.prune(input),
+);

--- a/test/features/prune/test_prune_ConstantIntersection.ts
+++ b/test/features/prune/test_prune_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_prune } from "../../internal/_test_prune";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_prune_ConstantIntersection = _test_prune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.prune(input),
+);

--- a/test/features/random/test_random_AtomicIntersection.ts
+++ b/test/features/random/test_random_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_random } from "../../internal/_test_random";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_random_AtomicIntersection = _test_random(
+    "AtomicIntersection",
+    () => typia.random<AtomicIntersection>(),
+    typia.createAssert<typia.Primitive<AtomicIntersection>>(),
+);

--- a/test/features/random/test_random_ConstantIntersection.ts
+++ b/test/features/random/test_random_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_random } from "../../internal/_test_random";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_random_ConstantIntersection = _test_random(
+    "ConstantIntersection",
+    () => typia.random<ConstantIntersection>(),
+    typia.createAssert<typia.Primitive<ConstantIntersection>>(),
+);

--- a/test/features/stringify/test_stringify_AtomicIntersection.ts
+++ b/test/features/stringify/test_stringify_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_stringify } from "../../internal/_test_stringify";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_stringify_AtomicIntersection = _test_stringify(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.stringify(input),
+);

--- a/test/features/stringify/test_stringify_ConstantIntersection.ts
+++ b/test/features/stringify/test_stringify_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_stringify } from "../../internal/_test_stringify";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_stringify_ConstantIntersection = _test_stringify(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.stringify(input),
+);

--- a/test/features/validate/test_validate_AtomicIntersection.ts
+++ b/test/features/validate/test_validate_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_validate_AtomicIntersection = _test_validate(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.validate(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/validate/test_validate_ConstantIntersection.ts
+++ b/test/features/validate/test_validate_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_validate_ConstantIntersection = _test_validate(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.validate(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/validateClone/test_validateClone_AtomicIntersection.ts
+++ b/test/features/validateClone/test_validateClone_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateClone } from "../../internal/_test_validateClone";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_validateClone_AtomicIntersection = _test_validateClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.validateClone(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/validateClone/test_validateClone_ConstantIntersection.ts
+++ b/test/features/validateClone/test_validateClone_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateClone } from "../../internal/_test_validateClone";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_validateClone_ConstantIntersection = _test_validateClone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.validateClone(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/validateEquals/test_validateEquals_AtomicIntersection.ts
+++ b/test/features/validateEquals/test_validateEquals_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_validateEquals_AtomicIntersection = _test_validateEquals(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.validateEquals(input),
+);

--- a/test/features/validateEquals/test_validateEquals_ConstantIntersection.ts
+++ b/test/features/validateEquals/test_validateEquals_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_validateEquals_ConstantIntersection = _test_validateEquals(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.validateEquals(input),
+);

--- a/test/features/validateParse/test_validateParse_AtomicIntersection.ts
+++ b/test/features/validateParse/test_validateParse_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateParse } from "../../internal/_test_validateParse";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_validateParse_AtomicIntersection = _test_validateParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.validateParse<AtomicIntersection>(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/validateParse/test_validateParse_ConstantIntersection.ts
+++ b/test/features/validateParse/test_validateParse_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validateParse } from "../../internal/_test_validateParse";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_validateParse_ConstantIntersection = _test_validateParse(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.validateParse<ConstantIntersection>(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/validatePrune/test_validatePrune_AtomicIntersection.ts
+++ b/test/features/validatePrune/test_validatePrune_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validatePrune } from "../../internal/_test_validatePrune";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_validatePrune_AtomicIntersection = _test_validatePrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) => typia.validatePrune(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/features/validatePrune/test_validatePrune_ConstantIntersection.ts
+++ b/test/features/validatePrune/test_validatePrune_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_validatePrune } from "../../internal/_test_validatePrune";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_validatePrune_ConstantIntersection = _test_validatePrune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) => typia.validatePrune(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/features/validateStringify/test_validateStringify_AtomicIntersection.ts
+++ b/test/features/validateStringify/test_validateStringify_AtomicIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_validateStringify } from "../../internal/_test_validateStringify";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_validateStringify_AtomicIntersection =
+    _test_validateStringify(
+        "AtomicIntersection",
+        AtomicIntersection.generate,
+        (input) => typia.validateStringify(input),
+        AtomicIntersection.SPOILERS,
+    );

--- a/test/features/validateStringify/test_validateStringify_ConstantIntersection.ts
+++ b/test/features/validateStringify/test_validateStringify_ConstantIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_validateStringify } from "../../internal/_test_validateStringify";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_validateStringify_ConstantIntersection =
+    _test_validateStringify(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        (input) => typia.validateStringify(input),
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/generated/output/application/ajv/test_application_ajv_AtomicIntersection.ts
+++ b/test/generated/output/application/ajv/test_application_ajv_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_application } from "../../../../internal/_test_application";
+import { AtomicIntersection } from "../../../../structures/AtomicIntersection";
+
+export const test_application_ajv_AtomicIntersection = _test_application("ajv")(
+    "AtomicIntersection",
+    typia.application<[AtomicIntersection], "ajv">(),
+);

--- a/test/generated/output/application/ajv/test_application_ajv_ConstantIntersection.ts
+++ b/test/generated/output/application/ajv/test_application_ajv_ConstantIntersection.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+import { _test_application } from "../../../../internal/_test_application";
+import { ConstantIntersection } from "../../../../structures/ConstantIntersection";
+
+export const test_application_ajv_ConstantIntersection = _test_application(
+    "ajv",
+)("ConstantIntersection", typia.application<[ConstantIntersection], "ajv">());

--- a/test/generated/output/application/swagger/test_application_swagger_AtomicIntersection.ts
+++ b/test/generated/output/application/swagger/test_application_swagger_AtomicIntersection.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+import { _test_application } from "../../../../internal/_test_application";
+import { AtomicIntersection } from "../../../../structures/AtomicIntersection";
+
+export const test_application_swagger_AtomicIntersection = _test_application(
+    "swagger",
+)("AtomicIntersection", typia.application<[AtomicIntersection], "swagger">());

--- a/test/generated/output/application/swagger/test_application_swagger_ConstantIntersection.ts
+++ b/test/generated/output/application/swagger/test_application_swagger_ConstantIntersection.ts
@@ -1,0 +1,11 @@
+import typia from "typia";
+
+import { _test_application } from "../../../../internal/_test_application";
+import { ConstantIntersection } from "../../../../structures/ConstantIntersection";
+
+export const test_application_swagger_ConstantIntersection = _test_application(
+    "swagger",
+)(
+    "ConstantIntersection",
+    typia.application<[ConstantIntersection], "swagger">(),
+);

--- a/test/generated/output/assert/test_assert_AtomicIntersection.ts
+++ b/test/generated/output/assert/test_assert_AtomicIntersection.ts
@@ -1,0 +1,85 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_assert_AtomicIntersection = _test_assert(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): [
+            AtomicIntersection.Wrapper<boolean>,
+            AtomicIntersection.Wrapper<number>,
+            AtomicIntersection.Wrapper<string>,
+        ] => {
+            const __is = (
+                input: any,
+            ): input is [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ] => {
+                    const $guard = (typia.assert as any).guard;
+                    return (
+                        ((Array.isArray(input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            ("boolean" === typeof input[0] ||
+                                $guard(true, {
+                                    path: _path + "[0]",
+                                    expected: "boolean",
+                                    value: input[0],
+                                })) &&
+                            (("number" === typeof input[1] &&
+                                Number.isFinite(input[1])) ||
+                                $guard(true, {
+                                    path: _path + "[1]",
+                                    expected: "number",
+                                    value: input[1],
+                                })) &&
+                            ("string" === typeof input[2] ||
+                                $guard(true, {
+                                    path: _path + "[2]",
+                                    expected: "string",
+                                    value: input[2],
+                                }))) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/assert/test_assert_ConstantIntersection.ts
+++ b/test/generated/output/assert/test_assert_ConstantIntersection.ts
@@ -1,0 +1,83 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_assert_ConstantIntersection = _test_assert(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): [
+            ConstantIntersection.Wrapper<false>,
+            ConstantIntersection.Wrapper<1>,
+            ConstantIntersection.Wrapper<"two">,
+        ] => {
+            const __is = (
+                input: any,
+            ): input is [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ] => {
+                    const $guard = (typia.assert as any).guard;
+                    return (
+                        ((Array.isArray(input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: '[false, 1, "two"]',
+                                    value: input,
+                                })) &&
+                            (false === input[0] ||
+                                $guard(true, {
+                                    path: _path + "[0]",
+                                    expected: "false",
+                                    value: input[0],
+                                })) &&
+                            (1 === input[1] ||
+                                $guard(true, {
+                                    path: _path + "[1]",
+                                    expected: "1",
+                                    value: input[1],
+                                })) &&
+                            ("two" === input[2] ||
+                                $guard(true, {
+                                    path: _path + "[2]",
+                                    expected: '"two"',
+                                    value: input[2],
+                                }))) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/assertClone/test_assertClone_AtomicIntersection.ts
+++ b/test/generated/output/assertClone/test_assertClone_AtomicIntersection.ts
@@ -1,0 +1,123 @@
+import typia from "../../../../src";
+import { _test_assertClone } from "../../../internal/_test_assertClone";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_assertClone_AtomicIntersection = _test_assertClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.Primitive<
+            [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ]
+        > => {
+            const assert = (
+                input: any,
+            ): [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ] => {
+                const __is = (
+                    input: any,
+                ): input is [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ] => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        "boolean" === typeof input[0] &&
+                        "number" === typeof input[1] &&
+                        Number.isFinite(input[1]) &&
+                        "string" === typeof input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is [
+                        AtomicIntersection.Wrapper<boolean>,
+                        AtomicIntersection.Wrapper<number>,
+                        AtomicIntersection.Wrapper<string>,
+                    ] => {
+                        const $guard = (typia.assertClone as any).guard;
+                        return (
+                            ((Array.isArray(input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "AtomicIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: "[boolean, number, string]",
+                                        value: input,
+                                    })) &&
+                                ("boolean" === typeof input[0] ||
+                                    $guard(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    })) &&
+                                (("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $guard(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    })) &&
+                                ("string" === typeof input[2] ||
+                                    $guard(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }))) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const clone = (
+                input: [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ],
+            ): typia.Primitive<
+                [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ]
+            > => {
+                return Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    "string" === typeof input[2]
+                    ? ([
+                          input[0] as any,
+                          input[1] as any,
+                          input[2] as any,
+                      ] as any)
+                    : (input as any);
+            };
+            assert(input);
+            const output = clone(input);
+            return output;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/assertClone/test_assertClone_ConstantIntersection.ts
+++ b/test/generated/output/assertClone/test_assertClone_ConstantIntersection.ts
@@ -1,0 +1,121 @@
+import typia from "../../../../src";
+import { _test_assertClone } from "../../../internal/_test_assertClone";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_assertClone_ConstantIntersection = _test_assertClone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.Primitive<
+            [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ]
+        > => {
+            const assert = (
+                input: any,
+            ): [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ] => {
+                const __is = (
+                    input: any,
+                ): input is [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ] => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is [
+                        ConstantIntersection.Wrapper<false>,
+                        ConstantIntersection.Wrapper<1>,
+                        ConstantIntersection.Wrapper<"two">,
+                    ] => {
+                        const $guard = (typia.assertClone as any).guard;
+                        return (
+                            ((Array.isArray(input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                (false === input[0] ||
+                                    $guard(true, {
+                                        path: _path + "[0]",
+                                        expected: "false",
+                                        value: input[0],
+                                    })) &&
+                                (1 === input[1] ||
+                                    $guard(true, {
+                                        path: _path + "[1]",
+                                        expected: "1",
+                                        value: input[1],
+                                    })) &&
+                                ("two" === input[2] ||
+                                    $guard(true, {
+                                        path: _path + "[2]",
+                                        expected: '"two"',
+                                        value: input[2],
+                                    }))) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const clone = (
+                input: [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ],
+            ): typia.Primitive<
+                [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ]
+            > => {
+                return Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                    ? ([
+                          input[0] as any,
+                          input[1] as any,
+                          input[2] as any,
+                      ] as any)
+                    : (input as any);
+            };
+            assert(input);
+            const output = clone(input);
+            return output;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/assertEquals/test_assertEquals_AtomicIntersection.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_AtomicIntersection.ts
@@ -1,0 +1,85 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_assertEquals_AtomicIntersection = _test_assertEquals(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): [
+            AtomicIntersection.Wrapper<boolean>,
+            AtomicIntersection.Wrapper<number>,
+            AtomicIntersection.Wrapper<string>,
+        ] => {
+            const __is = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): input is [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ] => {
+                    const $guard = (typia.assertEquals as any).guard;
+                    return (
+                        ((Array.isArray(input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            ("boolean" === typeof input[0] ||
+                                $guard(true, {
+                                    path: _path + "[0]",
+                                    expected: "boolean",
+                                    value: input[0],
+                                })) &&
+                            (("number" === typeof input[1] &&
+                                Number.isFinite(input[1])) ||
+                                $guard(true, {
+                                    path: _path + "[1]",
+                                    expected: "number",
+                                    value: input[1],
+                                })) &&
+                            ("string" === typeof input[2] ||
+                                $guard(true, {
+                                    path: _path + "[2]",
+                                    expected: "string",
+                                    value: input[2],
+                                }))) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        })(input),
+);

--- a/test/generated/output/assertEquals/test_assertEquals_ConstantIntersection.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_ConstantIntersection.ts
@@ -1,0 +1,83 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_assertEquals_ConstantIntersection = _test_assertEquals(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): [
+            ConstantIntersection.Wrapper<false>,
+            ConstantIntersection.Wrapper<1>,
+            ConstantIntersection.Wrapper<"two">,
+        ] => {
+            const __is = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): input is [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ] => {
+                    const $guard = (typia.assertEquals as any).guard;
+                    return (
+                        ((Array.isArray(input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: '[false, 1, "two"]',
+                                    value: input,
+                                })) &&
+                            (false === input[0] ||
+                                $guard(true, {
+                                    path: _path + "[0]",
+                                    expected: "false",
+                                    value: input[0],
+                                })) &&
+                            (1 === input[1] ||
+                                $guard(true, {
+                                    path: _path + "[1]",
+                                    expected: "1",
+                                    value: input[1],
+                                })) &&
+                            ("two" === input[2] ||
+                                $guard(true, {
+                                    path: _path + "[2]",
+                                    expected: '"two"',
+                                    value: input[2],
+                                }))) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        })(input),
+);

--- a/test/generated/output/assertParse/test_assertParse_AtomicIntersection.ts
+++ b/test/generated/output/assertParse/test_assertParse_AtomicIntersection.ts
@@ -1,0 +1,73 @@
+import typia from "../../../../src";
+import { _test_assertParse } from "../../../internal/_test_assertParse";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_assertParse_AtomicIntersection = _test_assertParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((input: string): typia.Primitive<AtomicIntersection> => {
+            const assert = (input: any): AtomicIntersection => {
+                const __is = (input: any): input is AtomicIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        "boolean" === typeof input[0] &&
+                        "number" === typeof input[1] &&
+                        Number.isFinite(input[1]) &&
+                        "string" === typeof input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is AtomicIntersection => {
+                        const $guard = (typia.assertParse as any).guard;
+                        return (
+                            ((Array.isArray(input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "AtomicIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: "[boolean, number, string]",
+                                        value: input,
+                                    })) &&
+                                ("boolean" === typeof input[0] ||
+                                    $guard(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    })) &&
+                                (("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $guard(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    })) &&
+                                ("string" === typeof input[2] ||
+                                    $guard(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }))) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            input = JSON.parse(input);
+            return assert(input) as any;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/assertParse/test_assertParse_ConstantIntersection.ts
+++ b/test/generated/output/assertParse/test_assertParse_ConstantIntersection.ts
@@ -1,0 +1,71 @@
+import typia from "../../../../src";
+import { _test_assertParse } from "../../../internal/_test_assertParse";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_assertParse_ConstantIntersection = _test_assertParse(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((input: string): typia.Primitive<ConstantIntersection> => {
+            const assert = (input: any): ConstantIntersection => {
+                const __is = (input: any): input is ConstantIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ConstantIntersection => {
+                        const $guard = (typia.assertParse as any).guard;
+                        return (
+                            ((Array.isArray(input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                (false === input[0] ||
+                                    $guard(true, {
+                                        path: _path + "[0]",
+                                        expected: "false",
+                                        value: input[0],
+                                    })) &&
+                                (1 === input[1] ||
+                                    $guard(true, {
+                                        path: _path + "[1]",
+                                        expected: "1",
+                                        value: input[1],
+                                    })) &&
+                                ("two" === input[2] ||
+                                    $guard(true, {
+                                        path: _path + "[2]",
+                                        expected: '"two"',
+                                        value: input[2],
+                                    }))) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            input = JSON.parse(input);
+            return assert(input) as any;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/assertPrune/test_assertPrune_AtomicIntersection.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_AtomicIntersection.ts
@@ -1,0 +1,103 @@
+import typia from "../../../../src";
+import { _test_assertPrune } from "../../../internal/_test_assertPrune";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_assertPrune_AtomicIntersection = _test_assertPrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): [
+            AtomicIntersection.Wrapper<boolean>,
+            AtomicIntersection.Wrapper<number>,
+            AtomicIntersection.Wrapper<string>,
+        ] => {
+            const assert = (
+                input: any,
+            ): [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ] => {
+                const __is = (
+                    input: any,
+                ): input is [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ] => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        "boolean" === typeof input[0] &&
+                        "number" === typeof input[1] &&
+                        Number.isFinite(input[1]) &&
+                        "string" === typeof input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is [
+                        AtomicIntersection.Wrapper<boolean>,
+                        AtomicIntersection.Wrapper<number>,
+                        AtomicIntersection.Wrapper<string>,
+                    ] => {
+                        const $guard = (typia.assertPrune as any).guard;
+                        return (
+                            ((Array.isArray(input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "AtomicIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: "[boolean, number, string]",
+                                        value: input,
+                                    })) &&
+                                ("boolean" === typeof input[0] ||
+                                    $guard(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    })) &&
+                                (("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $guard(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    })) &&
+                                ("string" === typeof input[2] ||
+                                    $guard(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }))) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const prune = (
+                input: [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ],
+            ): void => {};
+            assert(input);
+            prune(input);
+            return input;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/assertPrune/test_assertPrune_ConstantIntersection.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_ConstantIntersection.ts
@@ -1,0 +1,101 @@
+import typia from "../../../../src";
+import { _test_assertPrune } from "../../../internal/_test_assertPrune";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_assertPrune_ConstantIntersection = _test_assertPrune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): [
+            ConstantIntersection.Wrapper<false>,
+            ConstantIntersection.Wrapper<1>,
+            ConstantIntersection.Wrapper<"two">,
+        ] => {
+            const assert = (
+                input: any,
+            ): [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ] => {
+                const __is = (
+                    input: any,
+                ): input is [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ] => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is [
+                        ConstantIntersection.Wrapper<false>,
+                        ConstantIntersection.Wrapper<1>,
+                        ConstantIntersection.Wrapper<"two">,
+                    ] => {
+                        const $guard = (typia.assertPrune as any).guard;
+                        return (
+                            ((Array.isArray(input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                (false === input[0] ||
+                                    $guard(true, {
+                                        path: _path + "[0]",
+                                        expected: "false",
+                                        value: input[0],
+                                    })) &&
+                                (1 === input[1] ||
+                                    $guard(true, {
+                                        path: _path + "[1]",
+                                        expected: "1",
+                                        value: input[1],
+                                    })) &&
+                                ("two" === input[2] ||
+                                    $guard(true, {
+                                        path: _path + "[2]",
+                                        expected: '"two"',
+                                        value: input[2],
+                                    }))) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const prune = (
+                input: [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ],
+            ): void => {};
+            assert(input);
+            prune(input);
+            return input;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/assertStringify/test_assertStringify_AtomicIntersection.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_AtomicIntersection.ts
@@ -1,0 +1,101 @@
+import typia from "../../../../src";
+import { _test_assertStringify } from "../../../internal/_test_assertStringify";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_assertStringify_AtomicIntersection = _test_assertStringify(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((input: any): string => {
+            const assert = (
+                input: any,
+            ): [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ] => {
+                const __is = (
+                    input: any,
+                ): input is [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ] => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        "boolean" === typeof input[0] &&
+                        "number" === typeof input[1] &&
+                        Number.isFinite(input[1]) &&
+                        "string" === typeof input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is [
+                        AtomicIntersection.Wrapper<boolean>,
+                        AtomicIntersection.Wrapper<number>,
+                        AtomicIntersection.Wrapper<string>,
+                    ] => {
+                        const $guard = (typia.assertStringify as any).guard;
+                        return (
+                            ((Array.isArray(input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "AtomicIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: "[boolean, number, string]",
+                                        value: input,
+                                    })) &&
+                                ("boolean" === typeof input[0] ||
+                                    $guard(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    })) &&
+                                (("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $guard(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    })) &&
+                                ("string" === typeof input[2] ||
+                                    $guard(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }))) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const stringify = (
+                input: [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ],
+            ): string => {
+                const $number = (typia.assertStringify as any).number;
+                const $string = (typia.assertStringify as any).string;
+                return `[${input[0]},${$number(input[1])},${$string(
+                    input[2],
+                )}]`;
+            };
+            return stringify(assert(input));
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/assertStringify/test_assertStringify_ConstantIntersection.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_ConstantIntersection.ts
@@ -1,0 +1,106 @@
+import typia from "../../../../src";
+import { _test_assertStringify } from "../../../internal/_test_assertStringify";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_assertStringify_ConstantIntersection = _test_assertStringify(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((input: any): string => {
+            const assert = (
+                input: any,
+            ): [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ] => {
+                const __is = (
+                    input: any,
+                ): input is [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ] => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is [
+                        ConstantIntersection.Wrapper<false>,
+                        ConstantIntersection.Wrapper<1>,
+                        ConstantIntersection.Wrapper<"two">,
+                    ] => {
+                        const $guard = (typia.assertStringify as any).guard;
+                        return (
+                            ((Array.isArray(input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                (false === input[0] ||
+                                    $guard(true, {
+                                        path: _path + "[0]",
+                                        expected: "false",
+                                        value: input[0],
+                                    })) &&
+                                (1 === input[1] ||
+                                    $guard(true, {
+                                        path: _path + "[1]",
+                                        expected: "1",
+                                        value: input[1],
+                                    })) &&
+                                ("two" === input[2] ||
+                                    $guard(true, {
+                                        path: _path + "[2]",
+                                        expected: '"two"',
+                                        value: input[2],
+                                    }))) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const stringify = (
+                input: [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ],
+            ): string => {
+                const $number = (typia.assertStringify as any).number;
+                const $string = (typia.assertStringify as any).string;
+                const $throws = (typia.assertStringify as any).throws;
+                return `[${input[0]},${$number(input[1])},${(() => {
+                    if ("string" === typeof input[2]) return $string(input[2]);
+                    if ("string" === typeof input[2])
+                        return '"' + input[2] + '"';
+                    $throws({
+                        expected: '"two"',
+                        value: input[2],
+                    });
+                })()}]`;
+            };
+            return stringify(assert(input));
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/clone/test_clone_AtomicIntersection.ts
+++ b/test/generated/output/clone/test_clone_AtomicIntersection.ts
@@ -1,0 +1,30 @@
+import typia from "../../../../src";
+import { _test_clone } from "../../../internal/_test_clone";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_clone_AtomicIntersection = _test_clone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ],
+        ): typia.Primitive<
+            [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ]
+        > => {
+            return Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                "string" === typeof input[2]
+                ? ([input[0] as any, input[1] as any, input[2] as any] as any)
+                : (input as any);
+        })(input),
+);

--- a/test/generated/output/clone/test_clone_ConstantIntersection.ts
+++ b/test/generated/output/clone/test_clone_ConstantIntersection.ts
@@ -1,0 +1,30 @@
+import typia from "../../../../src";
+import { _test_clone } from "../../../internal/_test_clone";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_clone_ConstantIntersection = _test_clone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ],
+        ): typia.Primitive<
+            [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ]
+        > => {
+            return Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+                ? ([input[0] as any, input[1] as any, input[2] as any] as any)
+                : (input as any);
+        })(input),
+);

--- a/test/generated/output/createAssert/test_createAssert_AtomicIntersection.ts
+++ b/test/generated/output/createAssert/test_createAssert_AtomicIntersection.ts
@@ -1,0 +1,68 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createAssert_AtomicIntersection = _test_assert(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): AtomicIntersection => {
+        const __is = (input: any): input is AtomicIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is AtomicIntersection => {
+                const $guard = (typia.createAssert as any).guard;
+                return (
+                    ((Array.isArray(input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })) &&
+                        (input.length === 3 ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "[boolean, number, string]",
+                                value: input,
+                            })) &&
+                        ("boolean" === typeof input[0] ||
+                            $guard(true, {
+                                path: _path + "[0]",
+                                expected: "boolean",
+                                value: input[0],
+                            })) &&
+                        (("number" === typeof input[1] &&
+                            Number.isFinite(input[1])) ||
+                            $guard(true, {
+                                path: _path + "[1]",
+                                expected: "number",
+                                value: input[1],
+                            })) &&
+                        ("string" === typeof input[2] ||
+                            $guard(true, {
+                                path: _path + "[2]",
+                                expected: "string",
+                                value: input[2],
+                            }))) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "AtomicIntersection",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createAssert/test_createAssert_ConstantIntersection.ts
+++ b/test/generated/output/createAssert/test_createAssert_ConstantIntersection.ts
@@ -1,0 +1,66 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createAssert_ConstantIntersection = _test_assert(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: any): ConstantIntersection => {
+        const __is = (input: any): input is ConstantIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ConstantIntersection => {
+                const $guard = (typia.createAssert as any).guard;
+                return (
+                    ((Array.isArray(input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })) &&
+                        (input.length === 3 ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: '[false, 1, "two"]',
+                                value: input,
+                            })) &&
+                        (false === input[0] ||
+                            $guard(true, {
+                                path: _path + "[0]",
+                                expected: "false",
+                                value: input[0],
+                            })) &&
+                        (1 === input[1] ||
+                            $guard(true, {
+                                path: _path + "[1]",
+                                expected: "1",
+                                value: input[1],
+                            })) &&
+                        ("two" === input[2] ||
+                            $guard(true, {
+                                path: _path + "[2]",
+                                expected: '"two"',
+                                value: input[2],
+                            }))) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "ConstantIntersection",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/createAssertClone/test_createAssertClone_AtomicIntersection.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_AtomicIntersection.ts
@@ -1,0 +1,84 @@
+import typia from "../../../../src";
+import { _test_assertClone } from "../../../internal/_test_assertClone";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createAssertClone_AtomicIntersection = _test_assertClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): typia.Primitive<AtomicIntersection> => {
+        const assert = (input: any): AtomicIntersection => {
+            const __is = (input: any): input is AtomicIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is AtomicIntersection => {
+                    const $guard = (typia.createAssertClone as any).guard;
+                    return (
+                        ((Array.isArray(input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            ("boolean" === typeof input[0] ||
+                                $guard(true, {
+                                    path: _path + "[0]",
+                                    expected: "boolean",
+                                    value: input[0],
+                                })) &&
+                            (("number" === typeof input[1] &&
+                                Number.isFinite(input[1])) ||
+                                $guard(true, {
+                                    path: _path + "[1]",
+                                    expected: "number",
+                                    value: input[1],
+                                })) &&
+                            ("string" === typeof input[2] ||
+                                $guard(true, {
+                                    path: _path + "[2]",
+                                    expected: "string",
+                                    value: input[2],
+                                }))) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        const clone = (
+            input: AtomicIntersection,
+        ): typia.Primitive<AtomicIntersection> => {
+            return Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                "string" === typeof input[2]
+                ? ([input[0] as any, input[1] as any, input[2] as any] as any)
+                : (input as any);
+        };
+        assert(input);
+        const output = clone(input);
+        return output;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createAssertClone/test_createAssertClone_ConstantIntersection.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_ConstantIntersection.ts
@@ -1,0 +1,82 @@
+import typia from "../../../../src";
+import { _test_assertClone } from "../../../internal/_test_assertClone";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createAssertClone_ConstantIntersection = _test_assertClone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: any): typia.Primitive<ConstantIntersection> => {
+        const assert = (input: any): ConstantIntersection => {
+            const __is = (input: any): input is ConstantIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ConstantIntersection => {
+                    const $guard = (typia.createAssertClone as any).guard;
+                    return (
+                        ((Array.isArray(input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: '[false, 1, "two"]',
+                                    value: input,
+                                })) &&
+                            (false === input[0] ||
+                                $guard(true, {
+                                    path: _path + "[0]",
+                                    expected: "false",
+                                    value: input[0],
+                                })) &&
+                            (1 === input[1] ||
+                                $guard(true, {
+                                    path: _path + "[1]",
+                                    expected: "1",
+                                    value: input[1],
+                                })) &&
+                            ("two" === input[2] ||
+                                $guard(true, {
+                                    path: _path + "[2]",
+                                    expected: '"two"',
+                                    value: input[2],
+                                }))) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        const clone = (
+            input: ConstantIntersection,
+        ): typia.Primitive<ConstantIntersection> => {
+            return Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+                ? ([input[0] as any, input[1] as any, input[2] as any] as any)
+                : (input as any);
+        };
+        assert(input);
+        const output = clone(input);
+        return output;
+    },
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_AtomicIntersection.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_AtomicIntersection.ts
@@ -1,0 +1,70 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createAssertEquals_AtomicIntersection = _test_assertEquals(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): AtomicIntersection => {
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is AtomicIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is AtomicIntersection => {
+                const $guard = (typia.createAssertEquals as any).guard;
+                return (
+                    ((Array.isArray(input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })) &&
+                        (input.length === 3 ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "[boolean, number, string]",
+                                value: input,
+                            })) &&
+                        ("boolean" === typeof input[0] ||
+                            $guard(true, {
+                                path: _path + "[0]",
+                                expected: "boolean",
+                                value: input[0],
+                            })) &&
+                        (("number" === typeof input[1] &&
+                            Number.isFinite(input[1])) ||
+                            $guard(true, {
+                                path: _path + "[1]",
+                                expected: "number",
+                                value: input[1],
+                            })) &&
+                        ("string" === typeof input[2] ||
+                            $guard(true, {
+                                path: _path + "[2]",
+                                expected: "string",
+                                value: input[2],
+                            }))) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "AtomicIntersection",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+);

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_ConstantIntersection.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_ConstantIntersection.ts
@@ -1,0 +1,68 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createAssertEquals_ConstantIntersection = _test_assertEquals(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: any): ConstantIntersection => {
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is ConstantIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ConstantIntersection => {
+                const $guard = (typia.createAssertEquals as any).guard;
+                return (
+                    ((Array.isArray(input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })) &&
+                        (input.length === 3 ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: '[false, 1, "two"]',
+                                value: input,
+                            })) &&
+                        (false === input[0] ||
+                            $guard(true, {
+                                path: _path + "[0]",
+                                expected: "false",
+                                value: input[0],
+                            })) &&
+                        (1 === input[1] ||
+                            $guard(true, {
+                                path: _path + "[1]",
+                                expected: "1",
+                                value: input[1],
+                            })) &&
+                        ("two" === input[2] ||
+                            $guard(true, {
+                                path: _path + "[2]",
+                                expected: '"two"',
+                                value: input[2],
+                            }))) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "ConstantIntersection",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+);

--- a/test/generated/output/createAssertParse/test_createAssertParse_AtomicIntersection.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_AtomicIntersection.ts
@@ -1,0 +1,72 @@
+import typia from "../../../../src";
+import { _test_assertParse } from "../../../internal/_test_assertParse";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createAssertParse_AtomicIntersection = _test_assertParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: string): typia.Primitive<AtomicIntersection> => {
+        const assert = (input: any): AtomicIntersection => {
+            const __is = (input: any): input is AtomicIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is AtomicIntersection => {
+                    const $guard = (typia.createAssertParse as any).guard;
+                    return (
+                        ((Array.isArray(input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            ("boolean" === typeof input[0] ||
+                                $guard(true, {
+                                    path: _path + "[0]",
+                                    expected: "boolean",
+                                    value: input[0],
+                                })) &&
+                            (("number" === typeof input[1] &&
+                                Number.isFinite(input[1])) ||
+                                $guard(true, {
+                                    path: _path + "[1]",
+                                    expected: "number",
+                                    value: input[1],
+                                })) &&
+                            ("string" === typeof input[2] ||
+                                $guard(true, {
+                                    path: _path + "[2]",
+                                    expected: "string",
+                                    value: input[2],
+                                }))) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        input = JSON.parse(input);
+        return assert(input) as any;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createAssertParse/test_createAssertParse_ConstantIntersection.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_ConstantIntersection.ts
@@ -1,0 +1,70 @@
+import typia from "../../../../src";
+import { _test_assertParse } from "../../../internal/_test_assertParse";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createAssertParse_ConstantIntersection = _test_assertParse(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: string): typia.Primitive<ConstantIntersection> => {
+        const assert = (input: any): ConstantIntersection => {
+            const __is = (input: any): input is ConstantIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ConstantIntersection => {
+                    const $guard = (typia.createAssertParse as any).guard;
+                    return (
+                        ((Array.isArray(input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: '[false, 1, "two"]',
+                                    value: input,
+                                })) &&
+                            (false === input[0] ||
+                                $guard(true, {
+                                    path: _path + "[0]",
+                                    expected: "false",
+                                    value: input[0],
+                                })) &&
+                            (1 === input[1] ||
+                                $guard(true, {
+                                    path: _path + "[1]",
+                                    expected: "1",
+                                    value: input[1],
+                                })) &&
+                            ("two" === input[2] ||
+                                $guard(true, {
+                                    path: _path + "[2]",
+                                    expected: '"two"',
+                                    value: input[2],
+                                }))) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        input = JSON.parse(input);
+        return assert(input) as any;
+    },
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_AtomicIntersection.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_AtomicIntersection.ts
@@ -1,0 +1,74 @@
+import typia from "../../../../src";
+import { _test_assertPrune } from "../../../internal/_test_assertPrune";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createAssertPrune_AtomicIntersection = _test_assertPrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): AtomicIntersection => {
+        const assert = (input: any): AtomicIntersection => {
+            const __is = (input: any): input is AtomicIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is AtomicIntersection => {
+                    const $guard = (typia.createAssertPrune as any).guard;
+                    return (
+                        ((Array.isArray(input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            ("boolean" === typeof input[0] ||
+                                $guard(true, {
+                                    path: _path + "[0]",
+                                    expected: "boolean",
+                                    value: input[0],
+                                })) &&
+                            (("number" === typeof input[1] &&
+                                Number.isFinite(input[1])) ||
+                                $guard(true, {
+                                    path: _path + "[1]",
+                                    expected: "number",
+                                    value: input[1],
+                                })) &&
+                            ("string" === typeof input[2] ||
+                                $guard(true, {
+                                    path: _path + "[2]",
+                                    expected: "string",
+                                    value: input[2],
+                                }))) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        const prune = (input: AtomicIntersection): void => {};
+        assert(input);
+        prune(input);
+        return input;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_ConstantIntersection.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_ConstantIntersection.ts
@@ -1,0 +1,72 @@
+import typia from "../../../../src";
+import { _test_assertPrune } from "../../../internal/_test_assertPrune";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createAssertPrune_ConstantIntersection = _test_assertPrune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: any): ConstantIntersection => {
+        const assert = (input: any): ConstantIntersection => {
+            const __is = (input: any): input is ConstantIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ConstantIntersection => {
+                    const $guard = (typia.createAssertPrune as any).guard;
+                    return (
+                        ((Array.isArray(input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: '[false, 1, "two"]',
+                                    value: input,
+                                })) &&
+                            (false === input[0] ||
+                                $guard(true, {
+                                    path: _path + "[0]",
+                                    expected: "false",
+                                    value: input[0],
+                                })) &&
+                            (1 === input[1] ||
+                                $guard(true, {
+                                    path: _path + "[1]",
+                                    expected: "1",
+                                    value: input[1],
+                                })) &&
+                            ("two" === input[2] ||
+                                $guard(true, {
+                                    path: _path + "[2]",
+                                    expected: '"two"',
+                                    value: input[2],
+                                }))) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        const prune = (input: ConstantIntersection): void => {};
+        assert(input);
+        prune(input);
+        return input;
+    },
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_AtomicIntersection.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_AtomicIntersection.ts
@@ -1,0 +1,80 @@
+import typia from "../../../../src";
+import { _test_assertStringify } from "../../../internal/_test_assertStringify";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createAssertStringify_AtomicIntersection =
+    _test_assertStringify(
+        "AtomicIntersection",
+        AtomicIntersection.generate,
+        (input: any): string => {
+            const assert = (input: any): AtomicIntersection => {
+                const __is = (input: any): input is AtomicIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        "boolean" === typeof input[0] &&
+                        "number" === typeof input[1] &&
+                        Number.isFinite(input[1]) &&
+                        "string" === typeof input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is AtomicIntersection => {
+                        const $guard = (typia.createAssertStringify as any)
+                            .guard;
+                        return (
+                            ((Array.isArray(input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "AtomicIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: "[boolean, number, string]",
+                                        value: input,
+                                    })) &&
+                                ("boolean" === typeof input[0] ||
+                                    $guard(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    })) &&
+                                (("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $guard(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    })) &&
+                                ("string" === typeof input[2] ||
+                                    $guard(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }))) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const stringify = (input: AtomicIntersection): string => {
+                const $number = (typia.createAssertStringify as any).number;
+                const $string = (typia.createAssertStringify as any).string;
+                return `[${input[0]},${$number(input[1])},${$string(
+                    input[2],
+                )}]`;
+            };
+            return stringify(assert(input));
+        },
+        AtomicIntersection.SPOILERS,
+    );

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_ConstantIntersection.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_ConstantIntersection.ts
@@ -1,0 +1,85 @@
+import typia from "../../../../src";
+import { _test_assertStringify } from "../../../internal/_test_assertStringify";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createAssertStringify_ConstantIntersection =
+    _test_assertStringify(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        (input: any): string => {
+            const assert = (input: any): ConstantIntersection => {
+                const __is = (input: any): input is ConstantIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ConstantIntersection => {
+                        const $guard = (typia.createAssertStringify as any)
+                            .guard;
+                        return (
+                            ((Array.isArray(input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                (false === input[0] ||
+                                    $guard(true, {
+                                        path: _path + "[0]",
+                                        expected: "false",
+                                        value: input[0],
+                                    })) &&
+                                (1 === input[1] ||
+                                    $guard(true, {
+                                        path: _path + "[1]",
+                                        expected: "1",
+                                        value: input[1],
+                                    })) &&
+                                ("two" === input[2] ||
+                                    $guard(true, {
+                                        path: _path + "[2]",
+                                        expected: '"two"',
+                                        value: input[2],
+                                    }))) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const stringify = (input: ConstantIntersection): string => {
+                const $number = (typia.createAssertStringify as any).number;
+                const $string = (typia.createAssertStringify as any).string;
+                const $throws = (typia.createAssertStringify as any).throws;
+                return `[${input[0]},${$number(input[1])},${(() => {
+                    if ("string" === typeof input[2]) return $string(input[2]);
+                    if ("string" === typeof input[2])
+                        return '"' + input[2] + '"';
+                    $throws({
+                        expected: '"two"',
+                        value: input[2],
+                    });
+                })()}]`;
+            };
+            return stringify(assert(input));
+        },
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/generated/output/createClone/test_createClone_AtomicIntersection.ts
+++ b/test/generated/output/createClone/test_createClone_AtomicIntersection.ts
@@ -1,0 +1,17 @@
+import typia from "../../../../src";
+import { _test_clone } from "../../../internal/_test_clone";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createClone_AtomicIntersection = _test_clone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: AtomicIntersection): typia.Primitive<AtomicIntersection> => {
+        return Array.isArray(input) &&
+            input.length === 3 &&
+            "boolean" === typeof input[0] &&
+            "number" === typeof input[1] &&
+            "string" === typeof input[2]
+            ? ([input[0] as any, input[1] as any, input[2] as any] as any)
+            : (input as any);
+    },
+);

--- a/test/generated/output/createClone/test_createClone_ConstantIntersection.ts
+++ b/test/generated/output/createClone/test_createClone_ConstantIntersection.ts
@@ -1,0 +1,17 @@
+import typia from "../../../../src";
+import { _test_clone } from "../../../internal/_test_clone";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createClone_ConstantIntersection = _test_clone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: ConstantIntersection): typia.Primitive<ConstantIntersection> => {
+        return Array.isArray(input) &&
+            input.length === 3 &&
+            false === input[0] &&
+            1 === input[1] &&
+            "two" === input[2]
+            ? ([input[0] as any, input[1] as any, input[2] as any] as any)
+            : (input as any);
+    },
+);

--- a/test/generated/output/createEquals/test_createEquals_AtomicIntersection.ts
+++ b/test/generated/output/createEquals/test_createEquals_AtomicIntersection.ts
@@ -1,0 +1,21 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createEquals_AtomicIntersection = _test_equals(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (
+        input: any,
+        _exceptionable: boolean = true,
+    ): input is AtomicIntersection => {
+        return (
+            Array.isArray(input) &&
+            input.length === 3 &&
+            "boolean" === typeof input[0] &&
+            "number" === typeof input[1] &&
+            Number.isFinite(input[1]) &&
+            "string" === typeof input[2]
+        );
+    },
+);

--- a/test/generated/output/createEquals/test_createEquals_ConstantIntersection.ts
+++ b/test/generated/output/createEquals/test_createEquals_ConstantIntersection.ts
@@ -1,0 +1,20 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createEquals_ConstantIntersection = _test_equals(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (
+        input: any,
+        _exceptionable: boolean = true,
+    ): input is ConstantIntersection => {
+        return (
+            Array.isArray(input) &&
+            input.length === 3 &&
+            false === input[0] &&
+            1 === input[1] &&
+            "two" === input[2]
+        );
+    },
+);

--- a/test/generated/output/createIs/test_createIs_AtomicIntersection.ts
+++ b/test/generated/output/createIs/test_createIs_AtomicIntersection.ts
@@ -1,0 +1,19 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createIs_AtomicIntersection = _test_is(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): input is AtomicIntersection => {
+        return (
+            Array.isArray(input) &&
+            input.length === 3 &&
+            "boolean" === typeof input[0] &&
+            "number" === typeof input[1] &&
+            Number.isFinite(input[1]) &&
+            "string" === typeof input[2]
+        );
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createIs/test_createIs_ConstantIntersection.ts
+++ b/test/generated/output/createIs/test_createIs_ConstantIntersection.ts
@@ -1,0 +1,18 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createIs_ConstantIntersection = _test_is(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: any): input is ConstantIntersection => {
+        return (
+            Array.isArray(input) &&
+            input.length === 3 &&
+            false === input[0] &&
+            1 === input[1] &&
+            "two" === input[2]
+        );
+    },
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/createIsClone/test_createIsClone_AtomicIntersection.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_AtomicIntersection.ts
@@ -1,0 +1,35 @@
+import typia from "../../../../src";
+import { _test_isClone } from "../../../internal/_test_isClone";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createIsClone_AtomicIntersection = _test_isClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): typia.Primitive<AtomicIntersection> | null => {
+        const is = (input: any): input is AtomicIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        };
+        const clone = (
+            input: AtomicIntersection,
+        ): typia.Primitive<AtomicIntersection> => {
+            return Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                "string" === typeof input[2]
+                ? ([input[0] as any, input[1] as any, input[2] as any] as any)
+                : (input as any);
+        };
+        if (!is(input)) return null;
+        const output = clone(input);
+        return output;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createIsClone/test_createIsClone_ConstantIntersection.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_ConstantIntersection.ts
@@ -1,0 +1,34 @@
+import typia from "../../../../src";
+import { _test_isClone } from "../../../internal/_test_isClone";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createIsClone_ConstantIntersection = _test_isClone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: any): typia.Primitive<ConstantIntersection> | null => {
+        const is = (input: any): input is ConstantIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        };
+        const clone = (
+            input: ConstantIntersection,
+        ): typia.Primitive<ConstantIntersection> => {
+            return Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+                ? ([input[0] as any, input[1] as any, input[2] as any] as any)
+                : (input as any);
+        };
+        if (!is(input)) return null;
+        const output = clone(input);
+        return output;
+    },
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/createIsParse/test_createIsParse_AtomicIntersection.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_AtomicIntersection.ts
@@ -1,0 +1,23 @@
+import typia from "../../../../src";
+import { _test_isParse } from "../../../internal/_test_isParse";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createIsParse_AtomicIntersection = _test_isParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): typia.Primitive<AtomicIntersection> => {
+        const is = (input: any): input is AtomicIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        };
+        input = JSON.parse(input);
+        return is(input) ? (input as any) : null;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createIsParse/test_createIsParse_ConstantIntersection.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_ConstantIntersection.ts
@@ -1,0 +1,22 @@
+import typia from "../../../../src";
+import { _test_isParse } from "../../../internal/_test_isParse";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createIsParse_ConstantIntersection = _test_isParse(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: any): typia.Primitive<ConstantIntersection> => {
+        const is = (input: any): input is ConstantIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        };
+        input = JSON.parse(input);
+        return is(input) ? (input as any) : null;
+    },
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/createIsPrune/test_createIsPrune_AtomicIntersection.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_AtomicIntersection.ts
@@ -1,0 +1,25 @@
+import typia from "../../../../src";
+import { _test_isPrune } from "../../../internal/_test_isPrune";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createIsPrune_AtomicIntersection = _test_isPrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): input is AtomicIntersection => {
+        const is = (input: any): input is AtomicIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        };
+        const prune = (input: AtomicIntersection): void => {};
+        if (!is(input)) return false;
+        prune(input);
+        return true;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createIsPrune/test_createIsPrune_ConstantIntersection.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_ConstantIntersection.ts
@@ -1,0 +1,24 @@
+import typia from "../../../../src";
+import { _test_isPrune } from "../../../internal/_test_isPrune";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createIsPrune_ConstantIntersection = _test_isPrune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: any): input is ConstantIntersection => {
+        const is = (input: any): input is ConstantIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        };
+        const prune = (input: ConstantIntersection): void => {};
+        if (!is(input)) return false;
+        prune(input);
+        return true;
+    },
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/createIsStringify/test_createIsStringify_AtomicIntersection.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_AtomicIntersection.ts
@@ -1,0 +1,27 @@
+import typia from "../../../../src";
+import { _test_isStringify } from "../../../internal/_test_isStringify";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createIsStringify_AtomicIntersection = _test_isStringify(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: AtomicIntersection): string | null => {
+        const is = (input: any): input is AtomicIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        };
+        const stringify = (input: AtomicIntersection): string => {
+            const $number = (typia.createIsStringify as any).number;
+            const $string = (typia.createIsStringify as any).string;
+            return `[${input[0]},${$number(input[1])},${$string(input[2])}]`;
+        };
+        return is(input) ? stringify(input) : null;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createIsStringify/test_createIsStringify_ConstantIntersection.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_ConstantIntersection.ts
@@ -1,0 +1,34 @@
+import typia from "../../../../src";
+import { _test_isStringify } from "../../../internal/_test_isStringify";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createIsStringify_ConstantIntersection = _test_isStringify(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: ConstantIntersection): string | null => {
+        const is = (input: any): input is ConstantIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        };
+        const stringify = (input: ConstantIntersection): string => {
+            const $number = (typia.createIsStringify as any).number;
+            const $string = (typia.createIsStringify as any).string;
+            const $throws = (typia.createIsStringify as any).throws;
+            return `[${input[0]},${$number(input[1])},${(() => {
+                if ("string" === typeof input[2]) return $string(input[2]);
+                if ("string" === typeof input[2]) return '"' + input[2] + '"';
+                $throws({
+                    expected: '"two"',
+                    value: input[2],
+                });
+            })()}]`;
+        };
+        return is(input) ? stringify(input) : null;
+    },
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/createPrune/test_createPrune_AtomicIntersection.ts
+++ b/test/generated/output/createPrune/test_createPrune_AtomicIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../../src";
+import { _test_prune } from "../../../internal/_test_prune";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createPrune_AtomicIntersection = _test_prune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: AtomicIntersection): void => {},
+);

--- a/test/generated/output/createPrune/test_createPrune_ConstantIntersection.ts
+++ b/test/generated/output/createPrune/test_createPrune_ConstantIntersection.ts
@@ -1,0 +1,9 @@
+import typia from "../../../../src";
+import { _test_prune } from "../../../internal/_test_prune";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createPrune_ConstantIntersection = _test_prune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: ConstantIntersection): void => {},
+);

--- a/test/generated/output/createRandom/test_createRandom_AtomicIntersection.ts
+++ b/test/generated/output/createRandom/test_createRandom_AtomicIntersection.ts
@@ -1,0 +1,80 @@
+import typia from "../../../../src";
+import { _test_random } from "../../../internal/_test_random";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createRandom_AtomicIntersection = _test_random(
+    "AtomicIntersection",
+    (
+        generator?: Partial<typia.IRandomGenerator>,
+    ): typia.Primitive<AtomicIntersection> => {
+        const $generator = (typia.createRandom as any).generator;
+        return [
+            (generator?.boolean ?? $generator.boolean)(),
+            (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                (generator?.number ?? $generator.number)(0, 100),
+            (generator?.customs ?? $generator.customs)?.string?.([]) ??
+                (generator?.string ?? $generator.string)(),
+        ];
+    },
+    (input: any): typia.Primitive<AtomicIntersection> => {
+        const __is = (
+            input: any,
+        ): input is typia.Primitive<AtomicIntersection> => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is typia.Primitive<AtomicIntersection> => {
+                const $guard = (typia.createAssert as any).guard;
+                return (
+                    ((Array.isArray(input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })) &&
+                        (input.length === 3 ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "[boolean, number, string]",
+                                value: input,
+                            })) &&
+                        ("boolean" === typeof input[0] ||
+                            $guard(true, {
+                                path: _path + "[0]",
+                                expected: "boolean",
+                                value: input[0],
+                            })) &&
+                        (("number" === typeof input[1] &&
+                            Number.isFinite(input[1])) ||
+                            $guard(true, {
+                                path: _path + "[1]",
+                                expected: "number",
+                                value: input[1],
+                            })) &&
+                        ("string" === typeof input[2] ||
+                            $guard(true, {
+                                path: _path + "[2]",
+                                expected: "string",
+                                value: input[2],
+                            }))) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "AtomicIntersection",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+);

--- a/test/generated/output/createRandom/test_createRandom_ConstantIntersection.ts
+++ b/test/generated/output/createRandom/test_createRandom_ConstantIntersection.ts
@@ -1,0 +1,71 @@
+import typia from "../../../../src";
+import { _test_random } from "../../../internal/_test_random";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createRandom_ConstantIntersection = _test_random(
+    "ConstantIntersection",
+    (
+        generator?: Partial<typia.IRandomGenerator>,
+    ): typia.Primitive<ConstantIntersection> => {
+        return [false, 1, "two"];
+    },
+    (input: any): typia.Primitive<ConstantIntersection> => {
+        const __is = (
+            input: any,
+        ): input is typia.Primitive<ConstantIntersection> => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is typia.Primitive<ConstantIntersection> => {
+                const $guard = (typia.createAssert as any).guard;
+                return (
+                    ((Array.isArray(input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })) &&
+                        (input.length === 3 ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: '[false, 1, "two"]',
+                                value: input,
+                            })) &&
+                        (false === input[0] ||
+                            $guard(true, {
+                                path: _path + "[0]",
+                                expected: "false",
+                                value: input[0],
+                            })) &&
+                        (1 === input[1] ||
+                            $guard(true, {
+                                path: _path + "[1]",
+                                expected: "1",
+                                value: input[1],
+                            })) &&
+                        ("two" === input[2] ||
+                            $guard(true, {
+                                path: _path + "[2]",
+                                expected: '"two"',
+                                value: input[2],
+                            }))) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "ConstantIntersection",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+);

--- a/test/generated/output/createStringify/test_createStringify_AtomicIntersection.ts
+++ b/test/generated/output/createStringify/test_createStringify_AtomicIntersection.ts
@@ -1,0 +1,13 @@
+import typia from "../../../../src";
+import { _test_stringify } from "../../../internal/_test_stringify";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createStringify_AtomicIntersection = _test_stringify(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: AtomicIntersection): string => {
+        const $number = (typia.createStringify as any).number;
+        const $string = (typia.createStringify as any).string;
+        return `[${input[0]},${$number(input[1])},${$string(input[2])}]`;
+    },
+);

--- a/test/generated/output/createStringify/test_createStringify_ConstantIntersection.ts
+++ b/test/generated/output/createStringify/test_createStringify_ConstantIntersection.ts
@@ -1,0 +1,21 @@
+import typia from "../../../../src";
+import { _test_stringify } from "../../../internal/_test_stringify";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createStringify_ConstantIntersection = _test_stringify(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: ConstantIntersection): string => {
+        const $number = (typia.createStringify as any).number;
+        const $string = (typia.createStringify as any).string;
+        const $throws = (typia.createStringify as any).throws;
+        return `[${input[0]},${$number(input[1])},${(() => {
+            if ("string" === typeof input[2]) return $string(input[2]);
+            if ("string" === typeof input[2]) return '"' + input[2] + '"';
+            $throws({
+                expected: '"two"',
+                value: input[2],
+            });
+        })()}]`;
+    },
+);

--- a/test/generated/output/createValidate/test_createValidate_AtomicIntersection.ts
+++ b/test/generated/output/createValidate/test_createValidate_AtomicIntersection.ts
@@ -1,0 +1,76 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createValidate_AtomicIntersection = _test_validate(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): typia.IValidation<AtomicIntersection> => {
+        const errors = [] as any[];
+        const $report = (typia.createValidate as any).report(errors);
+        const __is = (input: any): input is AtomicIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is AtomicIntersection => {
+                return (
+                    ((Array.isArray(input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })) &&
+                        (input.length === 3 ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "[boolean, number, string]",
+                                value: input,
+                            })) &&
+                        [
+                            "boolean" === typeof input[0] ||
+                                $report(true, {
+                                    path: _path + "[0]",
+                                    expected: "boolean",
+                                    value: input[0],
+                                }),
+                            ("number" === typeof input[1] &&
+                                Number.isFinite(input[1])) ||
+                                $report(true, {
+                                    path: _path + "[1]",
+                                    expected: "number",
+                                    value: input[1],
+                                }),
+                            "string" === typeof input[2] ||
+                                $report(true, {
+                                    path: _path + "[2]",
+                                    expected: "string",
+                                    value: input[2],
+                                }),
+                        ].every((flag: boolean) => flag)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "AtomicIntersection",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createValidate/test_createValidate_ConstantIntersection.ts
+++ b/test/generated/output/createValidate/test_createValidate_ConstantIntersection.ts
@@ -1,0 +1,74 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createValidate_ConstantIntersection = _test_validate(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input: any): typia.IValidation<ConstantIntersection> => {
+        const errors = [] as any[];
+        const $report = (typia.createValidate as any).report(errors);
+        const __is = (input: any): input is ConstantIntersection => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ConstantIntersection => {
+                return (
+                    ((Array.isArray(input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })) &&
+                        (input.length === 3 ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: '[false, 1, "two"]',
+                                value: input,
+                            })) &&
+                        [
+                            false === input[0] ||
+                                $report(true, {
+                                    path: _path + "[0]",
+                                    expected: "false",
+                                    value: input[0],
+                                }),
+                            1 === input[1] ||
+                                $report(true, {
+                                    path: _path + "[1]",
+                                    expected: "1",
+                                    value: input[1],
+                                }),
+                            "two" === input[2] ||
+                                $report(true, {
+                                    path: _path + "[2]",
+                                    expected: '"two"',
+                                    value: input[2],
+                                }),
+                        ].every((flag: boolean) => flag)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "ConstantIntersection",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    },
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/createValidateClone/test_createValidateClone_AtomicIntersection.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_AtomicIntersection.ts
@@ -1,0 +1,94 @@
+import typia from "../../../../src";
+import { _test_validateClone } from "../../../internal/_test_validateClone";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createValidateClone_AtomicIntersection = _test_validateClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): typia.IValidation<typia.Primitive<AtomicIntersection>> => {
+        const validate = (
+            input: any,
+        ): typia.IValidation<AtomicIntersection> => {
+            const errors = [] as any[];
+            const $report = (typia.createValidateClone as any).report(errors);
+            const __is = (input: any): input is AtomicIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is AtomicIntersection => {
+                    return (
+                        ((Array.isArray(input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            [
+                                "boolean" === typeof input[0] ||
+                                    $report(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    }),
+                                ("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $report(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    }),
+                                "string" === typeof input[2] ||
+                                    $report(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }),
+                            ].every((flag: boolean) => flag)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const clone = (
+            input: AtomicIntersection,
+        ): typia.Primitive<AtomicIntersection> => {
+            return Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                "string" === typeof input[2]
+                ? ([input[0] as any, input[1] as any, input[2] as any] as any)
+                : (input as any);
+        };
+        const output = validate(input) as any;
+        if (output.success) output.data = clone(input);
+        return output;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createValidateClone/test_createValidateClone_ConstantIntersection.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_ConstantIntersection.ts
@@ -1,0 +1,101 @@
+import typia from "../../../../src";
+import { _test_validateClone } from "../../../internal/_test_validateClone";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createValidateClone_ConstantIntersection =
+    _test_validateClone(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        (
+            input: any,
+        ): typia.IValidation<typia.Primitive<ConstantIntersection>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ConstantIntersection> => {
+                const errors = [] as any[];
+                const $report = (typia.createValidateClone as any).report(
+                    errors,
+                );
+                const __is = (input: any): input is ConstantIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ConstantIntersection => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                [
+                                    false === input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "false",
+                                            value: input[0],
+                                        }),
+                                    1 === input[1] ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "1",
+                                            value: input[1],
+                                        }),
+                                    "two" === input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: '"two"',
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const clone = (
+                input: ConstantIntersection,
+            ): typia.Primitive<ConstantIntersection> => {
+                return Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                    ? ([
+                          input[0] as any,
+                          input[1] as any,
+                          input[2] as any,
+                      ] as any)
+                    : (input as any);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = clone(input);
+            return output;
+        },
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_AtomicIntersection.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_AtomicIntersection.ts
@@ -1,0 +1,79 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createValidateEquals_AtomicIntersection =
+    _test_validateEquals(
+        "AtomicIntersection",
+        AtomicIntersection.generate,
+        (input: any): typia.IValidation<AtomicIntersection> => {
+            const errors = [] as any[];
+            const $report = (typia.createValidateEquals as any).report(errors);
+            const __is = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): input is AtomicIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is AtomicIntersection => {
+                    return (
+                        ((Array.isArray(input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            [
+                                "boolean" === typeof input[0] ||
+                                    $report(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    }),
+                                ("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $report(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    }),
+                                "string" === typeof input[2] ||
+                                    $report(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }),
+                            ].every((flag: boolean) => flag)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        },
+    );

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_ConstantIntersection.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_ConstantIntersection.ts
@@ -1,0 +1,77 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createValidateEquals_ConstantIntersection =
+    _test_validateEquals(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        (input: any): typia.IValidation<ConstantIntersection> => {
+            const errors = [] as any[];
+            const $report = (typia.createValidateEquals as any).report(errors);
+            const __is = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): input is ConstantIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ConstantIntersection => {
+                    return (
+                        ((Array.isArray(input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: '[false, 1, "two"]',
+                                    value: input,
+                                })) &&
+                            [
+                                false === input[0] ||
+                                    $report(true, {
+                                        path: _path + "[0]",
+                                        expected: "false",
+                                        value: input[0],
+                                    }),
+                                1 === input[1] ||
+                                    $report(true, {
+                                        path: _path + "[1]",
+                                        expected: "1",
+                                        value: input[1],
+                                    }),
+                                "two" === input[2] ||
+                                    $report(true, {
+                                        path: _path + "[2]",
+                                        expected: '"two"',
+                                        value: input[2],
+                                    }),
+                            ].every((flag: boolean) => flag)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        },
+    );

--- a/test/generated/output/createValidateParse/test_createValidateParse_AtomicIntersection.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_AtomicIntersection.ts
@@ -1,0 +1,83 @@
+import typia from "../../../../src";
+import { _test_validateParse } from "../../../internal/_test_validateParse";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createValidateParse_AtomicIntersection = _test_validateParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: string): typia.IValidation<typia.Primitive<AtomicIntersection>> => {
+        const validate = (
+            input: any,
+        ): typia.IValidation<AtomicIntersection> => {
+            const errors = [] as any[];
+            const $report = (typia.createValidateParse as any).report(errors);
+            const __is = (input: any): input is AtomicIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is AtomicIntersection => {
+                    return (
+                        ((Array.isArray(input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            [
+                                "boolean" === typeof input[0] ||
+                                    $report(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    }),
+                                ("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $report(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    }),
+                                "string" === typeof input[2] ||
+                                    $report(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }),
+                            ].every((flag: boolean) => flag)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        input = JSON.parse(input);
+        const output = validate(input);
+        return output as any;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createValidateParse/test_createValidateParse_ConstantIntersection.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_ConstantIntersection.ts
@@ -1,0 +1,86 @@
+import typia from "../../../../src";
+import { _test_validateParse } from "../../../internal/_test_validateParse";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createValidateParse_ConstantIntersection =
+    _test_validateParse(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        (
+            input: string,
+        ): typia.IValidation<typia.Primitive<ConstantIntersection>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ConstantIntersection> => {
+                const errors = [] as any[];
+                const $report = (typia.createValidateParse as any).report(
+                    errors,
+                );
+                const __is = (input: any): input is ConstantIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ConstantIntersection => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                [
+                                    false === input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "false",
+                                            value: input[0],
+                                        }),
+                                    1 === input[1] ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "1",
+                                            value: input[1],
+                                        }),
+                                    "two" === input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: '"two"',
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            input = JSON.parse(input);
+            const output = validate(input);
+            return output as any;
+        },
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_AtomicIntersection.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_AtomicIntersection.ts
@@ -1,0 +1,84 @@
+import typia from "../../../../src";
+import { _test_validatePrune } from "../../../internal/_test_validatePrune";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createValidatePrune_AtomicIntersection = _test_validatePrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input: any): typia.IValidation<AtomicIntersection> => {
+        const validate = (
+            input: any,
+        ): typia.IValidation<AtomicIntersection> => {
+            const errors = [] as any[];
+            const $report = (typia.createValidatePrune as any).report(errors);
+            const __is = (input: any): input is AtomicIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is AtomicIntersection => {
+                    return (
+                        ((Array.isArray(input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            [
+                                "boolean" === typeof input[0] ||
+                                    $report(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    }),
+                                ("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $report(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    }),
+                                "string" === typeof input[2] ||
+                                    $report(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }),
+                            ].every((flag: boolean) => flag)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const prune = (input: AtomicIntersection): void => {};
+        const output = validate(input);
+        if (output.success) prune(input);
+        return output;
+    },
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_ConstantIntersection.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_ConstantIntersection.ts
@@ -1,0 +1,85 @@
+import typia from "../../../../src";
+import { _test_validatePrune } from "../../../internal/_test_validatePrune";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createValidatePrune_ConstantIntersection =
+    _test_validatePrune(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        (input: any): typia.IValidation<ConstantIntersection> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ConstantIntersection> => {
+                const errors = [] as any[];
+                const $report = (typia.createValidatePrune as any).report(
+                    errors,
+                );
+                const __is = (input: any): input is ConstantIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ConstantIntersection => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                [
+                                    false === input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "false",
+                                            value: input[0],
+                                        }),
+                                    1 === input[1] ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "1",
+                                            value: input[1],
+                                        }),
+                                    "two" === input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: '"two"',
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const prune = (input: ConstantIntersection): void => {};
+            const output = validate(input);
+            if (output.success) prune(input);
+            return output;
+        },
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_AtomicIntersection.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_AtomicIntersection.ts
@@ -1,0 +1,93 @@
+import typia from "../../../../src";
+import { _test_validateStringify } from "../../../internal/_test_validateStringify";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_createValidateStringify_AtomicIntersection =
+    _test_validateStringify(
+        "AtomicIntersection",
+        AtomicIntersection.generate,
+        (input: AtomicIntersection): typia.IValidation<string> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<AtomicIntersection> => {
+                const errors = [] as any[];
+                const $report = (typia.createValidateStringify as any).report(
+                    errors,
+                );
+                const __is = (input: any): input is AtomicIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        "boolean" === typeof input[0] &&
+                        "number" === typeof input[1] &&
+                        Number.isFinite(input[1]) &&
+                        "string" === typeof input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is AtomicIntersection => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "AtomicIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: "[boolean, number, string]",
+                                        value: input,
+                                    })) &&
+                                [
+                                    "boolean" === typeof input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "boolean",
+                                            value: input[0],
+                                        }),
+                                    ("number" === typeof input[1] &&
+                                        Number.isFinite(input[1])) ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "number",
+                                            value: input[1],
+                                        }),
+                                    "string" === typeof input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: "string",
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const stringify = (input: AtomicIntersection): string => {
+                const $number = (typia.createValidateStringify as any).number;
+                const $string = (typia.createValidateStringify as any).string;
+                return `[${input[0]},${$number(input[1])},${$string(
+                    input[2],
+                )}]`;
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = stringify(input);
+            return output;
+        },
+        AtomicIntersection.SPOILERS,
+    );

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_ConstantIntersection.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_ConstantIntersection.ts
@@ -1,0 +1,98 @@
+import typia from "../../../../src";
+import { _test_validateStringify } from "../../../internal/_test_validateStringify";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_createValidateStringify_ConstantIntersection =
+    _test_validateStringify(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        (input: ConstantIntersection): typia.IValidation<string> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ConstantIntersection> => {
+                const errors = [] as any[];
+                const $report = (typia.createValidateStringify as any).report(
+                    errors,
+                );
+                const __is = (input: any): input is ConstantIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ConstantIntersection => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                [
+                                    false === input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "false",
+                                            value: input[0],
+                                        }),
+                                    1 === input[1] ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "1",
+                                            value: input[1],
+                                        }),
+                                    "two" === input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: '"two"',
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const stringify = (input: ConstantIntersection): string => {
+                const $number = (typia.createValidateStringify as any).number;
+                const $string = (typia.createValidateStringify as any).string;
+                const $throws = (typia.createValidateStringify as any).throws;
+                return `[${input[0]},${$number(input[1])},${(() => {
+                    if ("string" === typeof input[2]) return $string(input[2]);
+                    if ("string" === typeof input[2])
+                        return '"' + input[2] + '"';
+                    $throws({
+                        expected: '"two"',
+                        value: input[2],
+                    });
+                })()}]`;
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = stringify(input);
+            return output;
+        },
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/generated/output/equals/test_equals_AtomicIntersection.ts
+++ b/test/generated/output/equals/test_equals_AtomicIntersection.ts
@@ -1,0 +1,26 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_equals_AtomicIntersection = _test_equals(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is [
+            AtomicIntersection.Wrapper<boolean>,
+            AtomicIntersection.Wrapper<number>,
+            AtomicIntersection.Wrapper<string>,
+        ] => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        })(input),
+);

--- a/test/generated/output/equals/test_equals_ConstantIntersection.ts
+++ b/test/generated/output/equals/test_equals_ConstantIntersection.ts
@@ -1,0 +1,25 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_equals_ConstantIntersection = _test_equals(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is [
+            ConstantIntersection.Wrapper<false>,
+            ConstantIntersection.Wrapper<1>,
+            ConstantIntersection.Wrapper<"two">,
+        ] => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        })(input),
+);

--- a/test/generated/output/is/test_is_AtomicIntersection.ts
+++ b/test/generated/output/is/test_is_AtomicIntersection.ts
@@ -1,0 +1,26 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_is_AtomicIntersection = _test_is(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): input is [
+            AtomicIntersection.Wrapper<boolean>,
+            AtomicIntersection.Wrapper<number>,
+            AtomicIntersection.Wrapper<string>,
+        ] => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/is/test_is_ConstantIntersection.ts
+++ b/test/generated/output/is/test_is_ConstantIntersection.ts
@@ -1,0 +1,25 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_is_ConstantIntersection = _test_is(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): input is [
+            ConstantIntersection.Wrapper<false>,
+            ConstantIntersection.Wrapper<1>,
+            ConstantIntersection.Wrapper<"two">,
+        ] => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/isClone/test_isClone_AtomicIntersection.ts
+++ b/test/generated/output/isClone/test_isClone_AtomicIntersection.ts
@@ -1,0 +1,64 @@
+import typia from "../../../../src";
+import { _test_isClone } from "../../../internal/_test_isClone";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_isClone_AtomicIntersection = _test_isClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.Primitive<
+            [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ]
+        > | null => {
+            const is = (
+                input: any,
+            ): input is [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            const clone = (
+                input: [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ],
+            ): typia.Primitive<
+                [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ]
+            > => {
+                return Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    "string" === typeof input[2]
+                    ? ([
+                          input[0] as any,
+                          input[1] as any,
+                          input[2] as any,
+                      ] as any)
+                    : (input as any);
+            };
+            if (!is(input)) return null;
+            const output = clone(input);
+            return output;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/isClone/test_isClone_ConstantIntersection.ts
+++ b/test/generated/output/isClone/test_isClone_ConstantIntersection.ts
@@ -1,0 +1,63 @@
+import typia from "../../../../src";
+import { _test_isClone } from "../../../internal/_test_isClone";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_isClone_ConstantIntersection = _test_isClone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.Primitive<
+            [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ]
+        > | null => {
+            const is = (
+                input: any,
+            ): input is [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            const clone = (
+                input: [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ],
+            ): typia.Primitive<
+                [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ]
+            > => {
+                return Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                    ? ([
+                          input[0] as any,
+                          input[1] as any,
+                          input[2] as any,
+                      ] as any)
+                    : (input as any);
+            };
+            if (!is(input)) return null;
+            const output = clone(input);
+            return output;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/isParse/test_isParse_AtomicIntersection.ts
+++ b/test/generated/output/isParse/test_isParse_AtomicIntersection.ts
@@ -1,0 +1,24 @@
+import typia from "../../../../src";
+import { _test_isParse } from "../../../internal/_test_isParse";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_isParse_AtomicIntersection = _test_isParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((input: any): typia.Primitive<AtomicIntersection> => {
+            const is = (input: any): input is AtomicIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            input = JSON.parse(input);
+            return is(input) ? (input as any) : null;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/isParse/test_isParse_ConstantIntersection.ts
+++ b/test/generated/output/isParse/test_isParse_ConstantIntersection.ts
@@ -1,0 +1,23 @@
+import typia from "../../../../src";
+import { _test_isParse } from "../../../internal/_test_isParse";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_isParse_ConstantIntersection = _test_isParse(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((input: any): typia.Primitive<ConstantIntersection> => {
+            const is = (input: any): input is ConstantIntersection => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            input = JSON.parse(input);
+            return is(input) ? (input as any) : null;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/isPrune/test_isPrune_AtomicIntersection.ts
+++ b/test/generated/output/isPrune/test_isPrune_AtomicIntersection.ts
@@ -1,0 +1,44 @@
+import typia from "../../../../src";
+import { _test_isPrune } from "../../../internal/_test_isPrune";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_isPrune_AtomicIntersection = _test_isPrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): input is [
+            AtomicIntersection.Wrapper<boolean>,
+            AtomicIntersection.Wrapper<number>,
+            AtomicIntersection.Wrapper<string>,
+        ] => {
+            const is = (
+                input: any,
+            ): input is [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            const prune = (
+                input: [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ],
+            ): void => {};
+            if (!is(input)) return false;
+            prune(input);
+            return true;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/isPrune/test_isPrune_ConstantIntersection.ts
+++ b/test/generated/output/isPrune/test_isPrune_ConstantIntersection.ts
@@ -1,0 +1,43 @@
+import typia from "../../../../src";
+import { _test_isPrune } from "../../../internal/_test_isPrune";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_isPrune_ConstantIntersection = _test_isPrune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): input is [
+            ConstantIntersection.Wrapper<false>,
+            ConstantIntersection.Wrapper<1>,
+            ConstantIntersection.Wrapper<"two">,
+        ] => {
+            const is = (
+                input: any,
+            ): input is [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            const prune = (
+                input: [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ],
+            ): void => {};
+            if (!is(input)) return false;
+            prune(input);
+            return true;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/isStringify/test_isStringify_AtomicIntersection.ts
+++ b/test/generated/output/isStringify/test_isStringify_AtomicIntersection.ts
@@ -1,0 +1,48 @@
+import typia from "../../../../src";
+import { _test_isStringify } from "../../../internal/_test_isStringify";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_isStringify_AtomicIntersection = _test_isStringify(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ],
+        ): string | null => {
+            const is = (
+                input: any,
+            ): input is [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            const stringify = (
+                input: [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ],
+            ): string => {
+                const $number = (typia.isStringify as any).number;
+                const $string = (typia.isStringify as any).string;
+                return `[${input[0]},${$number(input[1])},${$string(
+                    input[2],
+                )}]`;
+            };
+            return is(input) ? stringify(input) : null;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/isStringify/test_isStringify_ConstantIntersection.ts
+++ b/test/generated/output/isStringify/test_isStringify_ConstantIntersection.ts
@@ -1,0 +1,54 @@
+import typia from "../../../../src";
+import { _test_isStringify } from "../../../internal/_test_isStringify";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_isStringify_ConstantIntersection = _test_isStringify(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ],
+        ): string | null => {
+            const is = (
+                input: any,
+            ): input is [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            const stringify = (
+                input: [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ],
+            ): string => {
+                const $number = (typia.isStringify as any).number;
+                const $string = (typia.isStringify as any).string;
+                const $throws = (typia.isStringify as any).throws;
+                return `[${input[0]},${$number(input[1])},${(() => {
+                    if ("string" === typeof input[2]) return $string(input[2]);
+                    if ("string" === typeof input[2])
+                        return '"' + input[2] + '"';
+                    $throws({
+                        expected: '"two"',
+                        value: input[2],
+                    });
+                })()}]`;
+            };
+            return is(input) ? stringify(input) : null;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/prune/test_prune_AtomicIntersection.ts
+++ b/test/generated/output/prune/test_prune_AtomicIntersection.ts
@@ -1,0 +1,16 @@
+import typia from "../../../../src";
+import { _test_prune } from "../../../internal/_test_prune";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_prune_AtomicIntersection = _test_prune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ],
+        ): void => {})(input),
+);

--- a/test/generated/output/prune/test_prune_ConstantIntersection.ts
+++ b/test/generated/output/prune/test_prune_ConstantIntersection.ts
@@ -1,0 +1,16 @@
+import typia from "../../../../src";
+import { _test_prune } from "../../../internal/_test_prune";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_prune_ConstantIntersection = _test_prune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ],
+        ): void => {})(input),
+);

--- a/test/generated/output/random/test_random_AtomicIntersection.ts
+++ b/test/generated/output/random/test_random_AtomicIntersection.ts
@@ -1,0 +1,81 @@
+import typia from "../../../../src";
+import { _test_random } from "../../../internal/_test_random";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_random_AtomicIntersection = _test_random(
+    "AtomicIntersection",
+    () =>
+        ((
+            generator?: Partial<typia.IRandomGenerator>,
+        ): typia.Primitive<AtomicIntersection> => {
+            const $generator = (typia.random as any).generator;
+            return [
+                (generator?.boolean ?? $generator.boolean)(),
+                (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                    (generator?.number ?? $generator.number)(0, 100),
+                (generator?.customs ?? $generator.customs)?.string?.([]) ??
+                    (generator?.string ?? $generator.string)(),
+            ];
+        })(),
+    (input: any): typia.Primitive<AtomicIntersection> => {
+        const __is = (
+            input: any,
+        ): input is typia.Primitive<AtomicIntersection> => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                "boolean" === typeof input[0] &&
+                "number" === typeof input[1] &&
+                Number.isFinite(input[1]) &&
+                "string" === typeof input[2]
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is typia.Primitive<AtomicIntersection> => {
+                const $guard = (typia.createAssert as any).guard;
+                return (
+                    ((Array.isArray(input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })) &&
+                        (input.length === 3 ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "[boolean, number, string]",
+                                value: input,
+                            })) &&
+                        ("boolean" === typeof input[0] ||
+                            $guard(true, {
+                                path: _path + "[0]",
+                                expected: "boolean",
+                                value: input[0],
+                            })) &&
+                        (("number" === typeof input[1] &&
+                            Number.isFinite(input[1])) ||
+                            $guard(true, {
+                                path: _path + "[1]",
+                                expected: "number",
+                                value: input[1],
+                            })) &&
+                        ("string" === typeof input[2] ||
+                            $guard(true, {
+                                path: _path + "[2]",
+                                expected: "string",
+                                value: input[2],
+                            }))) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "AtomicIntersection",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+);

--- a/test/generated/output/random/test_random_ConstantIntersection.ts
+++ b/test/generated/output/random/test_random_ConstantIntersection.ts
@@ -1,0 +1,72 @@
+import typia from "../../../../src";
+import { _test_random } from "../../../internal/_test_random";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_random_ConstantIntersection = _test_random(
+    "ConstantIntersection",
+    () =>
+        ((
+            generator?: Partial<typia.IRandomGenerator>,
+        ): typia.Primitive<ConstantIntersection> => {
+            return [false, 1, "two"];
+        })(),
+    (input: any): typia.Primitive<ConstantIntersection> => {
+        const __is = (
+            input: any,
+        ): input is typia.Primitive<ConstantIntersection> => {
+            return (
+                Array.isArray(input) &&
+                input.length === 3 &&
+                false === input[0] &&
+                1 === input[1] &&
+                "two" === input[2]
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is typia.Primitive<ConstantIntersection> => {
+                const $guard = (typia.createAssert as any).guard;
+                return (
+                    ((Array.isArray(input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })) &&
+                        (input.length === 3 ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: '[false, 1, "two"]',
+                                value: input,
+                            })) &&
+                        (false === input[0] ||
+                            $guard(true, {
+                                path: _path + "[0]",
+                                expected: "false",
+                                value: input[0],
+                            })) &&
+                        (1 === input[1] ||
+                            $guard(true, {
+                                path: _path + "[1]",
+                                expected: "1",
+                                value: input[1],
+                            })) &&
+                        ("two" === input[2] ||
+                            $guard(true, {
+                                path: _path + "[2]",
+                                expected: '"two"',
+                                value: input[2],
+                            }))) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "ConstantIntersection",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+);

--- a/test/generated/output/stringify/test_stringify_AtomicIntersection.ts
+++ b/test/generated/output/stringify/test_stringify_AtomicIntersection.ts
@@ -1,0 +1,20 @@
+import typia from "../../../../src";
+import { _test_stringify } from "../../../internal/_test_stringify";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_stringify_AtomicIntersection = _test_stringify(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ],
+        ): string => {
+            const $number = (typia.stringify as any).number;
+            const $string = (typia.stringify as any).string;
+            return `[${input[0]},${$number(input[1])},${$string(input[2])}]`;
+        })(input),
+);

--- a/test/generated/output/stringify/test_stringify_ConstantIntersection.ts
+++ b/test/generated/output/stringify/test_stringify_ConstantIntersection.ts
@@ -1,0 +1,28 @@
+import typia from "../../../../src";
+import { _test_stringify } from "../../../internal/_test_stringify";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_stringify_ConstantIntersection = _test_stringify(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ],
+        ): string => {
+            const $number = (typia.stringify as any).number;
+            const $string = (typia.stringify as any).string;
+            const $throws = (typia.stringify as any).throws;
+            return `[${input[0]},${$number(input[1])},${(() => {
+                if ("string" === typeof input[2]) return $string(input[2]);
+                if ("string" === typeof input[2]) return '"' + input[2] + '"';
+                $throws({
+                    expected: '"two"',
+                    value: input[2],
+                });
+            })()}]`;
+        })(input),
+);

--- a/test/generated/output/validate/test_validate_AtomicIntersection.ts
+++ b/test/generated/output/validate/test_validate_AtomicIntersection.ts
@@ -1,0 +1,95 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_validate_AtomicIntersection = _test_validate(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.IValidation<
+            [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ]
+        > => {
+            const errors = [] as any[];
+            const $report = (typia.validate as any).report(errors);
+            const __is = (
+                input: any,
+            ): input is [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ] => {
+                    return (
+                        ((Array.isArray(input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            [
+                                "boolean" === typeof input[0] ||
+                                    $report(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    }),
+                                ("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $report(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    }),
+                                "string" === typeof input[2] ||
+                                    $report(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }),
+                            ].every((flag: boolean) => flag)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/validate/test_validate_ConstantIntersection.ts
+++ b/test/generated/output/validate/test_validate_ConstantIntersection.ts
@@ -1,0 +1,93 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_validate_ConstantIntersection = _test_validate(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.IValidation<
+            [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ]
+        > => {
+            const errors = [] as any[];
+            const $report = (typia.validate as any).report(errors);
+            const __is = (
+                input: any,
+            ): input is [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ] => {
+                    return (
+                        ((Array.isArray(input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: '[false, 1, "two"]',
+                                    value: input,
+                                })) &&
+                            [
+                                false === input[0] ||
+                                    $report(true, {
+                                        path: _path + "[0]",
+                                        expected: "false",
+                                        value: input[0],
+                                    }),
+                                1 === input[1] ||
+                                    $report(true, {
+                                        path: _path + "[1]",
+                                        expected: "1",
+                                        value: input[1],
+                                    }),
+                                "two" === input[2] ||
+                                    $report(true, {
+                                        path: _path + "[2]",
+                                        expected: '"two"',
+                                        value: input[2],
+                                    }),
+                            ].every((flag: boolean) => flag)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/validateClone/test_validateClone_AtomicIntersection.ts
+++ b/test/generated/output/validateClone/test_validateClone_AtomicIntersection.ts
@@ -1,0 +1,135 @@
+import typia from "../../../../src";
+import { _test_validateClone } from "../../../internal/_test_validateClone";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_validateClone_AtomicIntersection = _test_validateClone(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.IValidation<
+            typia.Primitive<
+                [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ]
+            >
+        > => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<
+                [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ]
+            > => {
+                const errors = [] as any[];
+                const $report = (typia.validateClone as any).report(errors);
+                const __is = (
+                    input: any,
+                ): input is [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ] => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        "boolean" === typeof input[0] &&
+                        "number" === typeof input[1] &&
+                        Number.isFinite(input[1]) &&
+                        "string" === typeof input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is [
+                        AtomicIntersection.Wrapper<boolean>,
+                        AtomicIntersection.Wrapper<number>,
+                        AtomicIntersection.Wrapper<string>,
+                    ] => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "AtomicIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: "[boolean, number, string]",
+                                        value: input,
+                                    })) &&
+                                [
+                                    "boolean" === typeof input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "boolean",
+                                            value: input[0],
+                                        }),
+                                    ("number" === typeof input[1] &&
+                                        Number.isFinite(input[1])) ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "number",
+                                            value: input[1],
+                                        }),
+                                    "string" === typeof input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: "string",
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const clone = (
+                input: [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ],
+            ): typia.Primitive<
+                [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ]
+            > => {
+                return Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    "string" === typeof input[2]
+                    ? ([
+                          input[0] as any,
+                          input[1] as any,
+                          input[2] as any,
+                      ] as any)
+                    : (input as any);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = clone(input);
+            return output;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/validateClone/test_validateClone_ConstantIntersection.ts
+++ b/test/generated/output/validateClone/test_validateClone_ConstantIntersection.ts
@@ -1,0 +1,133 @@
+import typia from "../../../../src";
+import { _test_validateClone } from "../../../internal/_test_validateClone";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_validateClone_ConstantIntersection = _test_validateClone(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.IValidation<
+            typia.Primitive<
+                [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ]
+            >
+        > => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<
+                [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ]
+            > => {
+                const errors = [] as any[];
+                const $report = (typia.validateClone as any).report(errors);
+                const __is = (
+                    input: any,
+                ): input is [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ] => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is [
+                        ConstantIntersection.Wrapper<false>,
+                        ConstantIntersection.Wrapper<1>,
+                        ConstantIntersection.Wrapper<"two">,
+                    ] => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                [
+                                    false === input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "false",
+                                            value: input[0],
+                                        }),
+                                    1 === input[1] ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "1",
+                                            value: input[1],
+                                        }),
+                                    "two" === input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: '"two"',
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const clone = (
+                input: [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ],
+            ): typia.Primitive<
+                [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ]
+            > => {
+                return Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                    ? ([
+                          input[0] as any,
+                          input[1] as any,
+                          input[2] as any,
+                      ] as any)
+                    : (input as any);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = clone(input);
+            return output;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/validateEquals/test_validateEquals_AtomicIntersection.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_AtomicIntersection.ts
@@ -1,0 +1,95 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_validateEquals_AtomicIntersection = _test_validateEquals(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.IValidation<
+            [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ]
+        > => {
+            const errors = [] as any[];
+            const $report = (typia.validateEquals as any).report(errors);
+            const __is = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): input is [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    "boolean" === typeof input[0] &&
+                    "number" === typeof input[1] &&
+                    Number.isFinite(input[1]) &&
+                    "string" === typeof input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ] => {
+                    return (
+                        ((Array.isArray(input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "[boolean, number, string]",
+                                    value: input,
+                                })) &&
+                            [
+                                "boolean" === typeof input[0] ||
+                                    $report(true, {
+                                        path: _path + "[0]",
+                                        expected: "boolean",
+                                        value: input[0],
+                                    }),
+                                ("number" === typeof input[1] &&
+                                    Number.isFinite(input[1])) ||
+                                    $report(true, {
+                                        path: _path + "[1]",
+                                        expected: "number",
+                                        value: input[1],
+                                    }),
+                                "string" === typeof input[2] ||
+                                    $report(true, {
+                                        path: _path + "[2]",
+                                        expected: "string",
+                                        value: input[2],
+                                    }),
+                            ].every((flag: boolean) => flag)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "AtomicIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        })(input),
+);

--- a/test/generated/output/validateEquals/test_validateEquals_ConstantIntersection.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_ConstantIntersection.ts
@@ -1,0 +1,93 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_validateEquals_ConstantIntersection = _test_validateEquals(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.IValidation<
+            [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ]
+        > => {
+            const errors = [] as any[];
+            const $report = (typia.validateEquals as any).report(errors);
+            const __is = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): input is [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ] => {
+                return (
+                    Array.isArray(input) &&
+                    input.length === 3 &&
+                    false === input[0] &&
+                    1 === input[1] &&
+                    "two" === input[2]
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ] => {
+                    return (
+                        ((Array.isArray(input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })) &&
+                            (input.length === 3 ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: '[false, 1, "two"]',
+                                    value: input,
+                                })) &&
+                            [
+                                false === input[0] ||
+                                    $report(true, {
+                                        path: _path + "[0]",
+                                        expected: "false",
+                                        value: input[0],
+                                    }),
+                                1 === input[1] ||
+                                    $report(true, {
+                                        path: _path + "[1]",
+                                        expected: "1",
+                                        value: input[1],
+                                    }),
+                                "two" === input[2] ||
+                                    $report(true, {
+                                        path: _path + "[2]",
+                                        expected: '"two"',
+                                        value: input[2],
+                                    }),
+                            ].every((flag: boolean) => flag)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "ConstantIntersection",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        })(input),
+);

--- a/test/generated/output/validateParse/test_validateParse_AtomicIntersection.ts
+++ b/test/generated/output/validateParse/test_validateParse_AtomicIntersection.ts
@@ -1,0 +1,86 @@
+import typia from "../../../../src";
+import { _test_validateParse } from "../../../internal/_test_validateParse";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_validateParse_AtomicIntersection = _test_validateParse(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: string,
+        ): typia.IValidation<typia.Primitive<AtomicIntersection>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<AtomicIntersection> => {
+                const errors = [] as any[];
+                const $report = (typia.validateParse as any).report(errors);
+                const __is = (input: any): input is AtomicIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        "boolean" === typeof input[0] &&
+                        "number" === typeof input[1] &&
+                        Number.isFinite(input[1]) &&
+                        "string" === typeof input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is AtomicIntersection => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "AtomicIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: "[boolean, number, string]",
+                                        value: input,
+                                    })) &&
+                                [
+                                    "boolean" === typeof input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "boolean",
+                                            value: input[0],
+                                        }),
+                                    ("number" === typeof input[1] &&
+                                        Number.isFinite(input[1])) ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "number",
+                                            value: input[1],
+                                        }),
+                                    "string" === typeof input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: "string",
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            input = JSON.parse(input);
+            const output = validate(input);
+            return output as any;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/validateParse/test_validateParse_ConstantIntersection.ts
+++ b/test/generated/output/validateParse/test_validateParse_ConstantIntersection.ts
@@ -1,0 +1,84 @@
+import typia from "../../../../src";
+import { _test_validateParse } from "../../../internal/_test_validateParse";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_validateParse_ConstantIntersection = _test_validateParse(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: string,
+        ): typia.IValidation<typia.Primitive<ConstantIntersection>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ConstantIntersection> => {
+                const errors = [] as any[];
+                const $report = (typia.validateParse as any).report(errors);
+                const __is = (input: any): input is ConstantIntersection => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ConstantIntersection => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                [
+                                    false === input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "false",
+                                            value: input[0],
+                                        }),
+                                    1 === input[1] ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "1",
+                                            value: input[1],
+                                        }),
+                                    "two" === input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: '"two"',
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            input = JSON.parse(input);
+            const output = validate(input);
+            return output as any;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/validatePrune/test_validatePrune_AtomicIntersection.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_AtomicIntersection.ts
@@ -1,0 +1,115 @@
+import typia from "../../../../src";
+import { _test_validatePrune } from "../../../internal/_test_validatePrune";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_validatePrune_AtomicIntersection = _test_validatePrune(
+    "AtomicIntersection",
+    AtomicIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.IValidation<
+            [
+                AtomicIntersection.Wrapper<boolean>,
+                AtomicIntersection.Wrapper<number>,
+                AtomicIntersection.Wrapper<string>,
+            ]
+        > => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<
+                [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ]
+            > => {
+                const errors = [] as any[];
+                const $report = (typia.validatePrune as any).report(errors);
+                const __is = (
+                    input: any,
+                ): input is [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ] => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        "boolean" === typeof input[0] &&
+                        "number" === typeof input[1] &&
+                        Number.isFinite(input[1]) &&
+                        "string" === typeof input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is [
+                        AtomicIntersection.Wrapper<boolean>,
+                        AtomicIntersection.Wrapper<number>,
+                        AtomicIntersection.Wrapper<string>,
+                    ] => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "AtomicIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: "[boolean, number, string]",
+                                        value: input,
+                                    })) &&
+                                [
+                                    "boolean" === typeof input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "boolean",
+                                            value: input[0],
+                                        }),
+                                    ("number" === typeof input[1] &&
+                                        Number.isFinite(input[1])) ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "number",
+                                            value: input[1],
+                                        }),
+                                    "string" === typeof input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: "string",
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "AtomicIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const prune = (
+                input: [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ],
+            ): void => {};
+            const output = validate(input);
+            if (output.success) prune(input);
+            return output;
+        })(input),
+    AtomicIntersection.SPOILERS,
+);

--- a/test/generated/output/validatePrune/test_validatePrune_ConstantIntersection.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_ConstantIntersection.ts
@@ -1,0 +1,113 @@
+import typia from "../../../../src";
+import { _test_validatePrune } from "../../../internal/_test_validatePrune";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_validatePrune_ConstantIntersection = _test_validatePrune(
+    "ConstantIntersection",
+    ConstantIntersection.generate,
+    (input) =>
+        ((
+            input: any,
+        ): typia.IValidation<
+            [
+                ConstantIntersection.Wrapper<false>,
+                ConstantIntersection.Wrapper<1>,
+                ConstantIntersection.Wrapper<"two">,
+            ]
+        > => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<
+                [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ]
+            > => {
+                const errors = [] as any[];
+                const $report = (typia.validatePrune as any).report(errors);
+                const __is = (
+                    input: any,
+                ): input is [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ] => {
+                    return (
+                        Array.isArray(input) &&
+                        input.length === 3 &&
+                        false === input[0] &&
+                        1 === input[1] &&
+                        "two" === input[2]
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is [
+                        ConstantIntersection.Wrapper<false>,
+                        ConstantIntersection.Wrapper<1>,
+                        ConstantIntersection.Wrapper<"two">,
+                    ] => {
+                        return (
+                            ((Array.isArray(input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })) &&
+                                (input.length === 3 ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: '[false, 1, "two"]',
+                                        value: input,
+                                    })) &&
+                                [
+                                    false === input[0] ||
+                                        $report(true, {
+                                            path: _path + "[0]",
+                                            expected: "false",
+                                            value: input[0],
+                                        }),
+                                    1 === input[1] ||
+                                        $report(true, {
+                                            path: _path + "[1]",
+                                            expected: "1",
+                                            value: input[1],
+                                        }),
+                                    "two" === input[2] ||
+                                        $report(true, {
+                                            path: _path + "[2]",
+                                            expected: '"two"',
+                                            value: input[2],
+                                        }),
+                                ].every((flag: boolean) => flag)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ConstantIntersection",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const prune = (
+                input: [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ],
+            ): void => {};
+            const output = validate(input);
+            if (output.success) prune(input);
+            return output;
+        })(input),
+    ConstantIntersection.SPOILERS,
+);

--- a/test/generated/output/validateStringify/test_validateStringify_AtomicIntersection.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_AtomicIntersection.ts
@@ -1,0 +1,123 @@
+import typia from "../../../../src";
+import { _test_validateStringify } from "../../../internal/_test_validateStringify";
+import { AtomicIntersection } from "../../../structures/AtomicIntersection";
+
+export const test_validateStringify_AtomicIntersection =
+    _test_validateStringify(
+        "AtomicIntersection",
+        AtomicIntersection.generate,
+        (input) =>
+            ((
+                input: [
+                    AtomicIntersection.Wrapper<boolean>,
+                    AtomicIntersection.Wrapper<number>,
+                    AtomicIntersection.Wrapper<string>,
+                ],
+            ): typia.IValidation<string> => {
+                const validate = (
+                    input: any,
+                ): typia.IValidation<
+                    [
+                        AtomicIntersection.Wrapper<boolean>,
+                        AtomicIntersection.Wrapper<number>,
+                        AtomicIntersection.Wrapper<string>,
+                    ]
+                > => {
+                    const errors = [] as any[];
+                    const $report = (typia.validateStringify as any).report(
+                        errors,
+                    );
+                    const __is = (
+                        input: any,
+                    ): input is [
+                        AtomicIntersection.Wrapper<boolean>,
+                        AtomicIntersection.Wrapper<number>,
+                        AtomicIntersection.Wrapper<string>,
+                    ] => {
+                        return (
+                            Array.isArray(input) &&
+                            input.length === 3 &&
+                            "boolean" === typeof input[0] &&
+                            "number" === typeof input[1] &&
+                            Number.isFinite(input[1]) &&
+                            "string" === typeof input[2]
+                        );
+                    };
+                    if (false === __is(input))
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is [
+                            AtomicIntersection.Wrapper<boolean>,
+                            AtomicIntersection.Wrapper<number>,
+                            AtomicIntersection.Wrapper<string>,
+                        ] => {
+                            return (
+                                ((Array.isArray(input) ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: "AtomicIntersection",
+                                        value: input,
+                                    })) &&
+                                    (input.length === 3 ||
+                                        $report(true, {
+                                            path: _path + "",
+                                            expected:
+                                                "[boolean, number, string]",
+                                            value: input,
+                                        })) &&
+                                    [
+                                        "boolean" === typeof input[0] ||
+                                            $report(true, {
+                                                path: _path + "[0]",
+                                                expected: "boolean",
+                                                value: input[0],
+                                            }),
+                                        ("number" === typeof input[1] &&
+                                            Number.isFinite(input[1])) ||
+                                            $report(true, {
+                                                path: _path + "[1]",
+                                                expected: "number",
+                                                value: input[1],
+                                            }),
+                                        "string" === typeof input[2] ||
+                                            $report(true, {
+                                                path: _path + "[2]",
+                                                expected: "string",
+                                                value: input[2],
+                                            }),
+                                    ].every((flag: boolean) => flag)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "AtomicIntersection",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    const success = 0 === errors.length;
+                    return {
+                        success,
+                        errors,
+                        data: success ? input : undefined,
+                    } as any;
+                };
+                const stringify = (
+                    input: [
+                        AtomicIntersection.Wrapper<boolean>,
+                        AtomicIntersection.Wrapper<number>,
+                        AtomicIntersection.Wrapper<string>,
+                    ],
+                ): string => {
+                    const $number = (typia.validateStringify as any).number;
+                    const $string = (typia.validateStringify as any).string;
+                    return `[${input[0]},${$number(input[1])},${$string(
+                        input[2],
+                    )}]`;
+                };
+                const output = validate(input) as any;
+                if (output.success) output.data = stringify(input);
+                return output;
+            })(input),
+        AtomicIntersection.SPOILERS,
+    );

--- a/test/generated/output/validateStringify/test_validateStringify_ConstantIntersection.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_ConstantIntersection.ts
@@ -1,0 +1,128 @@
+import typia from "../../../../src";
+import { _test_validateStringify } from "../../../internal/_test_validateStringify";
+import { ConstantIntersection } from "../../../structures/ConstantIntersection";
+
+export const test_validateStringify_ConstantIntersection =
+    _test_validateStringify(
+        "ConstantIntersection",
+        ConstantIntersection.generate,
+        (input) =>
+            ((
+                input: [
+                    ConstantIntersection.Wrapper<false>,
+                    ConstantIntersection.Wrapper<1>,
+                    ConstantIntersection.Wrapper<"two">,
+                ],
+            ): typia.IValidation<string> => {
+                const validate = (
+                    input: any,
+                ): typia.IValidation<
+                    [
+                        ConstantIntersection.Wrapper<false>,
+                        ConstantIntersection.Wrapper<1>,
+                        ConstantIntersection.Wrapper<"two">,
+                    ]
+                > => {
+                    const errors = [] as any[];
+                    const $report = (typia.validateStringify as any).report(
+                        errors,
+                    );
+                    const __is = (
+                        input: any,
+                    ): input is [
+                        ConstantIntersection.Wrapper<false>,
+                        ConstantIntersection.Wrapper<1>,
+                        ConstantIntersection.Wrapper<"two">,
+                    ] => {
+                        return (
+                            Array.isArray(input) &&
+                            input.length === 3 &&
+                            false === input[0] &&
+                            1 === input[1] &&
+                            "two" === input[2]
+                        );
+                    };
+                    if (false === __is(input))
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is [
+                            ConstantIntersection.Wrapper<false>,
+                            ConstantIntersection.Wrapper<1>,
+                            ConstantIntersection.Wrapper<"two">,
+                        ] => {
+                            return (
+                                ((Array.isArray(input) ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: "ConstantIntersection",
+                                        value: input,
+                                    })) &&
+                                    (input.length === 3 ||
+                                        $report(true, {
+                                            path: _path + "",
+                                            expected: '[false, 1, "two"]',
+                                            value: input,
+                                        })) &&
+                                    [
+                                        false === input[0] ||
+                                            $report(true, {
+                                                path: _path + "[0]",
+                                                expected: "false",
+                                                value: input[0],
+                                            }),
+                                        1 === input[1] ||
+                                            $report(true, {
+                                                path: _path + "[1]",
+                                                expected: "1",
+                                                value: input[1],
+                                            }),
+                                        "two" === input[2] ||
+                                            $report(true, {
+                                                path: _path + "[2]",
+                                                expected: '"two"',
+                                                value: input[2],
+                                            }),
+                                    ].every((flag: boolean) => flag)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ConstantIntersection",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    const success = 0 === errors.length;
+                    return {
+                        success,
+                        errors,
+                        data: success ? input : undefined,
+                    } as any;
+                };
+                const stringify = (
+                    input: [
+                        ConstantIntersection.Wrapper<false>,
+                        ConstantIntersection.Wrapper<1>,
+                        ConstantIntersection.Wrapper<"two">,
+                    ],
+                ): string => {
+                    const $number = (typia.validateStringify as any).number;
+                    const $string = (typia.validateStringify as any).string;
+                    const $throws = (typia.validateStringify as any).throws;
+                    return `[${input[0]},${$number(input[1])},${(() => {
+                        if ("string" === typeof input[2])
+                            return $string(input[2]);
+                        if ("string" === typeof input[2])
+                            return '"' + input[2] + '"';
+                        $throws({
+                            expected: '"two"',
+                            value: input[2],
+                        });
+                    })()}]`;
+                };
+                const output = validate(input) as any;
+                if (output.success) output.data = stringify(input);
+                return output;
+            })(input),
+        ConstantIntersection.SPOILERS,
+    );

--- a/test/issues/intersection.ts
+++ b/test/issues/intersection.ts
@@ -1,0 +1,4 @@
+import typia from "typia";
+
+type Intersection = typia.Primitive<number & { __x: string }>;
+console.log(typia.createIs<Intersection>().toString());

--- a/test/schemas/json/ajv/AtomicIntersection.json
+++ b/test/schemas/json/ajv/AtomicIntersection.json
@@ -1,0 +1,39 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/AtomicIntersection"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "AtomicIntersection": {
+        "$id": "#/components/schemas/AtomicIntersection",
+        "type": "array",
+        "items": [
+          {
+            "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_boolean_gt_"
+          },
+          {
+            "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_number_gt_"
+          },
+          {
+            "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_string_gt_"
+          }
+        ]
+      },
+      "AtomicIntersection.Wrapper_lt_boolean_gt_": {
+        "$id": "#/components/schemas/AtomicIntersection.Wrapper_lt_boolean_gt_",
+        "type": "boolean"
+      },
+      "AtomicIntersection.Wrapper_lt_number_gt_": {
+        "$id": "#/components/schemas/AtomicIntersection.Wrapper_lt_number_gt_",
+        "type": "number"
+      },
+      "AtomicIntersection.Wrapper_lt_string_gt_": {
+        "$id": "#/components/schemas/AtomicIntersection.Wrapper_lt_string_gt_",
+        "type": "string"
+      }
+    }
+  },
+  "purpose": "ajv"
+}

--- a/test/schemas/json/ajv/ConstantIntersection.json
+++ b/test/schemas/json/ajv/ConstantIntersection.json
@@ -1,0 +1,48 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/ConstantIntersection"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "ConstantIntersection": {
+        "$id": "#/components/schemas/ConstantIntersection",
+        "type": "array",
+        "items": [
+          {
+            "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_false_gt_"
+          },
+          {
+            "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_1_gt_"
+          },
+          {
+            "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_"
+          }
+        ]
+      },
+      "ConstantIntersection.Wrapper_lt_false_gt_": {
+        "$id": "#/components/schemas/ConstantIntersection.Wrapper_lt_false_gt_",
+        "type": "boolean",
+        "enum": [
+          false
+        ]
+      },
+      "ConstantIntersection.Wrapper_lt_1_gt_": {
+        "$id": "#/components/schemas/ConstantIntersection.Wrapper_lt_1_gt_",
+        "type": "number",
+        "enum": [
+          1
+        ]
+      },
+      "ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_": {
+        "$id": "#/components/schemas/ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_",
+        "type": "string",
+        "enum": [
+          "two"
+        ]
+      }
+    }
+  },
+  "purpose": "ajv"
+}

--- a/test/schemas/json/swagger/AtomicIntersection.json
+++ b/test/schemas/json/swagger/AtomicIntersection.json
@@ -1,0 +1,51 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/AtomicIntersection"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "AtomicIntersection": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_boolean_gt_"
+            },
+            {
+              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_number_gt_"
+            },
+            {
+              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_string_gt_"
+            }
+          ]
+        },
+        "x-typia-tuple": {
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_boolean_gt_"
+            },
+            {
+              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_number_gt_"
+            },
+            {
+              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_string_gt_"
+            }
+          ]
+        }
+      },
+      "AtomicIntersection.Wrapper_lt_boolean_gt_": {
+        "type": "boolean"
+      },
+      "AtomicIntersection.Wrapper_lt_number_gt_": {
+        "type": "number"
+      },
+      "AtomicIntersection.Wrapper_lt_string_gt_": {
+        "type": "string"
+      }
+    }
+  },
+  "purpose": "swagger"
+}

--- a/test/schemas/json/swagger/ConstantIntersection.json
+++ b/test/schemas/json/swagger/ConstantIntersection.json
@@ -1,0 +1,60 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/ConstantIntersection"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "ConstantIntersection": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_false_gt_"
+            },
+            {
+              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_1_gt_"
+            },
+            {
+              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_"
+            }
+          ]
+        },
+        "x-typia-tuple": {
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_false_gt_"
+            },
+            {
+              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_1_gt_"
+            },
+            {
+              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_"
+            }
+          ]
+        }
+      },
+      "ConstantIntersection.Wrapper_lt_false_gt_": {
+        "type": "boolean",
+        "enum": [
+          false
+        ]
+      },
+      "ConstantIntersection.Wrapper_lt_1_gt_": {
+        "type": "number",
+        "enum": [
+          1
+        ]
+      },
+      "ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_": {
+        "type": "string",
+        "enum": [
+          "two"
+        ]
+      }
+    }
+  },
+  "purpose": "swagger"
+}

--- a/test/structures/AtomicIntersection.ts
+++ b/test/structures/AtomicIntersection.ts
@@ -1,0 +1,33 @@
+import { Spoiler } from "../helpers/Spoiler";
+
+export type AtomicIntersection = [
+    AtomicIntersection.Wrapper<boolean>,
+    AtomicIntersection.Wrapper<number>,
+    AtomicIntersection.Wrapper<string>,
+];
+export namespace AtomicIntersection {
+    export type Wrapper<T> = T & { __meta?: object };
+
+    export function generate(): AtomicIntersection {
+        return [false, 1, "two"];
+    }
+
+    export const SPOILERS: Spoiler<AtomicIntersection>[] = [
+        (input) => {
+            input[0] = 0 as any;
+            return ["$input[0]"];
+        },
+        (input) => {
+            input[1] = "one" as any;
+            return ["$input[1]"];
+        },
+        (input) => {
+            input[2] = 2 as any;
+            return ["$input[2]"];
+        },
+        ...new Array(3).fill(0).map((_, i) => (input: AtomicIntersection) => {
+            input[i] = { __meta: {} } as any;
+            return [`$input[${i}]`];
+        }),
+    ];
+}

--- a/test/structures/ConstantIntersection.ts
+++ b/test/structures/ConstantIntersection.ts
@@ -1,0 +1,33 @@
+import { Spoiler } from "../helpers/Spoiler";
+
+export type ConstantIntersection = [
+    ConstantIntersection.Wrapper<false>,
+    ConstantIntersection.Wrapper<1>,
+    ConstantIntersection.Wrapper<"two">,
+];
+export namespace ConstantIntersection {
+    export type Wrapper<T> = T & { __meta?: object };
+
+    export function generate(): ConstantIntersection {
+        return [false, 1, "two"];
+    }
+
+    export const SPOILERS: Spoiler<ConstantIntersection>[] = [
+        (input) => {
+            input[0] = 0 as any;
+            return ["$input[0]"];
+        },
+        (input) => {
+            input[1] = "one" as any;
+            return ["$input[1]"];
+        },
+        (input) => {
+            input[2] = 2 as any;
+            return ["$input[2]"];
+        },
+        ...new Array(3).fill(0).map((_, i) => (input: ConstantIntersection) => {
+            input[i] = { __meta: {} } as any;
+            return [`$input[${i}]`];
+        }),
+    ];
+}


### PR DESCRIPTION
In TypeScript, intersection type combining atomic and object is possible. For an example, `numbe & { __value: string }` type is possible, even if it seems nonsensible.

Therefore, enhanced `typia` to support such crazy type. However, much more crazy type combing atomic value and array like `number & string[]` would be prohibited. Also, combining only objects is possible, but combing both object and array would be blocked.