### PR TITLE
Upgrade peerDependencies of TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.0.6-dev.20230611",
+  "version": "4.0.6-dev.20230612",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -77,7 +77,7 @@
     "randexp": "^0.5.3"
   },
   "peerDependencies": {
-    "typescript": ">= 4.5.2"
+    "typescript": ">= 4.7.4"
   },
   "devDependencies": {
     "@fastify/type-provider-typebox": "^3.0.0",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.0.6-dev.20230611",
+  "version": "4.0.6-dev.20230612",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,10 +68,10 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.0.6-dev.20230611"
+    "typia": "4.0.6-dev.20230612"
   },
   "peerDependencies": {
-    "typescript": ">= 4.5.2"
+    "typescript": ">= 4.7.4"
   },
   "stackblitzs": {
     "startCommand": "npm run prepare && npm run build && npm run build:test && npm run test"


### PR DESCRIPTION
@kakasoo and @8471919 had contributed to enhance `Primitive` type. By the way, the new `Primitive` type requires at least TS 4.7.

Therefore, change `peerDependencies` config.