### PR TITLE
Improve the performance of validate

### DIFF
--- a/src/programmers/ValidateProgrammer.ts
+++ b/src/programmers/ValidateProgrammer.ts
@@ -101,21 +101,6 @@ export namespace ValidateProgrammer {
                                 ),
                             ),
                         ),
-                        StatementFactory.constant(
-                            "$report",
-                            ts.factory.createCallExpression(
-                                IdentifierFactory.access(
-                                    ts.factory.createParenthesizedExpression(
-                                        ts.factory.createAsExpression(
-                                            modulo,
-                                            TypeFactory.keyword("any"),
-                                        ),
-                                    ),
-                                )("report"),
-                                [],
-                                [ts.factory.createIdentifier("errors")],
-                            ),
-                        ),
                         StatementFactory.constant("__is", is),
                         ts.factory.createIfStatement(
                             ts.factory.createStrictEquality(
@@ -126,19 +111,36 @@ export namespace ValidateProgrammer {
                                     [ts.factory.createIdentifier("input")],
                                 ),
                             ),
-                            ts.factory.createExpressionStatement(
-                                ts.factory.createCallExpression(
-                                    validate,
-                                    undefined,
-                                    [
-                                        ts.factory.createIdentifier("input"),
-                                        ts.factory.createStringLiteral(
-                                            "$input",
-                                        ),
-                                        ts.factory.createTrue(),
-                                    ],
+                            ts.factory.createBlock([
+                                StatementFactory.constant(
+                                    "$report",
+                                    ts.factory.createCallExpression(
+                                        IdentifierFactory.access(
+                                            ts.factory.createParenthesizedExpression(
+                                                ts.factory.createAsExpression(
+                                                    modulo,
+                                                    TypeFactory.keyword("any"),
+                                                ),
+                                            ),
+                                        )("report"),
+                                        [],
+                                        [ts.factory.createIdentifier("errors")],
+                                    ),
                                 ),
-                            ),
+                                ts.factory.createExpressionStatement(
+                                    ts.factory.createCallExpression(
+                                        validate,
+                                        undefined,
+                                        [
+                                            ts.factory.createIdentifier("input"),
+                                            ts.factory.createStringLiteral(
+                                                "$input",
+                                            ),
+                                            ts.factory.createTrue(),
+                                        ],
+                                    ),
+                                ),
+                            ]),
                         ),
                         StatementFactory.constant(
                             "success",


### PR DESCRIPTION
Hello,

I was investigating the code generated by typia to compare it with other tools like ajv, and I came across the following code generated by `typia.createValidate<string>()`

```ts
const validate = input => {
  const errors = [];
  const $report = typia.createValidate.report(errors);
  const __is = input => {
    return "string" === typeof input;
  };
  if (false === __is(input))
    ((input, _path, _exceptionable = true) => {
        return "string" === typeof input || $report(true, {
            path: _path + "",
            expected: "string",
            value: input
        });
    })(input, "$input", true);
  const success = 0 === errors.length;
  return { success, errors, data: success ? input : undefined };
}
```

As you can, the `$report` function is defined before the `if` statement but only used inside it. I figured that moving it inside the `if` statement would improve the performance when the input is valid.

I also refactored the `typia.createValidate.report` function.

I wrote a small project to compare the performance before/after these changes: https://github.com/webNeat/typia-perf-demo

The schema is

```ts
type User = {
  name: string
  age: number
  projects: Array<{
    name: string
    stars: number
    isPublic: boolean
  }>
}
const typiaValidate = typia.createValidate<User>()
```

Here are the results

**Before**
```
zod x 395,806 ops/sec ±0.40% (94 runs sampled)
typia x 9,382,214 ops/sec ±0.98% (96 runs sampled)
ajv x 18,223,948 ops/sec ±1.09% (91 runs sampled)
Fastest is ajv
```

**After**
```
zod x 386,725 ops/sec ±0.66% (95 runs sampled)
typia x 13,494,325 ops/sec ±0.79% (94 runs sampled)
ajv x 18,027,226 ops/sec ±0.42% (98 runs sampled)
Fastest is ajv
```

I see 40% improvement in this case and I think performance will increase for all types of inputs.

I didn't add any test because I didn't add any new feature, I believe the existing tests cover my changes.

Let me know if I missed something.

Thanks