### PR TITLE
Fix samchon/nestia#394 - intersection type in JSON schema

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,32 +1,19 @@
 module.exports = {
     root: true,
-    plugins: [
-        "@typescript-eslint",
-        "deprecation",
-    ],
-    extends: [
-        "plugin:@typescript-eslint/recommended",
-    ],
+    plugins: ["@typescript-eslint", "deprecation"],
+    extends: ["plugin:@typescript-eslint/recommended"],
     parser: "@typescript-eslint/parser",
     parserOptions: {
         project: [
             "tsconfig.json",
-            "tsconfig.test.json"
-        ]
+            "test/tsconfig.json",
+            "benchmark/tsconfig.json",
+        ],
     },
-    ignorePatterns: [
-        "bin", 
-        "website",
-        "lib/**/*.d.ts", 
-        "node_modules"
-    ],
+    ignorePatterns: ["bin", "website", "lib/**/*.d.ts", "node_modules"],
     overrides: [
         {
-            files: [
-                "benchmark/**/*.ts",
-                "src/**/*.ts", 
-                "test/**/*.ts", 
-            ],
+            files: ["benchmark/**/*.ts", "src/**/*.ts", "test/**/*.ts"],
             rules: {
                 "@typescript-eslint/ban-types": "off",
                 "@typescript-eslint/consistent-type-definitions": "off",
@@ -42,7 +29,7 @@ module.exports = {
                 "@typescript-eslint/no-floating-promises": "error",
                 "@typescript-eslint/prefer-as-const": "error",
                 "deprecation/deprecation": "error",
-            }
-        }
-    ]
+            },
+        },
+    ],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -94,8 +94,8 @@
     "@types/node": "^18.15.12",
     "@types/physical-cpu-count": "^2.0.0",
     "@types/uuid": "^8.3.4",
-    "@typescript-eslint/eslint-plugin": "^5.26.0",
-    "@typescript-eslint/parser": "^5.26.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.11",
+    "@typescript-eslint/parser": "^5.59.11",
     "autocannon": "^7.10.0",
     "benchmark": "^2.1.4",
     "chalk": "^4.1.0",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.0.8"
+    "typia": "4.0.9"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/factories/internal/metadata/iterate_metadata.ts
+++ b/src/factories/internal/metadata/iterate_metadata.ts
@@ -5,11 +5,11 @@ import { Metadata } from "../../../metadata/Metadata";
 // import { ArrayUtil } from "../../../utils/ArrayUtil";
 import { MetadataCollection } from "../../MetadataCollection";
 import { MetadataFactory } from "../../MetadataFactory";
+import { iterate_metadata_alias } from "./iterate_metadata_alias";
 import { iterate_metadata_array } from "./iterate_metadata_array";
 import { iterate_metadata_atomic } from "./iterate_metadata_atomic";
 import { iterate_metadata_coalesce } from "./iterate_metadata_coalesce";
 import { iterate_metadata_constant } from "./iterate_metadata_constant";
-import { iterate_metadata_definition } from "./iterate_metadata_definition";
 import { iterate_metadata_intersection } from "./iterate_metadata_intersection";
 import { iterate_metadata_map } from "./iterate_metadata_map";
 import { iterate_metadata_native } from "./iterate_metadata_native";
@@ -37,7 +37,7 @@ export const iterate_metadata =
         // CHECK SPECIAL CASES
         if (
             (aliased !== true &&
-                iterate_metadata_definition(checker)(options)(collection)(
+                iterate_metadata_alias(checker)(options)(collection)(
                     meta,
                     type,
                 )) ||

--- a/src/factories/internal/metadata/iterate_metadata_alias.ts
+++ b/src/factories/internal/metadata/iterate_metadata_alias.ts
@@ -9,7 +9,7 @@ import { MetadataCollection } from "../../MetadataCollection";
 import { MetadataFactory } from "../../MetadataFactory";
 import { emplace_metadata_definition } from "./emplace_metadata_definition";
 
-export const iterate_metadata_definition =
+export const iterate_metadata_alias =
     (checker: ts.TypeChecker) =>
     (options: MetadataFactory.IOptions) =>
     (collection: MetadataCollection) =>

--- a/src/factories/internal/metadata/iterate_metadata_intersection.ts
+++ b/src/factories/internal/metadata/iterate_metadata_intersection.ts
@@ -25,9 +25,10 @@ export const iterate_metadata_intersection =
         const children: Metadata[] = [
             ...new Map(
                 type.types.map((t) => {
-                    const m: Metadata = explore_metadata(checker)(options)(
-                        fakeCollection,
-                    )(t, resolved);
+                    const m: Metadata = explore_metadata(checker)({
+                        ...options,
+                        absorb: true,
+                    })(fakeCollection)(t, resolved);
                     return [m.getName(), m] as const;
                 }),
             ).values(),
@@ -81,6 +82,6 @@ export const iterate_metadata_intersection =
     };
 
 const message = (children: Metadata[]) =>
-    `Error on typia.MetadataFactory.analyze(): nonsensibl intersection type detected - ${children
+    `Error on typia.MetadataFactory.analyze(): nonsensible intersection type detected - ${children
         .map((c) => c.getName())
         .join(" & ")}.`;

--- a/src/programmers/helpers/PruneJoiner.ts
+++ b/src/programmers/helpers/PruneJoiner.ts
@@ -67,14 +67,13 @@ const iterate_dynamic_properties =
     (props: { regular: IExpressionEntry[]; dynamic: IExpressionEntry[] }) =>
     (input: ts.Expression) =>
         ts.factory.createCallExpression(
-            IdentifierFactory.join(
+            IdentifierFactory.access(
                 ts.factory.createCallExpression(
                     ts.factory.createIdentifier("Object.entries"),
                     undefined,
                     [input],
                 ),
-                "forEach",
-            ),
+            )("forEach"),
             undefined,
             [
                 ts.factory.createArrowFunction(

--- a/test/issues/nestia-394.ts
+++ b/test/issues/nestia-394.ts
@@ -1,0 +1,18 @@
+import typia from "typia";
+
+type MyNumber = number;
+interface Base {
+    a: string;
+    b: MyNumber;
+    c: boolean;
+}
+type OmitB = Omit<Base, "b">;
+type OnlyA = Pick<Base, "a">;
+type AA = Pick<OnlyA, "a">;
+type NotB = OmitB;
+type Alias = NotB & AA;
+type Alias2 = Alias;
+type Alias3 = Alias2;
+
+const app = typia.application<[Alias3], "ajv">();
+console.log(JSON.stringify(app.components.schemas ?? {}, null, 4));


### PR DESCRIPTION
When intersection type comes with alias definition, `typia.application<T>()` function had considered it as nonsensible.

Fixed such bug.