### PR TITLE
Enhance `Object.toJSON()` type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.0.6",
+  "version": "4.0.8",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.0.6",
+  "version": "4.0.8",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.0.6"
+    "typia": "4.0.8"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/factories/internal/metadata/emend_metadata_atomics.ts
+++ b/src/factories/internal/metadata/emend_metadata_atomics.ts
@@ -1,0 +1,33 @@
+import { Metadata } from "../../../metadata/Metadata";
+
+import { ArrayUtil } from "../../../utils/ArrayUtil";
+
+export const emend_metadata_atomics = (meta: Metadata) => {
+    // ATOMICS
+    for (const type of meta.atomics) {
+        const index: number = meta.constants.findIndex((c) => c.type === type);
+        if (index !== -1) meta.constants.splice(index, 1);
+    }
+
+    // BOOLEAN
+    {
+        const index: number = meta.constants.findIndex(
+            (c) => c.type === "boolean",
+        );
+        if (index !== -1 && meta.constants[index]!.values.length === 2) {
+            meta.constants.splice(index, 1);
+            ArrayUtil.take(
+                meta.atomics,
+                (type) => type === "boolean",
+                () => "boolean",
+            );
+        }
+    }
+
+    // TEMPLATE
+    if (
+        meta.templates.length &&
+        meta.atomics.find((type) => type === "string") !== undefined
+    )
+        meta.templates.splice(0, meta.templates.length);
+};

--- a/src/factories/internal/metadata/explore_metadata.ts
+++ b/src/factories/internal/metadata/explore_metadata.ts
@@ -2,10 +2,9 @@ import ts from "typescript";
 
 import { Metadata } from "../../../metadata/Metadata";
 
-import { ArrayUtil } from "../../../utils/ArrayUtil";
-
 import { MetadataCollection } from "../../MetadataCollection";
 import { MetadataFactory } from "../../MetadataFactory";
+import { emend_metadata_atomics } from "./emend_metadata_atomics";
 import { iterate_metadata } from "./iterate_metadata";
 
 export const explore_metadata =
@@ -32,35 +31,7 @@ export const explore_metadata =
             parentResolved,
             aliased,
         );
-
-        // EMEND ATOMICS
-        for (const type of meta.atomics) {
-            const index: number = meta.constants.findIndex(
-                (c) => c.type === type,
-            );
-            if (index !== -1) meta.constants.splice(index, 1);
-        }
-
-        // EMEND BOOLEAN
-        {
-            const index: number = meta.constants.findIndex(
-                (c) => c.type === "boolean",
-            );
-            if (index !== -1 && meta.constants[index]!.values.length === 2) {
-                meta.constants.splice(index, 1);
-                ArrayUtil.take(
-                    meta.atomics,
-                    (type) => type === "boolean",
-                    () => "boolean",
-                );
-            }
-        }
-
-        // EMEND TEMPLATE
-        if (
-            meta.templates.length &&
-            meta.atomics.find((type) => type === "string") !== undefined
-        )
-            meta.templates.splice(0, meta.templates.length);
+        emend_metadata_atomics(meta);
+        if (meta.resolved) emend_metadata_atomics(meta.resolved);
         return out(meta);
     };

--- a/src/factories/internal/metadata/iterate_metadata.ts
+++ b/src/factories/internal/metadata/iterate_metadata.ts
@@ -27,7 +27,7 @@ export const iterate_metadata =
     (
         meta: Metadata,
         type: ts.Type,
-        parentResolved: boolean,
+        resolved: boolean,
         aliased: boolean,
     ): void => {
         if (type.isTypeParameter() === true)
@@ -44,18 +44,19 @@ export const iterate_metadata =
             iterate_metadata_intersection(checker)(options)(collection)(
                 meta,
                 type,
-                parentResolved,
+                resolved,
                 aliased,
             ) ||
             iterate_metadata_union(checker)(options)(collection)(
                 meta,
                 type,
-                parentResolved,
+                resolved,
             ) ||
             iterate_metadata_resolve(checker)(options)(collection)(
                 meta,
                 type,
-                parentResolved,
+                resolved,
+                aliased,
             )
         )
             return;
@@ -79,6 +80,6 @@ export const iterate_metadata =
             iterate_metadata_object(checker)(options)(collection)(
                 meta,
                 type,
-                parentResolved,
+                resolved,
             );
     };

--- a/src/factories/internal/metadata/iterate_metadata_resolve.ts
+++ b/src/factories/internal/metadata/iterate_metadata_resolve.ts
@@ -7,21 +7,32 @@ import { Writable } from "../../../typings/Writable";
 import { MetadataCollection } from "../../MetadataCollection";
 import { MetadataFactory } from "../../MetadataFactory";
 import { TypeFactory } from "../../TypeFactory";
-import { explore_metadata } from "./explore_metadata";
+import { iterate_metadata } from "./iterate_metadata";
+
+// import { iterate_metadata_coalesce } from "./iterate_metadata_coalesce";
 
 export const iterate_metadata_resolve =
     (checker: ts.TypeChecker) =>
     (options: MetadataFactory.IOptions) =>
     (collection: MetadataCollection) =>
-    (meta: Metadata, type: ts.Type, parentResolved: boolean): boolean => {
-        if (options.resolve === true && parentResolved === false) {
-            const resolved: ts.Type | null = TypeFactory.resolve(checker)(type);
-            if (resolved !== null) {
-                Writable(meta).resolved = explore_metadata(checker)(options)(
-                    collection,
-                )(resolved, true);
-                return true;
-            }
-        }
-        return false;
+    (
+        meta: Metadata,
+        type: ts.Type,
+        resolved: boolean,
+        aliased: boolean,
+    ): boolean => {
+        if (options.resolve === false || resolved === true) return false;
+
+        const escaped: ts.Type | null = TypeFactory.resolve(checker)(type);
+        if (escaped === null) return false;
+
+        if (meta.resolved === null)
+            Writable(meta).resolved = Metadata.initialize();
+        iterate_metadata(checker)(options)(collection)(
+            meta.resolved!,
+            escaped,
+            true,
+            aliased,
+        );
+        return true;
     };

--- a/src/factories/internal/metadata/iterate_metadata_union.ts
+++ b/src/factories/internal/metadata/iterate_metadata_union.ts
@@ -2,11 +2,8 @@ import ts from "typescript";
 
 import { Metadata } from "../../../metadata/Metadata";
 
-import { Writable } from "../../../typings/Writable";
-
 import { MetadataCollection } from "../../MetadataCollection";
 import { MetadataFactory } from "../../MetadataFactory";
-import { TypeFactory } from "../../TypeFactory";
 import { iterate_metadata } from "./iterate_metadata";
 
 export const iterate_metadata_union =
@@ -15,52 +12,11 @@ export const iterate_metadata_union =
     (collection: MetadataCollection) =>
     (meta: Metadata, type: ts.Type, parentResolved: boolean): boolean => {
         if (!type.isUnion()) return false;
-        else if (options.resolve === false || parentResolved === true) {
-            type.types.forEach((t) =>
-                iterate_metadata(checker)(options)(collection)(
-                    meta,
-                    t,
-                    false,
-                    false,
-                ),
-            );
-            return true;
-        }
-
-        const filter = (flag: ts.TypeFlags, t: ts.Type) =>
-            (t.getFlags() & flag) !== 0;
-        const normals: ts.Type[] = [];
-        const toJsons: ts.Type[] = [];
-
-        for (const individual of type.types) {
-            if (filter(ts.TypeFlags.Object, individual)) {
-                const resolved: ts.Type | null =
-                    TypeFactory.resolve(checker)(individual);
-                if (resolved !== null) toJsons.push(resolved);
-                else normals.push(individual);
-            } else normals.push(individual);
-        }
-        if (toJsons.length !== 0) {
-            Writable(meta).resolved = (() => {
-                const union: Metadata = Metadata.initialize();
-                toJsons.forEach((t) =>
-                    iterate_metadata(checker)(options)(collection)(
-                        meta,
-                        t,
-                        true,
-                        false,
-                    ),
-                );
-                if (union.objects.length > 1)
-                    union.union_index = collection.getUnionIndex(union);
-                return union;
-            })();
-        }
-        normals.forEach((t) =>
+        type.types.forEach((t) =>
             iterate_metadata(checker)(options)(collection)(
                 meta,
                 t,
-                false,
+                parentResolved,
                 false,
             ),
         );

--- a/src/programmers/StringifyProgrammer.ts
+++ b/src/programmers/StringifyProgrammer.ts
@@ -194,23 +194,16 @@ export namespace StringifyProgrammer {
 
             // toJSON() METHOD
             if (meta.resolved !== null)
-                if (size === 1)
-                    return decode_to_json(project)(config)(importer)(
-                        input,
-                        meta.resolved,
-                        explore,
-                    );
-                else
-                    unions.push({
-                        type: "resolved",
-                        is: () => IsProgrammer.decode_to_json(false)(input),
-                        value: () =>
-                            decode_to_json(project)(config)(importer)(
-                                input,
-                                meta.resolved!,
-                                explore,
-                            ),
-                    });
+                unions.push({
+                    type: "resolved",
+                    is: () => IsProgrammer.decode_to_json(false)(input),
+                    value: () =>
+                        decode_to_json(project)(config)(importer)(
+                            input,
+                            meta.resolved!,
+                            explore,
+                        ),
+                });
             else if (meta.functional === true)
                 unions.push({
                     type: "functional",

--- a/test/generated/output/assertClone/test_assertClone_NativeUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_NativeUnion.ts
@@ -144,10 +144,6 @@ export const test_assertClone_NativeUnion = _test_assertClone(
             const clone = (
                 input: Array<NativeUnion.Union>,
             ): typia.Primitive<Array<NativeUnion.Union>> => {
-                const $io1 = (input: any): boolean =>
-                    "Buffer" === input.type &&
-                    Array.isArray(input.data) &&
-                    input.data.every((elem: any) => "number" === typeof elem);
                 const $cp0 = (input: any) =>
                     input.map((elem: any) =>
                         "object" === typeof elem && null !== elem
@@ -195,16 +191,16 @@ export const test_assertClone_NativeUnion = _test_assertClone(
                         "object" === typeof input.buffer &&
                         null !== input.buffer &&
                         "function" === typeof input.buffer.toJSON
-                            ? (input.buffer.toJSON() as any)
+                            ? "object" === typeof input.buffer.toJSON() &&
+                              null !== input.buffer.toJSON()
+                                ? $co1(input.buffer.toJSON())
+                                : (input.buffer.toJSON() as any)
                             : input.buffer instanceof ArrayBuffer
                             ? {}
                             : input.buffer instanceof SharedArrayBuffer
                             ? {}
                             : input.buffer instanceof DataView
                             ? {}
-                            : "object" === typeof input.buffer &&
-                              null !== input.buffer
-                            ? $co1(input.buffer)
                             : (input.buffer as any),
                     weak:
                         input.weak instanceof WeakSet

--- a/test/generated/output/assertClone/test_assertClone_ToJsonUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_ToJsonUnion.ts
@@ -276,9 +276,12 @@ export const test_assertClone_ToJsonUnion = _test_assertClone(
                         "object" === typeof elem &&
                         null !== elem &&
                         "function" === typeof elem.toJSON
-                            ? (elem.toJSON() as any)
+                            ? "object" === typeof elem.toJSON() &&
+                              null !== elem.toJSON()
+                                ? $cu0(elem.toJSON())
+                                : (elem.toJSON() as any)
                             : "object" === typeof elem && null !== elem
-                            ? $cu0(elem)
+                            ? $co0(elem)
                             : (elem as any),
                     );
                 const $co0 = (input: any): any => ({

--- a/test/generated/output/assertStringify/test_assertStringify_ToJsonDouble.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_ToJsonDouble.ts
@@ -44,9 +44,9 @@ export const test_assertStringify_ToJsonDouble = _test_assertStringify(
             };
             const stringify = (input: ToJsonDouble.Parent): string => {
                 const $number = (typia.assertStringify as any).number;
-                const $so0 = (input: any): any =>
-                    `{"id":${$number(input.id)},"flag":${input.flag}}`;
-                return $so0(input.toJSON());
+                return `{"id":${$number((input.toJSON() as any).id)},"flag":${
+                    (input.toJSON() as any).flag
+                }}`;
             };
             return stringify(assert(input));
         })(input),

--- a/test/generated/output/assertStringify/test_assertStringify_ToJsonTuple.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_ToJsonTuple.ts
@@ -187,13 +187,11 @@ export const test_assertStringify_ToJsonTuple = _test_assertStringify(
             ): string => {
                 const $string = (typia.assertStringify as any).string;
                 const $number = (typia.assertStringify as any).number;
-                const $so0 = (input: any): any =>
-                    `{"code":${$string(input.code)},"name":${$string(
-                        input.name,
-                    )}}`;
                 return `[${$string(input[0].toJSON())},${$number(
                     input[1].toJSON(),
-                )},${input[2].toJSON()},${$so0(input[3].toJSON())}]`;
+                )},${input[2].toJSON()},${`{"code":${$string(
+                    (input[3].toJSON() as any).code,
+                )},"name":${$string((input[3].toJSON() as any).name)}}`}]`;
             };
             return stringify(assert(input));
         })(input),

--- a/test/generated/output/assertStringify/test_assertStringify_ToJsonUnion.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_ToJsonUnion.ts
@@ -247,9 +247,9 @@ export const test_assertStringify_ToJsonUnion = _test_assertStringify(
                     "string" === typeof input.manufacturer &&
                     "string" === typeof input.brand &&
                     "string" === typeof input.name;
+                const $throws = (typia.assertStringify as any).throws;
                 const $string = (typia.assertStringify as any).string;
                 const $number = (typia.assertStringify as any).number;
-                const $throws = (typia.assertStringify as any).throws;
                 const $so0 = (input: any): any =>
                     `{"id":${$number(input.id)},"mobile":${$string(
                         input.mobile,
@@ -278,15 +278,31 @@ export const test_assertStringify_ToJsonUnion = _test_assertStringify(
                                 "object" === typeof elem &&
                                 "function" === typeof elem.toJSON
                             )
-                                return JSON.stringify(elem.toJSON());
+                                return (() => {
+                                    if ("boolean" === typeof elem.toJSON())
+                                        return elem.toJSON();
+                                    if (
+                                        "object" === typeof elem.toJSON() &&
+                                        null !== elem.toJSON()
+                                    )
+                                        return $su0(elem.toJSON());
+                                    $throws({
+                                        expected:
+                                            "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean)",
+                                        value: elem.toJSON(),
+                                    });
+                                })();
                             if ("string" === typeof elem) return $string(elem);
                             if ("number" === typeof elem) return $number(elem);
-                            if ("boolean" === typeof elem) return elem;
                             if ("object" === typeof elem && null !== elem)
-                                return $su0(elem);
+                                return `{"id":${$number(
+                                    (elem as any).id,
+                                )},"mobile":${$string(
+                                    (elem as any).mobile,
+                                )},"name":${$string((elem as any).name)}}`;
                             $throws({
                                 expected:
-                                    "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean | number | string | unknown)",
+                                    "((ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean) | ToJsonUnion.ICitizen | number | string)",
                                 value: elem,
                             });
                         })(),

--- a/test/generated/output/clone/test_clone_NativeUnion.ts
+++ b/test/generated/output/clone/test_clone_NativeUnion.ts
@@ -9,10 +9,6 @@ export const test_clone_NativeUnion = _test_clone(
         ((
             input: Array<NativeUnion.Union>,
         ): typia.Primitive<Array<NativeUnion.Union>> => {
-            const $io1 = (input: any): boolean =>
-                "Buffer" === input.type &&
-                Array.isArray(input.data) &&
-                input.data.every((elem: any) => "number" === typeof elem);
             const $cp0 = (input: any) =>
                 input.map((elem: any) =>
                     "object" === typeof elem && null !== elem
@@ -59,16 +55,16 @@ export const test_clone_NativeUnion = _test_clone(
                     "object" === typeof input.buffer &&
                     null !== input.buffer &&
                     "function" === typeof input.buffer.toJSON
-                        ? (input.buffer.toJSON() as any)
+                        ? "object" === typeof input.buffer.toJSON() &&
+                          null !== input.buffer.toJSON()
+                            ? $co1(input.buffer.toJSON())
+                            : (input.buffer.toJSON() as any)
                         : input.buffer instanceof ArrayBuffer
                         ? {}
                         : input.buffer instanceof SharedArrayBuffer
                         ? {}
                         : input.buffer instanceof DataView
                         ? {}
-                        : "object" === typeof input.buffer &&
-                          null !== input.buffer
-                        ? $co1(input.buffer)
                         : (input.buffer as any),
                 weak:
                     input.weak instanceof WeakSet

--- a/test/generated/output/clone/test_clone_ToJsonUnion.ts
+++ b/test/generated/output/clone/test_clone_ToJsonUnion.ts
@@ -39,9 +39,12 @@ export const test_clone_ToJsonUnion = _test_clone(
                     "object" === typeof elem &&
                     null !== elem &&
                     "function" === typeof elem.toJSON
-                        ? (elem.toJSON() as any)
+                        ? "object" === typeof elem.toJSON() &&
+                          null !== elem.toJSON()
+                            ? $cu0(elem.toJSON())
+                            : (elem.toJSON() as any)
                         : "object" === typeof elem && null !== elem
-                        ? $cu0(elem)
+                        ? $co0(elem)
                         : (elem as any),
                 );
             const $co0 = (input: any): any => ({

--- a/test/generated/output/createAssertClone/test_createAssertClone_NativeUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_NativeUnion.ts
@@ -138,10 +138,6 @@ export const test_createAssertClone_NativeUnion = _test_assertClone(
             return input;
         };
         const clone = (input: NativeUnion): typia.Primitive<NativeUnion> => {
-            const $io1 = (input: any): boolean =>
-                "Buffer" === input.type &&
-                Array.isArray(input.data) &&
-                input.data.every((elem: any) => "number" === typeof elem);
             const $cp0 = (input: any) =>
                 input.map((elem: any) =>
                     "object" === typeof elem && null !== elem
@@ -188,16 +184,16 @@ export const test_createAssertClone_NativeUnion = _test_assertClone(
                     "object" === typeof input.buffer &&
                     null !== input.buffer &&
                     "function" === typeof input.buffer.toJSON
-                        ? (input.buffer.toJSON() as any)
+                        ? "object" === typeof input.buffer.toJSON() &&
+                          null !== input.buffer.toJSON()
+                            ? $co1(input.buffer.toJSON())
+                            : (input.buffer.toJSON() as any)
                         : input.buffer instanceof ArrayBuffer
                         ? {}
                         : input.buffer instanceof SharedArrayBuffer
                         ? {}
                         : input.buffer instanceof DataView
                         ? {}
-                        : "object" === typeof input.buffer &&
-                          null !== input.buffer
-                        ? $co1(input.buffer)
                         : (input.buffer as any),
                 weak:
                     input.weak instanceof WeakSet

--- a/test/generated/output/createAssertClone/test_createAssertClone_ToJsonUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_ToJsonUnion.ts
@@ -203,9 +203,12 @@ export const test_createAssertClone_ToJsonUnion = _test_assertClone(
                     "object" === typeof elem &&
                     null !== elem &&
                     "function" === typeof elem.toJSON
-                        ? (elem.toJSON() as any)
+                        ? "object" === typeof elem.toJSON() &&
+                          null !== elem.toJSON()
+                            ? $cu0(elem.toJSON())
+                            : (elem.toJSON() as any)
                         : "object" === typeof elem && null !== elem
-                        ? $cu0(elem)
+                        ? $co0(elem)
                         : (elem as any),
                 );
             const $co0 = (input: any): any => ({

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_NativeUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_NativeUnion.ts
@@ -138,30 +138,12 @@ export const test_createAssertStringify_NativeUnion = _test_assertStringify(
             return input;
         };
         const stringify = (input: NativeUnion): string => {
-            const $io1 = (input: any): boolean =>
-                "Buffer" === input.type &&
-                Array.isArray(input.data) &&
-                input.data.every((elem: any) => "number" === typeof elem);
             const $string = (typia.createAssertStringify as any).string;
             const $throws = (typia.createAssertStringify as any).throws;
             const $number = (typia.createAssertStringify as any).number;
             const $so0 = (input: any): any =>
                 `{"date":${
-                    null !== input.date
-                        ? (() => {
-                              if (
-                                  "object" === typeof input.date &&
-                                  "function" === typeof input.date.toJSON
-                              )
-                                  return JSON.stringify(input.date.toJSON());
-                              if ("string" === typeof input.date)
-                                  return $string(input.date);
-                              $throws({
-                                  expected: "(null | string | unknown)",
-                                  value: input.date,
-                              });
-                          })()
-                        : "null"
+                    null !== input.date ? $string(input.date.toJSON()) : "null"
                 },"unsigned":${(() => {
                     if (input.unsigned instanceof Uint8Array) return "{}";
                     if (input.unsigned instanceof Uint8ClampedArray)
@@ -196,18 +178,13 @@ export const test_createAssertStringify_NativeUnion = _test_assertStringify(
                         "object" === typeof input.buffer &&
                         "function" === typeof input.buffer.toJSON
                     )
-                        return JSON.stringify(input.buffer.toJSON());
+                        return $so1(input.buffer.toJSON());
                     if (input.buffer instanceof ArrayBuffer) return "{}";
                     if (input.buffer instanceof SharedArrayBuffer) return "{}";
                     if (input.buffer instanceof DataView) return "{}";
-                    if (
-                        "object" === typeof input.buffer &&
-                        null !== input.buffer
-                    )
-                        return $so1(input.buffer);
                     $throws({
                         expected:
-                            "(ArrayBuffer | DataView | SharedArrayBuffer | __type | unknown)",
+                            "(ArrayBuffer | DataView | SharedArrayBuffer | __type)",
                         value: input.buffer,
                     });
                 })()},"weak":${(() => {

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_ToJsonDouble.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_ToJsonDouble.ts
@@ -43,9 +43,9 @@ export const test_createAssertStringify_ToJsonDouble = _test_assertStringify(
         };
         const stringify = (input: ToJsonDouble): string => {
             const $number = (typia.createAssertStringify as any).number;
-            const $so0 = (input: any): any =>
-                `{"id":${$number(input.id)},"flag":${input.flag}}`;
-            return $so0(input.toJSON());
+            return `{"id":${$number((input.toJSON() as any).id)},"flag":${
+                (input.toJSON() as any).flag
+            }}`;
         };
         return stringify(assert(input));
     },

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_ToJsonTuple.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_ToJsonTuple.ts
@@ -158,11 +158,11 @@ export const test_createAssertStringify_ToJsonTuple = _test_assertStringify(
         const stringify = (input: ToJsonTuple): string => {
             const $string = (typia.createAssertStringify as any).string;
             const $number = (typia.createAssertStringify as any).number;
-            const $so0 = (input: any): any =>
-                `{"code":${$string(input.code)},"name":${$string(input.name)}}`;
             return `[${$string(input[0].toJSON())},${$number(
                 input[1].toJSON(),
-            )},${input[2].toJSON()},${$so0(input[3].toJSON())}]`;
+            )},${input[2].toJSON()},${`{"code":${$string(
+                (input[3].toJSON() as any).code,
+            )},"name":${$string((input[3].toJSON() as any).name)}}`}]`;
         };
         return stringify(assert(input));
     },

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_ToJsonUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_ToJsonUnion.ts
@@ -194,9 +194,9 @@ export const test_createAssertStringify_ToJsonUnion = _test_assertStringify(
                 "string" === typeof input.manufacturer &&
                 "string" === typeof input.brand &&
                 "string" === typeof input.name;
+            const $throws = (typia.createAssertStringify as any).throws;
             const $string = (typia.createAssertStringify as any).string;
             const $number = (typia.createAssertStringify as any).number;
-            const $throws = (typia.createAssertStringify as any).throws;
             const $so0 = (input: any): any =>
                 `{"id":${$number(input.id)},"mobile":${$string(
                     input.mobile,
@@ -224,15 +224,31 @@ export const test_createAssertStringify_ToJsonUnion = _test_assertStringify(
                             "object" === typeof elem &&
                             "function" === typeof elem.toJSON
                         )
-                            return JSON.stringify(elem.toJSON());
+                            return (() => {
+                                if ("boolean" === typeof elem.toJSON())
+                                    return elem.toJSON();
+                                if (
+                                    "object" === typeof elem.toJSON() &&
+                                    null !== elem.toJSON()
+                                )
+                                    return $su0(elem.toJSON());
+                                $throws({
+                                    expected:
+                                        "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean)",
+                                    value: elem.toJSON(),
+                                });
+                            })();
                         if ("string" === typeof elem) return $string(elem);
                         if ("number" === typeof elem) return $number(elem);
-                        if ("boolean" === typeof elem) return elem;
                         if ("object" === typeof elem && null !== elem)
-                            return $su0(elem);
+                            return `{"id":${$number(
+                                (elem as any).id,
+                            )},"mobile":${$string(
+                                (elem as any).mobile,
+                            )},"name":${$string((elem as any).name)}}`;
                         $throws({
                             expected:
-                                "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean | number | string | unknown)",
+                                "((ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean) | ToJsonUnion.ICitizen | number | string)",
                             value: elem,
                         });
                     })(),

--- a/test/generated/output/createClone/test_createClone_NativeUnion.ts
+++ b/test/generated/output/createClone/test_createClone_NativeUnion.ts
@@ -6,10 +6,6 @@ export const test_createClone_NativeUnion = _test_clone(
     "NativeUnion",
     NativeUnion.generate,
     (input: NativeUnion): typia.Primitive<NativeUnion> => {
-        const $io1 = (input: any): boolean =>
-            "Buffer" === input.type &&
-            Array.isArray(input.data) &&
-            input.data.every((elem: any) => "number" === typeof elem);
         const $cp0 = (input: any) =>
             input.map((elem: any) =>
                 "object" === typeof elem && null !== elem
@@ -56,15 +52,16 @@ export const test_createClone_NativeUnion = _test_clone(
                 "object" === typeof input.buffer &&
                 null !== input.buffer &&
                 "function" === typeof input.buffer.toJSON
-                    ? (input.buffer.toJSON() as any)
+                    ? "object" === typeof input.buffer.toJSON() &&
+                      null !== input.buffer.toJSON()
+                        ? $co1(input.buffer.toJSON())
+                        : (input.buffer.toJSON() as any)
                     : input.buffer instanceof ArrayBuffer
                     ? {}
                     : input.buffer instanceof SharedArrayBuffer
                     ? {}
                     : input.buffer instanceof DataView
                     ? {}
-                    : "object" === typeof input.buffer && null !== input.buffer
-                    ? $co1(input.buffer)
                     : (input.buffer as any),
             weak:
                 input.weak instanceof WeakSet

--- a/test/generated/output/createClone/test_createClone_ToJsonUnion.ts
+++ b/test/generated/output/createClone/test_createClone_ToJsonUnion.ts
@@ -20,9 +20,12 @@ export const test_createClone_ToJsonUnion = _test_clone(
                 "object" === typeof elem &&
                 null !== elem &&
                 "function" === typeof elem.toJSON
-                    ? (elem.toJSON() as any)
+                    ? "object" === typeof elem.toJSON() &&
+                      null !== elem.toJSON()
+                        ? $cu0(elem.toJSON())
+                        : (elem.toJSON() as any)
                     : "object" === typeof elem && null !== elem
-                    ? $cu0(elem)
+                    ? $co0(elem)
                     : (elem as any),
             );
         const $co0 = (input: any): any => ({

--- a/test/generated/output/createIsClone/test_createIsClone_NativeUnion.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_NativeUnion.ts
@@ -35,10 +35,6 @@ export const test_createIsClone_NativeUnion = _test_isClone(
             );
         };
         const clone = (input: NativeUnion): typia.Primitive<NativeUnion> => {
-            const $io1 = (input: any): boolean =>
-                "Buffer" === input.type &&
-                Array.isArray(input.data) &&
-                input.data.every((elem: any) => "number" === typeof elem);
             const $cp0 = (input: any) =>
                 input.map((elem: any) =>
                     "object" === typeof elem && null !== elem
@@ -85,16 +81,16 @@ export const test_createIsClone_NativeUnion = _test_isClone(
                     "object" === typeof input.buffer &&
                     null !== input.buffer &&
                     "function" === typeof input.buffer.toJSON
-                        ? (input.buffer.toJSON() as any)
+                        ? "object" === typeof input.buffer.toJSON() &&
+                          null !== input.buffer.toJSON()
+                            ? $co1(input.buffer.toJSON())
+                            : (input.buffer.toJSON() as any)
                         : input.buffer instanceof ArrayBuffer
                         ? {}
                         : input.buffer instanceof SharedArrayBuffer
                         ? {}
                         : input.buffer instanceof DataView
                         ? {}
-                        : "object" === typeof input.buffer &&
-                          null !== input.buffer
-                        ? $co1(input.buffer)
                         : (input.buffer as any),
                 weak:
                     input.weak instanceof WeakSet

--- a/test/generated/output/createIsClone/test_createIsClone_ToJsonUnion.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_ToJsonUnion.ts
@@ -58,9 +58,12 @@ export const test_createIsClone_ToJsonUnion = _test_isClone(
                     "object" === typeof elem &&
                     null !== elem &&
                     "function" === typeof elem.toJSON
-                        ? (elem.toJSON() as any)
+                        ? "object" === typeof elem.toJSON() &&
+                          null !== elem.toJSON()
+                            ? $cu0(elem.toJSON())
+                            : (elem.toJSON() as any)
                         : "object" === typeof elem && null !== elem
-                        ? $cu0(elem)
+                        ? $co0(elem)
                         : (elem as any),
                 );
             const $co0 = (input: any): any => ({

--- a/test/generated/output/createIsStringify/test_createIsStringify_NativeUnion.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_NativeUnion.ts
@@ -35,30 +35,12 @@ export const test_createIsStringify_NativeUnion = _test_isStringify(
             );
         };
         const stringify = (input: NativeUnion): string => {
-            const $io1 = (input: any): boolean =>
-                "Buffer" === input.type &&
-                Array.isArray(input.data) &&
-                input.data.every((elem: any) => "number" === typeof elem);
             const $string = (typia.createIsStringify as any).string;
             const $throws = (typia.createIsStringify as any).throws;
             const $number = (typia.createIsStringify as any).number;
             const $so0 = (input: any): any =>
                 `{"date":${
-                    null !== input.date
-                        ? (() => {
-                              if (
-                                  "object" === typeof input.date &&
-                                  "function" === typeof input.date.toJSON
-                              )
-                                  return JSON.stringify(input.date.toJSON());
-                              if ("string" === typeof input.date)
-                                  return $string(input.date);
-                              $throws({
-                                  expected: "(null | string | unknown)",
-                                  value: input.date,
-                              });
-                          })()
-                        : "null"
+                    null !== input.date ? $string(input.date.toJSON()) : "null"
                 },"unsigned":${(() => {
                     if (input.unsigned instanceof Uint8Array) return "{}";
                     if (input.unsigned instanceof Uint8ClampedArray)
@@ -93,18 +75,13 @@ export const test_createIsStringify_NativeUnion = _test_isStringify(
                         "object" === typeof input.buffer &&
                         "function" === typeof input.buffer.toJSON
                     )
-                        return JSON.stringify(input.buffer.toJSON());
+                        return $so1(input.buffer.toJSON());
                     if (input.buffer instanceof ArrayBuffer) return "{}";
                     if (input.buffer instanceof SharedArrayBuffer) return "{}";
                     if (input.buffer instanceof DataView) return "{}";
-                    if (
-                        "object" === typeof input.buffer &&
-                        null !== input.buffer
-                    )
-                        return $so1(input.buffer);
                     $throws({
                         expected:
-                            "(ArrayBuffer | DataView | SharedArrayBuffer | __type | unknown)",
+                            "(ArrayBuffer | DataView | SharedArrayBuffer | __type)",
                         value: input.buffer,
                     });
                 })()},"weak":${(() => {

--- a/test/generated/output/createIsStringify/test_createIsStringify_ToJsonDouble.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_ToJsonDouble.ts
@@ -11,9 +11,9 @@ export const test_createIsStringify_ToJsonDouble = _test_isStringify(
         };
         const stringify = (input: ToJsonDouble): string => {
             const $number = (typia.createIsStringify as any).number;
-            const $so0 = (input: any): any =>
-                `{"id":${$number(input.id)},"flag":${input.flag}}`;
-            return $so0(input.toJSON());
+            return `{"id":${$number((input.toJSON() as any).id)},"flag":${
+                (input.toJSON() as any).flag
+            }}`;
         };
         return is(input) ? stringify(input) : null;
     },

--- a/test/generated/output/createIsStringify/test_createIsStringify_ToJsonTuple.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_ToJsonTuple.ts
@@ -31,11 +31,11 @@ export const test_createIsStringify_ToJsonTuple = _test_isStringify(
         const stringify = (input: ToJsonTuple): string => {
             const $string = (typia.createIsStringify as any).string;
             const $number = (typia.createIsStringify as any).number;
-            const $so0 = (input: any): any =>
-                `{"code":${$string(input.code)},"name":${$string(input.name)}}`;
             return `[${$string(input[0].toJSON())},${$number(
                 input[1].toJSON(),
-            )},${input[2].toJSON()},${$so0(input[3].toJSON())}]`;
+            )},${input[2].toJSON()},${`{"code":${$string(
+                (input[3].toJSON() as any).code,
+            )},"name":${$string((input[3].toJSON() as any).name)}}`}]`;
         };
         return is(input) ? stringify(input) : null;
     },

--- a/test/generated/output/createIsStringify/test_createIsStringify_ToJsonUnion.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_ToJsonUnion.ts
@@ -49,9 +49,9 @@ export const test_createIsStringify_ToJsonUnion = _test_isStringify(
                 "string" === typeof input.manufacturer &&
                 "string" === typeof input.brand &&
                 "string" === typeof input.name;
+            const $throws = (typia.createIsStringify as any).throws;
             const $string = (typia.createIsStringify as any).string;
             const $number = (typia.createIsStringify as any).number;
-            const $throws = (typia.createIsStringify as any).throws;
             const $so0 = (input: any): any =>
                 `{"id":${$number(input.id)},"mobile":${$string(
                     input.mobile,
@@ -79,15 +79,31 @@ export const test_createIsStringify_ToJsonUnion = _test_isStringify(
                             "object" === typeof elem &&
                             "function" === typeof elem.toJSON
                         )
-                            return JSON.stringify(elem.toJSON());
+                            return (() => {
+                                if ("boolean" === typeof elem.toJSON())
+                                    return elem.toJSON();
+                                if (
+                                    "object" === typeof elem.toJSON() &&
+                                    null !== elem.toJSON()
+                                )
+                                    return $su0(elem.toJSON());
+                                $throws({
+                                    expected:
+                                        "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean)",
+                                    value: elem.toJSON(),
+                                });
+                            })();
                         if ("string" === typeof elem) return $string(elem);
                         if ("number" === typeof elem) return $number(elem);
-                        if ("boolean" === typeof elem) return elem;
                         if ("object" === typeof elem && null !== elem)
-                            return $su0(elem);
+                            return `{"id":${$number(
+                                (elem as any).id,
+                            )},"mobile":${$string(
+                                (elem as any).mobile,
+                            )},"name":${$string((elem as any).name)}}`;
                         $throws({
                             expected:
-                                "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean | number | string | unknown)",
+                                "((ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean) | ToJsonUnion.ICitizen | number | string)",
                             value: elem,
                         });
                     })(),

--- a/test/generated/output/createStringify/test_createStringify_NativeUnion.ts
+++ b/test/generated/output/createStringify/test_createStringify_NativeUnion.ts
@@ -6,30 +6,12 @@ export const test_createStringify_NativeUnion = _test_stringify(
     "NativeUnion",
     NativeUnion.generate,
     (input: NativeUnion): string => {
-        const $io1 = (input: any): boolean =>
-            "Buffer" === input.type &&
-            Array.isArray(input.data) &&
-            input.data.every((elem: any) => "number" === typeof elem);
         const $string = (typia.createStringify as any).string;
         const $throws = (typia.createStringify as any).throws;
         const $number = (typia.createStringify as any).number;
         const $so0 = (input: any): any =>
             `{"date":${
-                null !== input.date
-                    ? (() => {
-                          if (
-                              "object" === typeof input.date &&
-                              "function" === typeof input.date.toJSON
-                          )
-                              return JSON.stringify(input.date.toJSON());
-                          if ("string" === typeof input.date)
-                              return $string(input.date);
-                          $throws({
-                              expected: "(null | string | unknown)",
-                              value: input.date,
-                          });
-                      })()
-                    : "null"
+                null !== input.date ? $string(input.date.toJSON()) : "null"
             },"unsigned":${(() => {
                 if (input.unsigned instanceof Uint8Array) return "{}";
                 if (input.unsigned instanceof Uint8ClampedArray) return "{}";
@@ -63,15 +45,13 @@ export const test_createStringify_NativeUnion = _test_stringify(
                     "object" === typeof input.buffer &&
                     "function" === typeof input.buffer.toJSON
                 )
-                    return JSON.stringify(input.buffer.toJSON());
+                    return $so1(input.buffer.toJSON());
                 if (input.buffer instanceof ArrayBuffer) return "{}";
                 if (input.buffer instanceof SharedArrayBuffer) return "{}";
                 if (input.buffer instanceof DataView) return "{}";
-                if ("object" === typeof input.buffer && null !== input.buffer)
-                    return $so1(input.buffer);
                 $throws({
                     expected:
-                        "(ArrayBuffer | DataView | SharedArrayBuffer | __type | unknown)",
+                        "(ArrayBuffer | DataView | SharedArrayBuffer | __type)",
                     value: input.buffer,
                 });
             })()},"weak":${(() => {

--- a/test/generated/output/createStringify/test_createStringify_ToJsonDouble.ts
+++ b/test/generated/output/createStringify/test_createStringify_ToJsonDouble.ts
@@ -7,8 +7,8 @@ export const test_createStringify_ToJsonDouble = _test_stringify(
     ToJsonDouble.generate,
     (input: ToJsonDouble): string => {
         const $number = (typia.createStringify as any).number;
-        const $so0 = (input: any): any =>
-            `{"id":${$number(input.id)},"flag":${input.flag}}`;
-        return $so0(input.toJSON());
+        return `{"id":${$number((input.toJSON() as any).id)},"flag":${
+            (input.toJSON() as any).flag
+        }}`;
     },
 );

--- a/test/generated/output/createStringify/test_createStringify_ToJsonTuple.ts
+++ b/test/generated/output/createStringify/test_createStringify_ToJsonTuple.ts
@@ -8,10 +8,10 @@ export const test_createStringify_ToJsonTuple = _test_stringify(
     (input: ToJsonTuple): string => {
         const $string = (typia.createStringify as any).string;
         const $number = (typia.createStringify as any).number;
-        const $so0 = (input: any): any =>
-            `{"code":${$string(input.code)},"name":${$string(input.name)}}`;
         return `[${$string(input[0].toJSON())},${$number(
             input[1].toJSON(),
-        )},${input[2].toJSON()},${$so0(input[3].toJSON())}]`;
+        )},${input[2].toJSON()},${`{"code":${$string(
+            (input[3].toJSON() as any).code,
+        )},"name":${$string((input[3].toJSON() as any).name)}}`}]`;
     },
 );

--- a/test/generated/output/createStringify/test_createStringify_ToJsonUnion.ts
+++ b/test/generated/output/createStringify/test_createStringify_ToJsonUnion.ts
@@ -14,9 +14,9 @@ export const test_createStringify_ToJsonUnion = _test_stringify(
             "string" === typeof input.manufacturer &&
             "string" === typeof input.brand &&
             "string" === typeof input.name;
+        const $throws = (typia.createStringify as any).throws;
         const $string = (typia.createStringify as any).string;
         const $number = (typia.createStringify as any).number;
-        const $throws = (typia.createStringify as any).throws;
         const $so0 = (input: any): any =>
             `{"id":${$number(input.id)},"mobile":${$string(
                 input.mobile,
@@ -41,15 +41,31 @@ export const test_createStringify_ToJsonUnion = _test_stringify(
                         "object" === typeof elem &&
                         "function" === typeof elem.toJSON
                     )
-                        return JSON.stringify(elem.toJSON());
+                        return (() => {
+                            if ("boolean" === typeof elem.toJSON())
+                                return elem.toJSON();
+                            if (
+                                "object" === typeof elem.toJSON() &&
+                                null !== elem.toJSON()
+                            )
+                                return $su0(elem.toJSON());
+                            $throws({
+                                expected:
+                                    "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean)",
+                                value: elem.toJSON(),
+                            });
+                        })();
                     if ("string" === typeof elem) return $string(elem);
                     if ("number" === typeof elem) return $number(elem);
-                    if ("boolean" === typeof elem) return elem;
                     if ("object" === typeof elem && null !== elem)
-                        return $su0(elem);
+                        return `{"id":${$number(
+                            (elem as any).id,
+                        )},"mobile":${$string(
+                            (elem as any).mobile,
+                        )},"name":${$string((elem as any).name)}}`;
                     $throws({
                         expected:
-                            "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean | number | string | unknown)",
+                            "((ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean) | ToJsonUnion.ICitizen | number | string)",
                         value: elem,
                     });
                 })(),

--- a/test/generated/output/createValidateClone/test_createValidateClone_NativeUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_NativeUnion.ts
@@ -149,10 +149,6 @@ export const test_createValidateClone_NativeUnion = _test_validateClone(
             } as any;
         };
         const clone = (input: NativeUnion): typia.Primitive<NativeUnion> => {
-            const $io1 = (input: any): boolean =>
-                "Buffer" === input.type &&
-                Array.isArray(input.data) &&
-                input.data.every((elem: any) => "number" === typeof elem);
             const $cp0 = (input: any) =>
                 input.map((elem: any) =>
                     "object" === typeof elem && null !== elem
@@ -199,16 +195,16 @@ export const test_createValidateClone_NativeUnion = _test_validateClone(
                     "object" === typeof input.buffer &&
                     null !== input.buffer &&
                     "function" === typeof input.buffer.toJSON
-                        ? (input.buffer.toJSON() as any)
+                        ? "object" === typeof input.buffer.toJSON() &&
+                          null !== input.buffer.toJSON()
+                            ? $co1(input.buffer.toJSON())
+                            : (input.buffer.toJSON() as any)
                         : input.buffer instanceof ArrayBuffer
                         ? {}
                         : input.buffer instanceof SharedArrayBuffer
                         ? {}
                         : input.buffer instanceof DataView
                         ? {}
-                        : "object" === typeof input.buffer &&
-                          null !== input.buffer
-                        ? $co1(input.buffer)
                         : (input.buffer as any),
                 weak:
                     input.weak instanceof WeakSet

--- a/test/generated/output/createValidateClone/test_createValidateClone_ToJsonUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_ToJsonUnion.ts
@@ -216,9 +216,12 @@ export const test_createValidateClone_ToJsonUnion = _test_validateClone(
                     "object" === typeof elem &&
                     null !== elem &&
                     "function" === typeof elem.toJSON
-                        ? (elem.toJSON() as any)
+                        ? "object" === typeof elem.toJSON() &&
+                          null !== elem.toJSON()
+                            ? $cu0(elem.toJSON())
+                            : (elem.toJSON() as any)
                         : "object" === typeof elem && null !== elem
-                        ? $cu0(elem)
+                        ? $co0(elem)
                         : (elem as any),
                 );
             const $co0 = (input: any): any => ({

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_NativeUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_NativeUnion.ts
@@ -151,30 +151,12 @@ export const test_createValidateStringify_NativeUnion = _test_validateStringify(
             } as any;
         };
         const stringify = (input: NativeUnion): string => {
-            const $io1 = (input: any): boolean =>
-                "Buffer" === input.type &&
-                Array.isArray(input.data) &&
-                input.data.every((elem: any) => "number" === typeof elem);
             const $string = (typia.createValidateStringify as any).string;
             const $throws = (typia.createValidateStringify as any).throws;
             const $number = (typia.createValidateStringify as any).number;
             const $so0 = (input: any): any =>
                 `{"date":${
-                    null !== input.date
-                        ? (() => {
-                              if (
-                                  "object" === typeof input.date &&
-                                  "function" === typeof input.date.toJSON
-                              )
-                                  return JSON.stringify(input.date.toJSON());
-                              if ("string" === typeof input.date)
-                                  return $string(input.date);
-                              $throws({
-                                  expected: "(null | string | unknown)",
-                                  value: input.date,
-                              });
-                          })()
-                        : "null"
+                    null !== input.date ? $string(input.date.toJSON()) : "null"
                 },"unsigned":${(() => {
                     if (input.unsigned instanceof Uint8Array) return "{}";
                     if (input.unsigned instanceof Uint8ClampedArray)
@@ -209,18 +191,13 @@ export const test_createValidateStringify_NativeUnion = _test_validateStringify(
                         "object" === typeof input.buffer &&
                         "function" === typeof input.buffer.toJSON
                     )
-                        return JSON.stringify(input.buffer.toJSON());
+                        return $so1(input.buffer.toJSON());
                     if (input.buffer instanceof ArrayBuffer) return "{}";
                     if (input.buffer instanceof SharedArrayBuffer) return "{}";
                     if (input.buffer instanceof DataView) return "{}";
-                    if (
-                        "object" === typeof input.buffer &&
-                        null !== input.buffer
-                    )
-                        return $so1(input.buffer);
                     $throws({
                         expected:
-                            "(ArrayBuffer | DataView | SharedArrayBuffer | __type | unknown)",
+                            "(ArrayBuffer | DataView | SharedArrayBuffer | __type)",
                         value: input.buffer,
                     });
                 })()},"weak":${(() => {

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_ToJsonDouble.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_ToJsonDouble.ts
@@ -52,9 +52,9 @@ export const test_createValidateStringify_ToJsonDouble =
             };
             const stringify = (input: ToJsonDouble): string => {
                 const $number = (typia.createValidateStringify as any).number;
-                const $so0 = (input: any): any =>
-                    `{"id":${$number(input.id)},"flag":${input.flag}}`;
-                return $so0(input.toJSON());
+                return `{"id":${$number((input.toJSON() as any).id)},"flag":${
+                    (input.toJSON() as any).flag
+                }}`;
             };
             const output = validate(input) as any;
             if (output.success) output.data = stringify(input);

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_ToJsonTuple.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_ToJsonTuple.ts
@@ -178,11 +178,11 @@ export const test_createValidateStringify_ToJsonTuple = _test_validateStringify(
         const stringify = (input: ToJsonTuple): string => {
             const $string = (typia.createValidateStringify as any).string;
             const $number = (typia.createValidateStringify as any).number;
-            const $so0 = (input: any): any =>
-                `{"code":${$string(input.code)},"name":${$string(input.name)}}`;
             return `[${$string(input[0].toJSON())},${$number(
                 input[1].toJSON(),
-            )},${input[2].toJSON()},${$so0(input[3].toJSON())}]`;
+            )},${input[2].toJSON()},${`{"code":${$string(
+                (input[3].toJSON() as any).code,
+            )},"name":${$string((input[3].toJSON() as any).name)}}`}]`;
         };
         const output = validate(input) as any;
         if (output.success) output.data = stringify(input);

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_ToJsonUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_ToJsonUnion.ts
@@ -212,9 +212,9 @@ export const test_createValidateStringify_ToJsonUnion = _test_validateStringify(
                 "string" === typeof input.manufacturer &&
                 "string" === typeof input.brand &&
                 "string" === typeof input.name;
+            const $throws = (typia.createValidateStringify as any).throws;
             const $string = (typia.createValidateStringify as any).string;
             const $number = (typia.createValidateStringify as any).number;
-            const $throws = (typia.createValidateStringify as any).throws;
             const $so0 = (input: any): any =>
                 `{"id":${$number(input.id)},"mobile":${$string(
                     input.mobile,
@@ -242,15 +242,31 @@ export const test_createValidateStringify_ToJsonUnion = _test_validateStringify(
                             "object" === typeof elem &&
                             "function" === typeof elem.toJSON
                         )
-                            return JSON.stringify(elem.toJSON());
+                            return (() => {
+                                if ("boolean" === typeof elem.toJSON())
+                                    return elem.toJSON();
+                                if (
+                                    "object" === typeof elem.toJSON() &&
+                                    null !== elem.toJSON()
+                                )
+                                    return $su0(elem.toJSON());
+                                $throws({
+                                    expected:
+                                        "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean)",
+                                    value: elem.toJSON(),
+                                });
+                            })();
                         if ("string" === typeof elem) return $string(elem);
                         if ("number" === typeof elem) return $number(elem);
-                        if ("boolean" === typeof elem) return elem;
                         if ("object" === typeof elem && null !== elem)
-                            return $su0(elem);
+                            return `{"id":${$number(
+                                (elem as any).id,
+                            )},"mobile":${$string(
+                                (elem as any).mobile,
+                            )},"name":${$string((elem as any).name)}}`;
                         $throws({
                             expected:
-                                "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean | number | string | unknown)",
+                                "((ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean) | ToJsonUnion.ICitizen | number | string)",
                             value: elem,
                         });
                     })(),

--- a/test/generated/output/isClone/test_isClone_NativeUnion.ts
+++ b/test/generated/output/isClone/test_isClone_NativeUnion.ts
@@ -40,10 +40,6 @@ export const test_isClone_NativeUnion = _test_isClone(
             const clone = (
                 input: Array<NativeUnion.Union>,
             ): typia.Primitive<Array<NativeUnion.Union>> => {
-                const $io1 = (input: any): boolean =>
-                    "Buffer" === input.type &&
-                    Array.isArray(input.data) &&
-                    input.data.every((elem: any) => "number" === typeof elem);
                 const $cp0 = (input: any) =>
                     input.map((elem: any) =>
                         "object" === typeof elem && null !== elem
@@ -91,16 +87,16 @@ export const test_isClone_NativeUnion = _test_isClone(
                         "object" === typeof input.buffer &&
                         null !== input.buffer &&
                         "function" === typeof input.buffer.toJSON
-                            ? (input.buffer.toJSON() as any)
+                            ? "object" === typeof input.buffer.toJSON() &&
+                              null !== input.buffer.toJSON()
+                                ? $co1(input.buffer.toJSON())
+                                : (input.buffer.toJSON() as any)
                             : input.buffer instanceof ArrayBuffer
                             ? {}
                             : input.buffer instanceof SharedArrayBuffer
                             ? {}
                             : input.buffer instanceof DataView
                             ? {}
-                            : "object" === typeof input.buffer &&
-                              null !== input.buffer
-                            ? $co1(input.buffer)
                             : (input.buffer as any),
                     weak:
                         input.weak instanceof WeakSet

--- a/test/generated/output/isClone/test_isClone_ToJsonUnion.ts
+++ b/test/generated/output/isClone/test_isClone_ToJsonUnion.ts
@@ -97,9 +97,12 @@ export const test_isClone_ToJsonUnion = _test_isClone(
                         "object" === typeof elem &&
                         null !== elem &&
                         "function" === typeof elem.toJSON
-                            ? (elem.toJSON() as any)
+                            ? "object" === typeof elem.toJSON() &&
+                              null !== elem.toJSON()
+                                ? $cu0(elem.toJSON())
+                                : (elem.toJSON() as any)
                             : "object" === typeof elem && null !== elem
-                            ? $cu0(elem)
+                            ? $co0(elem)
                             : (elem as any),
                     );
                 const $co0 = (input: any): any => ({

--- a/test/generated/output/isStringify/test_isStringify_ToJsonDouble.ts
+++ b/test/generated/output/isStringify/test_isStringify_ToJsonDouble.ts
@@ -12,9 +12,9 @@ export const test_isStringify_ToJsonDouble = _test_isStringify(
             };
             const stringify = (input: ToJsonDouble.Parent): string => {
                 const $number = (typia.isStringify as any).number;
-                const $so0 = (input: any): any =>
-                    `{"id":${$number(input.id)},"flag":${input.flag}}`;
-                return $so0(input.toJSON());
+                return `{"id":${$number((input.toJSON() as any).id)},"flag":${
+                    (input.toJSON() as any).flag
+                }}`;
             };
             return is(input) ? stringify(input) : null;
         })(input),

--- a/test/generated/output/isStringify/test_isStringify_ToJsonTuple.ts
+++ b/test/generated/output/isStringify/test_isStringify_ToJsonTuple.ts
@@ -53,13 +53,11 @@ export const test_isStringify_ToJsonTuple = _test_isStringify(
             ): string => {
                 const $string = (typia.isStringify as any).string;
                 const $number = (typia.isStringify as any).number;
-                const $so0 = (input: any): any =>
-                    `{"code":${$string(input.code)},"name":${$string(
-                        input.name,
-                    )}}`;
                 return `[${$string(input[0].toJSON())},${$number(
                     input[1].toJSON(),
-                )},${input[2].toJSON()},${$so0(input[3].toJSON())}]`;
+                )},${input[2].toJSON()},${`{"code":${$string(
+                    (input[3].toJSON() as any).code,
+                )},"name":${$string((input[3].toJSON() as any).name)}}`}]`;
             };
             return is(input) ? stringify(input) : null;
         })(input),

--- a/test/generated/output/isStringify/test_isStringify_ToJsonUnion.ts
+++ b/test/generated/output/isStringify/test_isStringify_ToJsonUnion.ts
@@ -77,9 +77,9 @@ export const test_isStringify_ToJsonUnion = _test_isStringify(
                     "string" === typeof input.manufacturer &&
                     "string" === typeof input.brand &&
                     "string" === typeof input.name;
+                const $throws = (typia.isStringify as any).throws;
                 const $string = (typia.isStringify as any).string;
                 const $number = (typia.isStringify as any).number;
-                const $throws = (typia.isStringify as any).throws;
                 const $so0 = (input: any): any =>
                     `{"id":${$number(input.id)},"mobile":${$string(
                         input.mobile,
@@ -108,15 +108,31 @@ export const test_isStringify_ToJsonUnion = _test_isStringify(
                                 "object" === typeof elem &&
                                 "function" === typeof elem.toJSON
                             )
-                                return JSON.stringify(elem.toJSON());
+                                return (() => {
+                                    if ("boolean" === typeof elem.toJSON())
+                                        return elem.toJSON();
+                                    if (
+                                        "object" === typeof elem.toJSON() &&
+                                        null !== elem.toJSON()
+                                    )
+                                        return $su0(elem.toJSON());
+                                    $throws({
+                                        expected:
+                                            "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean)",
+                                        value: elem.toJSON(),
+                                    });
+                                })();
                             if ("string" === typeof elem) return $string(elem);
                             if ("number" === typeof elem) return $number(elem);
-                            if ("boolean" === typeof elem) return elem;
                             if ("object" === typeof elem && null !== elem)
-                                return $su0(elem);
+                                return `{"id":${$number(
+                                    (elem as any).id,
+                                )},"mobile":${$string(
+                                    (elem as any).mobile,
+                                )},"name":${$string((elem as any).name)}}`;
                             $throws({
                                 expected:
-                                    "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean | number | string | unknown)",
+                                    "((ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean) | ToJsonUnion.ICitizen | number | string)",
                                 value: elem,
                             });
                         })(),

--- a/test/generated/output/stringify/test_stringify_ToJsonDouble.ts
+++ b/test/generated/output/stringify/test_stringify_ToJsonDouble.ts
@@ -8,8 +8,8 @@ export const test_stringify_ToJsonDouble = _test_stringify(
     (input) =>
         ((input: ToJsonDouble.Parent): string => {
             const $number = (typia.stringify as any).number;
-            const $so0 = (input: any): any =>
-                `{"id":${$number(input.id)},"flag":${input.flag}}`;
-            return $so0(input.toJSON());
+            return `{"id":${$number((input.toJSON() as any).id)},"flag":${
+                (input.toJSON() as any).flag
+            }}`;
         })(input),
 );

--- a/test/generated/output/stringify/test_stringify_ToJsonTuple.ts
+++ b/test/generated/output/stringify/test_stringify_ToJsonTuple.ts
@@ -16,10 +16,10 @@ export const test_stringify_ToJsonTuple = _test_stringify(
         ): string => {
             const $string = (typia.stringify as any).string;
             const $number = (typia.stringify as any).number;
-            const $so0 = (input: any): any =>
-                `{"code":${$string(input.code)},"name":${$string(input.name)}}`;
             return `[${$string(input[0].toJSON())},${$number(
                 input[1].toJSON(),
-            )},${input[2].toJSON()},${$so0(input[3].toJSON())}]`;
+            )},${input[2].toJSON()},${`{"code":${$string(
+                (input[3].toJSON() as any).code,
+            )},"name":${$string((input[3].toJSON() as any).name)}}`}]`;
         })(input),
 );

--- a/test/generated/output/stringify/test_stringify_ToJsonUnion.ts
+++ b/test/generated/output/stringify/test_stringify_ToJsonUnion.ts
@@ -24,9 +24,9 @@ export const test_stringify_ToJsonUnion = _test_stringify(
                 "string" === typeof input.manufacturer &&
                 "string" === typeof input.brand &&
                 "string" === typeof input.name;
+            const $throws = (typia.stringify as any).throws;
             const $string = (typia.stringify as any).string;
             const $number = (typia.stringify as any).number;
-            const $throws = (typia.stringify as any).throws;
             const $so0 = (input: any): any =>
                 `{"id":${$number(input.id)},"mobile":${$string(
                     input.mobile,
@@ -54,15 +54,31 @@ export const test_stringify_ToJsonUnion = _test_stringify(
                             "object" === typeof elem &&
                             "function" === typeof elem.toJSON
                         )
-                            return JSON.stringify(elem.toJSON());
+                            return (() => {
+                                if ("boolean" === typeof elem.toJSON())
+                                    return elem.toJSON();
+                                if (
+                                    "object" === typeof elem.toJSON() &&
+                                    null !== elem.toJSON()
+                                )
+                                    return $su0(elem.toJSON());
+                                $throws({
+                                    expected:
+                                        "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean)",
+                                    value: elem.toJSON(),
+                                });
+                            })();
                         if ("string" === typeof elem) return $string(elem);
                         if ("number" === typeof elem) return $number(elem);
-                        if ("boolean" === typeof elem) return elem;
                         if ("object" === typeof elem && null !== elem)
-                            return $su0(elem);
+                            return `{"id":${$number(
+                                (elem as any).id,
+                            )},"mobile":${$string(
+                                (elem as any).mobile,
+                            )},"name":${$string((elem as any).name)}}`;
                         $throws({
                             expected:
-                                "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean | number | string | unknown)",
+                                "((ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean) | ToJsonUnion.ICitizen | number | string)",
                             value: elem,
                         });
                     })(),

--- a/test/generated/output/validateClone/test_validateClone_NativeUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_NativeUnion.ts
@@ -165,10 +165,6 @@ export const test_validateClone_NativeUnion = _test_validateClone(
             const clone = (
                 input: Array<NativeUnion.Union>,
             ): typia.Primitive<Array<NativeUnion.Union>> => {
-                const $io1 = (input: any): boolean =>
-                    "Buffer" === input.type &&
-                    Array.isArray(input.data) &&
-                    input.data.every((elem: any) => "number" === typeof elem);
                 const $cp0 = (input: any) =>
                     input.map((elem: any) =>
                         "object" === typeof elem && null !== elem
@@ -216,16 +212,16 @@ export const test_validateClone_NativeUnion = _test_validateClone(
                         "object" === typeof input.buffer &&
                         null !== input.buffer &&
                         "function" === typeof input.buffer.toJSON
-                            ? (input.buffer.toJSON() as any)
+                            ? "object" === typeof input.buffer.toJSON() &&
+                              null !== input.buffer.toJSON()
+                                ? $co1(input.buffer.toJSON())
+                                : (input.buffer.toJSON() as any)
                             : input.buffer instanceof ArrayBuffer
                             ? {}
                             : input.buffer instanceof SharedArrayBuffer
                             ? {}
                             : input.buffer instanceof DataView
                             ? {}
-                            : "object" === typeof input.buffer &&
-                              null !== input.buffer
-                            ? $co1(input.buffer)
                             : (input.buffer as any),
                     weak:
                         input.weak instanceof WeakSet

--- a/test/generated/output/validateClone/test_validateClone_ToJsonUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_ToJsonUnion.ts
@@ -295,9 +295,12 @@ export const test_validateClone_ToJsonUnion = _test_validateClone(
                         "object" === typeof elem &&
                         null !== elem &&
                         "function" === typeof elem.toJSON
-                            ? (elem.toJSON() as any)
+                            ? "object" === typeof elem.toJSON() &&
+                              null !== elem.toJSON()
+                                ? $cu0(elem.toJSON())
+                                : (elem.toJSON() as any)
                             : "object" === typeof elem && null !== elem
-                            ? $cu0(elem)
+                            ? $co0(elem)
                             : (elem as any),
                     );
                 const $co0 = (input: any): any => ({

--- a/test/generated/output/validateStringify/test_validateStringify_ToJsonDouble.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_ToJsonDouble.ts
@@ -52,9 +52,9 @@ export const test_validateStringify_ToJsonDouble = _test_validateStringify(
             };
             const stringify = (input: ToJsonDouble.Parent): string => {
                 const $number = (typia.validateStringify as any).number;
-                const $so0 = (input: any): any =>
-                    `{"id":${$number(input.id)},"flag":${input.flag}}`;
-                return $so0(input.toJSON());
+                return `{"id":${$number((input.toJSON() as any).id)},"flag":${
+                    (input.toJSON() as any).flag
+                }}`;
             };
             const output = validate(input) as any;
             if (output.success) output.data = stringify(input);

--- a/test/generated/output/validateStringify/test_validateStringify_ToJsonTuple.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_ToJsonTuple.ts
@@ -216,13 +216,11 @@ export const test_validateStringify_ToJsonTuple = _test_validateStringify(
             ): string => {
                 const $string = (typia.validateStringify as any).string;
                 const $number = (typia.validateStringify as any).number;
-                const $so0 = (input: any): any =>
-                    `{"code":${$string(input.code)},"name":${$string(
-                        input.name,
-                    )}}`;
                 return `[${$string(input[0].toJSON())},${$number(
                     input[1].toJSON(),
-                )},${input[2].toJSON()},${$so0(input[3].toJSON())}]`;
+                )},${input[2].toJSON()},${`{"code":${$string(
+                    (input[3].toJSON() as any).code,
+                )},"name":${$string((input[3].toJSON() as any).name)}}`}]`;
             };
             const output = validate(input) as any;
             if (output.success) output.data = stringify(input);

--- a/test/generated/output/validateStringify/test_validateStringify_ToJsonUnion.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_ToJsonUnion.ts
@@ -276,9 +276,9 @@ export const test_validateStringify_ToJsonUnion = _test_validateStringify(
                     "string" === typeof input.manufacturer &&
                     "string" === typeof input.brand &&
                     "string" === typeof input.name;
+                const $throws = (typia.validateStringify as any).throws;
                 const $string = (typia.validateStringify as any).string;
                 const $number = (typia.validateStringify as any).number;
-                const $throws = (typia.validateStringify as any).throws;
                 const $so0 = (input: any): any =>
                     `{"id":${$number(input.id)},"mobile":${$string(
                         input.mobile,
@@ -307,15 +307,31 @@ export const test_validateStringify_ToJsonUnion = _test_validateStringify(
                                 "object" === typeof elem &&
                                 "function" === typeof elem.toJSON
                             )
-                                return JSON.stringify(elem.toJSON());
+                                return (() => {
+                                    if ("boolean" === typeof elem.toJSON())
+                                        return elem.toJSON();
+                                    if (
+                                        "object" === typeof elem.toJSON() &&
+                                        null !== elem.toJSON()
+                                    )
+                                        return $su0(elem.toJSON());
+                                    $throws({
+                                        expected:
+                                            "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean)",
+                                        value: elem.toJSON(),
+                                    });
+                                })();
                             if ("string" === typeof elem) return $string(elem);
                             if ("number" === typeof elem) return $number(elem);
-                            if ("boolean" === typeof elem) return elem;
                             if ("object" === typeof elem && null !== elem)
-                                return $su0(elem);
+                                return `{"id":${$number(
+                                    (elem as any).id,
+                                )},"mobile":${$string(
+                                    (elem as any).mobile,
+                                )},"name":${$string((elem as any).name)}}`;
                             $throws({
                                 expected:
-                                    "(ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean | number | string | unknown)",
+                                    "((ToJsonUnion.ICitizen | ToJsonUnion.IProduct | boolean) | ToJsonUnion.ICitizen | number | string)",
                                 value: elem,
                             });
                         })(),

--- a/test/issues/resolved.ts
+++ b/test/issues/resolved.ts
@@ -1,0 +1,7 @@
+import typia from "typia";
+
+type Union = Date | number | string | Buffer | null;
+console.log(
+    typia.createRandom<Union>().toString(),
+    typia.createStringify<Union>().toString(),
+);

--- a/test/schemas/json/ajv/NativeUnion.json
+++ b/test/schemas/json/ajv/NativeUnion.json
@@ -109,6 +109,9 @@
           "buffer": {
             "oneOf": [
               {
+                "$ref": "#/components/schemas/__type"
+              },
+              {
                 "x-typia-required": true,
                 "x-typia-optional": false,
                 "$ref": "#/components/objects/ArrayBuffer"
@@ -122,9 +125,6 @@
                 "x-typia-required": true,
                 "x-typia-optional": false,
                 "$ref": "#/components/objects/DataView"
-              },
-              {
-                "$ref": "#/components/schemas/__type"
               }
             ],
             "x-typia-required": true,
@@ -212,21 +212,6 @@
         "$id": "#/components/objects/Float64Array",
         "properties": {}
       },
-      "ArrayBuffer": {
-        "type": "object",
-        "$id": "#/components/objects/ArrayBuffer",
-        "properties": {}
-      },
-      "SharedArrayBuffer": {
-        "type": "object",
-        "$id": "#/components/objects/SharedArrayBuffer",
-        "properties": {}
-      },
-      "DataView": {
-        "type": "object",
-        "$id": "#/components/objects/DataView",
-        "properties": {}
-      },
       "__type": {
         "$id": "#/components/schemas/__type",
         "type": "object",
@@ -255,6 +240,21 @@
           "data"
         ],
         "x-typia-jsDocTags": []
+      },
+      "ArrayBuffer": {
+        "type": "object",
+        "$id": "#/components/objects/ArrayBuffer",
+        "properties": {}
+      },
+      "SharedArrayBuffer": {
+        "type": "object",
+        "$id": "#/components/objects/SharedArrayBuffer",
+        "properties": {}
+      },
+      "DataView": {
+        "type": "object",
+        "$id": "#/components/objects/DataView",
+        "properties": {}
       },
       "WeakSet": {
         "type": "object",

--- a/test/schemas/json/ajv/ToJsonUnion.json
+++ b/test/schemas/json/ajv/ToJsonUnion.json
@@ -11,7 +11,19 @@
         "type": "array",
         "items": {
           "oneOf": [
-            {},
+            {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/components/schemas/ToJsonUnion.ICitizen"
+                },
+                {
+                  "$ref": "#/components/schemas/ToJsonUnion.IProduct"
+                }
+              ]
+            },
             {
               "type": "string"
             },
@@ -19,13 +31,7 @@
               "type": "number"
             },
             {
-              "type": "boolean"
-            },
-            {
               "$ref": "#/components/schemas/ToJsonUnion.ICitizen"
-            },
-            {
-              "$ref": "#/components/schemas/ToJsonUnion.IProduct"
             }
           ]
         }

--- a/test/schemas/json/swagger/NativeUnion.json
+++ b/test/schemas/json/swagger/NativeUnion.json
@@ -18,8 +18,7 @@
           "date": {
             "x-typia-required": true,
             "x-typia-optional": false,
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "unsigned": {
             "oneOf": [
@@ -97,6 +96,9 @@
           "buffer": {
             "oneOf": [
               {
+                "$ref": "#/components/schemas/__type"
+              },
+              {
                 "x-typia-required": true,
                 "x-typia-optional": false,
                 "$ref": "#/components/objects/ArrayBuffer"
@@ -110,9 +112,6 @@
                 "x-typia-required": true,
                 "x-typia-optional": false,
                 "$ref": "#/components/objects/DataView"
-              },
-              {
-                "$ref": "#/components/schemas/__type"
               }
             ],
             "x-typia-required": true,
@@ -201,21 +200,6 @@
         "properties": {},
         "nullable": false
       },
-      "ArrayBuffer": {
-        "type": "object",
-        "properties": {},
-        "nullable": false
-      },
-      "SharedArrayBuffer": {
-        "type": "object",
-        "properties": {},
-        "nullable": false
-      },
-      "DataView": {
-        "type": "object",
-        "properties": {},
-        "nullable": false
-      },
       "__type": {
         "type": "object",
         "properties": {
@@ -244,6 +228,21 @@
           "data"
         ],
         "x-typia-jsDocTags": []
+      },
+      "ArrayBuffer": {
+        "type": "object",
+        "properties": {},
+        "nullable": false
+      },
+      "SharedArrayBuffer": {
+        "type": "object",
+        "properties": {},
+        "nullable": false
+      },
+      "DataView": {
+        "type": "object",
+        "properties": {},
+        "nullable": false
       },
       "WeakSet": {
         "type": "object",

--- a/test/schemas/json/swagger/ToJsonUnion.json
+++ b/test/schemas/json/swagger/ToJsonUnion.json
@@ -10,7 +10,19 @@
         "type": "array",
         "items": {
           "oneOf": [
-            {},
+            {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/components/schemas/ToJsonUnion.ICitizen"
+                },
+                {
+                  "$ref": "#/components/schemas/ToJsonUnion.IProduct"
+                }
+              ]
+            },
             {
               "type": "string"
             },
@@ -18,13 +30,7 @@
               "type": "number"
             },
             {
-              "type": "boolean"
-            },
-            {
               "$ref": "#/components/schemas/ToJsonUnion.ICitizen"
-            },
-            {
-              "$ref": "#/components/schemas/ToJsonUnion.IProduct"
             }
           ]
         }


### PR DESCRIPTION
When `toJSON()` method addicted type comes in `typia.random<T>()` function like `typia.random<Date | null>()`, generated data had not been exact. It was a bug, bug most users had not known that it was a rare case.

Anyway, found such phenomenon, therefore fixed it.