### PR TITLE
Enhance JSON schema type for AJV mode

### DIFF
--- a/benchmark/generate/validate.ts
+++ b/benchmark/generate/validate.ts
@@ -33,7 +33,7 @@ const LIBRARIES = (category: string): BenchmarkProgrammer.ILibrary[] => [
             ].join("\n");
         },
     },
-    ...["typebox", "ajv", "io-ts", "zod", "class-validator"].map((name) => ({
+    ...["typebox", "io-ts", "zod", "class-validator"].map((name) => ({
         name,
         body: (type: string) => {
             const schema: string = `${BenchmarkProgrammer.pascal(name)}${type}`;
@@ -50,6 +50,25 @@ const LIBRARIES = (category: string): BenchmarkProgrammer.ILibrary[] => [
             ].join("\n");
         },
     })),
+    {
+        name: "ajv",
+        body: (type: string) => {
+            const program: string = `create${BenchmarkProgrammer.pascal(
+                category,
+            )}AjvBenchmarkProgram`;
+
+            return [
+                `import typia from "typia";`,
+                ``,
+                `import { ${type} } from "../../../../test/structures/${type}";`,
+                `import { ${program} } from "./${program}";`,
+                ``,
+                `${program}(`,
+                `    typia.application<[${type}], "ajv">(),`,
+                `);`,
+            ].join("\n");
+        },
+    },
 ];
 
 async function main(): Promise<void> {

--- a/benchmark/programs/assert/ajv/createAssertAjvBenchmarkProgram.ts
+++ b/benchmark/programs/assert/ajv/createAssertAjvBenchmarkProgram.ts
@@ -1,9 +1,9 @@
 import Ajv from "ajv";
 import { IJsonApplication } from "typia";
 
-import { createIsBenchmarkProgram } from "../createIsBenchmarkProgram";
+import { createAssertBenchmarkProgram } from "../createAssertBenchmarkProgram";
 
-export const createIsAjvBenchmarkProgram = (app: IJsonApplication) => {
+export const createAssertAjvBenchmarkProgram = (app: IJsonApplication) => {
     const program = new Ajv({
         schemas: Object.values(app.components.schemas ?? {}),
         keywords: [
@@ -16,7 +16,13 @@ export const createIsAjvBenchmarkProgram = (app: IJsonApplication) => {
         ],
         strict: true,
         strictNumbers: false,
+        allErrors: false,
     });
     const validate = program.compile(app.schemas[0]);
-    return createIsBenchmarkProgram(validate);
+    createAssertBenchmarkProgram((input) => {
+        const success: boolean = validate(input);
+        if (!success)
+            throw new Error(validate.errors?.[0].message ?? "unknown");
+        return input;
+    });
 };

--- a/benchmark/programs/is/ajv/benchmark-is-ajv-ArrayRecursive.ts
+++ b/benchmark/programs/is/ajv/benchmark-is-ajv-ArrayRecursive.ts
@@ -1,4 +1,6 @@
-import { AjvArrayRecursive } from "../../../structures/ajv/AjvArrayRecursive";
+import typia from "typia";
+
+import { ArrayRecursive } from "../../../../test/structures/ArrayRecursive";
 import { createIsAjvBenchmarkProgram } from "./createIsAjvBenchmarkProgram";
 
-createIsAjvBenchmarkProgram(AjvArrayRecursive);
+createIsAjvBenchmarkProgram(typia.application<[ArrayRecursive], "ajv">());

--- a/benchmark/programs/is/ajv/benchmark-is-ajv-ArrayRecursiveUnionExplicit.ts
+++ b/benchmark/programs/is/ajv/benchmark-is-ajv-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,8 @@
-import { AjvArrayRecursiveUnionExplicit } from "../../../structures/ajv/AjvArrayRecursiveUnionExplicit";
+import typia from "typia";
+
+import { ArrayRecursiveUnionExplicit } from "../../../../test/structures/ArrayRecursiveUnionExplicit";
 import { createIsAjvBenchmarkProgram } from "./createIsAjvBenchmarkProgram";
 
-createIsAjvBenchmarkProgram(AjvArrayRecursiveUnionExplicit);
+createIsAjvBenchmarkProgram(
+    typia.application<[ArrayRecursiveUnionExplicit], "ajv">(),
+);

--- a/benchmark/programs/is/ajv/benchmark-is-ajv-ArrayRecursiveUnionImplicit.ts
+++ b/benchmark/programs/is/ajv/benchmark-is-ajv-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,8 @@
-import { AjvArrayRecursiveUnionImplicit } from "../../../structures/ajv/AjvArrayRecursiveUnionImplicit";
+import typia from "typia";
+
+import { ArrayRecursiveUnionImplicit } from "../../../../test/structures/ArrayRecursiveUnionImplicit";
 import { createIsAjvBenchmarkProgram } from "./createIsAjvBenchmarkProgram";
 
-createIsAjvBenchmarkProgram(AjvArrayRecursiveUnionImplicit);
+createIsAjvBenchmarkProgram(
+    typia.application<[ArrayRecursiveUnionImplicit], "ajv">(),
+);

--- a/benchmark/programs/is/ajv/benchmark-is-ajv-ObjectHierarchical.ts
+++ b/benchmark/programs/is/ajv/benchmark-is-ajv-ObjectHierarchical.ts
@@ -1,4 +1,6 @@
-import { AjvObjectHierarchical } from "../../../structures/ajv/AjvObjectHierarchical";
+import typia from "typia";
+
+import { ObjectHierarchical } from "../../../../test/structures/ObjectHierarchical";
 import { createIsAjvBenchmarkProgram } from "./createIsAjvBenchmarkProgram";
 
-createIsAjvBenchmarkProgram(AjvObjectHierarchical);
+createIsAjvBenchmarkProgram(typia.application<[ObjectHierarchical], "ajv">());

--- a/benchmark/programs/is/ajv/benchmark-is-ajv-ObjectRecursive.ts
+++ b/benchmark/programs/is/ajv/benchmark-is-ajv-ObjectRecursive.ts
@@ -1,4 +1,6 @@
-import { AjvObjectRecursive } from "../../../structures/ajv/AjvObjectRecursive";
+import typia from "typia";
+
+import { ObjectRecursive } from "../../../../test/structures/ObjectRecursive";
 import { createIsAjvBenchmarkProgram } from "./createIsAjvBenchmarkProgram";
 
-createIsAjvBenchmarkProgram(AjvObjectRecursive);
+createIsAjvBenchmarkProgram(typia.application<[ObjectRecursive], "ajv">());

--- a/benchmark/programs/is/ajv/benchmark-is-ajv-ObjectSimple.ts
+++ b/benchmark/programs/is/ajv/benchmark-is-ajv-ObjectSimple.ts
@@ -1,4 +1,6 @@
-import { AjvObjectSimple } from "../../../structures/ajv/AjvObjectSimple";
+import typia from "typia";
+
+import { ObjectSimple } from "../../../../test/structures/ObjectSimple";
 import { createIsAjvBenchmarkProgram } from "./createIsAjvBenchmarkProgram";
 
-createIsAjvBenchmarkProgram(AjvObjectSimple);
+createIsAjvBenchmarkProgram(typia.application<[ObjectSimple], "ajv">());

--- a/benchmark/programs/is/ajv/benchmark-is-ajv-ObjectUnionExplicit.ts
+++ b/benchmark/programs/is/ajv/benchmark-is-ajv-ObjectUnionExplicit.ts
@@ -1,4 +1,6 @@
-import { AjvObjectUnionExplicit } from "../../../structures/ajv/AjvObjectUnionExplicit";
+import typia from "typia";
+
+import { ObjectUnionExplicit } from "../../../../test/structures/ObjectUnionExplicit";
 import { createIsAjvBenchmarkProgram } from "./createIsAjvBenchmarkProgram";
 
-createIsAjvBenchmarkProgram(AjvObjectUnionExplicit);
+createIsAjvBenchmarkProgram(typia.application<[ObjectUnionExplicit], "ajv">());

--- a/benchmark/programs/is/ajv/benchmark-is-ajv-ObjectUnionImplicit.ts
+++ b/benchmark/programs/is/ajv/benchmark-is-ajv-ObjectUnionImplicit.ts
@@ -1,4 +1,6 @@
-import { AjvObjectUnionImplicit } from "../../../structures/ajv/AjvObjectUnionImplicit";
+import typia from "typia";
+
+import { ObjectUnionImplicit } from "../../../../test/structures/ObjectUnionImplicit";
 import { createIsAjvBenchmarkProgram } from "./createIsAjvBenchmarkProgram";
 
-createIsAjvBenchmarkProgram(AjvObjectUnionImplicit);
+createIsAjvBenchmarkProgram(typia.application<[ObjectUnionImplicit], "ajv">());

--- a/benchmark/programs/is/ajv/benchmark-is-ajv-UltimateUnion.ts
+++ b/benchmark/programs/is/ajv/benchmark-is-ajv-UltimateUnion.ts
@@ -1,4 +1,6 @@
-import { AjvUltimateUnion } from "../../../structures/ajv/AjvUltimateUnion";
+import typia from "typia";
+
+import { UltimateUnion } from "../../../../test/structures/UltimateUnion";
 import { createIsAjvBenchmarkProgram } from "./createIsAjvBenchmarkProgram";
 
-createIsAjvBenchmarkProgram(AjvUltimateUnion);
+createIsAjvBenchmarkProgram(typia.application<[UltimateUnion], "ajv">());

--- a/benchmark/programs/is/typebox/benchmark-is-typebox-ArrayRecursive.ts
+++ b/benchmark/programs/is/typebox/benchmark-is-typebox-ArrayRecursive.ts
@@ -1,4 +1,4 @@
 import { TypeboxArrayRecursive } from "../../../structures/typebox/TypeboxArrayRecursive";
-import { createIsTypeboxBenchmarkProgram } from "./createIsTypeBoxBenchmarkProgram";
+import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxArrayRecursive);

--- a/benchmark/programs/is/typebox/benchmark-is-typebox-ArrayRecursiveUnionExplicit.ts
+++ b/benchmark/programs/is/typebox/benchmark-is-typebox-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,4 @@
 import { TypeboxArrayRecursiveUnionExplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionExplicit";
-import { createIsTypeboxBenchmarkProgram } from "./createIsTypeBoxBenchmarkProgram";
+import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxArrayRecursiveUnionExplicit);

--- a/benchmark/programs/is/typebox/benchmark-is-typebox-ArrayRecursiveUnionImplicit.ts
+++ b/benchmark/programs/is/typebox/benchmark-is-typebox-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,4 @@
 import { TypeboxArrayRecursiveUnionImplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionImplicit";
-import { createIsTypeboxBenchmarkProgram } from "./createIsTypeBoxBenchmarkProgram";
+import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxArrayRecursiveUnionImplicit);

--- a/benchmark/programs/is/typebox/benchmark-is-typebox-ObjectHierarchical.ts
+++ b/benchmark/programs/is/typebox/benchmark-is-typebox-ObjectHierarchical.ts
@@ -1,4 +1,4 @@
 import { TypeboxObjectHierarchical } from "../../../structures/typebox/TypeboxObjectHierarchical";
-import { createIsTypeboxBenchmarkProgram } from "./createIsTypeBoxBenchmarkProgram";
+import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxObjectHierarchical);

--- a/benchmark/programs/is/typebox/benchmark-is-typebox-ObjectRecursive.ts
+++ b/benchmark/programs/is/typebox/benchmark-is-typebox-ObjectRecursive.ts
@@ -1,4 +1,4 @@
 import { TypeboxObjectRecursive } from "../../../structures/typebox/TypeboxObjectRecursive";
-import { createIsTypeboxBenchmarkProgram } from "./createIsTypeBoxBenchmarkProgram";
+import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxObjectRecursive);

--- a/benchmark/programs/is/typebox/benchmark-is-typebox-ObjectSimple.ts
+++ b/benchmark/programs/is/typebox/benchmark-is-typebox-ObjectSimple.ts
@@ -1,4 +1,4 @@
 import { TypeboxObjectSimple } from "../../../structures/typebox/TypeboxObjectSimple";
-import { createIsTypeboxBenchmarkProgram } from "./createIsTypeBoxBenchmarkProgram";
+import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxObjectSimple);

--- a/benchmark/programs/is/typebox/benchmark-is-typebox-ObjectUnionExplicit.ts
+++ b/benchmark/programs/is/typebox/benchmark-is-typebox-ObjectUnionExplicit.ts
@@ -1,4 +1,4 @@
 import { TypeboxObjectUnionExplicit } from "../../../structures/typebox/TypeboxObjectUnionExplicit";
-import { createIsTypeboxBenchmarkProgram } from "./createIsTypeBoxBenchmarkProgram";
+import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxObjectUnionExplicit);

--- a/benchmark/programs/is/typebox/benchmark-is-typebox-ObjectUnionImplicit.ts
+++ b/benchmark/programs/is/typebox/benchmark-is-typebox-ObjectUnionImplicit.ts
@@ -1,4 +1,4 @@
 import { TypeboxObjectUnionImplicit } from "../../../structures/typebox/TypeboxObjectUnionImplicit";
-import { createIsTypeboxBenchmarkProgram } from "./createIsTypeBoxBenchmarkProgram";
+import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxObjectUnionImplicit);

--- a/benchmark/programs/is/typebox/benchmark-is-typebox-UltimateUnion.ts
+++ b/benchmark/programs/is/typebox/benchmark-is-typebox-UltimateUnion.ts
@@ -1,4 +1,4 @@
 import { TypeboxUltimateUnion } from "../../../structures/typebox/TypeboxUltimateUnion";
-import { createIsTypeboxBenchmarkProgram } from "./createIsTypeBoxBenchmarkProgram";
+import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxUltimateUnion);

--- a/benchmark/programs/validate/ajv/createValidateAjvBenchmarkProgram.ts
+++ b/benchmark/programs/validate/ajv/createValidateAjvBenchmarkProgram.ts
@@ -1,9 +1,9 @@
 import Ajv from "ajv";
 import { IJsonApplication } from "typia";
 
-import { createIsBenchmarkProgram } from "../createIsBenchmarkProgram";
+import { createValidateBenchmarkProgram } from "../createValidateBenchmarkProgram";
 
-export const createIsAjvBenchmarkProgram = (app: IJsonApplication) => {
+export const createValidateAjvBenchmarkProgram = (app: IJsonApplication) => {
     const program = new Ajv({
         schemas: Object.values(app.components.schemas ?? {}),
         keywords: [
@@ -16,7 +16,11 @@ export const createIsAjvBenchmarkProgram = (app: IJsonApplication) => {
         ],
         strict: true,
         strictNumbers: false,
+        allErrors: true,
     });
     const validate = program.compile(app.schemas[0]);
-    return createIsBenchmarkProgram(validate);
+    createValidateBenchmarkProgram((input) => {
+        validate(input);
+        return validate.errors ?? [];
+    });
 };

--- a/benchmark/structures/ajv/AjvUltimateUnion.ts
+++ b/benchmark/structures/ajv/AjvUltimateUnion.ts
@@ -74,11 +74,6 @@ const Reference = Type.Object({
     ...Attribute,
 });
 
-const RecursiveReference = Type.Object({
-    $recursiveRef: Type.String(),
-    ...Attribute,
-});
-
 const OneOf = <T extends TSchema>(schema: T) =>
     Type.Object({
         oneOf: Type.Array(schema),
@@ -127,7 +122,6 @@ const Schema = Type.Recursive((schema) =>
         Array(schema),
         Tuple(schema),
         Reference,
-        RecursiveReference,
         OneOf(schema),
         Unknown,
         NullOnly,

--- a/benchmark/structures/io-ts/IoTsUltimateUnion.ts
+++ b/benchmark/structures/io-ts/IoTsUltimateUnion.ts
@@ -10,7 +10,6 @@ const Schema: t.Type<IJsonSchema> = t.recursion(
             Array,
             Tuple,
             Reference,
-            RecursiveReference,
             OneOf,
             Unknown,
         ]) as any,
@@ -56,10 +55,6 @@ const Tuple: t.Type<IJsonSchema.ITuple> = t.recursion(
 
 const Reference = t.type({
     $ref: t.string,
-    description: t.union([t.string, t.undefined]),
-});
-const RecursiveReference = t.type({
-    $recursiveRef: t.string,
     description: t.union([t.string, t.undefined]),
 });
 const OneOf: t.Type<IJsonSchema.IOneOf> = t.recursion(

--- a/benchmark/structures/typebox/TypeboxUltimateUnion.ts
+++ b/benchmark/structures/typebox/TypeboxUltimateUnion.ts
@@ -75,11 +75,6 @@ const Reference = Type.Object({
     ...Attribute,
 });
 
-const RecursiveReference = Type.Object({
-    $recursiveRef: Type.String(),
-    ...Attribute,
-});
-
 const OneOf = <T extends TSchema>(schema: T) =>
     Type.Object({
         oneOf: Type.Array(schema),
@@ -128,7 +123,6 @@ const Schema = Type.Recursive((schema) =>
         Array(schema),
         Tuple(schema),
         Reference,
-        RecursiveReference,
         OneOf(schema),
         Unknown,
         NullOnly,

--- a/benchmark/structures/zod/ZodUltimateUnion.ts
+++ b/benchmark/structures/zod/ZodUltimateUnion.ts
@@ -9,7 +9,6 @@ const Schema: z.ZodType<IJsonSchema> = z.lazy(
             Array,
             Tuple,
             Reference,
-            RecursiveReference,
             OneOf,
             Unknown,
         ]) as any,
@@ -73,6 +72,8 @@ const Tuple: z.ZodType<IJsonSchema.ITuple> = z.lazy(() =>
         type: z.literal("array"),
         items: z.array(Schema),
         nullable: z.boolean(),
+        minItems: z.number(),
+        maxItems: z.number().optional(),
         description: z.union([z.string(), z.undefined()]),
     }),
 );
@@ -81,12 +82,6 @@ const Reference: z.ZodType<IJsonSchema.IReference> = z.object({
     $ref: z.string(),
     description: z.union([z.string(), z.undefined()]),
 });
-const RecursiveReference: z.ZodType<IJsonSchema.IRecursiveReference> = z.object(
-    {
-        $recursiveRef: z.string(),
-        description: z.union([z.string(), z.undefined()]),
-    },
-);
 const OneOf: z.ZodType<IJsonSchema.IOneOf> = z.lazy(() =>
     z.object({
         oneOf: z.array(Schema),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -96,6 +96,7 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
+    "ajv": "^8.12.0",
     "autocannon": "^7.10.0",
     "benchmark": "^2.1.4",
     "chalk": "^4.1.0",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.0.10"
+    "typia": "4.0.11"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/programmers/internal/application_alias.ts
+++ b/src/programmers/internal/application_alias.ts
@@ -12,9 +12,7 @@ export const application_alias =
     <BlockNever extends boolean>(blockNever: BlockNever) =>
     (components: IJsonComponents) =>
     (alias: MetadataAlias) =>
-    (
-        nullable: boolean,
-    ): IJsonSchema.IReference | IJsonSchema.IRecursiveReference => {
+    (nullable: boolean): IJsonSchema.IReference => {
         if (alias.value.size() === 1 && alias.value.objects.length === 1)
             return application_object(options)(components)(
                 alias.value.objects[0]!,
@@ -45,7 +43,5 @@ export const application_alias =
                 ...schema,
             };
         }
-        return options.purpose === "ajv" && alias.recursive
-            ? { $recursiveRef: $id }
-            : { $ref: $id };
+        return { $ref: $id };
     };

--- a/src/programmers/internal/application_object.ts
+++ b/src/programmers/internal/application_object.ts
@@ -20,21 +20,16 @@ export const application_object =
     (options: ApplicationProgrammer.IOptions) =>
     (components: IJsonComponents) =>
     (obj: MetadataObject) =>
-    (
-        nullable: boolean,
-    ): IJsonSchema.IReference | IJsonSchema.IRecursiveReference => {
+    (nullable: boolean): IJsonSchema.IReference => {
         const key: string =
             options.purpose === "ajv"
                 ? obj.name
                 : `${obj.name}${nullable ? ".Nullable" : ""}`;
         const $id: string = `${JSON_COMPONENTS_PREFIX}/schemas/${key}`;
-        const out = () =>
-            options.purpose === "ajv" && obj.recursive
-                ? { $recursiveRef: $id }
-                : { $ref: $id };
+        const output = { $ref: $id };
 
         // TEMPORARY ASSIGNMENT
-        if (components.schemas?.[key] !== undefined) return out();
+        if (components.schemas?.[key] !== undefined) return output;
         components.schemas ??= {};
         components.schemas[key] = {} as any;
 
@@ -112,8 +107,8 @@ export const application_object =
         };
         const schema: IJsonComponents.IObject = {
             $id: options.purpose === "ajv" ? $id : undefined,
-            $recursiveAnchor:
-                (options.purpose === "ajv" && obj.recursive) || undefined,
+            // $recursiveAnchor:
+            //     (options.purpose === "ajv" && obj.recursive) || undefined,
             type: "object",
             properties,
             nullable: options.purpose === "swagger" ? nullable : undefined,
@@ -132,7 +127,7 @@ export const application_object =
                   }),
         };
         components.schemas[key] = schema;
-        return out();
+        return output;
     };
 
 const join =

--- a/src/programmers/internal/application_tuple.ts
+++ b/src/programmers/internal/application_tuple.ts
@@ -30,8 +30,15 @@ export const application_tuple =
                 }),
             ),
             ...attribute,
+            minItems: !!tuple.elements.at(-1)?.rest
+                ? tuple.elements.length - 1
+                : tuple.elements.length,
+            maxItems: !!tuple.elements.at(-1)?.rest
+                ? undefined
+                : tuple.elements.length,
         };
-        if (options.purpose === "ajv") return schema;
+        if (options.purpose === "ajv" && !tuple.elements.at(-1)?.rest)
+            return schema;
 
         const wrapper: IJsonSchema.IArray = {
             ...schema,
@@ -42,6 +49,8 @@ export const application_tuple =
                 ),
             )(tuple.recursive ? {} : attribute),
             "x-typia-tuple": schema,
+            minItems: schema.minItems,
+            maxItems: schema.maxItems,
         };
         return wrapper;
     };

--- a/src/schemas/IJsonComponents.ts
+++ b/src/schemas/IJsonComponents.ts
@@ -8,7 +8,6 @@ export interface IJsonComponents {
 export namespace IJsonComponents {
     export interface IObject {
         $id?: string;
-        $recursiveAnchor?: boolean;
         type: "object";
 
         /**

--- a/src/schemas/IJsonSchema.ts
+++ b/src/schemas/IJsonSchema.ts
@@ -17,7 +17,6 @@ export namespace IJsonSchema {
         | ITuple
         | IOneOf
         | IReference
-        | IRecursiveReference
         | INullOnly;
 
     export interface IUnknown extends IAttribute {
@@ -95,12 +94,17 @@ export namespace IJsonSchema {
     }
     export interface ITuple extends ISignificant<"array"> {
         items: IJsonSchema[];
+        /**
+         * @type uint
+         */
+        minItems: number;
+        /**
+         * @type uint
+         */
+        maxItems?: number;
     }
     export interface IReference extends IAttribute {
         $ref: string;
-    }
-    export interface IRecursiveReference extends IAttribute {
-        $recursiveRef: string;
     }
     export interface INullOnly extends IAttribute {
         type: "null";

--- a/test/generated/output/assert/test_assert_UltimateUnion.ts
+++ b/test/generated/output/assert/test_assert_UltimateUnion.ts
@@ -23,7 +23,7 @@ export const test_assert_UltimateUnion = _test_assert(
                     "object" === typeof input.components &&
                     null !== input.components &&
                     false === Array.isArray(input.components) &&
-                    $io32(input.components) &&
+                    $io31(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose);
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
@@ -456,6 +456,15 @@ export const test_assert_UltimateUnion = _test_assert(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -555,36 +564,6 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -614,7 +593,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -645,13 +624,13 @@ export const test_assert_UltimateUnion = _test_assert(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -664,23 +643,21 @@ export const test_assert_UltimateUnion = _test_assert(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -710,7 +687,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -720,7 +697,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -733,7 +710,7 @@ export const test_assert_UltimateUnion = _test_assert(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -775,7 +752,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) =>
@@ -819,7 +796,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -861,7 +838,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -899,7 +876,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
@@ -954,7 +931,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum))) &&
@@ -1006,7 +983,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
@@ -1058,7 +1035,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -1112,7 +1089,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -1121,6 +1098,15 @@ export const test_assert_UltimateUnion = _test_assert(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1156,7 +1142,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -1197,7 +1183,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1231,41 +1217,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1299,7 +1251,7 @@ export const test_assert_UltimateUnion = _test_assert(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -1357,9 +1309,7 @@ export const test_assert_UltimateUnion = _test_assert(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (() => {
                             if ($io20(input)) return $io20(input);
                             if ($io19(input)) return $io19(input);
@@ -1367,7 +1317,7 @@ export const test_assert_UltimateUnion = _test_assert(
                             if ($io21(input)) return $io21(input);
                             if ($io23(input)) return $io23(input);
                             if ($io24(input)) return $io24(input);
-                            if ($io31(input)) return $io31(input);
+                            if ($io30(input)) return $io30(input);
                             return false;
                         })();
                     })();
@@ -1394,15 +1344,15 @@ export const test_assert_UltimateUnion = _test_assert(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -1413,20 +1363,18 @@ export const test_assert_UltimateUnion = _test_assert(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (() => {
-                            if ($io38(input)) return $io38(input);
                             if ($io37(input)) return $io37(input);
                             if ($io36(input)) return $io36(input);
-                            if ($io39(input)) return $io39(input);
+                            if ($io35(input)) return $io35(input);
+                            if ($io38(input)) return $io38(input);
+                            if ($io40(input)) return $io40(input);
                             if ($io41(input)) return $io41(input);
-                            if ($io42(input)) return $io42(input);
-                            if ($io49(input)) return $io49(input);
+                            if ($io47(input)) return $io47(input);
                             return false;
                         })();
                     })();
@@ -1471,7 +1419,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 _index2 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -1483,7 +1431,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                         path:
                                             _path + ".schemas[" + _index2 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -1500,7 +1448,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: "IJsonComponents",
                                 value: input.components,
                             })) &&
-                            $ao32(
+                            $ao31(
                                 input.components,
                                 _path + ".components",
                                 true && _exceptionable,
@@ -3196,7 +3144,7 @@ export const test_assert_UltimateUnion = _test_assert(
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                 value: input.items,
                             })) &&
                             $au0(
@@ -3207,7 +3155,7 @@ export const test_assert_UltimateUnion = _test_assert(
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                 value: input.items,
                             })) &&
                         (undefined === input.minItems ||
@@ -3437,7 +3385,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 _index23 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -3449,7 +3397,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                         path:
                                             _path + ".items[" + _index23 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -3457,6 +3405,45 @@ export const test_assert_UltimateUnion = _test_assert(
                                 path: _path + ".items",
                                 expected: "Array<IJsonSchema>",
                                 value: input.items,
+                            })) &&
+                        (("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number",
+                                value: input.minItems,
+                            })) &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "(number | undefined)",
+                                value: input.maxItems,
                             })) &&
                         ("array" === input.type ||
                             $guard(_exceptionable, {
@@ -3626,7 +3613,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 _index26 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -3638,7 +3625,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                         path:
                                             _path + ".oneOf[" + _index26 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -3927,11 +3914,11 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$recursiveRef ||
+                        ("null" === input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$recursiveRef",
-                                expected: "string",
-                                value: input.$recursiveRef,
+                                path: _path + ".type",
+                                expected: '"null"',
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -4070,10 +4057,16 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("null" === input.type ||
+                        (null !== input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"null"',
+                                expected: "undefined",
+                                value: input.type,
+                            })) &&
+                        (undefined === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: "undefined",
                                 value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
@@ -4213,31 +4206,174 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (null !== input.type ||
+                        undefined === input.schemas ||
+                        ((("object" === typeof input.schemas &&
+                            null !== input.schemas &&
+                            false === Array.isArray(input.schemas)) ||
                             $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
+                                path: _path + ".schemas",
+                                expected:
+                                    "(Record<string, IObject | IAlias> | undefined)",
+                                value: input.schemas,
                             })) &&
-                        (undefined === input.type ||
+                            $ao32(
+                                input.schemas,
+                                _path + ".schemas",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".schemas",
+                            expected:
+                                "(Record<string, IObject | IAlias> | undefined)",
+                            value: input.schemas,
+                        });
+                    const $ao32 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        false === _exceptionable ||
+                        Object.keys(input).every((key: any) => {
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            if (RegExp(/(.*)/).test(key))
+                                return (
+                                    ((("object" === typeof value &&
+                                        null !== value &&
+                                        false === Array.isArray(value)) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + $join(key),
+                                            expected:
+                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                            value: value,
+                                        })) &&
+                                        $au2(
+                                            value,
+                                            _path + $join(key),
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected:
+                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                        value: value,
+                                    })
+                                );
+                            return true;
+                        });
+                    const $ao33 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.$id ||
+                            "string" === typeof input.$id ||
                             $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
+                                path: _path + ".$id",
                                 expected: "(string | undefined)",
-                                value: input.title,
+                                value: input.$id,
+                            })) &&
+                        ("object" === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: '"object"',
+                                value: input.type,
+                            })) &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
+                            $guard(_exceptionable, {
+                                path: _path + ".nullable",
+                                expected: "(boolean | undefined)",
+                                value: input.nullable,
+                            })) &&
+                        (((("object" === typeof input.properties &&
+                            null !== input.properties &&
+                            false === Array.isArray(input.properties)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".properties",
+                                expected: "Record<string, IJsonSchema>",
+                                value: input.properties,
+                            })) &&
+                            $ao34(
+                                input.properties,
+                                _path + ".properties",
+                                true && _exceptionable,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".properties",
+                                expected: "Record<string, IJsonSchema>",
+                                value: input.properties,
+                            })) &&
+                        (undefined === input.patternProperties ||
+                            ((("object" === typeof input.patternProperties &&
+                                null !== input.patternProperties &&
+                                false ===
+                                    Array.isArray(input.patternProperties)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                })) &&
+                                $ao34(
+                                    input.patternProperties,
+                                    _path + ".patternProperties",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".patternProperties",
+                                expected:
+                                    "(Record<string, IJsonSchema> | undefined)",
+                                value: input.patternProperties,
+                            })) &&
+                        (undefined === input.additionalProperties ||
+                            ((("object" === typeof input.additionalProperties &&
+                                null !== input.additionalProperties &&
+                                false ===
+                                    Array.isArray(
+                                        input.additionalProperties,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                })) &&
+                                $au0(
+                                    input.additionalProperties,
+                                    _path + ".additionalProperties",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".additionalProperties",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                value: input.additionalProperties,
+                            })) &&
+                        (undefined === input.required ||
+                            ((Array.isArray(input.required) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
+                                })) &&
+                                input.required.every(
+                                    (elem: any, _index35: number) =>
+                                        "string" === typeof elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".required[" +
+                                                _index35 +
+                                                "]",
+                                            expected: "string",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".required",
+                                expected: "(Array<string> | undefined)",
+                                value: input.required,
                             })) &&
                         (undefined === input.description ||
                             "string" === typeof input.description ||
@@ -4245,52 +4381,6 @@ export const test_assert_UltimateUnion = _test_assert(
                                 path: _path + ".description",
                                 expected: "(string | undefined)",
                                 value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index35: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index35 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
                             })) &&
                         (undefined === input["x-typia-jsDocTags"] ||
                             ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4336,259 +4426,6 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: "(Array<IJsDocTagInfo> | undefined)",
                                 value: input["x-typia-jsDocTags"],
                             })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            }));
-                    const $ao32 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        undefined === input.schemas ||
-                        ((("object" === typeof input.schemas &&
-                            null !== input.schemas &&
-                            false === Array.isArray(input.schemas)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".schemas",
-                                expected:
-                                    "(Record<string, IObject | IAlias> | undefined)",
-                                value: input.schemas,
-                            })) &&
-                            $ao33(
-                                input.schemas,
-                                _path + ".schemas",
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".schemas",
-                            expected:
-                                "(Record<string, IObject | IAlias> | undefined)",
-                            value: input.schemas,
-                        });
-                    const $ao33 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        false === _exceptionable ||
-                        Object.keys(input).every((key: any) => {
-                            const value = input[key];
-                            if (undefined === value) return true;
-                            if (RegExp(/(.*)/).test(key))
-                                return (
-                                    ((("object" === typeof value &&
-                                        null !== value &&
-                                        false === Array.isArray(value)) ||
-                                        $guard(_exceptionable, {
-                                            path: _path + $join(key),
-                                            expected:
-                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                            value: value,
-                                        })) &&
-                                        $au2(
-                                            value,
-                                            _path + $join(key),
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + $join(key),
-                                        expected:
-                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                        value: value,
-                                    })
-                                );
-                            return true;
-                        });
-                    const $ao34 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            })) &&
-                        ("object" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"object"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.nullable ||
-                            "boolean" === typeof input.nullable ||
-                            $guard(_exceptionable, {
-                                path: _path + ".nullable",
-                                expected: "(boolean | undefined)",
-                                value: input.nullable,
-                            })) &&
-                        (((("object" === typeof input.properties &&
-                            null !== input.properties &&
-                            false === Array.isArray(input.properties)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".properties",
-                                expected: "Record<string, IJsonSchema>",
-                                value: input.properties,
-                            })) &&
-                            $ao35(
-                                input.properties,
-                                _path + ".properties",
-                                true && _exceptionable,
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".properties",
-                                expected: "Record<string, IJsonSchema>",
-                                value: input.properties,
-                            })) &&
-                        (undefined === input.patternProperties ||
-                            ((("object" === typeof input.patternProperties &&
-                                null !== input.patternProperties &&
-                                false ===
-                                    Array.isArray(input.patternProperties)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                })) &&
-                                $ao35(
-                                    input.patternProperties,
-                                    _path + ".patternProperties",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".patternProperties",
-                                expected:
-                                    "(Record<string, IJsonSchema> | undefined)",
-                                value: input.patternProperties,
-                            })) &&
-                        (undefined === input.additionalProperties ||
-                            ((("object" === typeof input.additionalProperties &&
-                                null !== input.additionalProperties &&
-                                false ===
-                                    Array.isArray(
-                                        input.additionalProperties,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                })) &&
-                                $au0(
-                                    input.additionalProperties,
-                                    _path + ".additionalProperties",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".additionalProperties",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                value: input.additionalProperties,
-                            })) &&
-                        (undefined === input.required ||
-                            ((Array.isArray(input.required) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                })) &&
-                                input.required.every(
-                                    (elem: any, _index37: number) =>
-                                        "string" === typeof elem ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".required[" +
-                                                _index37 +
-                                                "]",
-                                            expected: "string",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".required",
-                                expected: "(Array<string> | undefined)",
-                                value: input.required,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index38: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index38 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
                         (undefined === input["x-typia-patternProperties"] ||
                             ((("object" ===
                                 typeof input["x-typia-patternProperties"] &&
@@ -4604,7 +4441,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                         "(Record<string, IJsonSchema> | undefined)",
                                     value: input["x-typia-patternProperties"],
                                 })) &&
-                                $ao35(
+                                $ao34(
                                     input["x-typia-patternProperties"],
                                     _path + '["x-typia-patternProperties"]',
                                     true && _exceptionable,
@@ -4629,7 +4466,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
@@ -4643,10 +4480,10 @@ export const test_assert_UltimateUnion = _test_assert(
                                 path:
                                     _path + '["x-typia-additionalProperties"]',
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                 value: input["x-typia-additionalProperties"],
                             }));
-                    const $ao35 = (
+                    const $ao34 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4663,7 +4500,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                         $guard(_exceptionable, {
                                             path: _path + $join(key),
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: value,
                                         })) &&
                                         $au0(
@@ -4674,13 +4511,13 @@ export const test_assert_UltimateUnion = _test_assert(
                                     $guard(_exceptionable, {
                                         path: _path + $join(key),
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: value,
                                     })
                                 );
                             return true;
                         });
-                    const $ao36 = (
+                    const $ao35 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4692,13 +4529,13 @@ export const test_assert_UltimateUnion = _test_assert(
                                 value: input["enum"],
                             })) &&
                             input["enum"].every(
-                                (elem: any, _index39: number) =>
+                                (elem: any, _index37: number) =>
                                     "boolean" === typeof elem ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +
                                             '["enum"][' +
-                                            _index39 +
+                                            _index37 +
                                             "]",
                                         expected: "boolean",
                                         value: elem,
@@ -4759,14 +4596,14 @@ export const test_assert_UltimateUnion = _test_assert(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index40: number) =>
+                                    (elem: any, _index38: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4776,7 +4613,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4784,7 +4621,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index40 +
+                                                _index38 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4805,14 +4642,14 @@ export const test_assert_UltimateUnion = _test_assert(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index41: number) =>
+                                    (elem: any, _index39: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -4821,7 +4658,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4829,7 +4666,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index41 +
+                                                _index39 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -4875,7 +4712,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: "(boolean | undefined)",
                                 value: input.$recursiveAnchor,
                             }));
-                    const $ao37 = (
+                    const $ao36 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4887,14 +4724,14 @@ export const test_assert_UltimateUnion = _test_assert(
                                 value: input["enum"],
                             })) &&
                             input["enum"].every(
-                                (elem: any, _index42: number) =>
+                                (elem: any, _index40: number) =>
                                     ("number" === typeof elem &&
                                         Number.isFinite(elem)) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +
                                             '["enum"][' +
-                                            _index42 +
+                                            _index40 +
                                             "]",
                                         expected: "number",
                                         value: elem,
@@ -4956,14 +4793,14 @@ export const test_assert_UltimateUnion = _test_assert(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index43: number) =>
+                                    (elem: any, _index41: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4973,7 +4810,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4981,7 +4818,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index43 +
+                                                _index41 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5002,14 +4839,14 @@ export const test_assert_UltimateUnion = _test_assert(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index44: number) =>
+                                    (elem: any, _index42: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index44 +
+                                                    _index42 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -5018,7 +4855,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index44 +
+                                                    _index42 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -5026,7 +4863,202 @@ export const test_assert_UltimateUnion = _test_assert(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
+                                                _index42 +
+                                                "]",
+                                            expected: "IJsDocTagInfo",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-jsDocTags"]',
+                                expected: "(Array<IJsDocTagInfo> | undefined)",
+                                value: input["x-typia-jsDocTags"],
+                            })) &&
+                        (undefined === input["x-typia-required"] ||
+                            "boolean" === typeof input["x-typia-required"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-required"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-required"],
+                            })) &&
+                        (undefined === input["x-typia-optional"] ||
+                            "boolean" === typeof input["x-typia-optional"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-optional"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-optional"],
+                            })) &&
+                        (undefined === input["x-typia-rest"] ||
+                            "boolean" === typeof input["x-typia-rest"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-rest"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-rest"],
+                            })) &&
+                        (undefined === input.$id ||
+                            "string" === typeof input.$id ||
+                            $guard(_exceptionable, {
+                                path: _path + ".$id",
+                                expected: "(string | undefined)",
+                                value: input.$id,
+                            })) &&
+                        (undefined === input.$recursiveAnchor ||
+                            "boolean" === typeof input.$recursiveAnchor ||
+                            $guard(_exceptionable, {
+                                path: _path + ".$recursiveAnchor",
+                                expected: "(boolean | undefined)",
+                                value: input.$recursiveAnchor,
+                            }));
+                    const $ao37 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (((Array.isArray(input["enum"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["enum"]',
+                                expected: "Array<string>",
+                                value: input["enum"],
+                            })) &&
+                            input["enum"].every(
+                                (elem: any, _index43: number) =>
+                                    "string" === typeof elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            '["enum"][' +
+                                            _index43 +
+                                            "]",
+                                        expected: "string",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["enum"]',
+                                expected: "Array<string>",
+                                value: input["enum"],
+                            })) &&
+                        (undefined === input["default"] ||
+                            "string" === typeof input["default"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["default"]',
+                                expected: "(string | undefined)",
+                                value: input["default"],
+                            })) &&
+                        ("string" === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: '"string"',
+                                value: input.type,
+                            })) &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
+                            $guard(_exceptionable, {
+                                path: _path + ".nullable",
+                                expected: "(boolean | undefined)",
+                                value: input.nullable,
+                            })) &&
+                        (undefined === input.deprecated ||
+                            "boolean" === typeof input.deprecated ||
+                            $guard(_exceptionable, {
+                                path: _path + ".deprecated",
+                                expected: "(boolean | undefined)",
+                                value: input.deprecated,
+                            })) &&
+                        (undefined === input.title ||
+                            "string" === typeof input.title ||
+                            $guard(_exceptionable, {
+                                path: _path + ".title",
+                                expected: "(string | undefined)",
+                                value: input.title,
+                            })) &&
+                        (undefined === input.description ||
+                            "string" === typeof input.description ||
+                            $guard(_exceptionable, {
+                                path: _path + ".description",
+                                expected: "(string | undefined)",
+                                value: input.description,
+                            })) &&
+                        (undefined === input["x-typia-metaTags"] ||
+                            ((Array.isArray(input["x-typia-metaTags"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                })) &&
+                                input["x-typia-metaTags"].every(
+                                    (elem: any, _index44: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-metaTags"][' +
+                                                    _index44 +
+                                                    "]",
+                                                expected:
+                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                value: elem,
+                                            })) &&
+                                            $au1(
+                                                elem,
+                                                _path +
+                                                    '["x-typia-metaTags"][' +
+                                                    _index44 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-metaTags"][' +
                                                 _index44 +
+                                                "]",
+                                            expected:
+                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-metaTags"]',
+                                expected: "(Array<IMetadataTag> | undefined)",
+                                value: input["x-typia-metaTags"],
+                            })) &&
+                        (undefined === input["x-typia-jsDocTags"] ||
+                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                })) &&
+                                input["x-typia-jsDocTags"].every(
+                                    (elem: any, _index45: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
+                                                    "]",
+                                                expected: "IJsDocTagInfo",
+                                                value: elem,
+                                            })) &&
+                                            $ao17(
+                                                elem,
+                                                _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-jsDocTags"][' +
+                                                _index45 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -5077,41 +5109,17 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input["enum"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["enum"]',
-                                expected: "Array<string>",
-                                value: input["enum"],
-                            })) &&
-                            input["enum"].every(
-                                (elem: any, _index45: number) =>
-                                    "string" === typeof elem ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["enum"][' +
-                                            _index45 +
-                                            "]",
-                                        expected: "string",
-                                        value: elem,
-                                    }),
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["enum"]',
-                                expected: "Array<string>",
-                                value: input["enum"],
-                            })) &&
                         (undefined === input["default"] ||
-                            "string" === typeof input["default"] ||
+                            "boolean" === typeof input["default"] ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(string | undefined)",
+                                expected: "(boolean | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("string" === input.type ||
+                        ("boolean" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"string"',
+                                expected: '"boolean"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5272,17 +5280,75 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (undefined === input.minimum ||
+                            ("number" === typeof input.minimum &&
+                                Number.isFinite(input.minimum) &&
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "(number | undefined)",
+                                value: input.minimum,
+                            })) &&
+                        (undefined === input.maximum ||
+                            ("number" === typeof input.maximum &&
+                                Number.isFinite(input.maximum) &&
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "(number | undefined)",
+                                value: input.maximum,
+                            })) &&
+                        (undefined === input.exclusiveMinimum ||
+                            "boolean" === typeof input.exclusiveMinimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "(boolean | undefined)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (undefined === input.exclusiveMaximum ||
+                            "boolean" === typeof input.exclusiveMaximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMaximum",
+                                expected: "(boolean | undefined)",
+                                value: input.exclusiveMaximum,
+                            })) &&
+                        (undefined === input.multipleOf ||
+                            ("number" === typeof input.multipleOf &&
+                                Number.isFinite(input.multipleOf) &&
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "(number | undefined)",
+                                value: input.multipleOf,
+                            })) &&
                         (undefined === input["default"] ||
-                            "boolean" === typeof input["default"] ||
+                            ("number" === typeof input["default"] &&
+                                Number.isFinite(input["default"])) ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(boolean | undefined)",
+                                expected: "(number | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("boolean" === input.type ||
+                        ("integer" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"boolean"',
+                                expected: '"integer"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5445,13 +5511,7 @@ export const test_assert_UltimateUnion = _test_assert(
                     ): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
-                                Number.isFinite(input.minimum) &&
-                                (parseInt(input.minimum) === input.minimum ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minimum",
-                                        expected: "number (@type int)",
-                                        value: input.minimum,
-                                    }))) ||
+                                Number.isFinite(input.minimum)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -5459,13 +5519,7 @@ export const test_assert_UltimateUnion = _test_assert(
                             })) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
-                                Number.isFinite(input.maximum) &&
-                                (parseInt(input.maximum) === input.maximum ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".maximum",
-                                        expected: "number (@type int)",
-                                        value: input.maximum,
-                                    }))) ||
+                                Number.isFinite(input.maximum)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -5487,14 +5541,7 @@ export const test_assert_UltimateUnion = _test_assert(
                             })) &&
                         (undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
-                                Number.isFinite(input.multipleOf) &&
-                                (parseInt(input.multipleOf) ===
-                                    input.multipleOf ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".multipleOf",
-                                        expected: "number (@type int)",
-                                        value: input.multipleOf,
-                                    }))) ||
+                                Number.isFinite(input.multipleOf)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -5508,10 +5555,10 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: "(number | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("integer" === input.type ||
+                        ("number" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"integer"',
+                                expected: '"number"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5672,56 +5719,73 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (undefined === input.minimum ||
-                            ("number" === typeof input.minimum &&
-                                Number.isFinite(input.minimum)) ||
+                        (undefined === input.minLength ||
+                            ("number" === typeof input.minLength &&
+                                Number.isFinite(input.minLength) &&
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".minimum",
+                                path: _path + ".minLength",
                                 expected: "(number | undefined)",
-                                value: input.minimum,
+                                value: input.minLength,
                             })) &&
-                        (undefined === input.maximum ||
-                            ("number" === typeof input.maximum &&
-                                Number.isFinite(input.maximum)) ||
+                        (undefined === input.maxLength ||
+                            ("number" === typeof input.maxLength &&
+                                Number.isFinite(input.maxLength) &&
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".maximum",
+                                path: _path + ".maxLength",
                                 expected: "(number | undefined)",
-                                value: input.maximum,
+                                value: input.maxLength,
                             })) &&
-                        (undefined === input.exclusiveMinimum ||
-                            "boolean" === typeof input.exclusiveMinimum ||
+                        (undefined === input.pattern ||
+                            "string" === typeof input.pattern ||
                             $guard(_exceptionable, {
-                                path: _path + ".exclusiveMinimum",
-                                expected: "(boolean | undefined)",
-                                value: input.exclusiveMinimum,
+                                path: _path + ".pattern",
+                                expected: "(string | undefined)",
+                                value: input.pattern,
                             })) &&
-                        (undefined === input.exclusiveMaximum ||
-                            "boolean" === typeof input.exclusiveMaximum ||
+                        (undefined === input.format ||
+                            "string" === typeof input.format ||
                             $guard(_exceptionable, {
-                                path: _path + ".exclusiveMaximum",
-                                expected: "(boolean | undefined)",
-                                value: input.exclusiveMaximum,
-                            })) &&
-                        (undefined === input.multipleOf ||
-                            ("number" === typeof input.multipleOf &&
-                                Number.isFinite(input.multipleOf)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".multipleOf",
-                                expected: "(number | undefined)",
-                                value: input.multipleOf,
+                                path: _path + ".format",
+                                expected: "(string | undefined)",
+                                value: input.format,
                             })) &&
                         (undefined === input["default"] ||
-                            ("number" === typeof input["default"] &&
-                                Number.isFinite(input["default"])) ||
+                            "string" === typeof input["default"] ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(number | undefined)",
+                                expected: "(string | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("number" === input.type ||
+                        ("string" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"number"',
+                                expected: '"string"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5882,73 +5946,89 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (undefined === input.minLength ||
-                            ("number" === typeof input.minLength &&
-                                Number.isFinite(input.minLength) &&
-                                (parseInt(input.minLength) ===
-                                    input.minLength ||
+                        (((("object" === typeof input.items &&
+                            null !== input.items &&
+                            false === Array.isArray(input.items)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                value: input.items,
+                            })) &&
+                            $au0(
+                                input.items,
+                                _path + ".items",
+                                true && _exceptionable,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                value: input.items,
+                            })) &&
+                        (undefined === input.minItems ||
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "number (@type uint)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     })) &&
-                                (0 <= input.minLength ||
+                                (0 <= input.minItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "number (@type uint)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".minLength",
+                                path: _path + ".minItems",
                                 expected: "(number | undefined)",
-                                value: input.minLength,
+                                value: input.minItems,
                             })) &&
-                        (undefined === input.maxLength ||
-                            ("number" === typeof input.maxLength &&
-                                Number.isFinite(input.maxLength) &&
-                                (parseInt(input.maxLength) ===
-                                    input.maxLength ||
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                (parseInt(input.maxItems) === input.maxItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "number (@type uint)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     })) &&
-                                (0 <= input.maxLength ||
+                                (0 <= input.maxItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "number (@type uint)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".maxLength",
+                                path: _path + ".maxItems",
                                 expected: "(number | undefined)",
-                                value: input.maxLength,
+                                value: input.maxItems,
                             })) &&
-                        (undefined === input.pattern ||
-                            "string" === typeof input.pattern ||
+                        (undefined === input["x-typia-tuple"] ||
+                            ((("object" === typeof input["x-typia-tuple"] &&
+                                null !== input["x-typia-tuple"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
+                                })) &&
+                                $ao26(
+                                    input["x-typia-tuple"],
+                                    _path + '["x-typia-tuple"]',
+                                    true && _exceptionable,
+                                )) ||
                             $guard(_exceptionable, {
-                                path: _path + ".pattern",
-                                expected: "(string | undefined)",
-                                value: input.pattern,
+                                path: _path + '["x-typia-tuple"]',
+                                expected: "(IJsonSchema.ITuple | undefined)",
+                                value: input["x-typia-tuple"],
                             })) &&
-                        (undefined === input.format ||
-                            "string" === typeof input.format ||
-                            $guard(_exceptionable, {
-                                path: _path + ".format",
-                                expected: "(string | undefined)",
-                                value: input.format,
-                            })) &&
-                        (undefined === input["default"] ||
-                            "string" === typeof input["default"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["default"]',
-                                expected: "(string | undefined)",
-                                value: input["default"],
-                            })) &&
-                        ("string" === input.type ||
+                        ("array" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"string"',
+                                expected: '"array"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -6109,44 +6189,62 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((("object" === typeof input.items &&
-                            null !== input.items &&
-                            false === Array.isArray(input.items)) ||
+                        (((Array.isArray(input.items) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                expected: "Array<IJsonSchema>",
                                 value: input.items,
                             })) &&
-                            $au0(
-                                input.items,
-                                _path + ".items",
-                                true && _exceptionable,
+                            input.items.every(
+                                (elem: any, _index56: number) =>
+                                    ((("object" === typeof elem &&
+                                        null !== elem &&
+                                        false === Array.isArray(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index56 +
+                                                "]",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            value: elem,
+                                        })) &&
+                                        $au0(
+                                            elem,
+                                            _path + ".items[" + _index56 + "]",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".items[" + _index56 + "]",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: elem,
+                                    }),
                             )) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                expected: "Array<IJsonSchema>",
                                 value: input.items,
                             })) &&
-                        (undefined === input.minItems ||
-                            ("number" === typeof input.minItems &&
-                                Number.isFinite(input.minItems) &&
-                                (parseInt(input.minItems) === input.minItems ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minItems",
-                                        expected: "number (@type uint)",
-                                        value: input.minItems,
-                                    })) &&
-                                (0 <= input.minItems ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minItems",
-                                        expected: "number (@type uint)",
-                                        value: input.minItems,
-                                    }))) ||
+                        (("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
-                                expected: "(number | undefined)",
+                                expected: "number",
                                 value: input.minItems,
                             })) &&
                         (undefined === input.maxItems ||
@@ -6168,25 +6266,6 @@ export const test_assert_UltimateUnion = _test_assert(
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",
                                 value: input.maxItems,
-                            })) &&
-                        (undefined === input["x-typia-tuple"] ||
-                            ((("object" === typeof input["x-typia-tuple"] &&
-                                null !== input["x-typia-tuple"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
-                                })) &&
-                                $ao26(
-                                    input["x-typia-tuple"],
-                                    _path + '["x-typia-tuple"]',
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-tuple"]',
-                                expected: "(IJsonSchema.ITuple | undefined)",
-                                value: input["x-typia-tuple"],
                             })) &&
                         ("array" === input.type ||
                             $guard(_exceptionable, {
@@ -6231,14 +6310,14 @@ export const test_assert_UltimateUnion = _test_assert(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index56: number) =>
+                                    (elem: any, _index57: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6248,7 +6327,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6256,7 +6335,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index56 +
+                                                _index57 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6277,14 +6356,14 @@ export const test_assert_UltimateUnion = _test_assert(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index57: number) =>
+                                    (elem: any, _index58: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6293,7 +6372,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6301,7 +6380,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index57 +
+                                                _index58 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -6352,57 +6431,44 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input.items) ||
+                        (((Array.isArray(input.oneOf) ||
                             $guard(_exceptionable, {
-                                path: _path + ".items",
+                                path: _path + ".oneOf",
                                 expected: "Array<IJsonSchema>",
-                                value: input.items,
+                                value: input.oneOf,
                             })) &&
-                            input.items.every(
-                                (elem: any, _index58: number) =>
+                            input.oneOf.every(
+                                (elem: any, _index59: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem)) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
-                                                ".items[" +
-                                                _index58 +
+                                                ".oneOf[" +
+                                                _index59 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                             true && _exceptionable,
                                         )) ||
                                     $guard(_exceptionable, {
                                         path:
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
                             $guard(_exceptionable, {
-                                path: _path + ".items",
+                                path: _path + ".oneOf",
                                 expected: "Array<IJsonSchema>",
-                                value: input.items,
-                            })) &&
-                        ("array" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"array"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.nullable ||
-                            "boolean" === typeof input.nullable ||
-                            $guard(_exceptionable, {
-                                path: _path + ".nullable",
-                                expected: "(boolean | undefined)",
-                                value: input.nullable,
+                                value: input.oneOf,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6434,14 +6500,14 @@ export const test_assert_UltimateUnion = _test_assert(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index59: number) =>
+                                    (elem: any, _index60: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6451,7 +6517,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6459,7 +6525,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index59 +
+                                                _index60 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6480,14 +6546,14 @@ export const test_assert_UltimateUnion = _test_assert(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index60: number) =>
+                                    (elem: any, _index61: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6496,7 +6562,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6504,7 +6570,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index60 +
+                                                _index61 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -6555,44 +6621,11 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input.oneOf) ||
+                        ("string" === typeof input.$ref ||
                             $guard(_exceptionable, {
-                                path: _path + ".oneOf",
-                                expected: "Array<IJsonSchema>",
-                                value: input.oneOf,
-                            })) &&
-                            input.oneOf.every(
-                                (elem: any, _index61: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem &&
-                                        false === Array.isArray(elem)) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".oneOf[" +
-                                                _index61 +
-                                                "]",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                            value: elem,
-                                        })) &&
-                                        $au0(
-                                            elem,
-                                            _path + ".oneOf[" + _index61 + "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path + ".oneOf[" + _index61 + "]",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                        value: elem,
-                                    }),
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".oneOf",
-                                expected: "Array<IJsonSchema>",
-                                value: input.oneOf,
+                                path: _path + ".$ref",
+                                expected: "string",
+                                value: input.$ref,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6745,11 +6778,11 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$ref ||
+                        ("null" === input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$ref",
-                                expected: "string",
-                                value: input.$ref,
+                                path: _path + ".type",
+                                expected: '"null"',
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6902,11 +6935,17 @@ export const test_assert_UltimateUnion = _test_assert(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$recursiveRef ||
+                        (null !== input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$recursiveRef",
-                                expected: "string",
-                                value: input.$recursiveRef,
+                                path: _path + ".type",
+                                expected: "undefined",
+                                value: input.type,
+                            })) &&
+                        (undefined === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: "undefined",
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -7054,326 +7093,6 @@ export const test_assert_UltimateUnion = _test_assert(
                                 expected: "(boolean | undefined)",
                                 value: input.$recursiveAnchor,
                             }));
-                    const $ao48 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        ("null" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"null"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index68: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index68 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index69: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index69 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            })) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }));
-                    const $ao49 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        (null !== input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index70: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index70 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index71: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index71 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            })) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }));
                     const $au0 = (
                         input: any,
                         _path: string,
@@ -7404,13 +7123,13 @@ export const test_assert_UltimateUnion = _test_assert(
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
-                                    (elem: any, _index72: number) =>
+                                    (elem: any, _index68: number) =>
                                         "object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index72 + "]",
+                                            _path + ".items[" + _index68 + "]",
                                             false && _exceptionable,
                                         ),
                                 )
@@ -7432,14 +7151,8 @@ export const test_assert_UltimateUnion = _test_assert(
                                     _path,
                                     true && _exceptionable,
                                 );
-                            if (undefined !== input.$recursiveRef)
-                                return $ao29(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
                             if ("null" === input.type)
-                                return $ao30(
+                                return $ao29(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7451,7 +7164,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                 $ao21(input, _path, false && _exceptionable) ||
                                 $ao23(input, _path, false && _exceptionable) ||
                                 $ao24(input, _path, false && _exceptionable) ||
-                                $ao31(input, _path, false && _exceptionable) ||
+                                $ao30(input, _path, false && _exceptionable) ||
                                 $guard(_exceptionable, {
                                     path: _path,
                                     expected:
@@ -7570,13 +7283,13 @@ export const test_assert_UltimateUnion = _test_assert(
                     ): any =>
                         (() => {
                             if ("object" === input.type)
-                                return $ao34(
+                                return $ao33(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("integer" === input.type)
-                                return $ao40(
+                                return $ao39(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7591,7 +7304,7 @@ export const test_assert_UltimateUnion = _test_assert(
                                     false && _exceptionable,
                                 )
                             )
-                                return $ao43(
+                                return $ao42(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7599,54 +7312,48 @@ export const test_assert_UltimateUnion = _test_assert(
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
-                                    (elem: any, _index73: number) =>
+                                    (elem: any, _index69: number) =>
                                         "object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index73 + "]",
+                                            _path + ".items[" + _index69 + "]",
                                             false && _exceptionable,
                                         ),
                                 )
                             )
-                                return $ao44(
+                                return $ao43(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.oneOf)
-                                return $ao45(
+                                return $ao44(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.$ref)
-                                return $ao46(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
-                            if (undefined !== input.$recursiveRef)
-                                return $ao47(
+                                return $ao45(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("null" === input.type)
-                                return $ao48(
+                                return $ao46(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             return (
-                                $ao38(input, _path, false && _exceptionable) ||
                                 $ao37(input, _path, false && _exceptionable) ||
                                 $ao36(input, _path, false && _exceptionable) ||
-                                $ao39(input, _path, false && _exceptionable) ||
+                                $ao35(input, _path, false && _exceptionable) ||
+                                $ao38(input, _path, false && _exceptionable) ||
+                                $ao40(input, _path, false && _exceptionable) ||
                                 $ao41(input, _path, false && _exceptionable) ||
-                                $ao42(input, _path, false && _exceptionable) ||
-                                $ao49(input, _path, false && _exceptionable) ||
+                                $ao47(input, _path, false && _exceptionable) ||
                                 $guard(_exceptionable, {
                                     path: _path,
                                     expected:

--- a/test/generated/output/assertClone/test_assertClone_UltimateUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_UltimateUnion.ts
@@ -24,7 +24,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "object" === typeof input.components &&
                         null !== input.components &&
                         false === Array.isArray(input.components) &&
-                        $io32(input.components) &&
+                        $io31(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose);
                     const $io1 = (input: any): boolean =>
@@ -461,6 +461,15 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -560,36 +569,6 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
                     const $io29 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]);
-                    const $io30 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -619,7 +598,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io31 = (input: any): boolean =>
+                    const $io30 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -650,13 +629,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io32 = (input: any): boolean =>
+                    const $io31 = (input: any): boolean =>
                         undefined === input.schemas ||
                         ("object" === typeof input.schemas &&
                             null !== input.schemas &&
                             false === Array.isArray(input.schemas) &&
-                            $io33(input.schemas));
-                    const $io33 = (input: any): boolean =>
+                            $io32(input.schemas));
+                    const $io32 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -669,24 +648,22 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 );
                             return true;
                         });
-                    const $io34 = (input: any): boolean =>
+                    const $io33 = (input: any): boolean =>
                         (undefined === input.$id ||
                             "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
-                        $io35(input.properties) &&
+                        $io34(input.properties) &&
                         (undefined === input.patternProperties ||
                             ("object" === typeof input.patternProperties &&
                                 null !== input.patternProperties &&
                                 false ===
                                     Array.isArray(input.patternProperties) &&
-                                $io35(input.patternProperties))) &&
+                                $io34(input.patternProperties))) &&
                         (undefined === input.additionalProperties ||
                             ("object" === typeof input.additionalProperties &&
                                 null !== input.additionalProperties &&
@@ -716,7 +693,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     Array.isArray(
                                         input["x-typia-patternProperties"],
                                     ) &&
-                                $io35(input["x-typia-patternProperties"]))) &&
+                                $io34(input["x-typia-patternProperties"]))) &&
                         (undefined === input["x-typia-additionalProperties"] ||
                             ("object" ===
                                 typeof input["x-typia-additionalProperties"] &&
@@ -727,7 +704,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         input["x-typia-additionalProperties"],
                                     ) &&
                                 $iu0(input["x-typia-additionalProperties"])));
-                    const $io35 = (input: any): boolean =>
+                    const $io34 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -740,7 +717,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 );
                             return true;
                         });
-                    const $io36 = (input: any): boolean =>
+                    const $io35 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "boolean" === typeof elem,
@@ -782,7 +759,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io37 = (input: any): boolean =>
+                    const $io36 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) =>
@@ -827,7 +804,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io38 = (input: any): boolean =>
+                    const $io37 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "string" === typeof elem,
@@ -869,7 +846,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io39 = (input: any): boolean =>
+                    const $io38 = (input: any): boolean =>
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
@@ -907,7 +884,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io40 = (input: any): boolean =>
+                    const $io39 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
@@ -963,7 +940,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io41 = (input: any): boolean =>
+                    const $io40 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum))) &&
@@ -1015,7 +992,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io42 = (input: any): boolean =>
+                    const $io41 = (input: any): boolean =>
                         (undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
@@ -1067,7 +1044,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io43 = (input: any): boolean =>
+                    const $io42 = (input: any): boolean =>
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
@@ -1121,7 +1098,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io44 = (input: any): boolean =>
+                    const $io43 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         input.items.every(
                             (elem: any) =>
@@ -1130,6 +1107,15 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -1165,7 +1151,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io45 = (input: any): boolean =>
+                    const $io44 = (input: any): boolean =>
                         Array.isArray(input.oneOf) &&
                         input.oneOf.every(
                             (elem: any) =>
@@ -1206,7 +1192,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io46 = (input: any): boolean =>
+                    const $io45 = (input: any): boolean =>
                         "string" === typeof input.$ref &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1240,41 +1226,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io47 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor);
-                    const $io48 = (input: any): boolean =>
+                    const $io46 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1308,7 +1260,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io49 = (input: any): boolean =>
+                    const $io47 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -1366,9 +1318,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 return $io26(input);
                             if (undefined !== input.oneOf) return $io27(input);
                             if (undefined !== input.$ref) return $io28(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io29(input);
-                            if ("null" === input.type) return $io30(input);
+                            if ("null" === input.type) return $io29(input);
                             return (() => {
                                 if ($io20(input)) return $io20(input);
                                 if ($io19(input)) return $io19(input);
@@ -1376,7 +1326,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 if ($io21(input)) return $io21(input);
                                 if ($io23(input)) return $io23(input);
                                 if ($io24(input)) return $io24(input);
-                                if ($io31(input)) return $io31(input);
+                                if ($io30(input)) return $io30(input);
                                 return false;
                             })();
                         })();
@@ -1403,15 +1353,15 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         })();
                     const $iu2 = (input: any): any =>
                         (() => {
-                            if ("object" === input.type) return $io34(input);
-                            if ("integer" === input.type) return $io40(input);
+                            if ("object" === input.type) return $io33(input);
+                            if ("integer" === input.type) return $io39(input);
                             if (
                                 "object" === typeof input.items &&
                                 null !== input.items &&
                                 false === Array.isArray(input.items) &&
                                 $iu0(input.items)
                             )
-                                return $io43(input);
+                                return $io42(input);
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
@@ -1422,20 +1372,18 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         $iu0(elem),
                                 )
                             )
-                                return $io44(input);
-                            if (undefined !== input.oneOf) return $io45(input);
-                            if (undefined !== input.$ref) return $io46(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io47(input);
-                            if ("null" === input.type) return $io48(input);
+                                return $io43(input);
+                            if (undefined !== input.oneOf) return $io44(input);
+                            if (undefined !== input.$ref) return $io45(input);
+                            if ("null" === input.type) return $io46(input);
                             return (() => {
-                                if ($io38(input)) return $io38(input);
                                 if ($io37(input)) return $io37(input);
                                 if ($io36(input)) return $io36(input);
-                                if ($io39(input)) return $io39(input);
+                                if ($io35(input)) return $io35(input);
+                                if ($io38(input)) return $io38(input);
+                                if ($io40(input)) return $io40(input);
                                 if ($io41(input)) return $io41(input);
-                                if ($io42(input)) return $io42(input);
-                                if ($io49(input)) return $io49(input);
+                                if ($io47(input)) return $io47(input);
                                 return false;
                             })();
                         })();
@@ -1480,7 +1428,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     _index2 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
@@ -1498,7 +1446,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 _index2 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
@@ -1515,7 +1463,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: "IJsonComponents",
                                     value: input.components,
                                 })) &&
-                                $ao32(
+                                $ao31(
                                     input.components,
                                     _path + ".components",
                                     true && _exceptionable,
@@ -3248,7 +3196,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 })) &&
                                 $au0(
@@ -3259,7 +3207,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 })) &&
                             (undefined === input.minItems ||
@@ -3496,7 +3444,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     _index23 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
@@ -3514,7 +3462,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 _index23 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
@@ -3522,6 +3470,46 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     path: _path + ".items",
                                     expected: "Array<IJsonSchema>",
                                     value: input.items,
+                                })) &&
+                            (("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number",
+                                    value: input.minItems,
+                                })) &&
+                            (undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "(number | undefined)",
+                                    value: input.maxItems,
                                 })) &&
                             ("array" === input.type ||
                                 $guard(_exceptionable, {
@@ -3695,7 +3683,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     _index26 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
@@ -3713,7 +3701,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 _index26 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
@@ -4010,11 +3998,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("string" === typeof input.$recursiveRef ||
+                            ("null" === input.type ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -4157,10 +4145,16 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("null" === input.type ||
+                            (null !== input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"null"',
+                                    expected: "undefined",
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: "undefined",
                                     value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -4304,31 +4298,178 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (null !== input.type ||
+                            undefined === input.schemas ||
+                            ((("object" === typeof input.schemas &&
+                                null !== input.schemas &&
+                                false === Array.isArray(input.schemas)) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
+                                    path: _path + ".schemas",
+                                    expected:
+                                        "(Record<string, IObject | IAlias> | undefined)",
+                                    value: input.schemas,
                                 })) &&
-                            (undefined === input.type ||
+                                $ao32(
+                                    input.schemas,
+                                    _path + ".schemas",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".schemas",
+                                expected:
+                                    "(Record<string, IObject | IAlias> | undefined)",
+                                value: input.schemas,
+                            });
+                        const $ao32 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            false === _exceptionable ||
+                            Object.keys(input).every((key: any) => {
+                                const value = input[key];
+                                if (undefined === value) return true;
+                                if (RegExp(/(.*)/).test(key))
+                                    return (
+                                        ((("object" === typeof value &&
+                                            null !== value &&
+                                            false === Array.isArray(value)) ||
+                                            $guard(_exceptionable, {
+                                                path: _path + $join(key),
+                                                expected:
+                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                value: value,
+                                            })) &&
+                                            $au2(
+                                                value,
+                                                _path + $join(key),
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + $join(key),
+                                            expected:
+                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                            value: value,
+                                        })
+                                    );
+                                return true;
+                            });
+                        const $ao33 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.$id ||
+                                "string" === typeof input.$id ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                })) &&
-                            (undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".title",
+                                    path: _path + ".$id",
                                     expected: "(string | undefined)",
-                                    value: input.title,
+                                    value: input.$id,
+                                })) &&
+                            ("object" === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: '"object"',
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                })) &&
+                            (((("object" === typeof input.properties &&
+                                null !== input.properties &&
+                                false === Array.isArray(input.properties)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                })) &&
+                                $ao34(
+                                    input.properties,
+                                    _path + ".properties",
+                                    true && _exceptionable,
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                })) &&
+                            (undefined === input.patternProperties ||
+                                ((("object" ===
+                                    typeof input.patternProperties &&
+                                    null !== input.patternProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.patternProperties,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".patternProperties",
+                                        expected:
+                                            "(Record<string, IJsonSchema> | undefined)",
+                                        value: input.patternProperties,
+                                    })) &&
+                                    $ao34(
+                                        input.patternProperties,
+                                        _path + ".patternProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                })) &&
+                            (undefined === input.additionalProperties ||
+                                ((("object" ===
+                                    typeof input.additionalProperties &&
+                                    null !== input.additionalProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.additionalProperties,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".additionalProperties",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        value: input.additionalProperties,
+                                    })) &&
+                                    $au0(
+                                        input.additionalProperties,
+                                        _path + ".additionalProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                })) &&
+                            (undefined === input.required ||
+                                ((Array.isArray(input.required) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".required",
+                                        expected: "(Array<string> | undefined)",
+                                        value: input.required,
+                                    })) &&
+                                    input.required.every(
+                                        (elem: any, _index35: number) =>
+                                            "string" === typeof elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".required[" +
+                                                    _index35 +
+                                                    "]",
+                                                expected: "string",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
                                 })) &&
                             (undefined === input.description ||
                                 "string" === typeof input.description ||
@@ -4336,53 +4477,6 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     path: _path + ".description",
                                     expected: "(string | undefined)",
                                     value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"].every(
-                                        (elem: any, _index35: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $au1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
                                 })) &&
                             (undefined === input["x-typia-jsDocTags"] ||
                                 ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4429,266 +4523,6 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         "(Array<IJsDocTagInfo> | undefined)",
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
-                            (undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                })) &&
-                            (undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                })) &&
-                            (undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }));
-                        const $ao32 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            undefined === input.schemas ||
-                            ((("object" === typeof input.schemas &&
-                                null !== input.schemas &&
-                                false === Array.isArray(input.schemas)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".schemas",
-                                    expected:
-                                        "(Record<string, IObject | IAlias> | undefined)",
-                                    value: input.schemas,
-                                })) &&
-                                $ao33(
-                                    input.schemas,
-                                    _path + ".schemas",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".schemas",
-                                expected:
-                                    "(Record<string, IObject | IAlias> | undefined)",
-                                value: input.schemas,
-                            });
-                        const $ao33 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            false === _exceptionable ||
-                            Object.keys(input).every((key: any) => {
-                                const value = input[key];
-                                if (undefined === value) return true;
-                                if (RegExp(/(.*)/).test(key))
-                                    return (
-                                        ((("object" === typeof value &&
-                                            null !== value &&
-                                            false === Array.isArray(value)) ||
-                                            $guard(_exceptionable, {
-                                                path: _path + $join(key),
-                                                expected:
-                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                value: value,
-                                            })) &&
-                                            $au2(
-                                                value,
-                                                _path + $join(key),
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path: _path + $join(key),
-                                            expected:
-                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                            value: value,
-                                        })
-                                    );
-                                return true;
-                            });
-                        const $ao34 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            (undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                })) &&
-                            (undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                })) &&
-                            ("object" === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"object"',
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
-                                })) &&
-                            (((("object" === typeof input.properties &&
-                                null !== input.properties &&
-                                false === Array.isArray(input.properties)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                })) &&
-                                $ao35(
-                                    input.properties,
-                                    _path + ".properties",
-                                    true && _exceptionable,
-                                )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                })) &&
-                            (undefined === input.patternProperties ||
-                                ((("object" ===
-                                    typeof input.patternProperties &&
-                                    null !== input.patternProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.patternProperties,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".patternProperties",
-                                        expected:
-                                            "(Record<string, IJsonSchema> | undefined)",
-                                        value: input.patternProperties,
-                                    })) &&
-                                    $ao35(
-                                        input.patternProperties,
-                                        _path + ".patternProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                })) &&
-                            (undefined === input.additionalProperties ||
-                                ((("object" ===
-                                    typeof input.additionalProperties &&
-                                    null !== input.additionalProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.additionalProperties,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".additionalProperties",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                        value: input.additionalProperties,
-                                    })) &&
-                                    $au0(
-                                        input.additionalProperties,
-                                        _path + ".additionalProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                })) &&
-                            (undefined === input.required ||
-                                ((Array.isArray(input.required) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".required",
-                                        expected: "(Array<string> | undefined)",
-                                        value: input.required,
-                                    })) &&
-                                    input.required.every(
-                                        (elem: any, _index37: number) =>
-                                            "string" === typeof elem ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".required[" +
-                                                    _index37 +
-                                                    "]",
-                                                expected: "string",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                })) &&
-                            (undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index38: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $ao17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
                             (undefined === input["x-typia-patternProperties"] ||
                                 ((("object" ===
                                     typeof input["x-typia-patternProperties"] &&
@@ -4708,7 +4542,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             "x-typia-patternProperties"
                                         ],
                                     })) &&
-                                    $ao35(
+                                    $ao34(
                                         input["x-typia-patternProperties"],
                                         _path + '["x-typia-patternProperties"]',
                                         true && _exceptionable,
@@ -4739,7 +4573,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             _path +
                                             '["x-typia-additionalProperties"]',
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                         value: input[
                                             "x-typia-additionalProperties"
                                         ],
@@ -4755,12 +4589,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
                                 }));
-                        const $ao35 = (
+                        const $ao34 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -4777,7 +4611,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             $guard(_exceptionable, {
                                                 path: _path + $join(key),
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: value,
                                             })) &&
                                             $au0(
@@ -4788,13 +4622,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         $guard(_exceptionable, {
                                             path: _path + $join(key),
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: value,
                                         })
                                     );
                                 return true;
                             });
-                        const $ao36 = (
+                        const $ao35 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -4806,13 +4640,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     value: input["enum"],
                                 })) &&
                                 input["enum"].every(
-                                    (elem: any, _index39: number) =>
+                                    (elem: any, _index37: number) =>
                                         "boolean" === typeof elem ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["enum"][' +
-                                                _index39 +
+                                                _index37 +
                                                 "]",
                                             expected: "boolean",
                                             value: elem,
@@ -4873,14 +4707,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index40: number) =>
+                                        (elem: any, _index38: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4890,7 +4724,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -4898,7 +4732,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4920,14 +4754,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index41: number) =>
+                                        (elem: any, _index39: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -4936,7 +4770,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -4944,7 +4778,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -4993,7 +4827,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: "(boolean | undefined)",
                                     value: input.$recursiveAnchor,
                                 }));
-                        const $ao37 = (
+                        const $ao36 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5005,14 +4839,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     value: input["enum"],
                                 })) &&
                                 input["enum"].every(
-                                    (elem: any, _index42: number) =>
+                                    (elem: any, _index40: number) =>
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem)) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["enum"][' +
-                                                _index42 +
+                                                _index40 +
                                                 "]",
                                             expected: "number",
                                             value: elem,
@@ -5074,14 +4908,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index43: number) =>
+                                        (elem: any, _index41: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5091,7 +4925,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -5099,7 +4933,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5121,14 +4955,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index44: number) =>
+                                        (elem: any, _index42: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index44 +
+                                                        _index42 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -5137,7 +4971,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index44 +
+                                                        _index42 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -5145,7 +4979,206 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
+                                                    _index42 +
+                                                    "]",
+                                                expected: "IJsDocTagInfo",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                })) &&
+                            (undefined === input["x-typia-required"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-required"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-required"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-required"],
+                                })) &&
+                            (undefined === input["x-typia-optional"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-optional"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-optional"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-optional"],
+                                })) &&
+                            (undefined === input["x-typia-rest"] ||
+                                "boolean" === typeof input["x-typia-rest"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-rest"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-rest"],
+                                })) &&
+                            (undefined === input.$id ||
+                                "string" === typeof input.$id ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".$id",
+                                    expected: "(string | undefined)",
+                                    value: input.$id,
+                                })) &&
+                            (undefined === input.$recursiveAnchor ||
+                                "boolean" === typeof input.$recursiveAnchor ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".$recursiveAnchor",
+                                    expected: "(boolean | undefined)",
+                                    value: input.$recursiveAnchor,
+                                }));
+                        const $ao37 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (((Array.isArray(input["enum"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                })) &&
+                                input["enum"].every(
+                                    (elem: any, _index43: number) =>
+                                        "string" === typeof elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["enum"][' +
+                                                _index43 +
+                                                "]",
+                                            expected: "string",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                })) &&
+                            (undefined === input["default"] ||
+                                "string" === typeof input["default"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["default"]',
+                                    expected: "(string | undefined)",
+                                    value: input["default"],
+                                })) &&
+                            ("string" === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: '"string"',
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                })) &&
+                            (undefined === input.deprecated ||
+                                "boolean" === typeof input.deprecated ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".deprecated",
+                                    expected: "(boolean | undefined)",
+                                    value: input.deprecated,
+                                })) &&
+                            (undefined === input.title ||
+                                "string" === typeof input.title ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".title",
+                                    expected: "(string | undefined)",
+                                    value: input.title,
+                                })) &&
+                            (undefined === input.description ||
+                                "string" === typeof input.description ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".description",
+                                    expected: "(string | undefined)",
+                                    value: input.description,
+                                })) &&
+                            (undefined === input["x-typia-metaTags"] ||
+                                ((Array.isArray(input["x-typia-metaTags"]) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + '["x-typia-metaTags"]',
+                                        expected:
+                                            "(Array<IMetadataTag> | undefined)",
+                                        value: input["x-typia-metaTags"],
+                                    })) &&
+                                    input["x-typia-metaTags"].every(
+                                        (elem: any, _index44: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-metaTags"][' +
+                                                        _index44 +
+                                                        "]",
+                                                    expected:
+                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                    value: elem,
+                                                })) &&
+                                                $au1(
+                                                    elem,
+                                                    _path +
+                                                        '["x-typia-metaTags"][' +
+                                                        _index44 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-metaTags"][' +
                                                     _index44 +
+                                                    "]",
+                                                expected:
+                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                })) &&
+                            (undefined === input["x-typia-jsDocTags"] ||
+                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + '["x-typia-jsDocTags"]',
+                                        expected:
+                                            "(Array<IJsDocTagInfo> | undefined)",
+                                        value: input["x-typia-jsDocTags"],
+                                    })) &&
+                                    input["x-typia-jsDocTags"].every(
+                                        (elem: any, _index45: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
+                                                        "]",
+                                                    expected: "IJsDocTagInfo",
+                                                    value: elem,
+                                                })) &&
+                                                $ao17(
+                                                    elem,
+                                                    _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -5199,41 +5232,17 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((Array.isArray(input["enum"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                })) &&
-                                input["enum"].every(
-                                    (elem: any, _index45: number) =>
-                                        "string" === typeof elem ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["enum"][' +
-                                                _index45 +
-                                                "]",
-                                            expected: "string",
-                                            value: elem,
-                                        }),
-                                )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                })) &&
                             (undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
+                                "boolean" === typeof input["default"] ||
                                 $guard(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(string | undefined)",
+                                    expected: "(boolean | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("string" === input.type ||
+                            ("boolean" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"boolean"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -5398,17 +5407,77 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
+                            (undefined === input.minimum ||
+                                ("number" === typeof input.minimum &&
+                                    Number.isFinite(input.minimum) &&
+                                    (parseInt(input.minimum) ===
+                                        input.minimum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "(number | undefined)",
+                                    value: input.minimum,
+                                })) &&
+                            (undefined === input.maximum ||
+                                ("number" === typeof input.maximum &&
+                                    Number.isFinite(input.maximum) &&
+                                    (parseInt(input.maximum) ===
+                                        input.maximum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "(number | undefined)",
+                                    value: input.maximum,
+                                })) &&
+                            (undefined === input.exclusiveMinimum ||
+                                "boolean" === typeof input.exclusiveMinimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (undefined === input.exclusiveMaximum ||
+                                "boolean" === typeof input.exclusiveMaximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMaximum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMaximum,
+                                })) &&
+                            (undefined === input.multipleOf ||
+                                ("number" === typeof input.multipleOf &&
+                                    Number.isFinite(input.multipleOf) &&
+                                    (parseInt(input.multipleOf) ===
+                                        input.multipleOf ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "(number | undefined)",
+                                    value: input.multipleOf,
+                                })) &&
                             (undefined === input["default"] ||
-                                "boolean" === typeof input["default"] ||
+                                ("number" === typeof input["default"] &&
+                                    Number.isFinite(input["default"])) ||
                                 $guard(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(boolean | undefined)",
+                                    expected: "(number | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("boolean" === input.type ||
+                            ("integer" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"boolean"',
+                                    expected: '"integer"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -5575,14 +5644,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         ): boolean =>
                             (undefined === input.minimum ||
                                 ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum) &&
-                                    (parseInt(input.minimum) ===
-                                        input.minimum ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".minimum",
-                                            expected: "number (@type int)",
-                                            value: input.minimum,
-                                        }))) ||
+                                    Number.isFinite(input.minimum)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "(number | undefined)",
@@ -5590,14 +5652,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 })) &&
                             (undefined === input.maximum ||
                                 ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum) &&
-                                    (parseInt(input.maximum) ===
-                                        input.maximum ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".maximum",
-                                            expected: "number (@type int)",
-                                            value: input.maximum,
-                                        }))) ||
+                                    Number.isFinite(input.maximum)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "(number | undefined)",
@@ -5619,14 +5674,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 })) &&
                             (undefined === input.multipleOf ||
                                 ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf) &&
-                                    (parseInt(input.multipleOf) ===
-                                        input.multipleOf ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".multipleOf",
-                                            expected: "number (@type int)",
-                                            value: input.multipleOf,
-                                        }))) ||
+                                    Number.isFinite(input.multipleOf)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "(number | undefined)",
@@ -5640,10 +5688,10 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: "(number | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("integer" === input.type ||
+                            ("number" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"integer"',
+                                    expected: '"number"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -5808,56 +5856,73 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (undefined === input.minimum ||
-                                ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum)) ||
+                            (undefined === input.minLength ||
+                                ("number" === typeof input.minLength &&
+                                    Number.isFinite(input.minLength) &&
+                                    (parseInt(input.minLength) ===
+                                        input.minLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        })) &&
+                                    (0 <= input.minLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minimum",
+                                    path: _path + ".minLength",
                                     expected: "(number | undefined)",
-                                    value: input.minimum,
+                                    value: input.minLength,
                                 })) &&
-                            (undefined === input.maximum ||
-                                ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum)) ||
+                            (undefined === input.maxLength ||
+                                ("number" === typeof input.maxLength &&
+                                    Number.isFinite(input.maxLength) &&
+                                    (parseInt(input.maxLength) ===
+                                        input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (0 <= input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maximum",
+                                    path: _path + ".maxLength",
                                     expected: "(number | undefined)",
-                                    value: input.maximum,
+                                    value: input.maxLength,
                                 })) &&
-                            (undefined === input.exclusiveMinimum ||
-                                "boolean" === typeof input.exclusiveMinimum ||
+                            (undefined === input.pattern ||
+                                "string" === typeof input.pattern ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".exclusiveMinimum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMinimum,
+                                    path: _path + ".pattern",
+                                    expected: "(string | undefined)",
+                                    value: input.pattern,
                                 })) &&
-                            (undefined === input.exclusiveMaximum ||
-                                "boolean" === typeof input.exclusiveMaximum ||
+                            (undefined === input.format ||
+                                "string" === typeof input.format ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".exclusiveMaximum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMaximum,
-                                })) &&
-                            (undefined === input.multipleOf ||
-                                ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".multipleOf",
-                                    expected: "(number | undefined)",
-                                    value: input.multipleOf,
+                                    path: _path + ".format",
+                                    expected: "(string | undefined)",
+                                    value: input.format,
                                 })) &&
                             (undefined === input["default"] ||
-                                ("number" === typeof input["default"] &&
-                                    Number.isFinite(input["default"])) ||
+                                "string" === typeof input["default"] ||
                                 $guard(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(number | undefined)",
+                                    expected: "(string | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("number" === input.type ||
+                            ("string" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"number"',
+                                    expected: '"string"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -6022,73 +6087,92 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (undefined === input.minLength ||
-                                ("number" === typeof input.minLength &&
-                                    Number.isFinite(input.minLength) &&
-                                    (parseInt(input.minLength) ===
-                                        input.minLength ||
+                            (((("object" === typeof input.items &&
+                                null !== input.items &&
+                                false === Array.isArray(input.items)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                })) &&
+                                $au0(
+                                    input.items,
+                                    _path + ".items",
+                                    true && _exceptionable,
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                })) &&
+                            (undefined === input.minItems ||
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         })) &&
-                                    (0 <= input.minLength ||
+                                    (0 <= input.minItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "(number | undefined)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 })) &&
-                            (undefined === input.maxLength ||
-                                ("number" === typeof input.maxLength &&
-                                    Number.isFinite(input.maxLength) &&
-                                    (parseInt(input.maxLength) ===
-                                        input.maxLength ||
+                            (undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         })) &&
-                                    (0 <= input.maxLength ||
+                                    (0 <= input.maxItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "(number | undefined)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 })) &&
-                            (undefined === input.pattern ||
-                                "string" === typeof input.pattern ||
+                            (undefined === input["x-typia-tuple"] ||
+                                ((("object" === typeof input["x-typia-tuple"] &&
+                                    null !== input["x-typia-tuple"]) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + '["x-typia-tuple"]',
+                                        expected:
+                                            "(IJsonSchema.ITuple | undefined)",
+                                        value: input["x-typia-tuple"],
+                                    })) &&
+                                    $ao26(
+                                        input["x-typia-tuple"],
+                                        _path + '["x-typia-tuple"]',
+                                        true && _exceptionable,
+                                    )) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".pattern",
-                                    expected: "(string | undefined)",
-                                    value: input.pattern,
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
                                 })) &&
-                            (undefined === input.format ||
-                                "string" === typeof input.format ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".format",
-                                    expected: "(string | undefined)",
-                                    value: input.format,
-                                })) &&
-                            (undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["default"]',
-                                    expected: "(string | undefined)",
-                                    value: input["default"],
-                                })) &&
-                            ("string" === input.type ||
+                            ("array" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"array"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -6253,45 +6337,68 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((("object" === typeof input.items &&
-                                null !== input.items &&
-                                false === Array.isArray(input.items)) ||
+                            (((Array.isArray(input.items) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 })) &&
-                                $au0(
-                                    input.items,
-                                    _path + ".items",
-                                    true && _exceptionable,
+                                input.items.every(
+                                    (elem: any, _index56: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem &&
+                                            false === Array.isArray(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                expected:
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                value: elem,
+                                            })) &&
+                                            $au0(
+                                                elem,
+                                                _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index56 +
+                                                "]",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            value: elem,
+                                        }),
                                 )) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 })) &&
-                            (undefined === input.minItems ||
-                                ("number" === typeof input.minItems &&
-                                    Number.isFinite(input.minItems) &&
-                                    (parseInt(input.minItems) ===
-                                        input.minItems ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        })) &&
-                                    (0 <= input.minItems ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        }))) ||
+                            (("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
-                                    expected: "(number | undefined)",
+                                    expected: "number",
                                     value: input.minItems,
                                 })) &&
                             (undefined === input.maxItems ||
@@ -6314,26 +6421,6 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     path: _path + ".maxItems",
                                     expected: "(number | undefined)",
                                     value: input.maxItems,
-                                })) &&
-                            (undefined === input["x-typia-tuple"] ||
-                                ((("object" === typeof input["x-typia-tuple"] &&
-                                    null !== input["x-typia-tuple"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-tuple"]',
-                                        expected:
-                                            "(IJsonSchema.ITuple | undefined)",
-                                        value: input["x-typia-tuple"],
-                                    })) &&
-                                    $ao26(
-                                        input["x-typia-tuple"],
-                                        _path + '["x-typia-tuple"]',
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
                                 })) &&
                             ("array" === input.type ||
                                 $guard(_exceptionable, {
@@ -6378,14 +6465,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index56: number) =>
+                                        (elem: any, _index57: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6395,7 +6482,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6403,7 +6490,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6425,14 +6512,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index57: number) =>
+                                        (elem: any, _index58: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6441,7 +6528,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6449,7 +6536,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6503,63 +6590,50 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((Array.isArray(input.items) ||
+                            (((Array.isArray(input.oneOf) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
+                                    value: input.oneOf,
                                 })) &&
-                                input.items.every(
-                                    (elem: any, _index58: number) =>
+                                input.oneOf.every(
+                                    (elem: any, _index59: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem)) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
                                                 elem,
                                                 _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
-                                                ".items[" +
-                                                _index58 +
+                                                ".oneOf[" +
+                                                _index59 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
-                                })) &&
-                            ("array" === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"array"',
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
+                                    value: input.oneOf,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -6591,14 +6665,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index59: number) =>
+                                        (elem: any, _index60: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6608,7 +6682,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6616,7 +6690,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6638,14 +6712,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index60: number) =>
+                                        (elem: any, _index61: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6654,7 +6728,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6662,7 +6736,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6716,50 +6790,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((Array.isArray(input.oneOf) ||
+                            ("string" === typeof input.$ref ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
-                                })) &&
-                                input.oneOf.every(
-                                    (elem: any, _index61: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem &&
-                                            false === Array.isArray(elem)) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                value: elem,
-                                            })) &&
-                                            $au0(
-                                                elem,
-                                                _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".oneOf[" +
-                                                _index61 +
-                                                "]",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                            value: elem,
-                                        }),
-                                )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
+                                    path: _path + ".$ref",
+                                    expected: "string",
+                                    value: input.$ref,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -6916,11 +6951,11 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("string" === typeof input.$ref ||
+                            ("null" === input.type ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".$ref",
-                                    expected: "string",
-                                    value: input.$ref,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7077,11 +7112,17 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("string" === typeof input.$recursiveRef ||
+                            (null !== input.type ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7233,334 +7274,6 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     expected: "(boolean | undefined)",
                                     value: input.$recursiveAnchor,
                                 }));
-                        const $ao48 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            ("null" === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"null"',
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                })) &&
-                            (undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                })) &&
-                            (undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"].every(
-                                        (elem: any, _index68: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $au1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                            (undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index69: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $ao17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                            (undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                })) &&
-                            (undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                })) &&
-                            (undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                })) &&
-                            (undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                })) &&
-                            (undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }));
-                        const $ao49 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            (null !== input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                })) &&
-                            (undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                })) &&
-                            (undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"].every(
-                                        (elem: any, _index70: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $au1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                            (undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index71: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $ao17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                            (undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                })) &&
-                            (undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                })) &&
-                            (undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                })) &&
-                            (undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                })) &&
-                            (undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }));
                         const $au0 = (
                             input: any,
                             _path: string,
@@ -7591,7 +7304,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 if (
                                     Array.isArray(input.items) &&
                                     input.items.every(
-                                        (elem: any, _index72: number) =>
+                                        (elem: any, _index68: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -7599,7 +7312,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index72 +
+                                                    _index68 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
@@ -7622,14 +7335,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         _path,
                                         true && _exceptionable,
                                     );
-                                if (undefined !== input.$recursiveRef)
-                                    return $ao29(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
                                 if ("null" === input.type)
-                                    return $ao30(
+                                    return $ao29(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -7665,7 +7372,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $ao31(
+                                    $ao30(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -7788,13 +7495,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         ): any =>
                             (() => {
                                 if ("object" === input.type)
-                                    return $ao34(
+                                    return $ao33(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("integer" === input.type)
-                                    return $ao40(
+                                    return $ao39(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -7809,7 +7516,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         false && _exceptionable,
                                     )
                                 )
-                                    return $ao43(
+                                    return $ao42(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -7817,7 +7524,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 if (
                                     Array.isArray(input.items) &&
                                     input.items.every(
-                                        (elem: any, _index73: number) =>
+                                        (elem: any, _index69: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -7825,47 +7532,36 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index73 +
+                                                    _index69 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
                                     )
                                 )
-                                    return $ao44(
+                                    return $ao43(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.oneOf)
-                                    return $ao45(
+                                    return $ao44(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.$ref)
-                                    return $ao46(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
-                                if (undefined !== input.$recursiveRef)
-                                    return $ao47(
+                                    return $ao45(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("null" === input.type)
-                                    return $ao48(
+                                    return $ao46(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 return (
-                                    $ao38(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
                                     $ao37(
                                         input,
                                         _path,
@@ -7876,7 +7572,17 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $ao39(
+                                    $ao35(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $ao38(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $ao40(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -7886,12 +7592,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $ao42(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
-                                    $ao49(
+                                    $ao47(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -8344,6 +8045,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -8443,36 +8151,6 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -8502,7 +8180,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -8533,13 +8211,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -8552,23 +8230,21 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -8598,7 +8274,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -8608,7 +8284,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -8621,7 +8297,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -8663,7 +8339,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "number" === typeof elem,
@@ -8705,7 +8381,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -8747,7 +8423,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -8785,7 +8461,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             parseInt(input.minimum) === input.minimum)) &&
@@ -8836,7 +8512,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         "number" === typeof input.minimum) &&
                     (undefined === input.maximum ||
@@ -8884,7 +8560,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             parseInt(input.minLength) === input.minLength &&
@@ -8934,7 +8610,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -8986,7 +8662,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -8995,6 +8671,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9030,7 +8713,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -9071,7 +8754,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -9105,41 +8788,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -9173,7 +8822,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -9231,9 +8880,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (
                             $io20(input) ||
                             $io19(input) ||
@@ -9241,7 +8888,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             $io21(input) ||
                             $io23(input) ||
                             $io24(input) ||
-                            $io31(input)
+                            $io30(input)
                         );
                     })();
                 const $iu1 = (input: any): any =>
@@ -9267,15 +8914,15 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -9286,20 +8933,18 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (
-                            $io38(input) ||
                             $io37(input) ||
                             $io36(input) ||
-                            $io39(input) ||
+                            $io35(input) ||
+                            $io38(input) ||
+                            $io40(input) ||
                             $io41(input) ||
-                            $io42(input) ||
-                            $io49(input)
+                            $io47(input)
                         );
                     })();
                 const $join = (typia.assertClone as any).join;
@@ -9347,7 +8992,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     components:
                         "object" === typeof input.components &&
                         null !== input.components
-                            ? $co32(input.components)
+                            ? $co31(input.components)
                             : (input.components as any),
                     purpose: input.purpose as any,
                 });
@@ -9610,6 +9255,8 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     items: Array.isArray(input.items)
                         ? $cp1(input.items)
                         : (input.items as any),
+                    minItems: input.minItems as any,
+                    maxItems: input.maxItems as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
                     deprecated: input.deprecated as any,
@@ -9664,7 +9311,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     "x-typia-rest": input["x-typia-rest"] as any,
                 });
                 const $co29 = (input: any): any => ({
-                    $recursiveRef: input.$recursiveRef as any,
+                    type: input.type as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
                     description: input.description as any,
@@ -9698,30 +9345,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     "x-typia-rest": input["x-typia-rest"] as any,
                 });
                 const $co31 = (input: any): any => ({
-                    type: input.type as any,
-                    deprecated: input.deprecated as any,
-                    title: input.title as any,
-                    description: input.description as any,
-                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                        ? $cp3(input["x-typia-metaTags"])
-                        : (input["x-typia-metaTags"] as any),
-                    "x-typia-jsDocTags": Array.isArray(
-                        input["x-typia-jsDocTags"],
-                    )
-                        ? $cp4(input["x-typia-jsDocTags"])
-                        : (input["x-typia-jsDocTags"] as any),
-                    "x-typia-required": input["x-typia-required"] as any,
-                    "x-typia-optional": input["x-typia-optional"] as any,
-                    "x-typia-rest": input["x-typia-rest"] as any,
-                });
-                const $co32 = (input: any): any => ({
                     schemas:
                         "object" === typeof input.schemas &&
                         null !== input.schemas
-                            ? $co33(input.schemas)
+                            ? $co32(input.schemas)
                             : (input.schemas as any),
                 });
-                const $co33 = (input: any): any => {
+                const $co32 = (input: any): any => {
                     const output = {} as any;
                     for (const [key, value] of Object.entries(input)) {
                         if (RegExp(/(.*)/).test(key)) {
@@ -9734,20 +9364,19 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     }
                     return output;
                 };
-                const $co34 = (input: any): any => ({
+                const $co33 = (input: any): any => ({
                     $id: input.$id as any,
-                    $recursiveAnchor: input.$recursiveAnchor as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
                     properties:
                         "object" === typeof input.properties &&
                         null !== input.properties
-                            ? $co35(input.properties)
+                            ? $co34(input.properties)
                             : (input.properties as any),
                     patternProperties:
                         "object" === typeof input.patternProperties &&
                         null !== input.patternProperties
-                            ? $co35(input.patternProperties)
+                            ? $co34(input.patternProperties)
                             : (input.patternProperties as any),
                     additionalProperties:
                         "object" === typeof input.additionalProperties &&
@@ -9767,7 +9396,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         "object" ===
                             typeof input["x-typia-patternProperties"] &&
                         null !== input["x-typia-patternProperties"]
-                            ? $co35(input["x-typia-patternProperties"])
+                            ? $co34(input["x-typia-patternProperties"])
                             : (input["x-typia-patternProperties"] as any),
                     "x-typia-additionalProperties":
                         "object" ===
@@ -9776,7 +9405,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             ? $cu0(input["x-typia-additionalProperties"])
                             : (input["x-typia-additionalProperties"] as any),
                 });
-                const $co35 = (input: any): any => {
+                const $co34 = (input: any): any => {
                     const output = {} as any;
                     for (const [key, value] of Object.entries(input)) {
                         if (RegExp(/(.*)/).test(key)) {
@@ -9789,7 +9418,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     }
                     return output;
                 };
-                const $co36 = (input: any): any => ({
+                const $co35 = (input: any): any => ({
                     enum: Array.isArray(input["enum"])
                         ? $cp2(input["enum"])
                         : (input["enum"] as any),
@@ -9813,7 +9442,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co37 = (input: any): any => ({
+                const $co36 = (input: any): any => ({
                     enum: Array.isArray(input["enum"])
                         ? $cp6(input["enum"])
                         : (input["enum"] as any),
@@ -9837,7 +9466,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co38 = (input: any): any => ({
+                const $co37 = (input: any): any => ({
                     enum: Array.isArray(input["enum"])
                         ? $cp7(input["enum"])
                         : (input["enum"] as any),
@@ -9861,7 +9490,33 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
+                const $co38 = (input: any): any => ({
+                    default: input["default"] as any,
+                    type: input.type as any,
+                    nullable: input.nullable as any,
+                    deprecated: input.deprecated as any,
+                    title: input.title as any,
+                    description: input.description as any,
+                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
+                        ? $cp3(input["x-typia-metaTags"])
+                        : (input["x-typia-metaTags"] as any),
+                    "x-typia-jsDocTags": Array.isArray(
+                        input["x-typia-jsDocTags"],
+                    )
+                        ? $cp4(input["x-typia-jsDocTags"])
+                        : (input["x-typia-jsDocTags"] as any),
+                    "x-typia-required": input["x-typia-required"] as any,
+                    "x-typia-optional": input["x-typia-optional"] as any,
+                    "x-typia-rest": input["x-typia-rest"] as any,
+                    $id: input.$id as any,
+                    $recursiveAnchor: input.$recursiveAnchor as any,
+                });
                 const $co39 = (input: any): any => ({
+                    minimum: input.minimum as any,
+                    maximum: input.maximum as any,
+                    exclusiveMinimum: input.exclusiveMinimum as any,
+                    exclusiveMaximum: input.exclusiveMaximum as any,
+                    multipleOf: input.multipleOf as any,
                     default: input["default"] as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
@@ -9909,32 +9564,6 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
                 const $co41 = (input: any): any => ({
-                    minimum: input.minimum as any,
-                    maximum: input.maximum as any,
-                    exclusiveMinimum: input.exclusiveMinimum as any,
-                    exclusiveMaximum: input.exclusiveMaximum as any,
-                    multipleOf: input.multipleOf as any,
-                    default: input["default"] as any,
-                    type: input.type as any,
-                    nullable: input.nullable as any,
-                    deprecated: input.deprecated as any,
-                    title: input.title as any,
-                    description: input.description as any,
-                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                        ? $cp3(input["x-typia-metaTags"])
-                        : (input["x-typia-metaTags"] as any),
-                    "x-typia-jsDocTags": Array.isArray(
-                        input["x-typia-jsDocTags"],
-                    )
-                        ? $cp4(input["x-typia-jsDocTags"])
-                        : (input["x-typia-jsDocTags"] as any),
-                    "x-typia-required": input["x-typia-required"] as any,
-                    "x-typia-optional": input["x-typia-optional"] as any,
-                    "x-typia-rest": input["x-typia-rest"] as any,
-                    $id: input.$id as any,
-                    $recursiveAnchor: input.$recursiveAnchor as any,
-                });
-                const $co42 = (input: any): any => ({
                     minLength: input.minLength as any,
                     maxLength: input.maxLength as any,
                     pattern: input.pattern as any,
@@ -9959,7 +9588,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co43 = (input: any): any => ({
+                const $co42 = (input: any): any => ({
                     items:
                         "object" === typeof input.items && null !== input.items
                             ? $cu0(input.items)
@@ -9990,10 +9619,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co44 = (input: any): any => ({
+                const $co43 = (input: any): any => ({
                     items: Array.isArray(input.items)
                         ? $cp1(input.items)
                         : (input.items as any),
+                    minItems: input.minItems as any,
+                    maxItems: input.maxItems as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
                     deprecated: input.deprecated as any,
@@ -10013,7 +9644,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co45 = (input: any): any => ({
+                const $co44 = (input: any): any => ({
                     oneOf: Array.isArray(input.oneOf)
                         ? $cp1(input.oneOf)
                         : (input.oneOf as any),
@@ -10034,7 +9665,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co46 = (input: any): any => ({
+                const $co45 = (input: any): any => ({
                     $ref: input.$ref as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
@@ -10053,26 +9684,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co47 = (input: any): any => ({
-                    $recursiveRef: input.$recursiveRef as any,
-                    deprecated: input.deprecated as any,
-                    title: input.title as any,
-                    description: input.description as any,
-                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                        ? $cp3(input["x-typia-metaTags"])
-                        : (input["x-typia-metaTags"] as any),
-                    "x-typia-jsDocTags": Array.isArray(
-                        input["x-typia-jsDocTags"],
-                    )
-                        ? $cp4(input["x-typia-jsDocTags"])
-                        : (input["x-typia-jsDocTags"] as any),
-                    "x-typia-required": input["x-typia-required"] as any,
-                    "x-typia-optional": input["x-typia-optional"] as any,
-                    "x-typia-rest": input["x-typia-rest"] as any,
-                    $id: input.$id as any,
-                    $recursiveAnchor: input.$recursiveAnchor as any,
-                });
-                const $co48 = (input: any): any => ({
+                const $co46 = (input: any): any => ({
                     type: input.type as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
@@ -10091,7 +9703,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co49 = (input: any): any => ({
+                const $co47 = (input: any): any => ({
                     type: input.type as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
@@ -10133,9 +9745,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             return $co26(input);
                         if (undefined !== input.oneOf) return $co27(input);
                         if (undefined !== input.$ref) return $co28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $co29(input);
-                        if ("null" === input.type) return $co30(input);
+                        if ("null" === input.type) return $co29(input);
                         return (() => {
                             if ($io20(input)) return $co20(input);
                             if ($io19(input)) return $co19(input);
@@ -10143,7 +9753,7 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             if ($io21(input)) return $co21(input);
                             if ($io23(input)) return $co23(input);
                             if ($io24(input)) return $co24(input);
-                            if ($io31(input)) return $co31(input);
+                            if ($io30(input)) return $co30(input);
                             $throws({
                                 expected:
                                     '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -10178,15 +9788,15 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     })();
                 const $cu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $co34(input);
-                        if ("integer" === input.type) return $co40(input);
+                        if ("object" === input.type) return $co33(input);
+                        if ("integer" === input.type) return $co39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $co43(input);
+                            return $co42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -10197,20 +9807,18 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     $iu0(elem),
                             )
                         )
-                            return $co44(input);
-                        if (undefined !== input.oneOf) return $co45(input);
-                        if (undefined !== input.$ref) return $co46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $co47(input);
-                        if ("null" === input.type) return $co48(input);
+                            return $co43(input);
+                        if (undefined !== input.oneOf) return $co44(input);
+                        if (undefined !== input.$ref) return $co45(input);
+                        if ("null" === input.type) return $co46(input);
                         return (() => {
-                            if ($io38(input)) return $co38(input);
                             if ($io37(input)) return $co37(input);
                             if ($io36(input)) return $co36(input);
-                            if ($io39(input)) return $co39(input);
+                            if ($io35(input)) return $co35(input);
+                            if ($io38(input)) return $co38(input);
+                            if ($io40(input)) return $co40(input);
                             if ($io41(input)) return $co41(input);
-                            if ($io42(input)) return $co42(input);
-                            if ($io49(input)) return $co49(input);
+                            if ($io47(input)) return $co47(input);
                             $throws({
                                 expected:
                                     '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/assertParse/test_assertParse_UltimateUnion.ts
+++ b/test/generated/output/assertParse/test_assertParse_UltimateUnion.ts
@@ -22,7 +22,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         "object" === typeof input.components &&
                         null !== input.components &&
                         false === Array.isArray(input.components) &&
-                        $io32(input.components) &&
+                        $io31(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose);
                     const $io1 = (input: any): boolean =>
@@ -459,6 +459,15 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -558,36 +567,6 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
                     const $io29 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]);
-                    const $io30 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -617,7 +596,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io31 = (input: any): boolean =>
+                    const $io30 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -648,13 +627,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io32 = (input: any): boolean =>
+                    const $io31 = (input: any): boolean =>
                         undefined === input.schemas ||
                         ("object" === typeof input.schemas &&
                             null !== input.schemas &&
                             false === Array.isArray(input.schemas) &&
-                            $io33(input.schemas));
-                    const $io33 = (input: any): boolean =>
+                            $io32(input.schemas));
+                    const $io32 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -667,24 +646,22 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 );
                             return true;
                         });
-                    const $io34 = (input: any): boolean =>
+                    const $io33 = (input: any): boolean =>
                         (undefined === input.$id ||
                             "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
-                        $io35(input.properties) &&
+                        $io34(input.properties) &&
                         (undefined === input.patternProperties ||
                             ("object" === typeof input.patternProperties &&
                                 null !== input.patternProperties &&
                                 false ===
                                     Array.isArray(input.patternProperties) &&
-                                $io35(input.patternProperties))) &&
+                                $io34(input.patternProperties))) &&
                         (undefined === input.additionalProperties ||
                             ("object" === typeof input.additionalProperties &&
                                 null !== input.additionalProperties &&
@@ -714,7 +691,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     Array.isArray(
                                         input["x-typia-patternProperties"],
                                     ) &&
-                                $io35(input["x-typia-patternProperties"]))) &&
+                                $io34(input["x-typia-patternProperties"]))) &&
                         (undefined === input["x-typia-additionalProperties"] ||
                             ("object" ===
                                 typeof input["x-typia-additionalProperties"] &&
@@ -725,7 +702,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         input["x-typia-additionalProperties"],
                                     ) &&
                                 $iu0(input["x-typia-additionalProperties"])));
-                    const $io35 = (input: any): boolean =>
+                    const $io34 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -738,7 +715,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 );
                             return true;
                         });
-                    const $io36 = (input: any): boolean =>
+                    const $io35 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "boolean" === typeof elem,
@@ -780,7 +757,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io37 = (input: any): boolean =>
+                    const $io36 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) =>
@@ -825,7 +802,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io38 = (input: any): boolean =>
+                    const $io37 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "string" === typeof elem,
@@ -867,7 +844,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io39 = (input: any): boolean =>
+                    const $io38 = (input: any): boolean =>
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
@@ -905,7 +882,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io40 = (input: any): boolean =>
+                    const $io39 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
@@ -961,7 +938,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io41 = (input: any): boolean =>
+                    const $io40 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum))) &&
@@ -1013,7 +990,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io42 = (input: any): boolean =>
+                    const $io41 = (input: any): boolean =>
                         (undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
@@ -1065,7 +1042,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io43 = (input: any): boolean =>
+                    const $io42 = (input: any): boolean =>
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
@@ -1119,7 +1096,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io44 = (input: any): boolean =>
+                    const $io43 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         input.items.every(
                             (elem: any) =>
@@ -1128,6 +1105,15 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -1163,7 +1149,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io45 = (input: any): boolean =>
+                    const $io44 = (input: any): boolean =>
                         Array.isArray(input.oneOf) &&
                         input.oneOf.every(
                             (elem: any) =>
@@ -1204,7 +1190,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io46 = (input: any): boolean =>
+                    const $io45 = (input: any): boolean =>
                         "string" === typeof input.$ref &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1238,41 +1224,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io47 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor);
-                    const $io48 = (input: any): boolean =>
+                    const $io46 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1306,7 +1258,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io49 = (input: any): boolean =>
+                    const $io47 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -1364,9 +1316,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 return $io26(input);
                             if (undefined !== input.oneOf) return $io27(input);
                             if (undefined !== input.$ref) return $io28(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io29(input);
-                            if ("null" === input.type) return $io30(input);
+                            if ("null" === input.type) return $io29(input);
                             return (() => {
                                 if ($io20(input)) return $io20(input);
                                 if ($io19(input)) return $io19(input);
@@ -1374,7 +1324,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 if ($io21(input)) return $io21(input);
                                 if ($io23(input)) return $io23(input);
                                 if ($io24(input)) return $io24(input);
-                                if ($io31(input)) return $io31(input);
+                                if ($io30(input)) return $io30(input);
                                 return false;
                             })();
                         })();
@@ -1401,15 +1351,15 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         })();
                     const $iu2 = (input: any): any =>
                         (() => {
-                            if ("object" === input.type) return $io34(input);
-                            if ("integer" === input.type) return $io40(input);
+                            if ("object" === input.type) return $io33(input);
+                            if ("integer" === input.type) return $io39(input);
                             if (
                                 "object" === typeof input.items &&
                                 null !== input.items &&
                                 false === Array.isArray(input.items) &&
                                 $iu0(input.items)
                             )
-                                return $io43(input);
+                                return $io42(input);
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
@@ -1420,20 +1370,18 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         $iu0(elem),
                                 )
                             )
-                                return $io44(input);
-                            if (undefined !== input.oneOf) return $io45(input);
-                            if (undefined !== input.$ref) return $io46(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io47(input);
-                            if ("null" === input.type) return $io48(input);
+                                return $io43(input);
+                            if (undefined !== input.oneOf) return $io44(input);
+                            if (undefined !== input.$ref) return $io45(input);
+                            if ("null" === input.type) return $io46(input);
                             return (() => {
-                                if ($io38(input)) return $io38(input);
                                 if ($io37(input)) return $io37(input);
                                 if ($io36(input)) return $io36(input);
-                                if ($io39(input)) return $io39(input);
+                                if ($io35(input)) return $io35(input);
+                                if ($io38(input)) return $io38(input);
+                                if ($io40(input)) return $io40(input);
                                 if ($io41(input)) return $io41(input);
-                                if ($io42(input)) return $io42(input);
-                                if ($io49(input)) return $io49(input);
+                                if ($io47(input)) return $io47(input);
                                 return false;
                             })();
                         })();
@@ -1478,7 +1426,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     _index2 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
@@ -1496,7 +1444,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 _index2 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
@@ -1513,7 +1461,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: "IJsonComponents",
                                     value: input.components,
                                 })) &&
-                                $ao32(
+                                $ao31(
                                     input.components,
                                     _path + ".components",
                                     true && _exceptionable,
@@ -3246,7 +3194,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 })) &&
                                 $au0(
@@ -3257,7 +3205,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 })) &&
                             (undefined === input.minItems ||
@@ -3494,7 +3442,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     _index23 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
@@ -3512,7 +3460,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 _index23 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
@@ -3520,6 +3468,46 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     path: _path + ".items",
                                     expected: "Array<IJsonSchema>",
                                     value: input.items,
+                                })) &&
+                            (("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number",
+                                    value: input.minItems,
+                                })) &&
+                            (undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "(number | undefined)",
+                                    value: input.maxItems,
                                 })) &&
                             ("array" === input.type ||
                                 $guard(_exceptionable, {
@@ -3693,7 +3681,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     _index26 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
@@ -3711,7 +3699,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 _index26 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
@@ -4008,11 +3996,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("string" === typeof input.$recursiveRef ||
+                            ("null" === input.type ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -4155,10 +4143,16 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("null" === input.type ||
+                            (null !== input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"null"',
+                                    expected: "undefined",
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: "undefined",
                                     value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -4302,31 +4296,178 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (null !== input.type ||
+                            undefined === input.schemas ||
+                            ((("object" === typeof input.schemas &&
+                                null !== input.schemas &&
+                                false === Array.isArray(input.schemas)) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
+                                    path: _path + ".schemas",
+                                    expected:
+                                        "(Record<string, IObject | IAlias> | undefined)",
+                                    value: input.schemas,
                                 })) &&
-                            (undefined === input.type ||
+                                $ao32(
+                                    input.schemas,
+                                    _path + ".schemas",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".schemas",
+                                expected:
+                                    "(Record<string, IObject | IAlias> | undefined)",
+                                value: input.schemas,
+                            });
+                        const $ao32 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            false === _exceptionable ||
+                            Object.keys(input).every((key: any) => {
+                                const value = input[key];
+                                if (undefined === value) return true;
+                                if (RegExp(/(.*)/).test(key))
+                                    return (
+                                        ((("object" === typeof value &&
+                                            null !== value &&
+                                            false === Array.isArray(value)) ||
+                                            $guard(_exceptionable, {
+                                                path: _path + $join(key),
+                                                expected:
+                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                value: value,
+                                            })) &&
+                                            $au2(
+                                                value,
+                                                _path + $join(key),
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + $join(key),
+                                            expected:
+                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                            value: value,
+                                        })
+                                    );
+                                return true;
+                            });
+                        const $ao33 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.$id ||
+                                "string" === typeof input.$id ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                })) &&
-                            (undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".title",
+                                    path: _path + ".$id",
                                     expected: "(string | undefined)",
-                                    value: input.title,
+                                    value: input.$id,
+                                })) &&
+                            ("object" === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: '"object"',
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                })) &&
+                            (((("object" === typeof input.properties &&
+                                null !== input.properties &&
+                                false === Array.isArray(input.properties)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                })) &&
+                                $ao34(
+                                    input.properties,
+                                    _path + ".properties",
+                                    true && _exceptionable,
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                })) &&
+                            (undefined === input.patternProperties ||
+                                ((("object" ===
+                                    typeof input.patternProperties &&
+                                    null !== input.patternProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.patternProperties,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".patternProperties",
+                                        expected:
+                                            "(Record<string, IJsonSchema> | undefined)",
+                                        value: input.patternProperties,
+                                    })) &&
+                                    $ao34(
+                                        input.patternProperties,
+                                        _path + ".patternProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                })) &&
+                            (undefined === input.additionalProperties ||
+                                ((("object" ===
+                                    typeof input.additionalProperties &&
+                                    null !== input.additionalProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.additionalProperties,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".additionalProperties",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        value: input.additionalProperties,
+                                    })) &&
+                                    $au0(
+                                        input.additionalProperties,
+                                        _path + ".additionalProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                })) &&
+                            (undefined === input.required ||
+                                ((Array.isArray(input.required) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".required",
+                                        expected: "(Array<string> | undefined)",
+                                        value: input.required,
+                                    })) &&
+                                    input.required.every(
+                                        (elem: any, _index35: number) =>
+                                            "string" === typeof elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".required[" +
+                                                    _index35 +
+                                                    "]",
+                                                expected: "string",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
                                 })) &&
                             (undefined === input.description ||
                                 "string" === typeof input.description ||
@@ -4334,53 +4475,6 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     path: _path + ".description",
                                     expected: "(string | undefined)",
                                     value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"].every(
-                                        (elem: any, _index35: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $au1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
                                 })) &&
                             (undefined === input["x-typia-jsDocTags"] ||
                                 ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4427,266 +4521,6 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         "(Array<IJsDocTagInfo> | undefined)",
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
-                            (undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                })) &&
-                            (undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                })) &&
-                            (undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }));
-                        const $ao32 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            undefined === input.schemas ||
-                            ((("object" === typeof input.schemas &&
-                                null !== input.schemas &&
-                                false === Array.isArray(input.schemas)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".schemas",
-                                    expected:
-                                        "(Record<string, IObject | IAlias> | undefined)",
-                                    value: input.schemas,
-                                })) &&
-                                $ao33(
-                                    input.schemas,
-                                    _path + ".schemas",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".schemas",
-                                expected:
-                                    "(Record<string, IObject | IAlias> | undefined)",
-                                value: input.schemas,
-                            });
-                        const $ao33 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            false === _exceptionable ||
-                            Object.keys(input).every((key: any) => {
-                                const value = input[key];
-                                if (undefined === value) return true;
-                                if (RegExp(/(.*)/).test(key))
-                                    return (
-                                        ((("object" === typeof value &&
-                                            null !== value &&
-                                            false === Array.isArray(value)) ||
-                                            $guard(_exceptionable, {
-                                                path: _path + $join(key),
-                                                expected:
-                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                value: value,
-                                            })) &&
-                                            $au2(
-                                                value,
-                                                _path + $join(key),
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path: _path + $join(key),
-                                            expected:
-                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                            value: value,
-                                        })
-                                    );
-                                return true;
-                            });
-                        const $ao34 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            (undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                })) &&
-                            (undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                })) &&
-                            ("object" === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"object"',
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
-                                })) &&
-                            (((("object" === typeof input.properties &&
-                                null !== input.properties &&
-                                false === Array.isArray(input.properties)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                })) &&
-                                $ao35(
-                                    input.properties,
-                                    _path + ".properties",
-                                    true && _exceptionable,
-                                )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                })) &&
-                            (undefined === input.patternProperties ||
-                                ((("object" ===
-                                    typeof input.patternProperties &&
-                                    null !== input.patternProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.patternProperties,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".patternProperties",
-                                        expected:
-                                            "(Record<string, IJsonSchema> | undefined)",
-                                        value: input.patternProperties,
-                                    })) &&
-                                    $ao35(
-                                        input.patternProperties,
-                                        _path + ".patternProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                })) &&
-                            (undefined === input.additionalProperties ||
-                                ((("object" ===
-                                    typeof input.additionalProperties &&
-                                    null !== input.additionalProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.additionalProperties,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".additionalProperties",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                        value: input.additionalProperties,
-                                    })) &&
-                                    $au0(
-                                        input.additionalProperties,
-                                        _path + ".additionalProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                })) &&
-                            (undefined === input.required ||
-                                ((Array.isArray(input.required) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".required",
-                                        expected: "(Array<string> | undefined)",
-                                        value: input.required,
-                                    })) &&
-                                    input.required.every(
-                                        (elem: any, _index37: number) =>
-                                            "string" === typeof elem ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".required[" +
-                                                    _index37 +
-                                                    "]",
-                                                expected: "string",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                })) &&
-                            (undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index38: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $ao17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
                             (undefined === input["x-typia-patternProperties"] ||
                                 ((("object" ===
                                     typeof input["x-typia-patternProperties"] &&
@@ -4706,7 +4540,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             "x-typia-patternProperties"
                                         ],
                                     })) &&
-                                    $ao35(
+                                    $ao34(
                                         input["x-typia-patternProperties"],
                                         _path + '["x-typia-patternProperties"]',
                                         true && _exceptionable,
@@ -4737,7 +4571,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             _path +
                                             '["x-typia-additionalProperties"]',
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                         value: input[
                                             "x-typia-additionalProperties"
                                         ],
@@ -4753,12 +4587,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
                                 }));
-                        const $ao35 = (
+                        const $ao34 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -4775,7 +4609,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             $guard(_exceptionable, {
                                                 path: _path + $join(key),
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: value,
                                             })) &&
                                             $au0(
@@ -4786,13 +4620,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         $guard(_exceptionable, {
                                             path: _path + $join(key),
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: value,
                                         })
                                     );
                                 return true;
                             });
-                        const $ao36 = (
+                        const $ao35 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -4804,13 +4638,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     value: input["enum"],
                                 })) &&
                                 input["enum"].every(
-                                    (elem: any, _index39: number) =>
+                                    (elem: any, _index37: number) =>
                                         "boolean" === typeof elem ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["enum"][' +
-                                                _index39 +
+                                                _index37 +
                                                 "]",
                                             expected: "boolean",
                                             value: elem,
@@ -4871,14 +4705,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index40: number) =>
+                                        (elem: any, _index38: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4888,7 +4722,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -4896,7 +4730,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4918,14 +4752,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index41: number) =>
+                                        (elem: any, _index39: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -4934,7 +4768,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -4942,7 +4776,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -4991,7 +4825,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: "(boolean | undefined)",
                                     value: input.$recursiveAnchor,
                                 }));
-                        const $ao37 = (
+                        const $ao36 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5003,14 +4837,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     value: input["enum"],
                                 })) &&
                                 input["enum"].every(
-                                    (elem: any, _index42: number) =>
+                                    (elem: any, _index40: number) =>
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem)) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["enum"][' +
-                                                _index42 +
+                                                _index40 +
                                                 "]",
                                             expected: "number",
                                             value: elem,
@@ -5072,14 +4906,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index43: number) =>
+                                        (elem: any, _index41: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5089,7 +4923,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -5097,7 +4931,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5119,14 +4953,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index44: number) =>
+                                        (elem: any, _index42: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index44 +
+                                                        _index42 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -5135,7 +4969,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index44 +
+                                                        _index42 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -5143,7 +4977,206 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
+                                                    _index42 +
+                                                    "]",
+                                                expected: "IJsDocTagInfo",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                })) &&
+                            (undefined === input["x-typia-required"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-required"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-required"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-required"],
+                                })) &&
+                            (undefined === input["x-typia-optional"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-optional"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-optional"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-optional"],
+                                })) &&
+                            (undefined === input["x-typia-rest"] ||
+                                "boolean" === typeof input["x-typia-rest"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-rest"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-rest"],
+                                })) &&
+                            (undefined === input.$id ||
+                                "string" === typeof input.$id ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".$id",
+                                    expected: "(string | undefined)",
+                                    value: input.$id,
+                                })) &&
+                            (undefined === input.$recursiveAnchor ||
+                                "boolean" === typeof input.$recursiveAnchor ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".$recursiveAnchor",
+                                    expected: "(boolean | undefined)",
+                                    value: input.$recursiveAnchor,
+                                }));
+                        const $ao37 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (((Array.isArray(input["enum"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                })) &&
+                                input["enum"].every(
+                                    (elem: any, _index43: number) =>
+                                        "string" === typeof elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["enum"][' +
+                                                _index43 +
+                                                "]",
+                                            expected: "string",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                })) &&
+                            (undefined === input["default"] ||
+                                "string" === typeof input["default"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["default"]',
+                                    expected: "(string | undefined)",
+                                    value: input["default"],
+                                })) &&
+                            ("string" === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: '"string"',
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                })) &&
+                            (undefined === input.deprecated ||
+                                "boolean" === typeof input.deprecated ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".deprecated",
+                                    expected: "(boolean | undefined)",
+                                    value: input.deprecated,
+                                })) &&
+                            (undefined === input.title ||
+                                "string" === typeof input.title ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".title",
+                                    expected: "(string | undefined)",
+                                    value: input.title,
+                                })) &&
+                            (undefined === input.description ||
+                                "string" === typeof input.description ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".description",
+                                    expected: "(string | undefined)",
+                                    value: input.description,
+                                })) &&
+                            (undefined === input["x-typia-metaTags"] ||
+                                ((Array.isArray(input["x-typia-metaTags"]) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + '["x-typia-metaTags"]',
+                                        expected:
+                                            "(Array<IMetadataTag> | undefined)",
+                                        value: input["x-typia-metaTags"],
+                                    })) &&
+                                    input["x-typia-metaTags"].every(
+                                        (elem: any, _index44: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-metaTags"][' +
+                                                        _index44 +
+                                                        "]",
+                                                    expected:
+                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                    value: elem,
+                                                })) &&
+                                                $au1(
+                                                    elem,
+                                                    _path +
+                                                        '["x-typia-metaTags"][' +
+                                                        _index44 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-metaTags"][' +
                                                     _index44 +
+                                                    "]",
+                                                expected:
+                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                })) &&
+                            (undefined === input["x-typia-jsDocTags"] ||
+                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + '["x-typia-jsDocTags"]',
+                                        expected:
+                                            "(Array<IJsDocTagInfo> | undefined)",
+                                        value: input["x-typia-jsDocTags"],
+                                    })) &&
+                                    input["x-typia-jsDocTags"].every(
+                                        (elem: any, _index45: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
+                                                        "]",
+                                                    expected: "IJsDocTagInfo",
+                                                    value: elem,
+                                                })) &&
+                                                $ao17(
+                                                    elem,
+                                                    _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -5197,41 +5230,17 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((Array.isArray(input["enum"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                })) &&
-                                input["enum"].every(
-                                    (elem: any, _index45: number) =>
-                                        "string" === typeof elem ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["enum"][' +
-                                                _index45 +
-                                                "]",
-                                            expected: "string",
-                                            value: elem,
-                                        }),
-                                )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                })) &&
                             (undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
+                                "boolean" === typeof input["default"] ||
                                 $guard(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(string | undefined)",
+                                    expected: "(boolean | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("string" === input.type ||
+                            ("boolean" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"boolean"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -5396,17 +5405,77 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
+                            (undefined === input.minimum ||
+                                ("number" === typeof input.minimum &&
+                                    Number.isFinite(input.minimum) &&
+                                    (parseInt(input.minimum) ===
+                                        input.minimum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "(number | undefined)",
+                                    value: input.minimum,
+                                })) &&
+                            (undefined === input.maximum ||
+                                ("number" === typeof input.maximum &&
+                                    Number.isFinite(input.maximum) &&
+                                    (parseInt(input.maximum) ===
+                                        input.maximum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "(number | undefined)",
+                                    value: input.maximum,
+                                })) &&
+                            (undefined === input.exclusiveMinimum ||
+                                "boolean" === typeof input.exclusiveMinimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (undefined === input.exclusiveMaximum ||
+                                "boolean" === typeof input.exclusiveMaximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMaximum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMaximum,
+                                })) &&
+                            (undefined === input.multipleOf ||
+                                ("number" === typeof input.multipleOf &&
+                                    Number.isFinite(input.multipleOf) &&
+                                    (parseInt(input.multipleOf) ===
+                                        input.multipleOf ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "(number | undefined)",
+                                    value: input.multipleOf,
+                                })) &&
                             (undefined === input["default"] ||
-                                "boolean" === typeof input["default"] ||
+                                ("number" === typeof input["default"] &&
+                                    Number.isFinite(input["default"])) ||
                                 $guard(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(boolean | undefined)",
+                                    expected: "(number | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("boolean" === input.type ||
+                            ("integer" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"boolean"',
+                                    expected: '"integer"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -5573,14 +5642,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         ): boolean =>
                             (undefined === input.minimum ||
                                 ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum) &&
-                                    (parseInt(input.minimum) ===
-                                        input.minimum ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".minimum",
-                                            expected: "number (@type int)",
-                                            value: input.minimum,
-                                        }))) ||
+                                    Number.isFinite(input.minimum)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "(number | undefined)",
@@ -5588,14 +5650,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 })) &&
                             (undefined === input.maximum ||
                                 ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum) &&
-                                    (parseInt(input.maximum) ===
-                                        input.maximum ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".maximum",
-                                            expected: "number (@type int)",
-                                            value: input.maximum,
-                                        }))) ||
+                                    Number.isFinite(input.maximum)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "(number | undefined)",
@@ -5617,14 +5672,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 })) &&
                             (undefined === input.multipleOf ||
                                 ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf) &&
-                                    (parseInt(input.multipleOf) ===
-                                        input.multipleOf ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".multipleOf",
-                                            expected: "number (@type int)",
-                                            value: input.multipleOf,
-                                        }))) ||
+                                    Number.isFinite(input.multipleOf)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "(number | undefined)",
@@ -5638,10 +5686,10 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: "(number | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("integer" === input.type ||
+                            ("number" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"integer"',
+                                    expected: '"number"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -5806,56 +5854,73 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (undefined === input.minimum ||
-                                ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum)) ||
+                            (undefined === input.minLength ||
+                                ("number" === typeof input.minLength &&
+                                    Number.isFinite(input.minLength) &&
+                                    (parseInt(input.minLength) ===
+                                        input.minLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        })) &&
+                                    (0 <= input.minLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minimum",
+                                    path: _path + ".minLength",
                                     expected: "(number | undefined)",
-                                    value: input.minimum,
+                                    value: input.minLength,
                                 })) &&
-                            (undefined === input.maximum ||
-                                ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum)) ||
+                            (undefined === input.maxLength ||
+                                ("number" === typeof input.maxLength &&
+                                    Number.isFinite(input.maxLength) &&
+                                    (parseInt(input.maxLength) ===
+                                        input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (0 <= input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maximum",
+                                    path: _path + ".maxLength",
                                     expected: "(number | undefined)",
-                                    value: input.maximum,
+                                    value: input.maxLength,
                                 })) &&
-                            (undefined === input.exclusiveMinimum ||
-                                "boolean" === typeof input.exclusiveMinimum ||
+                            (undefined === input.pattern ||
+                                "string" === typeof input.pattern ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".exclusiveMinimum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMinimum,
+                                    path: _path + ".pattern",
+                                    expected: "(string | undefined)",
+                                    value: input.pattern,
                                 })) &&
-                            (undefined === input.exclusiveMaximum ||
-                                "boolean" === typeof input.exclusiveMaximum ||
+                            (undefined === input.format ||
+                                "string" === typeof input.format ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".exclusiveMaximum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMaximum,
-                                })) &&
-                            (undefined === input.multipleOf ||
-                                ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".multipleOf",
-                                    expected: "(number | undefined)",
-                                    value: input.multipleOf,
+                                    path: _path + ".format",
+                                    expected: "(string | undefined)",
+                                    value: input.format,
                                 })) &&
                             (undefined === input["default"] ||
-                                ("number" === typeof input["default"] &&
-                                    Number.isFinite(input["default"])) ||
+                                "string" === typeof input["default"] ||
                                 $guard(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(number | undefined)",
+                                    expected: "(string | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("number" === input.type ||
+                            ("string" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"number"',
+                                    expected: '"string"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -6020,73 +6085,92 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (undefined === input.minLength ||
-                                ("number" === typeof input.minLength &&
-                                    Number.isFinite(input.minLength) &&
-                                    (parseInt(input.minLength) ===
-                                        input.minLength ||
+                            (((("object" === typeof input.items &&
+                                null !== input.items &&
+                                false === Array.isArray(input.items)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                })) &&
+                                $au0(
+                                    input.items,
+                                    _path + ".items",
+                                    true && _exceptionable,
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                })) &&
+                            (undefined === input.minItems ||
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         })) &&
-                                    (0 <= input.minLength ||
+                                    (0 <= input.minItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "(number | undefined)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 })) &&
-                            (undefined === input.maxLength ||
-                                ("number" === typeof input.maxLength &&
-                                    Number.isFinite(input.maxLength) &&
-                                    (parseInt(input.maxLength) ===
-                                        input.maxLength ||
+                            (undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         })) &&
-                                    (0 <= input.maxLength ||
+                                    (0 <= input.maxItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "(number | undefined)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 })) &&
-                            (undefined === input.pattern ||
-                                "string" === typeof input.pattern ||
+                            (undefined === input["x-typia-tuple"] ||
+                                ((("object" === typeof input["x-typia-tuple"] &&
+                                    null !== input["x-typia-tuple"]) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + '["x-typia-tuple"]',
+                                        expected:
+                                            "(IJsonSchema.ITuple | undefined)",
+                                        value: input["x-typia-tuple"],
+                                    })) &&
+                                    $ao26(
+                                        input["x-typia-tuple"],
+                                        _path + '["x-typia-tuple"]',
+                                        true && _exceptionable,
+                                    )) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".pattern",
-                                    expected: "(string | undefined)",
-                                    value: input.pattern,
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
                                 })) &&
-                            (undefined === input.format ||
-                                "string" === typeof input.format ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".format",
-                                    expected: "(string | undefined)",
-                                    value: input.format,
-                                })) &&
-                            (undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["default"]',
-                                    expected: "(string | undefined)",
-                                    value: input["default"],
-                                })) &&
-                            ("string" === input.type ||
+                            ("array" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"array"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -6251,45 +6335,68 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((("object" === typeof input.items &&
-                                null !== input.items &&
-                                false === Array.isArray(input.items)) ||
+                            (((Array.isArray(input.items) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 })) &&
-                                $au0(
-                                    input.items,
-                                    _path + ".items",
-                                    true && _exceptionable,
+                                input.items.every(
+                                    (elem: any, _index56: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem &&
+                                            false === Array.isArray(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                expected:
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                value: elem,
+                                            })) &&
+                                            $au0(
+                                                elem,
+                                                _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index56 +
+                                                "]",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            value: elem,
+                                        }),
                                 )) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 })) &&
-                            (undefined === input.minItems ||
-                                ("number" === typeof input.minItems &&
-                                    Number.isFinite(input.minItems) &&
-                                    (parseInt(input.minItems) ===
-                                        input.minItems ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        })) &&
-                                    (0 <= input.minItems ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        }))) ||
+                            (("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
-                                    expected: "(number | undefined)",
+                                    expected: "number",
                                     value: input.minItems,
                                 })) &&
                             (undefined === input.maxItems ||
@@ -6312,26 +6419,6 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     path: _path + ".maxItems",
                                     expected: "(number | undefined)",
                                     value: input.maxItems,
-                                })) &&
-                            (undefined === input["x-typia-tuple"] ||
-                                ((("object" === typeof input["x-typia-tuple"] &&
-                                    null !== input["x-typia-tuple"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-tuple"]',
-                                        expected:
-                                            "(IJsonSchema.ITuple | undefined)",
-                                        value: input["x-typia-tuple"],
-                                    })) &&
-                                    $ao26(
-                                        input["x-typia-tuple"],
-                                        _path + '["x-typia-tuple"]',
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
                                 })) &&
                             ("array" === input.type ||
                                 $guard(_exceptionable, {
@@ -6376,14 +6463,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index56: number) =>
+                                        (elem: any, _index57: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6393,7 +6480,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6401,7 +6488,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6423,14 +6510,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index57: number) =>
+                                        (elem: any, _index58: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6439,7 +6526,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6447,7 +6534,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6501,63 +6588,50 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((Array.isArray(input.items) ||
+                            (((Array.isArray(input.oneOf) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
+                                    value: input.oneOf,
                                 })) &&
-                                input.items.every(
-                                    (elem: any, _index58: number) =>
+                                input.oneOf.every(
+                                    (elem: any, _index59: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem)) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
                                                 elem,
                                                 _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
-                                                ".items[" +
-                                                _index58 +
+                                                ".oneOf[" +
+                                                _index59 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
-                                })) &&
-                            ("array" === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"array"',
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
+                                    value: input.oneOf,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -6589,14 +6663,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index59: number) =>
+                                        (elem: any, _index60: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6606,7 +6680,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6614,7 +6688,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6636,14 +6710,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index60: number) =>
+                                        (elem: any, _index61: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6652,7 +6726,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6660,7 +6734,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6714,50 +6788,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((Array.isArray(input.oneOf) ||
+                            ("string" === typeof input.$ref ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
-                                })) &&
-                                input.oneOf.every(
-                                    (elem: any, _index61: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem &&
-                                            false === Array.isArray(elem)) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                value: elem,
-                                            })) &&
-                                            $au0(
-                                                elem,
-                                                _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".oneOf[" +
-                                                _index61 +
-                                                "]",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                            value: elem,
-                                        }),
-                                )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
+                                    path: _path + ".$ref",
+                                    expected: "string",
+                                    value: input.$ref,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -6914,11 +6949,11 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("string" === typeof input.$ref ||
+                            ("null" === input.type ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".$ref",
-                                    expected: "string",
-                                    value: input.$ref,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7075,11 +7110,17 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("string" === typeof input.$recursiveRef ||
+                            (null !== input.type ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7231,334 +7272,6 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     expected: "(boolean | undefined)",
                                     value: input.$recursiveAnchor,
                                 }));
-                        const $ao48 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            ("null" === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"null"',
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                })) &&
-                            (undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                })) &&
-                            (undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"].every(
-                                        (elem: any, _index68: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $au1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                            (undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index69: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $ao17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                            (undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                })) &&
-                            (undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                })) &&
-                            (undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                })) &&
-                            (undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                })) &&
-                            (undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }));
-                        const $ao49 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            (null !== input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                })) &&
-                            (undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                })) &&
-                            (undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"].every(
-                                        (elem: any, _index70: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $au1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                            (undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index71: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $ao17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                            (undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                })) &&
-                            (undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                })) &&
-                            (undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                })) &&
-                            (undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                })) &&
-                            (undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }));
                         const $au0 = (
                             input: any,
                             _path: string,
@@ -7589,7 +7302,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 if (
                                     Array.isArray(input.items) &&
                                     input.items.every(
-                                        (elem: any, _index72: number) =>
+                                        (elem: any, _index68: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -7597,7 +7310,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index72 +
+                                                    _index68 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
@@ -7620,14 +7333,8 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         _path,
                                         true && _exceptionable,
                                     );
-                                if (undefined !== input.$recursiveRef)
-                                    return $ao29(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
                                 if ("null" === input.type)
-                                    return $ao30(
+                                    return $ao29(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -7663,7 +7370,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $ao31(
+                                    $ao30(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -7786,13 +7493,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         ): any =>
                             (() => {
                                 if ("object" === input.type)
-                                    return $ao34(
+                                    return $ao33(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("integer" === input.type)
-                                    return $ao40(
+                                    return $ao39(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -7807,7 +7514,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         false && _exceptionable,
                                     )
                                 )
-                                    return $ao43(
+                                    return $ao42(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -7815,7 +7522,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 if (
                                     Array.isArray(input.items) &&
                                     input.items.every(
-                                        (elem: any, _index73: number) =>
+                                        (elem: any, _index69: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -7823,47 +7530,36 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index73 +
+                                                    _index69 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
                                     )
                                 )
-                                    return $ao44(
+                                    return $ao43(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.oneOf)
-                                    return $ao45(
+                                    return $ao44(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.$ref)
-                                    return $ao46(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
-                                if (undefined !== input.$recursiveRef)
-                                    return $ao47(
+                                    return $ao45(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("null" === input.type)
-                                    return $ao48(
+                                    return $ao46(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 return (
-                                    $ao38(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
                                     $ao37(
                                         input,
                                         _path,
@@ -7874,7 +7570,17 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $ao39(
+                                    $ao35(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $ao38(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $ao40(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -7884,12 +7590,7 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $ao42(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
-                                    $ao49(
+                                    $ao47(
                                         input,
                                         _path,
                                         false && _exceptionable,

--- a/test/generated/output/assertStringify/test_assertStringify_UltimateUnion.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_UltimateUnion.ts
@@ -24,7 +24,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "object" === typeof input.components &&
                         null !== input.components &&
                         false === Array.isArray(input.components) &&
-                        $io32(input.components) &&
+                        $io31(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose);
                     const $io1 = (input: any): boolean =>
@@ -461,6 +461,15 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -560,36 +569,6 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
                     const $io29 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]);
-                    const $io30 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -619,7 +598,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io31 = (input: any): boolean =>
+                    const $io30 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -650,13 +629,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io32 = (input: any): boolean =>
+                    const $io31 = (input: any): boolean =>
                         undefined === input.schemas ||
                         ("object" === typeof input.schemas &&
                             null !== input.schemas &&
                             false === Array.isArray(input.schemas) &&
-                            $io33(input.schemas));
-                    const $io33 = (input: any): boolean =>
+                            $io32(input.schemas));
+                    const $io32 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -669,24 +648,22 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 );
                             return true;
                         });
-                    const $io34 = (input: any): boolean =>
+                    const $io33 = (input: any): boolean =>
                         (undefined === input.$id ||
                             "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
-                        $io35(input.properties) &&
+                        $io34(input.properties) &&
                         (undefined === input.patternProperties ||
                             ("object" === typeof input.patternProperties &&
                                 null !== input.patternProperties &&
                                 false ===
                                     Array.isArray(input.patternProperties) &&
-                                $io35(input.patternProperties))) &&
+                                $io34(input.patternProperties))) &&
                         (undefined === input.additionalProperties ||
                             ("object" === typeof input.additionalProperties &&
                                 null !== input.additionalProperties &&
@@ -716,7 +693,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     Array.isArray(
                                         input["x-typia-patternProperties"],
                                     ) &&
-                                $io35(input["x-typia-patternProperties"]))) &&
+                                $io34(input["x-typia-patternProperties"]))) &&
                         (undefined === input["x-typia-additionalProperties"] ||
                             ("object" ===
                                 typeof input["x-typia-additionalProperties"] &&
@@ -727,7 +704,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         input["x-typia-additionalProperties"],
                                     ) &&
                                 $iu0(input["x-typia-additionalProperties"])));
-                    const $io35 = (input: any): boolean =>
+                    const $io34 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -740,7 +717,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 );
                             return true;
                         });
-                    const $io36 = (input: any): boolean =>
+                    const $io35 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "boolean" === typeof elem,
@@ -782,7 +759,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io37 = (input: any): boolean =>
+                    const $io36 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) =>
@@ -827,7 +804,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io38 = (input: any): boolean =>
+                    const $io37 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "string" === typeof elem,
@@ -869,7 +846,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io39 = (input: any): boolean =>
+                    const $io38 = (input: any): boolean =>
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
@@ -907,7 +884,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io40 = (input: any): boolean =>
+                    const $io39 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
@@ -963,7 +940,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io41 = (input: any): boolean =>
+                    const $io40 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum))) &&
@@ -1015,7 +992,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io42 = (input: any): boolean =>
+                    const $io41 = (input: any): boolean =>
                         (undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
@@ -1067,7 +1044,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io43 = (input: any): boolean =>
+                    const $io42 = (input: any): boolean =>
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
@@ -1121,7 +1098,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io44 = (input: any): boolean =>
+                    const $io43 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         input.items.every(
                             (elem: any) =>
@@ -1130,6 +1107,15 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -1165,7 +1151,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io45 = (input: any): boolean =>
+                    const $io44 = (input: any): boolean =>
                         Array.isArray(input.oneOf) &&
                         input.oneOf.every(
                             (elem: any) =>
@@ -1206,7 +1192,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io46 = (input: any): boolean =>
+                    const $io45 = (input: any): boolean =>
                         "string" === typeof input.$ref &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1240,41 +1226,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io47 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor);
-                    const $io48 = (input: any): boolean =>
+                    const $io46 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1308,7 +1260,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io49 = (input: any): boolean =>
+                    const $io47 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -1366,9 +1318,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 return $io26(input);
                             if (undefined !== input.oneOf) return $io27(input);
                             if (undefined !== input.$ref) return $io28(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io29(input);
-                            if ("null" === input.type) return $io30(input);
+                            if ("null" === input.type) return $io29(input);
                             return (() => {
                                 if ($io20(input)) return $io20(input);
                                 if ($io19(input)) return $io19(input);
@@ -1376,7 +1326,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 if ($io21(input)) return $io21(input);
                                 if ($io23(input)) return $io23(input);
                                 if ($io24(input)) return $io24(input);
-                                if ($io31(input)) return $io31(input);
+                                if ($io30(input)) return $io30(input);
                                 return false;
                             })();
                         })();
@@ -1403,15 +1353,15 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         })();
                     const $iu2 = (input: any): any =>
                         (() => {
-                            if ("object" === input.type) return $io34(input);
-                            if ("integer" === input.type) return $io40(input);
+                            if ("object" === input.type) return $io33(input);
+                            if ("integer" === input.type) return $io39(input);
                             if (
                                 "object" === typeof input.items &&
                                 null !== input.items &&
                                 false === Array.isArray(input.items) &&
                                 $iu0(input.items)
                             )
-                                return $io43(input);
+                                return $io42(input);
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
@@ -1422,20 +1372,18 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         $iu0(elem),
                                 )
                             )
-                                return $io44(input);
-                            if (undefined !== input.oneOf) return $io45(input);
-                            if (undefined !== input.$ref) return $io46(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io47(input);
-                            if ("null" === input.type) return $io48(input);
+                                return $io43(input);
+                            if (undefined !== input.oneOf) return $io44(input);
+                            if (undefined !== input.$ref) return $io45(input);
+                            if ("null" === input.type) return $io46(input);
                             return (() => {
-                                if ($io38(input)) return $io38(input);
                                 if ($io37(input)) return $io37(input);
                                 if ($io36(input)) return $io36(input);
-                                if ($io39(input)) return $io39(input);
+                                if ($io35(input)) return $io35(input);
+                                if ($io38(input)) return $io38(input);
+                                if ($io40(input)) return $io40(input);
                                 if ($io41(input)) return $io41(input);
-                                if ($io42(input)) return $io42(input);
-                                if ($io49(input)) return $io49(input);
+                                if ($io47(input)) return $io47(input);
                                 return false;
                             })();
                         })();
@@ -1480,7 +1428,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     _index2 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
@@ -1498,7 +1446,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 _index2 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
@@ -1515,7 +1463,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: "IJsonComponents",
                                     value: input.components,
                                 })) &&
-                                $ao32(
+                                $ao31(
                                     input.components,
                                     _path + ".components",
                                     true && _exceptionable,
@@ -3248,7 +3196,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 })) &&
                                 $au0(
@@ -3259,7 +3207,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 })) &&
                             (undefined === input.minItems ||
@@ -3496,7 +3444,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     _index23 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
@@ -3514,7 +3462,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 _index23 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
@@ -3522,6 +3470,46 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     path: _path + ".items",
                                     expected: "Array<IJsonSchema>",
                                     value: input.items,
+                                })) &&
+                            (("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number",
+                                    value: input.minItems,
+                                })) &&
+                            (undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "(number | undefined)",
+                                    value: input.maxItems,
                                 })) &&
                             ("array" === input.type ||
                                 $guard(_exceptionable, {
@@ -3695,7 +3683,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     _index26 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
@@ -3713,7 +3701,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 _index26 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
@@ -4010,11 +3998,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("string" === typeof input.$recursiveRef ||
+                            ("null" === input.type ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -4157,10 +4145,16 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("null" === input.type ||
+                            (null !== input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"null"',
+                                    expected: "undefined",
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: "undefined",
                                     value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
@@ -4304,31 +4298,178 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (null !== input.type ||
+                            undefined === input.schemas ||
+                            ((("object" === typeof input.schemas &&
+                                null !== input.schemas &&
+                                false === Array.isArray(input.schemas)) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
+                                    path: _path + ".schemas",
+                                    expected:
+                                        "(Record<string, IObject | IAlias> | undefined)",
+                                    value: input.schemas,
                                 })) &&
-                            (undefined === input.type ||
+                                $ao32(
+                                    input.schemas,
+                                    _path + ".schemas",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".schemas",
+                                expected:
+                                    "(Record<string, IObject | IAlias> | undefined)",
+                                value: input.schemas,
+                            });
+                        const $ao32 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            false === _exceptionable ||
+                            Object.keys(input).every((key: any) => {
+                                const value = input[key];
+                                if (undefined === value) return true;
+                                if (RegExp(/(.*)/).test(key))
+                                    return (
+                                        ((("object" === typeof value &&
+                                            null !== value &&
+                                            false === Array.isArray(value)) ||
+                                            $guard(_exceptionable, {
+                                                path: _path + $join(key),
+                                                expected:
+                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                value: value,
+                                            })) &&
+                                            $au2(
+                                                value,
+                                                _path + $join(key),
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + $join(key),
+                                            expected:
+                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                            value: value,
+                                        })
+                                    );
+                                return true;
+                            });
+                        const $ao33 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.$id ||
+                                "string" === typeof input.$id ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                })) &&
-                            (undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".title",
+                                    path: _path + ".$id",
                                     expected: "(string | undefined)",
-                                    value: input.title,
+                                    value: input.$id,
+                                })) &&
+                            ("object" === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: '"object"',
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                })) &&
+                            (((("object" === typeof input.properties &&
+                                null !== input.properties &&
+                                false === Array.isArray(input.properties)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                })) &&
+                                $ao34(
+                                    input.properties,
+                                    _path + ".properties",
+                                    true && _exceptionable,
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                })) &&
+                            (undefined === input.patternProperties ||
+                                ((("object" ===
+                                    typeof input.patternProperties &&
+                                    null !== input.patternProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.patternProperties,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".patternProperties",
+                                        expected:
+                                            "(Record<string, IJsonSchema> | undefined)",
+                                        value: input.patternProperties,
+                                    })) &&
+                                    $ao34(
+                                        input.patternProperties,
+                                        _path + ".patternProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                })) &&
+                            (undefined === input.additionalProperties ||
+                                ((("object" ===
+                                    typeof input.additionalProperties &&
+                                    null !== input.additionalProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.additionalProperties,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".additionalProperties",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        value: input.additionalProperties,
+                                    })) &&
+                                    $au0(
+                                        input.additionalProperties,
+                                        _path + ".additionalProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                })) &&
+                            (undefined === input.required ||
+                                ((Array.isArray(input.required) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".required",
+                                        expected: "(Array<string> | undefined)",
+                                        value: input.required,
+                                    })) &&
+                                    input.required.every(
+                                        (elem: any, _index35: number) =>
+                                            "string" === typeof elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".required[" +
+                                                    _index35 +
+                                                    "]",
+                                                expected: "string",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
                                 })) &&
                             (undefined === input.description ||
                                 "string" === typeof input.description ||
@@ -4336,53 +4477,6 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     path: _path + ".description",
                                     expected: "(string | undefined)",
                                     value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"].every(
-                                        (elem: any, _index35: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $au1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
                                 })) &&
                             (undefined === input["x-typia-jsDocTags"] ||
                                 ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4429,266 +4523,6 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         "(Array<IJsDocTagInfo> | undefined)",
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
-                            (undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                })) &&
-                            (undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                })) &&
-                            (undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }));
-                        const $ao32 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            undefined === input.schemas ||
-                            ((("object" === typeof input.schemas &&
-                                null !== input.schemas &&
-                                false === Array.isArray(input.schemas)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".schemas",
-                                    expected:
-                                        "(Record<string, IObject | IAlias> | undefined)",
-                                    value: input.schemas,
-                                })) &&
-                                $ao33(
-                                    input.schemas,
-                                    _path + ".schemas",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".schemas",
-                                expected:
-                                    "(Record<string, IObject | IAlias> | undefined)",
-                                value: input.schemas,
-                            });
-                        const $ao33 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            false === _exceptionable ||
-                            Object.keys(input).every((key: any) => {
-                                const value = input[key];
-                                if (undefined === value) return true;
-                                if (RegExp(/(.*)/).test(key))
-                                    return (
-                                        ((("object" === typeof value &&
-                                            null !== value &&
-                                            false === Array.isArray(value)) ||
-                                            $guard(_exceptionable, {
-                                                path: _path + $join(key),
-                                                expected:
-                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                value: value,
-                                            })) &&
-                                            $au2(
-                                                value,
-                                                _path + $join(key),
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path: _path + $join(key),
-                                            expected:
-                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                            value: value,
-                                        })
-                                    );
-                                return true;
-                            });
-                        const $ao34 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            (undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                })) &&
-                            (undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                })) &&
-                            ("object" === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"object"',
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
-                                })) &&
-                            (((("object" === typeof input.properties &&
-                                null !== input.properties &&
-                                false === Array.isArray(input.properties)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                })) &&
-                                $ao35(
-                                    input.properties,
-                                    _path + ".properties",
-                                    true && _exceptionable,
-                                )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                })) &&
-                            (undefined === input.patternProperties ||
-                                ((("object" ===
-                                    typeof input.patternProperties &&
-                                    null !== input.patternProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.patternProperties,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".patternProperties",
-                                        expected:
-                                            "(Record<string, IJsonSchema> | undefined)",
-                                        value: input.patternProperties,
-                                    })) &&
-                                    $ao35(
-                                        input.patternProperties,
-                                        _path + ".patternProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                })) &&
-                            (undefined === input.additionalProperties ||
-                                ((("object" ===
-                                    typeof input.additionalProperties &&
-                                    null !== input.additionalProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.additionalProperties,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".additionalProperties",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                        value: input.additionalProperties,
-                                    })) &&
-                                    $au0(
-                                        input.additionalProperties,
-                                        _path + ".additionalProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                })) &&
-                            (undefined === input.required ||
-                                ((Array.isArray(input.required) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".required",
-                                        expected: "(Array<string> | undefined)",
-                                        value: input.required,
-                                    })) &&
-                                    input.required.every(
-                                        (elem: any, _index37: number) =>
-                                            "string" === typeof elem ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".required[" +
-                                                    _index37 +
-                                                    "]",
-                                                expected: "string",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                })) &&
-                            (undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index38: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $ao17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
                             (undefined === input["x-typia-patternProperties"] ||
                                 ((("object" ===
                                     typeof input["x-typia-patternProperties"] &&
@@ -4708,7 +4542,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             "x-typia-patternProperties"
                                         ],
                                     })) &&
-                                    $ao35(
+                                    $ao34(
                                         input["x-typia-patternProperties"],
                                         _path + '["x-typia-patternProperties"]',
                                         true && _exceptionable,
@@ -4739,7 +4573,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             _path +
                                             '["x-typia-additionalProperties"]',
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                         value: input[
                                             "x-typia-additionalProperties"
                                         ],
@@ -4755,12 +4589,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
                                 }));
-                        const $ao35 = (
+                        const $ao34 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -4777,7 +4611,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             $guard(_exceptionable, {
                                                 path: _path + $join(key),
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: value,
                                             })) &&
                                             $au0(
@@ -4788,13 +4622,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         $guard(_exceptionable, {
                                             path: _path + $join(key),
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: value,
                                         })
                                     );
                                 return true;
                             });
-                        const $ao36 = (
+                        const $ao35 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -4806,13 +4640,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     value: input["enum"],
                                 })) &&
                                 input["enum"].every(
-                                    (elem: any, _index39: number) =>
+                                    (elem: any, _index37: number) =>
                                         "boolean" === typeof elem ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["enum"][' +
-                                                _index39 +
+                                                _index37 +
                                                 "]",
                                             expected: "boolean",
                                             value: elem,
@@ -4873,14 +4707,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index40: number) =>
+                                        (elem: any, _index38: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4890,7 +4724,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -4898,7 +4732,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4920,14 +4754,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index41: number) =>
+                                        (elem: any, _index39: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -4936,7 +4770,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -4944,7 +4778,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -4993,7 +4827,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: "(boolean | undefined)",
                                     value: input.$recursiveAnchor,
                                 }));
-                        const $ao37 = (
+                        const $ao36 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5005,14 +4839,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     value: input["enum"],
                                 })) &&
                                 input["enum"].every(
-                                    (elem: any, _index42: number) =>
+                                    (elem: any, _index40: number) =>
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem)) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["enum"][' +
-                                                _index42 +
+                                                _index40 +
                                                 "]",
                                             expected: "number",
                                             value: elem,
@@ -5074,14 +4908,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index43: number) =>
+                                        (elem: any, _index41: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5091,7 +4925,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -5099,7 +4933,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5121,14 +4955,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index44: number) =>
+                                        (elem: any, _index42: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index44 +
+                                                        _index42 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -5137,7 +4971,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index44 +
+                                                        _index42 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -5145,7 +4979,206 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
+                                                    _index42 +
+                                                    "]",
+                                                expected: "IJsDocTagInfo",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                })) &&
+                            (undefined === input["x-typia-required"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-required"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-required"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-required"],
+                                })) &&
+                            (undefined === input["x-typia-optional"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-optional"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-optional"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-optional"],
+                                })) &&
+                            (undefined === input["x-typia-rest"] ||
+                                "boolean" === typeof input["x-typia-rest"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-rest"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-rest"],
+                                })) &&
+                            (undefined === input.$id ||
+                                "string" === typeof input.$id ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".$id",
+                                    expected: "(string | undefined)",
+                                    value: input.$id,
+                                })) &&
+                            (undefined === input.$recursiveAnchor ||
+                                "boolean" === typeof input.$recursiveAnchor ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".$recursiveAnchor",
+                                    expected: "(boolean | undefined)",
+                                    value: input.$recursiveAnchor,
+                                }));
+                        const $ao37 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (((Array.isArray(input["enum"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                })) &&
+                                input["enum"].every(
+                                    (elem: any, _index43: number) =>
+                                        "string" === typeof elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["enum"][' +
+                                                _index43 +
+                                                "]",
+                                            expected: "string",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                })) &&
+                            (undefined === input["default"] ||
+                                "string" === typeof input["default"] ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["default"]',
+                                    expected: "(string | undefined)",
+                                    value: input["default"],
+                                })) &&
+                            ("string" === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: '"string"',
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                })) &&
+                            (undefined === input.deprecated ||
+                                "boolean" === typeof input.deprecated ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".deprecated",
+                                    expected: "(boolean | undefined)",
+                                    value: input.deprecated,
+                                })) &&
+                            (undefined === input.title ||
+                                "string" === typeof input.title ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".title",
+                                    expected: "(string | undefined)",
+                                    value: input.title,
+                                })) &&
+                            (undefined === input.description ||
+                                "string" === typeof input.description ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".description",
+                                    expected: "(string | undefined)",
+                                    value: input.description,
+                                })) &&
+                            (undefined === input["x-typia-metaTags"] ||
+                                ((Array.isArray(input["x-typia-metaTags"]) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + '["x-typia-metaTags"]',
+                                        expected:
+                                            "(Array<IMetadataTag> | undefined)",
+                                        value: input["x-typia-metaTags"],
+                                    })) &&
+                                    input["x-typia-metaTags"].every(
+                                        (elem: any, _index44: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-metaTags"][' +
+                                                        _index44 +
+                                                        "]",
+                                                    expected:
+                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                    value: elem,
+                                                })) &&
+                                                $au1(
+                                                    elem,
+                                                    _path +
+                                                        '["x-typia-metaTags"][' +
+                                                        _index44 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-metaTags"][' +
                                                     _index44 +
+                                                    "]",
+                                                expected:
+                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                })) &&
+                            (undefined === input["x-typia-jsDocTags"] ||
+                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + '["x-typia-jsDocTags"]',
+                                        expected:
+                                            "(Array<IJsDocTagInfo> | undefined)",
+                                        value: input["x-typia-jsDocTags"],
+                                    })) &&
+                                    input["x-typia-jsDocTags"].every(
+                                        (elem: any, _index45: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
+                                                        "]",
+                                                    expected: "IJsDocTagInfo",
+                                                    value: elem,
+                                                })) &&
+                                                $ao17(
+                                                    elem,
+                                                    _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -5199,41 +5232,17 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((Array.isArray(input["enum"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                })) &&
-                                input["enum"].every(
-                                    (elem: any, _index45: number) =>
-                                        "string" === typeof elem ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["enum"][' +
-                                                _index45 +
-                                                "]",
-                                            expected: "string",
-                                            value: elem,
-                                        }),
-                                )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                })) &&
                             (undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
+                                "boolean" === typeof input["default"] ||
                                 $guard(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(string | undefined)",
+                                    expected: "(boolean | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("string" === input.type ||
+                            ("boolean" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"boolean"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -5398,17 +5407,77 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
+                            (undefined === input.minimum ||
+                                ("number" === typeof input.minimum &&
+                                    Number.isFinite(input.minimum) &&
+                                    (parseInt(input.minimum) ===
+                                        input.minimum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "(number | undefined)",
+                                    value: input.minimum,
+                                })) &&
+                            (undefined === input.maximum ||
+                                ("number" === typeof input.maximum &&
+                                    Number.isFinite(input.maximum) &&
+                                    (parseInt(input.maximum) ===
+                                        input.maximum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "(number | undefined)",
+                                    value: input.maximum,
+                                })) &&
+                            (undefined === input.exclusiveMinimum ||
+                                "boolean" === typeof input.exclusiveMinimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMinimum,
+                                })) &&
+                            (undefined === input.exclusiveMaximum ||
+                                "boolean" === typeof input.exclusiveMaximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".exclusiveMaximum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMaximum,
+                                })) &&
+                            (undefined === input.multipleOf ||
+                                ("number" === typeof input.multipleOf &&
+                                    Number.isFinite(input.multipleOf) &&
+                                    (parseInt(input.multipleOf) ===
+                                        input.multipleOf ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "(number | undefined)",
+                                    value: input.multipleOf,
+                                })) &&
                             (undefined === input["default"] ||
-                                "boolean" === typeof input["default"] ||
+                                ("number" === typeof input["default"] &&
+                                    Number.isFinite(input["default"])) ||
                                 $guard(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(boolean | undefined)",
+                                    expected: "(number | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("boolean" === input.type ||
+                            ("integer" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"boolean"',
+                                    expected: '"integer"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -5575,14 +5644,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         ): boolean =>
                             (undefined === input.minimum ||
                                 ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum) &&
-                                    (parseInt(input.minimum) ===
-                                        input.minimum ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".minimum",
-                                            expected: "number (@type int)",
-                                            value: input.minimum,
-                                        }))) ||
+                                    Number.isFinite(input.minimum)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "(number | undefined)",
@@ -5590,14 +5652,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 })) &&
                             (undefined === input.maximum ||
                                 ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum) &&
-                                    (parseInt(input.maximum) ===
-                                        input.maximum ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".maximum",
-                                            expected: "number (@type int)",
-                                            value: input.maximum,
-                                        }))) ||
+                                    Number.isFinite(input.maximum)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "(number | undefined)",
@@ -5619,14 +5674,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 })) &&
                             (undefined === input.multipleOf ||
                                 ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf) &&
-                                    (parseInt(input.multipleOf) ===
-                                        input.multipleOf ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".multipleOf",
-                                            expected: "number (@type int)",
-                                            value: input.multipleOf,
-                                        }))) ||
+                                    Number.isFinite(input.multipleOf)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "(number | undefined)",
@@ -5640,10 +5688,10 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: "(number | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("integer" === input.type ||
+                            ("number" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"integer"',
+                                    expected: '"number"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -5808,56 +5856,73 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (undefined === input.minimum ||
-                                ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum)) ||
+                            (undefined === input.minLength ||
+                                ("number" === typeof input.minLength &&
+                                    Number.isFinite(input.minLength) &&
+                                    (parseInt(input.minLength) ===
+                                        input.minLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        })) &&
+                                    (0 <= input.minLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minimum",
+                                    path: _path + ".minLength",
                                     expected: "(number | undefined)",
-                                    value: input.minimum,
+                                    value: input.minLength,
                                 })) &&
-                            (undefined === input.maximum ||
-                                ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum)) ||
+                            (undefined === input.maxLength ||
+                                ("number" === typeof input.maxLength &&
+                                    Number.isFinite(input.maxLength) &&
+                                    (parseInt(input.maxLength) ===
+                                        input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (0 <= input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maximum",
+                                    path: _path + ".maxLength",
                                     expected: "(number | undefined)",
-                                    value: input.maximum,
+                                    value: input.maxLength,
                                 })) &&
-                            (undefined === input.exclusiveMinimum ||
-                                "boolean" === typeof input.exclusiveMinimum ||
+                            (undefined === input.pattern ||
+                                "string" === typeof input.pattern ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".exclusiveMinimum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMinimum,
+                                    path: _path + ".pattern",
+                                    expected: "(string | undefined)",
+                                    value: input.pattern,
                                 })) &&
-                            (undefined === input.exclusiveMaximum ||
-                                "boolean" === typeof input.exclusiveMaximum ||
+                            (undefined === input.format ||
+                                "string" === typeof input.format ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".exclusiveMaximum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMaximum,
-                                })) &&
-                            (undefined === input.multipleOf ||
-                                ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".multipleOf",
-                                    expected: "(number | undefined)",
-                                    value: input.multipleOf,
+                                    path: _path + ".format",
+                                    expected: "(string | undefined)",
+                                    value: input.format,
                                 })) &&
                             (undefined === input["default"] ||
-                                ("number" === typeof input["default"] &&
-                                    Number.isFinite(input["default"])) ||
+                                "string" === typeof input["default"] ||
                                 $guard(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(number | undefined)",
+                                    expected: "(string | undefined)",
                                     value: input["default"],
                                 })) &&
-                            ("number" === input.type ||
+                            ("string" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"number"',
+                                    expected: '"string"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -6022,73 +6087,92 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (undefined === input.minLength ||
-                                ("number" === typeof input.minLength &&
-                                    Number.isFinite(input.minLength) &&
-                                    (parseInt(input.minLength) ===
-                                        input.minLength ||
+                            (((("object" === typeof input.items &&
+                                null !== input.items &&
+                                false === Array.isArray(input.items)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                })) &&
+                                $au0(
+                                    input.items,
+                                    _path + ".items",
+                                    true && _exceptionable,
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                })) &&
+                            (undefined === input.minItems ||
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         })) &&
-                                    (0 <= input.minLength ||
+                                    (0 <= input.minItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "(number | undefined)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 })) &&
-                            (undefined === input.maxLength ||
-                                ("number" === typeof input.maxLength &&
-                                    Number.isFinite(input.maxLength) &&
-                                    (parseInt(input.maxLength) ===
-                                        input.maxLength ||
+                            (undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         })) &&
-                                    (0 <= input.maxLength ||
+                                    (0 <= input.maxItems ||
                                         $guard(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         }))) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "(number | undefined)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 })) &&
-                            (undefined === input.pattern ||
-                                "string" === typeof input.pattern ||
+                            (undefined === input["x-typia-tuple"] ||
+                                ((("object" === typeof input["x-typia-tuple"] &&
+                                    null !== input["x-typia-tuple"]) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + '["x-typia-tuple"]',
+                                        expected:
+                                            "(IJsonSchema.ITuple | undefined)",
+                                        value: input["x-typia-tuple"],
+                                    })) &&
+                                    $ao26(
+                                        input["x-typia-tuple"],
+                                        _path + '["x-typia-tuple"]',
+                                        true && _exceptionable,
+                                    )) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".pattern",
-                                    expected: "(string | undefined)",
-                                    value: input.pattern,
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
                                 })) &&
-                            (undefined === input.format ||
-                                "string" === typeof input.format ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".format",
-                                    expected: "(string | undefined)",
-                                    value: input.format,
-                                })) &&
-                            (undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["default"]',
-                                    expected: "(string | undefined)",
-                                    value: input["default"],
-                                })) &&
-                            ("string" === input.type ||
+                            ("array" === input.type ||
                                 $guard(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"array"',
                                     value: input.type,
                                 })) &&
                             (undefined === input.nullable ||
@@ -6253,45 +6337,68 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((("object" === typeof input.items &&
-                                null !== input.items &&
-                                false === Array.isArray(input.items)) ||
+                            (((Array.isArray(input.items) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 })) &&
-                                $au0(
-                                    input.items,
-                                    _path + ".items",
-                                    true && _exceptionable,
+                                input.items.every(
+                                    (elem: any, _index56: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem &&
+                                            false === Array.isArray(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                expected:
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                value: elem,
+                                            })) &&
+                                            $au0(
+                                                elem,
+                                                _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index56 +
+                                                "]",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            value: elem,
+                                        }),
                                 )) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 })) &&
-                            (undefined === input.minItems ||
-                                ("number" === typeof input.minItems &&
-                                    Number.isFinite(input.minItems) &&
-                                    (parseInt(input.minItems) ===
-                                        input.minItems ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        })) &&
-                                    (0 <= input.minItems ||
-                                        $guard(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        }))) ||
+                            (("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
-                                    expected: "(number | undefined)",
+                                    expected: "number",
                                     value: input.minItems,
                                 })) &&
                             (undefined === input.maxItems ||
@@ -6314,26 +6421,6 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     path: _path + ".maxItems",
                                     expected: "(number | undefined)",
                                     value: input.maxItems,
-                                })) &&
-                            (undefined === input["x-typia-tuple"] ||
-                                ((("object" === typeof input["x-typia-tuple"] &&
-                                    null !== input["x-typia-tuple"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-tuple"]',
-                                        expected:
-                                            "(IJsonSchema.ITuple | undefined)",
-                                        value: input["x-typia-tuple"],
-                                    })) &&
-                                    $ao26(
-                                        input["x-typia-tuple"],
-                                        _path + '["x-typia-tuple"]',
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
                                 })) &&
                             ("array" === input.type ||
                                 $guard(_exceptionable, {
@@ -6378,14 +6465,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index56: number) =>
+                                        (elem: any, _index57: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6395,7 +6482,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6403,7 +6490,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6425,14 +6512,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index57: number) =>
+                                        (elem: any, _index58: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6441,7 +6528,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6449,7 +6536,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6503,63 +6590,50 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((Array.isArray(input.items) ||
+                            (((Array.isArray(input.oneOf) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
+                                    value: input.oneOf,
                                 })) &&
-                                input.items.every(
-                                    (elem: any, _index58: number) =>
+                                input.oneOf.every(
+                                    (elem: any, _index59: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem)) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $au0(
                                                 elem,
                                                 _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
-                                                ".items[" +
-                                                _index58 +
+                                                ".oneOf[" +
+                                                _index59 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
-                                })) &&
-                            ("array" === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"array"',
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
+                                    value: input.oneOf,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -6591,14 +6665,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         value: input["x-typia-metaTags"],
                                     })) &&
                                     input["x-typia-metaTags"].every(
-                                        (elem: any, _index59: number) =>
+                                        (elem: any, _index60: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6608,7 +6682,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6616,7 +6690,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6638,14 +6712,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         value: input["x-typia-jsDocTags"],
                                     })) &&
                                     input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index60: number) =>
+                                        (elem: any, _index61: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $guard(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6654,7 +6728,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6662,7 +6736,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6716,50 +6790,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            (((Array.isArray(input.oneOf) ||
+                            ("string" === typeof input.$ref ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
-                                })) &&
-                                input.oneOf.every(
-                                    (elem: any, _index61: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem &&
-                                            false === Array.isArray(elem)) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                value: elem,
-                                            })) &&
-                                            $au0(
-                                                elem,
-                                                _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".oneOf[" +
-                                                _index61 +
-                                                "]",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                            value: elem,
-                                        }),
-                                )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
+                                    path: _path + ".$ref",
+                                    expected: "string",
+                                    value: input.$ref,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -6916,11 +6951,11 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("string" === typeof input.$ref ||
+                            ("null" === input.type ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".$ref",
-                                    expected: "string",
-                                    value: input.$ref,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7077,11 +7112,17 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
-                            ("string" === typeof input.$recursiveRef ||
+                            (null !== input.type ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
+                                })) &&
+                            (undefined === input.type ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
                                 })) &&
                             (undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7233,334 +7274,6 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     expected: "(boolean | undefined)",
                                     value: input.$recursiveAnchor,
                                 }));
-                        const $ao48 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            ("null" === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"null"',
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                })) &&
-                            (undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                })) &&
-                            (undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"].every(
-                                        (elem: any, _index68: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $au1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                            (undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index69: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $ao17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                            (undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                })) &&
-                            (undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                })) &&
-                            (undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                })) &&
-                            (undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                })) &&
-                            (undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }));
-                        const $ao49 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            (null !== input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.type ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                            (undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                })) &&
-                            (undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                })) &&
-                            (undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                })) &&
-                            (undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"].every(
-                                        (elem: any, _index70: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $au1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                            (undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"].every(
-                                        (elem: any, _index71: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $guard(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $ao17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                            (undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                })) &&
-                            (undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                })) &&
-                            (undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                })) &&
-                            (undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                })) &&
-                            (undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }));
                         const $au0 = (
                             input: any,
                             _path: string,
@@ -7591,7 +7304,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 if (
                                     Array.isArray(input.items) &&
                                     input.items.every(
-                                        (elem: any, _index72: number) =>
+                                        (elem: any, _index68: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -7599,7 +7312,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index72 +
+                                                    _index68 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
@@ -7622,14 +7335,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         _path,
                                         true && _exceptionable,
                                     );
-                                if (undefined !== input.$recursiveRef)
-                                    return $ao29(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
                                 if ("null" === input.type)
-                                    return $ao30(
+                                    return $ao29(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -7665,7 +7372,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $ao31(
+                                    $ao30(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -7788,13 +7495,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         ): any =>
                             (() => {
                                 if ("object" === input.type)
-                                    return $ao34(
+                                    return $ao33(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("integer" === input.type)
-                                    return $ao40(
+                                    return $ao39(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -7809,7 +7516,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         false && _exceptionable,
                                     )
                                 )
-                                    return $ao43(
+                                    return $ao42(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -7817,7 +7524,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 if (
                                     Array.isArray(input.items) &&
                                     input.items.every(
-                                        (elem: any, _index73: number) =>
+                                        (elem: any, _index69: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -7825,47 +7532,36 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index73 +
+                                                    _index69 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
                                     )
                                 )
-                                    return $ao44(
+                                    return $ao43(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.oneOf)
-                                    return $ao45(
+                                    return $ao44(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.$ref)
-                                    return $ao46(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
-                                if (undefined !== input.$recursiveRef)
-                                    return $ao47(
+                                    return $ao45(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("null" === input.type)
-                                    return $ao48(
+                                    return $ao46(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 return (
-                                    $ao38(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
                                     $ao37(
                                         input,
                                         _path,
@@ -7876,7 +7572,17 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $ao39(
+                                    $ao35(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $ao38(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $ao40(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -7886,12 +7592,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $ao42(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
-                                    $ao49(
+                                    $ao47(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -8344,6 +8045,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -8443,36 +8151,6 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -8502,7 +8180,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -8533,13 +8211,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -8552,23 +8230,21 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -8598,7 +8274,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -8608,7 +8284,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -8621,7 +8297,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -8663,7 +8339,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "number" === typeof elem,
@@ -8705,7 +8381,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -8747,7 +8423,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -8785,7 +8461,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             parseInt(input.minimum) === input.minimum)) &&
@@ -8836,7 +8512,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         "number" === typeof input.minimum) &&
                     (undefined === input.maximum ||
@@ -8884,7 +8560,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             parseInt(input.minLength) === input.minLength &&
@@ -8934,7 +8610,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -8986,7 +8662,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -8995,6 +8671,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9030,7 +8713,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -9071,7 +8754,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -9105,41 +8788,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -9173,7 +8822,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -9231,9 +8880,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (
                             $io20(input) ||
                             $io19(input) ||
@@ -9241,7 +8888,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             $io21(input) ||
                             $io23(input) ||
                             $io24(input) ||
-                            $io31(input)
+                            $io30(input)
                         );
                     })();
                 const $iu1 = (input: any): any =>
@@ -9267,15 +8914,15 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -9286,20 +8933,18 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (
-                            $io38(input) ||
                             $io37(input) ||
                             $io36(input) ||
-                            $io39(input) ||
+                            $io35(input) ||
+                            $io38(input) ||
+                            $io40(input) ||
                             $io41(input) ||
-                            $io42(input) ||
-                            $io49(input)
+                            $io47(input)
                         );
                     })();
                 const $string = (typia.assertStringify as any).string;
@@ -9310,7 +8955,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                 const $so0 = (input: any): any =>
                     `{"schemas":${`[${input.schemas
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"components":${$so32(
+                        .join(",")}]`},"components":${$so31(
                         input.components,
                     )},"purpose":${(() => {
                         if ("string" === typeof input.purpose)
@@ -10421,6 +10066,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     })()}}`;
                 const $so26 = (input: any): any =>
                     `{${
+                        undefined === input.maxItems
+                            ? ""
+                            : `"maxItems":${
+                                  undefined !== input.maxItems
+                                      ? $number(input.maxItems)
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.nullable
                             ? ""
                             : `"nullable":${
@@ -10498,7 +10151,9 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                               },`
                     }"items":${`[${input.items
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"type":${(() => {
+                        .join(",")}]`},"minItems":${$number(
+                        input.minItems,
+                    )},"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
                         if ("string" === typeof input.type)
@@ -10719,76 +10374,6 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                       ? input["x-typia-rest"]
                                       : undefined
                               },`
-                    }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-                const $so30 = (input: any): any =>
-                    `{${
-                        undefined === input.deprecated
-                            ? ""
-                            : `"deprecated":${
-                                  undefined !== input.deprecated
-                                      ? input.deprecated
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.title
-                            ? ""
-                            : `"title":${
-                                  undefined !== input.title
-                                      ? $string(input.title)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.description
-                            ? ""
-                            : `"description":${
-                                  undefined !== input.description
-                                      ? $string(input.description)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-metaTags"]
-                            ? ""
-                            : `"x-typia-metaTags":${
-                                  undefined !== input["x-typia-metaTags"]
-                                      ? `[${input["x-typia-metaTags"]
-                                            .map((elem: any) => $su1(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-jsDocTags"]
-                            ? ""
-                            : `"x-typia-jsDocTags":${
-                                  undefined !== input["x-typia-jsDocTags"]
-                                      ? `[${input["x-typia-jsDocTags"]
-                                            .map((elem: any) => $so17(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-required"]
-                            ? ""
-                            : `"x-typia-required":${
-                                  undefined !== input["x-typia-required"]
-                                      ? input["x-typia-required"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-optional"]
-                            ? ""
-                            : `"x-typia-optional":${
-                                  undefined !== input["x-typia-optional"]
-                                      ? input["x-typia-optional"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-rest"]
-                            ? ""
-                            : `"x-typia-rest":${
-                                  undefined !== input["x-typia-rest"]
-                                      ? input["x-typia-rest"]
-                                      : undefined
-                              },`
                     }"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
@@ -10799,7 +10384,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so31 = (input: any): any =>
+                const $so30 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.deprecated
@@ -10871,19 +10456,19 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                   }`
                         }`,
                     )}}`;
-                const $so32 = (input: any): any =>
+                const $so31 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.schemas
                                 ? ""
                                 : `"schemas":${
                                       undefined !== input.schemas
-                                          ? $so33(input.schemas)
+                                          ? $so32(input.schemas)
                                           : undefined
                                   }`
                         }`,
                     )}}`;
-                const $so33 = (input: any): any =>
+                const $so32 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
@@ -10891,21 +10476,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;
-                const $so34 = (input: any): any =>
+                const $so33 = (input: any): any =>
                     `{${
                         undefined === input.$id
                             ? ""
                             : `"$id":${
                                   undefined !== input.$id
                                       ? $string(input.$id)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$recursiveAnchor
-                            ? ""
-                            : `"$recursiveAnchor":${
-                                  undefined !== input.$recursiveAnchor
-                                      ? input.$recursiveAnchor
                                       : undefined
                               },`
                     }${
@@ -10921,7 +10498,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             ? ""
                             : `"patternProperties":${
                                   undefined !== input.patternProperties
-                                      ? $so35(input.patternProperties)
+                                      ? $so34(input.patternProperties)
                                       : undefined
                               },`
                     }${
@@ -10966,7 +10543,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             : `"x-typia-patternProperties":${
                                   undefined !==
                                   input["x-typia-patternProperties"]
-                                      ? $so35(
+                                      ? $so34(
                                             input["x-typia-patternProperties"],
                                         )
                                       : undefined
@@ -10993,8 +10570,8 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             expected: '"object"',
                             value: input.type,
                         });
-                    })()},"properties":${$so35(input.properties)}}`;
-                const $so35 = (input: any): any =>
+                    })()},"properties":${$so34(input.properties)}}`;
+                const $so34 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
@@ -11002,7 +10579,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;
-                const $so36 = (input: any): any =>
+                const $so35 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -11115,7 +10692,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so37 = (input: any): any =>
+                const $so36 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -11228,7 +10805,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so38 = (input: any): any =>
+                const $so37 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -11341,7 +10918,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so39 = (input: any): any =>
+                const $so38 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -11452,7 +11029,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so40 = (input: any): any =>
+                const $so39 = (input: any): any =>
                     `{${
                         undefined === input.minimum
                             ? ""
@@ -11603,7 +11180,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so41 = (input: any): any =>
+                const $so40 = (input: any): any =>
                     `{${
                         undefined === input.minimum
                             ? ""
@@ -11754,7 +11331,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so42 = (input: any): any =>
+                const $so41 = (input: any): any =>
                     `{${
                         undefined === input.minLength
                             ? ""
@@ -11897,7 +11474,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so43 = (input: any): any =>
+                const $so42 = (input: any): any =>
                     `{${
                         undefined === input.minItems
                             ? ""
@@ -12024,8 +11601,16 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so44 = (input: any): any =>
+                const $so43 = (input: any): any =>
                     `{${
+                        undefined === input.maxItems
+                            ? ""
+                            : `"maxItems":${
+                                  undefined !== input.maxItems
+                                      ? $number(input.maxItems)
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.nullable
                             ? ""
                             : `"nullable":${
@@ -12119,7 +11704,9 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                               },`
                     }"items":${`[${input.items
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"type":${(() => {
+                        .join(",")}]`},"minItems":${$number(
+                        input.minItems,
+                    )},"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
                         if ("string" === typeof input.type)
@@ -12129,7 +11716,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so45 = (input: any): any =>
+                const $so44 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -12217,7 +11804,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     }"oneOf":${`[${input.oneOf
                         .map((elem: any) => $su0(elem))
                         .join(",")}]`}}`;
-                const $so46 = (input: any): any =>
+                const $so45 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -12303,93 +11890,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                       : undefined
                               },`
                     }"$ref":${$string(input.$ref)}}`;
-                const $so47 = (input: any): any =>
-                    `{${
-                        undefined === input.deprecated
-                            ? ""
-                            : `"deprecated":${
-                                  undefined !== input.deprecated
-                                      ? input.deprecated
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.title
-                            ? ""
-                            : `"title":${
-                                  undefined !== input.title
-                                      ? $string(input.title)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.description
-                            ? ""
-                            : `"description":${
-                                  undefined !== input.description
-                                      ? $string(input.description)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-metaTags"]
-                            ? ""
-                            : `"x-typia-metaTags":${
-                                  undefined !== input["x-typia-metaTags"]
-                                      ? `[${input["x-typia-metaTags"]
-                                            .map((elem: any) => $su1(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-jsDocTags"]
-                            ? ""
-                            : `"x-typia-jsDocTags":${
-                                  undefined !== input["x-typia-jsDocTags"]
-                                      ? `[${input["x-typia-jsDocTags"]
-                                            .map((elem: any) => $so17(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-required"]
-                            ? ""
-                            : `"x-typia-required":${
-                                  undefined !== input["x-typia-required"]
-                                      ? input["x-typia-required"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-optional"]
-                            ? ""
-                            : `"x-typia-optional":${
-                                  undefined !== input["x-typia-optional"]
-                                      ? input["x-typia-optional"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-rest"]
-                            ? ""
-                            : `"x-typia-rest":${
-                                  undefined !== input["x-typia-rest"]
-                                      ? input["x-typia-rest"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$id
-                            ? ""
-                            : `"$id":${
-                                  undefined !== input.$id
-                                      ? $string(input.$id)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$recursiveAnchor
-                            ? ""
-                            : `"$recursiveAnchor":${
-                                  undefined !== input.$recursiveAnchor
-                                      ? input.$recursiveAnchor
-                                      : undefined
-                              },`
-                    }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-                const $so48 = (input: any): any =>
+                const $so46 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -12484,7 +11985,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so49 = (input: any): any =>
+                const $so47 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.deprecated
@@ -12595,9 +12096,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             return $so26(input);
                         if (undefined !== input.oneOf) return $so27(input);
                         if (undefined !== input.$ref) return $so28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $so29(input);
-                        if ("null" === input.type) return $so30(input);
+                        if ("null" === input.type) return $so29(input);
                         return (() => {
                             if ($io20(input)) return $so20(input);
                             if ($io19(input)) return $so19(input);
@@ -12605,7 +12104,7 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             if ($io21(input)) return $so21(input);
                             if ($io23(input)) return $so23(input);
                             if ($io24(input)) return $so24(input);
-                            if ($io31(input)) return $so31(input);
+                            if ($io30(input)) return $so30(input);
                             $throws({
                                 expected:
                                     '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -12640,15 +12139,15 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     })();
                 const $su2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $so34(input);
-                        if ("integer" === input.type) return $so40(input);
+                        if ("object" === input.type) return $so33(input);
+                        if ("integer" === input.type) return $so39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $so43(input);
+                            return $so42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -12659,20 +12158,18 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     $iu0(elem),
                             )
                         )
-                            return $so44(input);
-                        if (undefined !== input.oneOf) return $so45(input);
-                        if (undefined !== input.$ref) return $so46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $so47(input);
-                        if ("null" === input.type) return $so48(input);
+                            return $so43(input);
+                        if (undefined !== input.oneOf) return $so44(input);
+                        if (undefined !== input.$ref) return $so45(input);
+                        if ("null" === input.type) return $so46(input);
                         return (() => {
-                            if ($io38(input)) return $so38(input);
                             if ($io37(input)) return $so37(input);
                             if ($io36(input)) return $so36(input);
-                            if ($io39(input)) return $so39(input);
+                            if ($io35(input)) return $so35(input);
+                            if ($io38(input)) return $so38(input);
+                            if ($io40(input)) return $so40(input);
                             if ($io41(input)) return $so41(input);
-                            if ($io42(input)) return $so42(input);
-                            if ($io49(input)) return $so49(input);
+                            if ($io47(input)) return $so47(input);
                             $throws({
                                 expected:
                                     '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/clone/test_clone_UltimateUnion.ts
+++ b/test/generated/output/clone/test_clone_UltimateUnion.ts
@@ -398,6 +398,13 @@ export const test_clone_UltimateUnion = _test_clone(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -497,36 +504,6 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -556,7 +533,7 @@ export const test_clone_UltimateUnion = _test_clone(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -587,13 +564,13 @@ export const test_clone_UltimateUnion = _test_clone(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -606,22 +583,20 @@ export const test_clone_UltimateUnion = _test_clone(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -647,7 +622,7 @@ export const test_clone_UltimateUnion = _test_clone(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -657,7 +632,7 @@ export const test_clone_UltimateUnion = _test_clone(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -670,7 +645,7 @@ export const test_clone_UltimateUnion = _test_clone(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -709,7 +684,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "number" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -748,7 +723,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -787,7 +762,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -824,7 +799,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         parseInt(input.minimum) === input.minimum)) &&
@@ -874,7 +849,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     "number" === typeof input.minimum) &&
                 (undefined === input.maximum ||
@@ -921,7 +896,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         parseInt(input.minLength) === input.minLength &&
@@ -970,7 +945,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -1021,7 +996,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -1030,6 +1005,13 @@ export const test_clone_UltimateUnion = _test_clone(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1064,7 +1046,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -1104,7 +1086,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1137,40 +1119,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1203,7 +1152,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -1260,8 +1209,7 @@ export const test_clone_UltimateUnion = _test_clone(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (
                         $io20(input) ||
                         $io19(input) ||
@@ -1269,7 +1217,7 @@ export const test_clone_UltimateUnion = _test_clone(
                         $io21(input) ||
                         $io23(input) ||
                         $io24(input) ||
-                        $io31(input)
+                        $io30(input)
                     );
                 })();
             const $iu1 = (input: any): any =>
@@ -1293,15 +1241,15 @@ export const test_clone_UltimateUnion = _test_clone(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -1312,19 +1260,18 @@ export const test_clone_UltimateUnion = _test_clone(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (
-                        $io38(input) ||
                         $io37(input) ||
                         $io36(input) ||
-                        $io39(input) ||
+                        $io35(input) ||
+                        $io38(input) ||
+                        $io40(input) ||
                         $io41(input) ||
-                        $io42(input) ||
-                        $io49(input)
+                        $io47(input)
                     );
                 })();
             const $join = (typia.clone as any).join;
@@ -1369,7 +1316,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 components:
                     "object" === typeof input.components &&
                     null !== input.components
-                        ? $co32(input.components)
+                        ? $co31(input.components)
                         : (input.components as any),
                 purpose: input.purpose as any,
             });
@@ -1616,6 +1563,8 @@ export const test_clone_UltimateUnion = _test_clone(
                 items: Array.isArray(input.items)
                     ? $cp1(input.items)
                     : (input.items as any),
+                minItems: input.minItems as any,
+                maxItems: input.maxItems as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 deprecated: input.deprecated as any,
@@ -1664,7 +1613,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 "x-typia-rest": input["x-typia-rest"] as any,
             });
             const $co29 = (input: any): any => ({
-                $recursiveRef: input.$recursiveRef as any,
+                type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
                 description: input.description as any,
@@ -1694,27 +1643,12 @@ export const test_clone_UltimateUnion = _test_clone(
                 "x-typia-rest": input["x-typia-rest"] as any,
             });
             const $co31 = (input: any): any => ({
-                type: input.type as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-            });
-            const $co32 = (input: any): any => ({
                 schemas:
                     "object" === typeof input.schemas && null !== input.schemas
-                        ? $co33(input.schemas)
+                        ? $co32(input.schemas)
                         : (input.schemas as any),
             });
-            const $co33 = (input: any): any => {
+            const $co32 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
                     if (RegExp(/(.*)/).test(key)) {
@@ -1727,20 +1661,19 @@ export const test_clone_UltimateUnion = _test_clone(
                 }
                 return output;
             };
-            const $co34 = (input: any): any => ({
+            const $co33 = (input: any): any => ({
                 $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 properties:
                     "object" === typeof input.properties &&
                     null !== input.properties
-                        ? $co35(input.properties)
+                        ? $co34(input.properties)
                         : (input.properties as any),
                 patternProperties:
                     "object" === typeof input.patternProperties &&
                     null !== input.patternProperties
-                        ? $co35(input.patternProperties)
+                        ? $co34(input.patternProperties)
                         : (input.patternProperties as any),
                 additionalProperties:
                     "object" === typeof input.additionalProperties &&
@@ -1757,7 +1690,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 "x-typia-patternProperties":
                     "object" === typeof input["x-typia-patternProperties"] &&
                     null !== input["x-typia-patternProperties"]
-                        ? $co35(input["x-typia-patternProperties"])
+                        ? $co34(input["x-typia-patternProperties"])
                         : (input["x-typia-patternProperties"] as any),
                 "x-typia-additionalProperties":
                     "object" === typeof input["x-typia-additionalProperties"] &&
@@ -1765,7 +1698,7 @@ export const test_clone_UltimateUnion = _test_clone(
                         ? $cu0(input["x-typia-additionalProperties"])
                         : (input["x-typia-additionalProperties"] as any),
             });
-            const $co35 = (input: any): any => {
+            const $co34 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
                     if (RegExp(/(.*)/).test(key)) {
@@ -1778,7 +1711,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 }
                 return output;
             };
-            const $co36 = (input: any): any => ({
+            const $co35 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp2(input["enum"])
                     : (input["enum"] as any),
@@ -1800,7 +1733,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co37 = (input: any): any => ({
+            const $co36 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp6(input["enum"])
                     : (input["enum"] as any),
@@ -1822,7 +1755,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co38 = (input: any): any => ({
+            const $co37 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp7(input["enum"])
                     : (input["enum"] as any),
@@ -1844,7 +1777,31 @@ export const test_clone_UltimateUnion = _test_clone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
+            const $co38 = (input: any): any => ({
+                default: input["default"] as any,
+                type: input.type as any,
+                nullable: input.nullable as any,
+                deprecated: input.deprecated as any,
+                title: input.title as any,
+                description: input.description as any,
+                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
+                    ? $cp3(input["x-typia-metaTags"])
+                    : (input["x-typia-metaTags"] as any),
+                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
+                    ? $cp4(input["x-typia-jsDocTags"])
+                    : (input["x-typia-jsDocTags"] as any),
+                "x-typia-required": input["x-typia-required"] as any,
+                "x-typia-optional": input["x-typia-optional"] as any,
+                "x-typia-rest": input["x-typia-rest"] as any,
+                $id: input.$id as any,
+                $recursiveAnchor: input.$recursiveAnchor as any,
+            });
             const $co39 = (input: any): any => ({
+                minimum: input.minimum as any,
+                maximum: input.maximum as any,
+                exclusiveMinimum: input.exclusiveMinimum as any,
+                exclusiveMaximum: input.exclusiveMaximum as any,
+                multipleOf: input.multipleOf as any,
                 default: input["default"] as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
@@ -1888,30 +1845,6 @@ export const test_clone_UltimateUnion = _test_clone(
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
             const $co41 = (input: any): any => ({
-                minimum: input.minimum as any,
-                maximum: input.maximum as any,
-                exclusiveMinimum: input.exclusiveMinimum as any,
-                exclusiveMaximum: input.exclusiveMaximum as any,
-                multipleOf: input.multipleOf as any,
-                default: input["default"] as any,
-                type: input.type as any,
-                nullable: input.nullable as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-                $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
-            });
-            const $co42 = (input: any): any => ({
                 minLength: input.minLength as any,
                 maxLength: input.maxLength as any,
                 pattern: input.pattern as any,
@@ -1934,7 +1867,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co43 = (input: any): any => ({
+            const $co42 = (input: any): any => ({
                 items:
                     "object" === typeof input.items && null !== input.items
                         ? $cu0(input.items)
@@ -1963,10 +1896,12 @@ export const test_clone_UltimateUnion = _test_clone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co44 = (input: any): any => ({
+            const $co43 = (input: any): any => ({
                 items: Array.isArray(input.items)
                     ? $cp1(input.items)
                     : (input.items as any),
+                minItems: input.minItems as any,
+                maxItems: input.maxItems as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 deprecated: input.deprecated as any,
@@ -1984,7 +1919,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co45 = (input: any): any => ({
+            const $co44 = (input: any): any => ({
                 oneOf: Array.isArray(input.oneOf)
                     ? $cp1(input.oneOf)
                     : (input.oneOf as any),
@@ -2003,7 +1938,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co46 = (input: any): any => ({
+            const $co45 = (input: any): any => ({
                 $ref: input.$ref as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -2020,24 +1955,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co47 = (input: any): any => ({
-                $recursiveRef: input.$recursiveRef as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-                $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
-            });
-            const $co48 = (input: any): any => ({
+            const $co46 = (input: any): any => ({
                 type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -2054,7 +1972,7 @@ export const test_clone_UltimateUnion = _test_clone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co49 = (input: any): any => ({
+            const $co47 = (input: any): any => ({
                 type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -2094,8 +2012,7 @@ export const test_clone_UltimateUnion = _test_clone(
                         return $co26(input);
                     if (undefined !== input.oneOf) return $co27(input);
                     if (undefined !== input.$ref) return $co28(input);
-                    if (undefined !== input.$recursiveRef) return $co29(input);
-                    if ("null" === input.type) return $co30(input);
+                    if ("null" === input.type) return $co29(input);
                     return (() => {
                         if ($io20(input)) return $co20(input);
                         if ($io19(input)) return $co19(input);
@@ -2103,7 +2020,7 @@ export const test_clone_UltimateUnion = _test_clone(
                         if ($io21(input)) return $co21(input);
                         if ($io23(input)) return $co23(input);
                         if ($io24(input)) return $co24(input);
-                        if ($io31(input)) return $co31(input);
+                        if ($io30(input)) return $co30(input);
                         $throws({
                             expected:
                                 '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -2136,15 +2053,15 @@ export const test_clone_UltimateUnion = _test_clone(
                 })();
             const $cu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $co34(input);
-                    if ("integer" === input.type) return $co40(input);
+                    if ("object" === input.type) return $co33(input);
+                    if ("integer" === input.type) return $co39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $co43(input);
+                        return $co42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -2155,19 +2072,18 @@ export const test_clone_UltimateUnion = _test_clone(
                                 $iu0(elem),
                         )
                     )
-                        return $co44(input);
-                    if (undefined !== input.oneOf) return $co45(input);
-                    if (undefined !== input.$ref) return $co46(input);
-                    if (undefined !== input.$recursiveRef) return $co47(input);
-                    if ("null" === input.type) return $co48(input);
+                        return $co43(input);
+                    if (undefined !== input.oneOf) return $co44(input);
+                    if (undefined !== input.$ref) return $co45(input);
+                    if ("null" === input.type) return $co46(input);
                     return (() => {
-                        if ($io38(input)) return $co38(input);
                         if ($io37(input)) return $co37(input);
                         if ($io36(input)) return $co36(input);
-                        if ($io39(input)) return $co39(input);
+                        if ($io35(input)) return $co35(input);
+                        if ($io38(input)) return $co38(input);
+                        if ($io40(input)) return $co40(input);
                         if ($io41(input)) return $co41(input);
-                        if ($io42(input)) return $co42(input);
-                        if ($io49(input)) return $co49(input);
+                        if ($io47(input)) return $co47(input);
                         $throws({
                             expected:
                                 '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/createAssert/test_createAssert_UltimateUnion.ts
+++ b/test/generated/output/createAssert/test_createAssert_UltimateUnion.ts
@@ -20,7 +20,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 "object" === typeof input.components &&
                 null !== input.components &&
                 false === Array.isArray(input.components) &&
-                $io32(input.components) &&
+                $io31(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose);
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
@@ -449,6 +449,15 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -548,36 +557,6 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -607,7 +586,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -638,13 +617,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -657,22 +636,20 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -698,7 +675,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -708,7 +685,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -721,7 +698,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -760,7 +737,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every(
                     (elem: any) =>
@@ -803,7 +780,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -842,7 +819,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -879,7 +856,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
@@ -933,7 +910,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum))) &&
@@ -984,7 +961,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
@@ -1035,7 +1012,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -1088,7 +1065,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -1097,6 +1074,15 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1131,7 +1117,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -1171,7 +1157,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1204,40 +1190,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1270,7 +1223,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -1327,8 +1280,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (() => {
                         if ($io20(input)) return $io20(input);
                         if ($io19(input)) return $io19(input);
@@ -1336,7 +1288,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         if ($io21(input)) return $io21(input);
                         if ($io23(input)) return $io23(input);
                         if ($io24(input)) return $io24(input);
-                        if ($io31(input)) return $io31(input);
+                        if ($io30(input)) return $io30(input);
                         return false;
                     })();
                 })();
@@ -1361,15 +1313,15 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -1380,19 +1332,18 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (() => {
-                        if ($io38(input)) return $io38(input);
                         if ($io37(input)) return $io37(input);
                         if ($io36(input)) return $io36(input);
-                        if ($io39(input)) return $io39(input);
+                        if ($io35(input)) return $io35(input);
+                        if ($io38(input)) return $io38(input);
+                        if ($io40(input)) return $io40(input);
                         if ($io41(input)) return $io41(input);
-                        if ($io42(input)) return $io42(input);
-                        if ($io49(input)) return $io49(input);
+                        if ($io47(input)) return $io47(input);
                         return false;
                     })();
                 })();
@@ -1432,7 +1383,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path + ".schemas[" + _index2 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
@@ -1443,7 +1394,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 $guard(_exceptionable, {
                                     path: _path + ".schemas[" + _index2 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
@@ -1460,7 +1411,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: "IJsonComponents",
                             value: input.components,
                         })) &&
-                        $ao32(
+                        $ao31(
                             input.components,
                             _path + ".components",
                             true && _exceptionable,
@@ -3126,7 +3077,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                             value: input.items,
                         })) &&
                         $au0(
@@ -3137,7 +3088,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                             value: input.items,
                         })) &&
                     (undefined === input.minItems ||
@@ -3361,7 +3312,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path + ".items[" + _index23 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
@@ -3372,7 +3323,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 $guard(_exceptionable, {
                                     path: _path + ".items[" + _index23 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
@@ -3380,6 +3331,45 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             path: _path + ".items",
                             expected: "Array<IJsonSchema>",
                             value: input.items,
+                        })) &&
+                    (("number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        (parseInt(input.minItems) === input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            })) &&
+                        (0 <= input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minItems",
+                            expected: "number",
+                            value: input.minItems,
+                        })) &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            (parseInt(input.maxItems) === input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maxItems",
+                            expected: "(number | undefined)",
+                            value: input.maxItems,
                         })) &&
                     ("array" === input.type ||
                         $guard(_exceptionable, {
@@ -3544,7 +3534,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path + ".oneOf[" + _index26 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
@@ -3555,7 +3545,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 $guard(_exceptionable, {
                                     path: _path + ".oneOf[" + _index26 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
@@ -3840,11 +3830,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("string" === typeof input.$recursiveRef ||
+                    ("null" === input.type ||
                         $guard(_exceptionable, {
-                            path: _path + ".$recursiveRef",
-                            expected: "string",
-                            value: input.$recursiveRef,
+                            path: _path + ".type",
+                            expected: '"null"',
+                            value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -3981,10 +3971,16 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("null" === input.type ||
+                    (null !== input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"null"',
+                            expected: "undefined",
+                            value: input.type,
+                        })) &&
+                    (undefined === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: "undefined",
                             value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
@@ -4122,31 +4118,171 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (null !== input.type ||
+                    undefined === input.schemas ||
+                    ((("object" === typeof input.schemas &&
+                        null !== input.schemas &&
+                        false === Array.isArray(input.schemas)) ||
                         $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
+                            path: _path + ".schemas",
+                            expected:
+                                "(Record<string, IObject | IAlias> | undefined)",
+                            value: input.schemas,
                         })) &&
-                    (undefined === input.type ||
+                        $ao32(
+                            input.schemas,
+                            _path + ".schemas",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".schemas",
+                        expected:
+                            "(Record<string, IObject | IAlias> | undefined)",
+                        value: input.schemas,
+                    });
+                const $ao32 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    false === _exceptionable ||
+                    Object.keys(input).every((key: any) => {
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        if (RegExp(/(.*)/).test(key))
+                            return (
+                                ((("object" === typeof value &&
+                                    null !== value &&
+                                    false === Array.isArray(value)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected:
+                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                        value: value,
+                                    })) &&
+                                    $au2(
+                                        value,
+                                        _path + $join(key),
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + $join(key),
+                                    expected:
+                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                    value: value,
+                                })
+                            );
+                        return true;
+                    });
+                const $ao33 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.$id ||
+                        "string" === typeof input.$id ||
                         $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
-                        })) &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated ||
-                        $guard(_exceptionable, {
-                            path: _path + ".deprecated",
-                            expected: "(boolean | undefined)",
-                            value: input.deprecated,
-                        })) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title ||
-                        $guard(_exceptionable, {
-                            path: _path + ".title",
+                            path: _path + ".$id",
                             expected: "(string | undefined)",
-                            value: input.title,
+                            value: input.$id,
+                        })) &&
+                    ("object" === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: '"object"',
+                            value: input.type,
+                        })) &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
+                        $guard(_exceptionable, {
+                            path: _path + ".nullable",
+                            expected: "(boolean | undefined)",
+                            value: input.nullable,
+                        })) &&
+                    (((("object" === typeof input.properties &&
+                        null !== input.properties &&
+                        false === Array.isArray(input.properties)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".properties",
+                            expected: "Record<string, IJsonSchema>",
+                            value: input.properties,
+                        })) &&
+                        $ao34(
+                            input.properties,
+                            _path + ".properties",
+                            true && _exceptionable,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".properties",
+                            expected: "Record<string, IJsonSchema>",
+                            value: input.properties,
+                        })) &&
+                    (undefined === input.patternProperties ||
+                        ((("object" === typeof input.patternProperties &&
+                            null !== input.patternProperties &&
+                            false === Array.isArray(input.patternProperties)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".patternProperties",
+                                expected:
+                                    "(Record<string, IJsonSchema> | undefined)",
+                                value: input.patternProperties,
+                            })) &&
+                            $ao34(
+                                input.patternProperties,
+                                _path + ".patternProperties",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".patternProperties",
+                            expected:
+                                "(Record<string, IJsonSchema> | undefined)",
+                            value: input.patternProperties,
+                        })) &&
+                    (undefined === input.additionalProperties ||
+                        ((("object" === typeof input.additionalProperties &&
+                            null !== input.additionalProperties &&
+                            false ===
+                                Array.isArray(input.additionalProperties)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".additionalProperties",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                value: input.additionalProperties,
+                            })) &&
+                            $au0(
+                                input.additionalProperties,
+                                _path + ".additionalProperties",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".additionalProperties",
+                            expected:
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                            value: input.additionalProperties,
+                        })) &&
+                    (undefined === input.required ||
+                        ((Array.isArray(input.required) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".required",
+                                expected: "(Array<string> | undefined)",
+                                value: input.required,
+                            })) &&
+                            input.required.every(
+                                (elem: any, _index35: number) =>
+                                    "string" === typeof elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".required[" +
+                                            _index35 +
+                                            "]",
+                                        expected: "string",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".required",
+                            expected: "(Array<string> | undefined)",
+                            value: input.required,
                         })) &&
                     (undefined === input.description ||
                         "string" === typeof input.description ||
@@ -4154,51 +4290,6 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             path: _path + ".description",
                             expected: "(string | undefined)",
                             value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        ((Array.isArray(input["x-typia-metaTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any, _index35: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index35 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        })) &&
-                                        $au1(
-                                            elem,
-                                            _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index35 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-metaTags"][' +
-                                            _index35 +
-                                            "]",
-                                        expected:
-                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-metaTags"]',
-                            expected: "(Array<IMetadataTag> | undefined)",
-                            value: input["x-typia-metaTags"],
                         })) &&
                     (undefined === input["x-typia-jsDocTags"] ||
                         ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4243,255 +4334,6 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: "(Array<IJsDocTagInfo> | undefined)",
                             value: input["x-typia-jsDocTags"],
                         })) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-required"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-required"],
-                        })) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-optional"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-optional"],
-                        })) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-rest"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-rest"],
-                        }));
-                const $ao32 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    undefined === input.schemas ||
-                    ((("object" === typeof input.schemas &&
-                        null !== input.schemas &&
-                        false === Array.isArray(input.schemas)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".schemas",
-                            expected:
-                                "(Record<string, IObject | IAlias> | undefined)",
-                            value: input.schemas,
-                        })) &&
-                        $ao33(
-                            input.schemas,
-                            _path + ".schemas",
-                            true && _exceptionable,
-                        )) ||
-                    $guard(_exceptionable, {
-                        path: _path + ".schemas",
-                        expected:
-                            "(Record<string, IObject | IAlias> | undefined)",
-                        value: input.schemas,
-                    });
-                const $ao33 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    false === _exceptionable ||
-                    Object.keys(input).every((key: any) => {
-                        const value = input[key];
-                        if (undefined === value) return true;
-                        if (RegExp(/(.*)/).test(key))
-                            return (
-                                ((("object" === typeof value &&
-                                    null !== value &&
-                                    false === Array.isArray(value)) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + $join(key),
-                                        expected:
-                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                        value: value,
-                                    })) &&
-                                    $au2(
-                                        value,
-                                        _path + $join(key),
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + $join(key),
-                                    expected:
-                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                    value: value,
-                                })
-                            );
-                        return true;
-                    });
-                const $ao34 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$id",
-                            expected: "(string | undefined)",
-                            value: input.$id,
-                        })) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$recursiveAnchor",
-                            expected: "(boolean | undefined)",
-                            value: input.$recursiveAnchor,
-                        })) &&
-                    ("object" === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: '"object"',
-                            value: input.type,
-                        })) &&
-                    (undefined === input.nullable ||
-                        "boolean" === typeof input.nullable ||
-                        $guard(_exceptionable, {
-                            path: _path + ".nullable",
-                            expected: "(boolean | undefined)",
-                            value: input.nullable,
-                        })) &&
-                    (((("object" === typeof input.properties &&
-                        null !== input.properties &&
-                        false === Array.isArray(input.properties)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".properties",
-                            expected: "Record<string, IJsonSchema>",
-                            value: input.properties,
-                        })) &&
-                        $ao35(
-                            input.properties,
-                            _path + ".properties",
-                            true && _exceptionable,
-                        )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".properties",
-                            expected: "Record<string, IJsonSchema>",
-                            value: input.properties,
-                        })) &&
-                    (undefined === input.patternProperties ||
-                        ((("object" === typeof input.patternProperties &&
-                            null !== input.patternProperties &&
-                            false === Array.isArray(input.patternProperties)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".patternProperties",
-                                expected:
-                                    "(Record<string, IJsonSchema> | undefined)",
-                                value: input.patternProperties,
-                            })) &&
-                            $ao35(
-                                input.patternProperties,
-                                _path + ".patternProperties",
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".patternProperties",
-                            expected:
-                                "(Record<string, IJsonSchema> | undefined)",
-                            value: input.patternProperties,
-                        })) &&
-                    (undefined === input.additionalProperties ||
-                        ((("object" === typeof input.additionalProperties &&
-                            null !== input.additionalProperties &&
-                            false ===
-                                Array.isArray(input.additionalProperties)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".additionalProperties",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                value: input.additionalProperties,
-                            })) &&
-                            $au0(
-                                input.additionalProperties,
-                                _path + ".additionalProperties",
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".additionalProperties",
-                            expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                            value: input.additionalProperties,
-                        })) &&
-                    (undefined === input.required ||
-                        ((Array.isArray(input.required) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".required",
-                                expected: "(Array<string> | undefined)",
-                                value: input.required,
-                            })) &&
-                            input.required.every(
-                                (elem: any, _index37: number) =>
-                                    "string" === typeof elem ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            ".required[" +
-                                            _index37 +
-                                            "]",
-                                        expected: "string",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".required",
-                            expected: "(Array<string> | undefined)",
-                            value: input.required,
-                        })) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description ||
-                        $guard(_exceptionable, {
-                            path: _path + ".description",
-                            expected: "(string | undefined)",
-                            value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any, _index38: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index38 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        })) &&
-                                        $ao17(
-                                            elem,
-                                            _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index38 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-jsDocTags"][' +
-                                            _index38 +
-                                            "]",
-                                        expected: "IJsDocTagInfo",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-jsDocTags"]',
-                            expected: "(Array<IJsDocTagInfo> | undefined)",
-                            value: input["x-typia-jsDocTags"],
-                        })) &&
                     (undefined === input["x-typia-patternProperties"] ||
                         ((("object" ===
                             typeof input["x-typia-patternProperties"] &&
@@ -4506,7 +4348,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     "(Record<string, IJsonSchema> | undefined)",
                                 value: input["x-typia-patternProperties"],
                             })) &&
-                            $ao35(
+                            $ao34(
                                 input["x-typia-patternProperties"],
                                 _path + '["x-typia-patternProperties"]',
                                 true && _exceptionable,
@@ -4529,7 +4371,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 path:
                                     _path + '["x-typia-additionalProperties"]',
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                 value: input["x-typia-additionalProperties"],
                             })) &&
                             $au0(
@@ -4540,10 +4382,10 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         $guard(_exceptionable, {
                             path: _path + '["x-typia-additionalProperties"]',
                             expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                             value: input["x-typia-additionalProperties"],
                         }));
-                const $ao35 = (
+                const $ao34 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -4560,7 +4402,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     $guard(_exceptionable, {
                                         path: _path + $join(key),
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: value,
                                     })) &&
                                     $au0(
@@ -4571,13 +4413,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 $guard(_exceptionable, {
                                     path: _path + $join(key),
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: value,
                                 })
                             );
                         return true;
                     });
-                const $ao36 = (
+                const $ao35 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -4589,10 +4431,10 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             value: input["enum"],
                         })) &&
                         input["enum"].every(
-                            (elem: any, _index39: number) =>
+                            (elem: any, _index37: number) =>
                                 "boolean" === typeof elem ||
                                 $guard(_exceptionable, {
-                                    path: _path + '["enum"][' + _index39 + "]",
+                                    path: _path + '["enum"][' + _index37 + "]",
                                     expected: "boolean",
                                     value: elem,
                                 }),
@@ -4651,14 +4493,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index40: number) =>
+                                (elem: any, _index38: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index40 +
+                                                _index38 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4668,7 +4510,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index40 +
+                                                _index38 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -4676,7 +4518,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index40 +
+                                            _index38 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4696,14 +4538,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index41: number) =>
+                                (elem: any, _index39: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index41 +
+                                                _index39 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -4712,7 +4554,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index41 +
+                                                _index39 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -4720,7 +4562,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
-                                            _index41 +
+                                            _index39 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -4766,7 +4608,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: "(boolean | undefined)",
                             value: input.$recursiveAnchor,
                         }));
-                const $ao37 = (
+                const $ao36 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -4778,11 +4620,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             value: input["enum"],
                         })) &&
                         input["enum"].every(
-                            (elem: any, _index42: number) =>
+                            (elem: any, _index40: number) =>
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem)) ||
                                 $guard(_exceptionable, {
-                                    path: _path + '["enum"][' + _index42 + "]",
+                                    path: _path + '["enum"][' + _index40 + "]",
                                     expected: "number",
                                     value: elem,
                                 }),
@@ -4842,14 +4684,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index43: number) =>
+                                (elem: any, _index41: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index43 +
+                                                _index41 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4859,7 +4701,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index43 +
+                                                _index41 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -4867,7 +4709,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index43 +
+                                            _index41 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4887,14 +4729,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index44: number) =>
+                                (elem: any, _index42: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index44 +
+                                                _index42 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -4903,7 +4745,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index44 +
+                                                _index42 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -4911,7 +4753,196 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
+                                            _index42 +
+                                            "]",
+                                        expected: "IJsDocTagInfo",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-jsDocTags"]',
+                            expected: "(Array<IJsDocTagInfo> | undefined)",
+                            value: input["x-typia-jsDocTags"],
+                        })) &&
+                    (undefined === input["x-typia-required"] ||
+                        "boolean" === typeof input["x-typia-required"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-required"]',
+                            expected: "(boolean | undefined)",
+                            value: input["x-typia-required"],
+                        })) &&
+                    (undefined === input["x-typia-optional"] ||
+                        "boolean" === typeof input["x-typia-optional"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-optional"]',
+                            expected: "(boolean | undefined)",
+                            value: input["x-typia-optional"],
+                        })) &&
+                    (undefined === input["x-typia-rest"] ||
+                        "boolean" === typeof input["x-typia-rest"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-rest"]',
+                            expected: "(boolean | undefined)",
+                            value: input["x-typia-rest"],
+                        })) &&
+                    (undefined === input.$id ||
+                        "string" === typeof input.$id ||
+                        $guard(_exceptionable, {
+                            path: _path + ".$id",
+                            expected: "(string | undefined)",
+                            value: input.$id,
+                        })) &&
+                    (undefined === input.$recursiveAnchor ||
+                        "boolean" === typeof input.$recursiveAnchor ||
+                        $guard(_exceptionable, {
+                            path: _path + ".$recursiveAnchor",
+                            expected: "(boolean | undefined)",
+                            value: input.$recursiveAnchor,
+                        }));
+                const $ao37 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (((Array.isArray(input["enum"]) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["enum"]',
+                            expected: "Array<string>",
+                            value: input["enum"],
+                        })) &&
+                        input["enum"].every(
+                            (elem: any, _index43: number) =>
+                                "string" === typeof elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["enum"][' + _index43 + "]",
+                                    expected: "string",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["enum"]',
+                            expected: "Array<string>",
+                            value: input["enum"],
+                        })) &&
+                    (undefined === input["default"] ||
+                        "string" === typeof input["default"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["default"]',
+                            expected: "(string | undefined)",
+                            value: input["default"],
+                        })) &&
+                    ("string" === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: '"string"',
+                            value: input.type,
+                        })) &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
+                        $guard(_exceptionable, {
+                            path: _path + ".nullable",
+                            expected: "(boolean | undefined)",
+                            value: input.nullable,
+                        })) &&
+                    (undefined === input.deprecated ||
+                        "boolean" === typeof input.deprecated ||
+                        $guard(_exceptionable, {
+                            path: _path + ".deprecated",
+                            expected: "(boolean | undefined)",
+                            value: input.deprecated,
+                        })) &&
+                    (undefined === input.title ||
+                        "string" === typeof input.title ||
+                        $guard(_exceptionable, {
+                            path: _path + ".title",
+                            expected: "(string | undefined)",
+                            value: input.title,
+                        })) &&
+                    (undefined === input.description ||
+                        "string" === typeof input.description ||
+                        $guard(_exceptionable, {
+                            path: _path + ".description",
+                            expected: "(string | undefined)",
+                            value: input.description,
+                        })) &&
+                    (undefined === input["x-typia-metaTags"] ||
+                        ((Array.isArray(input["x-typia-metaTags"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-metaTags"]',
+                                expected: "(Array<IMetadataTag> | undefined)",
+                                value: input["x-typia-metaTags"],
+                            })) &&
+                            input["x-typia-metaTags"].every(
+                                (elem: any, _index44: number) =>
+                                    ((("object" === typeof elem &&
+                                        null !== elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-metaTags"][' +
+                                                _index44 +
+                                                "]",
+                                            expected:
+                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                            value: elem,
+                                        })) &&
+                                        $au1(
+                                            elem,
+                                            _path +
+                                                '["x-typia-metaTags"][' +
+                                                _index44 +
+                                                "]",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            '["x-typia-metaTags"][' +
                                             _index44 +
+                                            "]",
+                                        expected:
+                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-metaTags"]',
+                            expected: "(Array<IMetadataTag> | undefined)",
+                            value: input["x-typia-metaTags"],
+                        })) &&
+                    (undefined === input["x-typia-jsDocTags"] ||
+                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-jsDocTags"]',
+                                expected: "(Array<IJsDocTagInfo> | undefined)",
+                                value: input["x-typia-jsDocTags"],
+                            })) &&
+                            input["x-typia-jsDocTags"].every(
+                                (elem: any, _index45: number) =>
+                                    ((("object" === typeof elem &&
+                                        null !== elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-jsDocTags"][' +
+                                                _index45 +
+                                                "]",
+                                            expected: "IJsDocTagInfo",
+                                            value: elem,
+                                        })) &&
+                                        $ao17(
+                                            elem,
+                                            _path +
+                                                '["x-typia-jsDocTags"][' +
+                                                _index45 +
+                                                "]",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            '["x-typia-jsDocTags"][' +
+                                            _index45 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -4962,37 +4993,17 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((Array.isArray(input["enum"]) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["enum"]',
-                            expected: "Array<string>",
-                            value: input["enum"],
-                        })) &&
-                        input["enum"].every(
-                            (elem: any, _index45: number) =>
-                                "string" === typeof elem ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["enum"][' + _index45 + "]",
-                                    expected: "string",
-                                    value: elem,
-                                }),
-                        )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["enum"]',
-                            expected: "Array<string>",
-                            value: input["enum"],
-                        })) &&
                     (undefined === input["default"] ||
-                        "string" === typeof input["default"] ||
+                        "boolean" === typeof input["default"] ||
                         $guard(_exceptionable, {
                             path: _path + '["default"]',
-                            expected: "(string | undefined)",
+                            expected: "(boolean | undefined)",
                             value: input["default"],
                         })) &&
-                    ("string" === input.type ||
+                    ("boolean" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"string"',
+                            expected: '"boolean"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -5151,17 +5162,74 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
+                    (undefined === input.minimum ||
+                        ("number" === typeof input.minimum &&
+                            Number.isFinite(input.minimum) &&
+                            (parseInt(input.minimum) === input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "(number | undefined)",
+                            value: input.minimum,
+                        })) &&
+                    (undefined === input.maximum ||
+                        ("number" === typeof input.maximum &&
+                            Number.isFinite(input.maximum) &&
+                            (parseInt(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "(number | undefined)",
+                            value: input.maximum,
+                        })) &&
+                    (undefined === input.exclusiveMinimum ||
+                        "boolean" === typeof input.exclusiveMinimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "(boolean | undefined)",
+                            value: input.exclusiveMinimum,
+                        })) &&
+                    (undefined === input.exclusiveMaximum ||
+                        "boolean" === typeof input.exclusiveMaximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMaximum",
+                            expected: "(boolean | undefined)",
+                            value: input.exclusiveMaximum,
+                        })) &&
+                    (undefined === input.multipleOf ||
+                        ("number" === typeof input.multipleOf &&
+                            Number.isFinite(input.multipleOf) &&
+                            (parseInt(input.multipleOf) === input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "(number | undefined)",
+                            value: input.multipleOf,
+                        })) &&
                     (undefined === input["default"] ||
-                        "boolean" === typeof input["default"] ||
+                        ("number" === typeof input["default"] &&
+                            Number.isFinite(input["default"])) ||
                         $guard(_exceptionable, {
                             path: _path + '["default"]',
-                            expected: "(boolean | undefined)",
+                            expected: "(number | undefined)",
                             value: input["default"],
                         })) &&
-                    ("boolean" === input.type ||
+                    ("integer" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"boolean"',
+                            expected: '"integer"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -5322,13 +5390,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 ): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Number.isFinite(input.minimum) &&
-                            (parseInt(input.minimum) === input.minimum ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".minimum",
-                                    expected: "number (@type int)",
-                                    value: input.minimum,
-                                }))) ||
+                            Number.isFinite(input.minimum)) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "(number | undefined)",
@@ -5336,13 +5398,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         })) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Number.isFinite(input.maximum) &&
-                            (parseInt(input.maximum) === input.maximum ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".maximum",
-                                    expected: "number (@type int)",
-                                    value: input.maximum,
-                                }))) ||
+                            Number.isFinite(input.maximum)) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "(number | undefined)",
@@ -5364,13 +5420,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         })) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Number.isFinite(input.multipleOf) &&
-                            (parseInt(input.multipleOf) === input.multipleOf ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".multipleOf",
-                                    expected: "number (@type int)",
-                                    value: input.multipleOf,
-                                }))) ||
+                            Number.isFinite(input.multipleOf)) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "(number | undefined)",
@@ -5384,10 +5434,10 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: "(number | undefined)",
                             value: input["default"],
                         })) &&
-                    ("integer" === input.type ||
+                    ("number" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"integer"',
+                            expected: '"number"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -5546,56 +5596,71 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (undefined === input.minimum ||
-                        ("number" === typeof input.minimum &&
-                            Number.isFinite(input.minimum)) ||
+                    (undefined === input.minLength ||
+                        ("number" === typeof input.minLength &&
+                            Number.isFinite(input.minLength) &&
+                            (parseInt(input.minLength) === input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                })) &&
+                            (0 <= input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".minimum",
+                            path: _path + ".minLength",
                             expected: "(number | undefined)",
-                            value: input.minimum,
+                            value: input.minLength,
                         })) &&
-                    (undefined === input.maximum ||
-                        ("number" === typeof input.maximum &&
-                            Number.isFinite(input.maximum)) ||
+                    (undefined === input.maxLength ||
+                        ("number" === typeof input.maxLength &&
+                            Number.isFinite(input.maxLength) &&
+                            (parseInt(input.maxLength) === input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".maximum",
+                            path: _path + ".maxLength",
                             expected: "(number | undefined)",
-                            value: input.maximum,
+                            value: input.maxLength,
                         })) &&
-                    (undefined === input.exclusiveMinimum ||
-                        "boolean" === typeof input.exclusiveMinimum ||
+                    (undefined === input.pattern ||
+                        "string" === typeof input.pattern ||
                         $guard(_exceptionable, {
-                            path: _path + ".exclusiveMinimum",
-                            expected: "(boolean | undefined)",
-                            value: input.exclusiveMinimum,
+                            path: _path + ".pattern",
+                            expected: "(string | undefined)",
+                            value: input.pattern,
                         })) &&
-                    (undefined === input.exclusiveMaximum ||
-                        "boolean" === typeof input.exclusiveMaximum ||
+                    (undefined === input.format ||
+                        "string" === typeof input.format ||
                         $guard(_exceptionable, {
-                            path: _path + ".exclusiveMaximum",
-                            expected: "(boolean | undefined)",
-                            value: input.exclusiveMaximum,
-                        })) &&
-                    (undefined === input.multipleOf ||
-                        ("number" === typeof input.multipleOf &&
-                            Number.isFinite(input.multipleOf)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".multipleOf",
-                            expected: "(number | undefined)",
-                            value: input.multipleOf,
+                            path: _path + ".format",
+                            expected: "(string | undefined)",
+                            value: input.format,
                         })) &&
                     (undefined === input["default"] ||
-                        ("number" === typeof input["default"] &&
-                            Number.isFinite(input["default"])) ||
+                        "string" === typeof input["default"] ||
                         $guard(_exceptionable, {
                             path: _path + '["default"]',
-                            expected: "(number | undefined)",
+                            expected: "(string | undefined)",
                             value: input["default"],
                         })) &&
-                    ("number" === input.type ||
+                    ("string" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"number"',
+                            expected: '"string"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -5754,71 +5819,88 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (undefined === input.minLength ||
-                        ("number" === typeof input.minLength &&
-                            Number.isFinite(input.minLength) &&
-                            (parseInt(input.minLength) === input.minLength ||
+                    (((("object" === typeof input.items &&
+                        null !== input.items &&
+                        false === Array.isArray(input.items)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".items",
+                            expected:
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            value: input.items,
+                        })) &&
+                        $au0(
+                            input.items,
+                            _path + ".items",
+                            true && _exceptionable,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".items",
+                            expected:
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            value: input.items,
+                        })) &&
+                    (undefined === input.minItems ||
+                        ("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "number (@type uint)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 })) &&
-                            (0 <= input.minLength ||
+                            (0 <= input.minItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "number (@type uint)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".minLength",
+                            path: _path + ".minItems",
                             expected: "(number | undefined)",
-                            value: input.minLength,
+                            value: input.minItems,
                         })) &&
-                    (undefined === input.maxLength ||
-                        ("number" === typeof input.maxLength &&
-                            Number.isFinite(input.maxLength) &&
-                            (parseInt(input.maxLength) === input.maxLength ||
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            (parseInt(input.maxItems) === input.maxItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "number (@type uint)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 })) &&
-                            (0 <= input.maxLength ||
+                            (0 <= input.maxItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "number (@type uint)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".maxLength",
+                            path: _path + ".maxItems",
                             expected: "(number | undefined)",
-                            value: input.maxLength,
+                            value: input.maxItems,
                         })) &&
-                    (undefined === input.pattern ||
-                        "string" === typeof input.pattern ||
+                    (undefined === input["x-typia-tuple"] ||
+                        ((("object" === typeof input["x-typia-tuple"] &&
+                            null !== input["x-typia-tuple"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-tuple"]',
+                                expected: "(IJsonSchema.ITuple | undefined)",
+                                value: input["x-typia-tuple"],
+                            })) &&
+                            $ao26(
+                                input["x-typia-tuple"],
+                                _path + '["x-typia-tuple"]',
+                                true && _exceptionable,
+                            )) ||
                         $guard(_exceptionable, {
-                            path: _path + ".pattern",
-                            expected: "(string | undefined)",
-                            value: input.pattern,
+                            path: _path + '["x-typia-tuple"]',
+                            expected: "(IJsonSchema.ITuple | undefined)",
+                            value: input["x-typia-tuple"],
                         })) &&
-                    (undefined === input.format ||
-                        "string" === typeof input.format ||
-                        $guard(_exceptionable, {
-                            path: _path + ".format",
-                            expected: "(string | undefined)",
-                            value: input.format,
-                        })) &&
-                    (undefined === input["default"] ||
-                        "string" === typeof input["default"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["default"]',
-                            expected: "(string | undefined)",
-                            value: input["default"],
-                        })) &&
-                    ("string" === input.type ||
+                    ("array" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"string"',
+                            expected: '"array"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -5977,44 +6059,58 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((("object" === typeof input.items &&
-                        null !== input.items &&
-                        false === Array.isArray(input.items)) ||
+                    (((Array.isArray(input.items) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
-                            expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            expected: "Array<IJsonSchema>",
                             value: input.items,
                         })) &&
-                        $au0(
-                            input.items,
-                            _path + ".items",
-                            true && _exceptionable,
+                        input.items.every(
+                            (elem: any, _index56: number) =>
+                                ((("object" === typeof elem &&
+                                    null !== elem &&
+                                    false === Array.isArray(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".items[" + _index56 + "]",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: elem,
+                                    })) &&
+                                    $au0(
+                                        elem,
+                                        _path + ".items[" + _index56 + "]",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items[" + _index56 + "]",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: elem,
+                                }),
                         )) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
-                            expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            expected: "Array<IJsonSchema>",
                             value: input.items,
                         })) &&
-                    (undefined === input.minItems ||
-                        ("number" === typeof input.minItems &&
-                            Number.isFinite(input.minItems) &&
-                            (parseInt(input.minItems) === input.minItems ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".minItems",
-                                    expected: "number (@type uint)",
-                                    value: input.minItems,
-                                })) &&
-                            (0 <= input.minItems ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".minItems",
-                                    expected: "number (@type uint)",
-                                    value: input.minItems,
-                                }))) ||
+                    (("number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        (parseInt(input.minItems) === input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            })) &&
+                        (0 <= input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
-                            expected: "(number | undefined)",
+                            expected: "number",
                             value: input.minItems,
                         })) &&
                     (undefined === input.maxItems ||
@@ -6036,24 +6132,6 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             path: _path + ".maxItems",
                             expected: "(number | undefined)",
                             value: input.maxItems,
-                        })) &&
-                    (undefined === input["x-typia-tuple"] ||
-                        ((("object" === typeof input["x-typia-tuple"] &&
-                            null !== input["x-typia-tuple"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-tuple"]',
-                                expected: "(IJsonSchema.ITuple | undefined)",
-                                value: input["x-typia-tuple"],
-                            })) &&
-                            $ao26(
-                                input["x-typia-tuple"],
-                                _path + '["x-typia-tuple"]',
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-tuple"]',
-                            expected: "(IJsonSchema.ITuple | undefined)",
-                            value: input["x-typia-tuple"],
                         })) &&
                     ("array" === input.type ||
                         $guard(_exceptionable, {
@@ -6097,14 +6175,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index56: number) =>
+                                (elem: any, _index57: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index56 +
+                                                _index57 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6114,7 +6192,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index56 +
+                                                _index57 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -6122,7 +6200,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index56 +
+                                            _index57 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6142,14 +6220,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index57: number) =>
+                                (elem: any, _index58: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index57 +
+                                                _index58 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -6158,7 +6236,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index57 +
+                                                _index58 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -6166,7 +6244,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
-                                            _index57 +
+                                            _index58 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -6217,53 +6295,40 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((Array.isArray(input.items) ||
+                    (((Array.isArray(input.oneOf) ||
                         $guard(_exceptionable, {
-                            path: _path + ".items",
+                            path: _path + ".oneOf",
                             expected: "Array<IJsonSchema>",
-                            value: input.items,
+                            value: input.oneOf,
                         })) &&
-                        input.items.every(
-                            (elem: any, _index58: number) =>
+                        input.oneOf.every(
+                            (elem: any, _index59: number) =>
                                 ((("object" === typeof elem &&
                                     null !== elem &&
                                     false === Array.isArray(elem)) ||
                                     $guard(_exceptionable, {
                                         path:
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
                                         elem,
-                                        _path + ".items[" + _index58 + "]",
+                                        _path + ".oneOf[" + _index59 + "]",
                                         true && _exceptionable,
                                     )) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".items[" + _index58 + "]",
+                                    path: _path + ".oneOf[" + _index59 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
                         $guard(_exceptionable, {
-                            path: _path + ".items",
+                            path: _path + ".oneOf",
                             expected: "Array<IJsonSchema>",
-                            value: input.items,
-                        })) &&
-                    ("array" === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: '"array"',
-                            value: input.type,
-                        })) &&
-                    (undefined === input.nullable ||
-                        "boolean" === typeof input.nullable ||
-                        $guard(_exceptionable, {
-                            path: _path + ".nullable",
-                            expected: "(boolean | undefined)",
-                            value: input.nullable,
+                            value: input.oneOf,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -6294,14 +6359,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index59: number) =>
+                                (elem: any, _index60: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index59 +
+                                                _index60 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6311,7 +6376,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index59 +
+                                                _index60 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -6319,7 +6384,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index59 +
+                                            _index60 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6339,14 +6404,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index60: number) =>
+                                (elem: any, _index61: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index60 +
+                                                _index61 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -6355,7 +6420,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index60 +
+                                                _index61 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -6363,7 +6428,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
-                                            _index60 +
+                                            _index61 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -6414,40 +6479,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((Array.isArray(input.oneOf) ||
+                    ("string" === typeof input.$ref ||
                         $guard(_exceptionable, {
-                            path: _path + ".oneOf",
-                            expected: "Array<IJsonSchema>",
-                            value: input.oneOf,
-                        })) &&
-                        input.oneOf.every(
-                            (elem: any, _index61: number) =>
-                                ((("object" === typeof elem &&
-                                    null !== elem &&
-                                    false === Array.isArray(elem)) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path + ".oneOf[" + _index61 + "]",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                        value: elem,
-                                    })) &&
-                                    $au0(
-                                        elem,
-                                        _path + ".oneOf[" + _index61 + "]",
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".oneOf[" + _index61 + "]",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                    value: elem,
-                                }),
-                        )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".oneOf",
-                            expected: "Array<IJsonSchema>",
-                            value: input.oneOf,
+                            path: _path + ".$ref",
+                            expected: "string",
+                            value: input.$ref,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -6598,11 +6634,11 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("string" === typeof input.$ref ||
+                    ("null" === input.type ||
                         $guard(_exceptionable, {
-                            path: _path + ".$ref",
-                            expected: "string",
-                            value: input.$ref,
+                            path: _path + ".type",
+                            expected: '"null"',
+                            value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -6753,11 +6789,17 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("string" === typeof input.$recursiveRef ||
+                    (null !== input.type ||
                         $guard(_exceptionable, {
-                            path: _path + ".$recursiveRef",
-                            expected: "string",
-                            value: input.$recursiveRef,
+                            path: _path + ".type",
+                            expected: "undefined",
+                            value: input.type,
+                        })) &&
+                    (undefined === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: "undefined",
+                            value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -6903,322 +6945,6 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             expected: "(boolean | undefined)",
                             value: input.$recursiveAnchor,
                         }));
-                const $ao48 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    ("null" === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: '"null"',
-                            value: input.type,
-                        })) &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated ||
-                        $guard(_exceptionable, {
-                            path: _path + ".deprecated",
-                            expected: "(boolean | undefined)",
-                            value: input.deprecated,
-                        })) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title ||
-                        $guard(_exceptionable, {
-                            path: _path + ".title",
-                            expected: "(string | undefined)",
-                            value: input.title,
-                        })) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description ||
-                        $guard(_exceptionable, {
-                            path: _path + ".description",
-                            expected: "(string | undefined)",
-                            value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        ((Array.isArray(input["x-typia-metaTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any, _index68: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index68 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        })) &&
-                                        $au1(
-                                            elem,
-                                            _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index68 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-metaTags"][' +
-                                            _index68 +
-                                            "]",
-                                        expected:
-                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-metaTags"]',
-                            expected: "(Array<IMetadataTag> | undefined)",
-                            value: input["x-typia-metaTags"],
-                        })) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any, _index69: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index69 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        })) &&
-                                        $ao17(
-                                            elem,
-                                            _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index69 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-jsDocTags"][' +
-                                            _index69 +
-                                            "]",
-                                        expected: "IJsDocTagInfo",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-jsDocTags"]',
-                            expected: "(Array<IJsDocTagInfo> | undefined)",
-                            value: input["x-typia-jsDocTags"],
-                        })) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-required"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-required"],
-                        })) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-optional"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-optional"],
-                        })) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-rest"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-rest"],
-                        })) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$id",
-                            expected: "(string | undefined)",
-                            value: input.$id,
-                        })) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$recursiveAnchor",
-                            expected: "(boolean | undefined)",
-                            value: input.$recursiveAnchor,
-                        }));
-                const $ao49 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    (null !== input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
-                        })) &&
-                    (undefined === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
-                        })) &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated ||
-                        $guard(_exceptionable, {
-                            path: _path + ".deprecated",
-                            expected: "(boolean | undefined)",
-                            value: input.deprecated,
-                        })) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title ||
-                        $guard(_exceptionable, {
-                            path: _path + ".title",
-                            expected: "(string | undefined)",
-                            value: input.title,
-                        })) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description ||
-                        $guard(_exceptionable, {
-                            path: _path + ".description",
-                            expected: "(string | undefined)",
-                            value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        ((Array.isArray(input["x-typia-metaTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any, _index70: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index70 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        })) &&
-                                        $au1(
-                                            elem,
-                                            _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index70 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-metaTags"][' +
-                                            _index70 +
-                                            "]",
-                                        expected:
-                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-metaTags"]',
-                            expected: "(Array<IMetadataTag> | undefined)",
-                            value: input["x-typia-metaTags"],
-                        })) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any, _index71: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index71 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        })) &&
-                                        $ao17(
-                                            elem,
-                                            _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index71 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-jsDocTags"][' +
-                                            _index71 +
-                                            "]",
-                                        expected: "IJsDocTagInfo",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-jsDocTags"]',
-                            expected: "(Array<IJsDocTagInfo> | undefined)",
-                            value: input["x-typia-jsDocTags"],
-                        })) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-required"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-required"],
-                        })) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-optional"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-optional"],
-                        })) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-rest"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-rest"],
-                        })) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$id",
-                            expected: "(string | undefined)",
-                            value: input.$id,
-                        })) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$recursiveAnchor",
-                            expected: "(boolean | undefined)",
-                            value: input.$recursiveAnchor,
-                        }));
                 const $au0 = (
                     input: any,
                     _path: string,
@@ -7241,13 +6967,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
-                                (elem: any, _index72: number) =>
+                                (elem: any, _index68: number) =>
                                     "object" === typeof elem &&
                                     null !== elem &&
                                     false === Array.isArray(elem) &&
                                     $au0(
                                         elem,
-                                        _path + ".items[" + _index72 + "]",
+                                        _path + ".items[" + _index68 + "]",
                                         false && _exceptionable,
                                     ),
                             )
@@ -7257,10 +6983,8 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             return $ao27(input, _path, true && _exceptionable);
                         if (undefined !== input.$ref)
                             return $ao28(input, _path, true && _exceptionable);
-                        if (undefined !== input.$recursiveRef)
-                            return $ao29(input, _path, true && _exceptionable);
                         if ("null" === input.type)
-                            return $ao30(input, _path, true && _exceptionable);
+                            return $ao29(input, _path, true && _exceptionable);
                         return (
                             $ao20(input, _path, false && _exceptionable) ||
                             $ao19(input, _path, false && _exceptionable) ||
@@ -7268,7 +6992,7 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             $ao21(input, _path, false && _exceptionable) ||
                             $ao23(input, _path, false && _exceptionable) ||
                             $ao24(input, _path, false && _exceptionable) ||
-                            $ao31(input, _path, false && _exceptionable) ||
+                            $ao30(input, _path, false && _exceptionable) ||
                             $guard(_exceptionable, {
                                 path: _path,
                                 expected:
@@ -7327,9 +7051,9 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 ): any =>
                     (() => {
                         if ("object" === input.type)
-                            return $ao34(input, _path, true && _exceptionable);
+                            return $ao33(input, _path, true && _exceptionable);
                         if ("integer" === input.type)
-                            return $ao40(input, _path, true && _exceptionable);
+                            return $ao39(input, _path, true && _exceptionable);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
@@ -7340,38 +7064,36 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 false && _exceptionable,
                             )
                         )
-                            return $ao43(input, _path, true && _exceptionable);
+                            return $ao42(input, _path, true && _exceptionable);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
-                                (elem: any, _index73: number) =>
+                                (elem: any, _index69: number) =>
                                     "object" === typeof elem &&
                                     null !== elem &&
                                     false === Array.isArray(elem) &&
                                     $au0(
                                         elem,
-                                        _path + ".items[" + _index73 + "]",
+                                        _path + ".items[" + _index69 + "]",
                                         false && _exceptionable,
                                     ),
                             )
                         )
-                            return $ao44(input, _path, true && _exceptionable);
+                            return $ao43(input, _path, true && _exceptionable);
                         if (undefined !== input.oneOf)
-                            return $ao45(input, _path, true && _exceptionable);
+                            return $ao44(input, _path, true && _exceptionable);
                         if (undefined !== input.$ref)
-                            return $ao46(input, _path, true && _exceptionable);
-                        if (undefined !== input.$recursiveRef)
-                            return $ao47(input, _path, true && _exceptionable);
+                            return $ao45(input, _path, true && _exceptionable);
                         if ("null" === input.type)
-                            return $ao48(input, _path, true && _exceptionable);
+                            return $ao46(input, _path, true && _exceptionable);
                         return (
-                            $ao38(input, _path, false && _exceptionable) ||
                             $ao37(input, _path, false && _exceptionable) ||
                             $ao36(input, _path, false && _exceptionable) ||
-                            $ao39(input, _path, false && _exceptionable) ||
+                            $ao35(input, _path, false && _exceptionable) ||
+                            $ao38(input, _path, false && _exceptionable) ||
+                            $ao40(input, _path, false && _exceptionable) ||
                             $ao41(input, _path, false && _exceptionable) ||
-                            $ao42(input, _path, false && _exceptionable) ||
-                            $ao49(input, _path, false && _exceptionable) ||
+                            $ao47(input, _path, false && _exceptionable) ||
                             $guard(_exceptionable, {
                                 path: _path,
                                 expected:

--- a/test/generated/output/createAssertClone/test_createAssertClone_UltimateUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_UltimateUnion.ts
@@ -21,7 +21,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     "object" === typeof input.components &&
                     null !== input.components &&
                     false === Array.isArray(input.components) &&
-                    $io32(input.components) &&
+                    $io31(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose);
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
@@ -454,6 +454,15 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -553,36 +562,6 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -612,7 +591,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -643,13 +622,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -662,23 +641,21 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -708,7 +685,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -718,7 +695,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -731,7 +708,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -773,7 +750,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) =>
@@ -817,7 +794,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -859,7 +836,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -897,7 +874,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
@@ -952,7 +929,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum))) &&
@@ -1004,7 +981,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
@@ -1056,7 +1033,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -1110,7 +1087,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -1119,6 +1096,15 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1154,7 +1140,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -1195,7 +1181,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1229,41 +1215,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1297,7 +1249,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -1355,9 +1307,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (() => {
                             if ($io20(input)) return $io20(input);
                             if ($io19(input)) return $io19(input);
@@ -1365,7 +1315,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             if ($io21(input)) return $io21(input);
                             if ($io23(input)) return $io23(input);
                             if ($io24(input)) return $io24(input);
-                            if ($io31(input)) return $io31(input);
+                            if ($io30(input)) return $io30(input);
                             return false;
                         })();
                     })();
@@ -1392,15 +1342,15 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -1411,20 +1361,18 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (() => {
-                            if ($io38(input)) return $io38(input);
                             if ($io37(input)) return $io37(input);
                             if ($io36(input)) return $io36(input);
-                            if ($io39(input)) return $io39(input);
+                            if ($io35(input)) return $io35(input);
+                            if ($io38(input)) return $io38(input);
+                            if ($io40(input)) return $io40(input);
                             if ($io41(input)) return $io41(input);
-                            if ($io42(input)) return $io42(input);
-                            if ($io49(input)) return $io49(input);
+                            if ($io47(input)) return $io47(input);
                             return false;
                         })();
                     })();
@@ -1469,7 +1417,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 _index2 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -1481,7 +1429,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         path:
                                             _path + ".schemas[" + _index2 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -1498,7 +1446,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: "IJsonComponents",
                                 value: input.components,
                             })) &&
-                            $ao32(
+                            $ao31(
                                 input.components,
                                 _path + ".components",
                                 true && _exceptionable,
@@ -3194,7 +3142,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                 value: input.items,
                             })) &&
                             $au0(
@@ -3205,7 +3153,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                 value: input.items,
                             })) &&
                         (undefined === input.minItems ||
@@ -3435,7 +3383,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 _index23 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -3447,7 +3395,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         path:
                                             _path + ".items[" + _index23 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -3455,6 +3403,45 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 path: _path + ".items",
                                 expected: "Array<IJsonSchema>",
                                 value: input.items,
+                            })) &&
+                        (("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number",
+                                value: input.minItems,
+                            })) &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "(number | undefined)",
+                                value: input.maxItems,
                             })) &&
                         ("array" === input.type ||
                             $guard(_exceptionable, {
@@ -3624,7 +3611,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 _index26 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -3636,7 +3623,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         path:
                                             _path + ".oneOf[" + _index26 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -3925,11 +3912,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$recursiveRef ||
+                        ("null" === input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$recursiveRef",
-                                expected: "string",
-                                value: input.$recursiveRef,
+                                path: _path + ".type",
+                                expected: '"null"',
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -4068,10 +4055,16 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("null" === input.type ||
+                        (null !== input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"null"',
+                                expected: "undefined",
+                                value: input.type,
+                            })) &&
+                        (undefined === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: "undefined",
                                 value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
@@ -4211,31 +4204,174 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (null !== input.type ||
+                        undefined === input.schemas ||
+                        ((("object" === typeof input.schemas &&
+                            null !== input.schemas &&
+                            false === Array.isArray(input.schemas)) ||
                             $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
+                                path: _path + ".schemas",
+                                expected:
+                                    "(Record<string, IObject | IAlias> | undefined)",
+                                value: input.schemas,
                             })) &&
-                        (undefined === input.type ||
+                            $ao32(
+                                input.schemas,
+                                _path + ".schemas",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".schemas",
+                            expected:
+                                "(Record<string, IObject | IAlias> | undefined)",
+                            value: input.schemas,
+                        });
+                    const $ao32 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        false === _exceptionable ||
+                        Object.keys(input).every((key: any) => {
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            if (RegExp(/(.*)/).test(key))
+                                return (
+                                    ((("object" === typeof value &&
+                                        null !== value &&
+                                        false === Array.isArray(value)) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + $join(key),
+                                            expected:
+                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                            value: value,
+                                        })) &&
+                                        $au2(
+                                            value,
+                                            _path + $join(key),
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected:
+                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                        value: value,
+                                    })
+                                );
+                            return true;
+                        });
+                    const $ao33 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.$id ||
+                            "string" === typeof input.$id ||
                             $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
+                                path: _path + ".$id",
                                 expected: "(string | undefined)",
-                                value: input.title,
+                                value: input.$id,
+                            })) &&
+                        ("object" === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: '"object"',
+                                value: input.type,
+                            })) &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
+                            $guard(_exceptionable, {
+                                path: _path + ".nullable",
+                                expected: "(boolean | undefined)",
+                                value: input.nullable,
+                            })) &&
+                        (((("object" === typeof input.properties &&
+                            null !== input.properties &&
+                            false === Array.isArray(input.properties)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".properties",
+                                expected: "Record<string, IJsonSchema>",
+                                value: input.properties,
+                            })) &&
+                            $ao34(
+                                input.properties,
+                                _path + ".properties",
+                                true && _exceptionable,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".properties",
+                                expected: "Record<string, IJsonSchema>",
+                                value: input.properties,
+                            })) &&
+                        (undefined === input.patternProperties ||
+                            ((("object" === typeof input.patternProperties &&
+                                null !== input.patternProperties &&
+                                false ===
+                                    Array.isArray(input.patternProperties)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                })) &&
+                                $ao34(
+                                    input.patternProperties,
+                                    _path + ".patternProperties",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".patternProperties",
+                                expected:
+                                    "(Record<string, IJsonSchema> | undefined)",
+                                value: input.patternProperties,
+                            })) &&
+                        (undefined === input.additionalProperties ||
+                            ((("object" === typeof input.additionalProperties &&
+                                null !== input.additionalProperties &&
+                                false ===
+                                    Array.isArray(
+                                        input.additionalProperties,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                })) &&
+                                $au0(
+                                    input.additionalProperties,
+                                    _path + ".additionalProperties",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".additionalProperties",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                value: input.additionalProperties,
+                            })) &&
+                        (undefined === input.required ||
+                            ((Array.isArray(input.required) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
+                                })) &&
+                                input.required.every(
+                                    (elem: any, _index35: number) =>
+                                        "string" === typeof elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".required[" +
+                                                _index35 +
+                                                "]",
+                                            expected: "string",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".required",
+                                expected: "(Array<string> | undefined)",
+                                value: input.required,
                             })) &&
                         (undefined === input.description ||
                             "string" === typeof input.description ||
@@ -4243,52 +4379,6 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 path: _path + ".description",
                                 expected: "(string | undefined)",
                                 value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index35: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index35 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
                             })) &&
                         (undefined === input["x-typia-jsDocTags"] ||
                             ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4334,259 +4424,6 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: "(Array<IJsDocTagInfo> | undefined)",
                                 value: input["x-typia-jsDocTags"],
                             })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            }));
-                    const $ao32 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        undefined === input.schemas ||
-                        ((("object" === typeof input.schemas &&
-                            null !== input.schemas &&
-                            false === Array.isArray(input.schemas)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".schemas",
-                                expected:
-                                    "(Record<string, IObject | IAlias> | undefined)",
-                                value: input.schemas,
-                            })) &&
-                            $ao33(
-                                input.schemas,
-                                _path + ".schemas",
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".schemas",
-                            expected:
-                                "(Record<string, IObject | IAlias> | undefined)",
-                            value: input.schemas,
-                        });
-                    const $ao33 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        false === _exceptionable ||
-                        Object.keys(input).every((key: any) => {
-                            const value = input[key];
-                            if (undefined === value) return true;
-                            if (RegExp(/(.*)/).test(key))
-                                return (
-                                    ((("object" === typeof value &&
-                                        null !== value &&
-                                        false === Array.isArray(value)) ||
-                                        $guard(_exceptionable, {
-                                            path: _path + $join(key),
-                                            expected:
-                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                            value: value,
-                                        })) &&
-                                        $au2(
-                                            value,
-                                            _path + $join(key),
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + $join(key),
-                                        expected:
-                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                        value: value,
-                                    })
-                                );
-                            return true;
-                        });
-                    const $ao34 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            })) &&
-                        ("object" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"object"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.nullable ||
-                            "boolean" === typeof input.nullable ||
-                            $guard(_exceptionable, {
-                                path: _path + ".nullable",
-                                expected: "(boolean | undefined)",
-                                value: input.nullable,
-                            })) &&
-                        (((("object" === typeof input.properties &&
-                            null !== input.properties &&
-                            false === Array.isArray(input.properties)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".properties",
-                                expected: "Record<string, IJsonSchema>",
-                                value: input.properties,
-                            })) &&
-                            $ao35(
-                                input.properties,
-                                _path + ".properties",
-                                true && _exceptionable,
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".properties",
-                                expected: "Record<string, IJsonSchema>",
-                                value: input.properties,
-                            })) &&
-                        (undefined === input.patternProperties ||
-                            ((("object" === typeof input.patternProperties &&
-                                null !== input.patternProperties &&
-                                false ===
-                                    Array.isArray(input.patternProperties)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                })) &&
-                                $ao35(
-                                    input.patternProperties,
-                                    _path + ".patternProperties",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".patternProperties",
-                                expected:
-                                    "(Record<string, IJsonSchema> | undefined)",
-                                value: input.patternProperties,
-                            })) &&
-                        (undefined === input.additionalProperties ||
-                            ((("object" === typeof input.additionalProperties &&
-                                null !== input.additionalProperties &&
-                                false ===
-                                    Array.isArray(
-                                        input.additionalProperties,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                })) &&
-                                $au0(
-                                    input.additionalProperties,
-                                    _path + ".additionalProperties",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".additionalProperties",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                value: input.additionalProperties,
-                            })) &&
-                        (undefined === input.required ||
-                            ((Array.isArray(input.required) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                })) &&
-                                input.required.every(
-                                    (elem: any, _index37: number) =>
-                                        "string" === typeof elem ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".required[" +
-                                                _index37 +
-                                                "]",
-                                            expected: "string",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".required",
-                                expected: "(Array<string> | undefined)",
-                                value: input.required,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index38: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index38 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
                         (undefined === input["x-typia-patternProperties"] ||
                             ((("object" ===
                                 typeof input["x-typia-patternProperties"] &&
@@ -4602,7 +4439,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         "(Record<string, IJsonSchema> | undefined)",
                                     value: input["x-typia-patternProperties"],
                                 })) &&
-                                $ao35(
+                                $ao34(
                                     input["x-typia-patternProperties"],
                                     _path + '["x-typia-patternProperties"]',
                                     true && _exceptionable,
@@ -4627,7 +4464,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
@@ -4641,10 +4478,10 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 path:
                                     _path + '["x-typia-additionalProperties"]',
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                 value: input["x-typia-additionalProperties"],
                             }));
-                    const $ao35 = (
+                    const $ao34 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4661,7 +4498,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         $guard(_exceptionable, {
                                             path: _path + $join(key),
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: value,
                                         })) &&
                                         $au0(
@@ -4672,13 +4509,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     $guard(_exceptionable, {
                                         path: _path + $join(key),
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: value,
                                     })
                                 );
                             return true;
                         });
-                    const $ao36 = (
+                    const $ao35 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4690,13 +4527,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 value: input["enum"],
                             })) &&
                             input["enum"].every(
-                                (elem: any, _index39: number) =>
+                                (elem: any, _index37: number) =>
                                     "boolean" === typeof elem ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +
                                             '["enum"][' +
-                                            _index39 +
+                                            _index37 +
                                             "]",
                                         expected: "boolean",
                                         value: elem,
@@ -4757,14 +4594,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index40: number) =>
+                                    (elem: any, _index38: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4774,7 +4611,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4782,7 +4619,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index40 +
+                                                _index38 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4803,14 +4640,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index41: number) =>
+                                    (elem: any, _index39: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -4819,7 +4656,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4827,7 +4664,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index41 +
+                                                _index39 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -4873,7 +4710,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: "(boolean | undefined)",
                                 value: input.$recursiveAnchor,
                             }));
-                    const $ao37 = (
+                    const $ao36 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4885,14 +4722,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 value: input["enum"],
                             })) &&
                             input["enum"].every(
-                                (elem: any, _index42: number) =>
+                                (elem: any, _index40: number) =>
                                     ("number" === typeof elem &&
                                         Number.isFinite(elem)) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +
                                             '["enum"][' +
-                                            _index42 +
+                                            _index40 +
                                             "]",
                                         expected: "number",
                                         value: elem,
@@ -4954,14 +4791,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index43: number) =>
+                                    (elem: any, _index41: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4971,7 +4808,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4979,7 +4816,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index43 +
+                                                _index41 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5000,14 +4837,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index44: number) =>
+                                    (elem: any, _index42: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index44 +
+                                                    _index42 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -5016,7 +4853,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index44 +
+                                                    _index42 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -5024,7 +4861,202 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
+                                                _index42 +
+                                                "]",
+                                            expected: "IJsDocTagInfo",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-jsDocTags"]',
+                                expected: "(Array<IJsDocTagInfo> | undefined)",
+                                value: input["x-typia-jsDocTags"],
+                            })) &&
+                        (undefined === input["x-typia-required"] ||
+                            "boolean" === typeof input["x-typia-required"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-required"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-required"],
+                            })) &&
+                        (undefined === input["x-typia-optional"] ||
+                            "boolean" === typeof input["x-typia-optional"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-optional"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-optional"],
+                            })) &&
+                        (undefined === input["x-typia-rest"] ||
+                            "boolean" === typeof input["x-typia-rest"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-rest"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-rest"],
+                            })) &&
+                        (undefined === input.$id ||
+                            "string" === typeof input.$id ||
+                            $guard(_exceptionable, {
+                                path: _path + ".$id",
+                                expected: "(string | undefined)",
+                                value: input.$id,
+                            })) &&
+                        (undefined === input.$recursiveAnchor ||
+                            "boolean" === typeof input.$recursiveAnchor ||
+                            $guard(_exceptionable, {
+                                path: _path + ".$recursiveAnchor",
+                                expected: "(boolean | undefined)",
+                                value: input.$recursiveAnchor,
+                            }));
+                    const $ao37 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (((Array.isArray(input["enum"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["enum"]',
+                                expected: "Array<string>",
+                                value: input["enum"],
+                            })) &&
+                            input["enum"].every(
+                                (elem: any, _index43: number) =>
+                                    "string" === typeof elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            '["enum"][' +
+                                            _index43 +
+                                            "]",
+                                        expected: "string",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["enum"]',
+                                expected: "Array<string>",
+                                value: input["enum"],
+                            })) &&
+                        (undefined === input["default"] ||
+                            "string" === typeof input["default"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["default"]',
+                                expected: "(string | undefined)",
+                                value: input["default"],
+                            })) &&
+                        ("string" === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: '"string"',
+                                value: input.type,
+                            })) &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
+                            $guard(_exceptionable, {
+                                path: _path + ".nullable",
+                                expected: "(boolean | undefined)",
+                                value: input.nullable,
+                            })) &&
+                        (undefined === input.deprecated ||
+                            "boolean" === typeof input.deprecated ||
+                            $guard(_exceptionable, {
+                                path: _path + ".deprecated",
+                                expected: "(boolean | undefined)",
+                                value: input.deprecated,
+                            })) &&
+                        (undefined === input.title ||
+                            "string" === typeof input.title ||
+                            $guard(_exceptionable, {
+                                path: _path + ".title",
+                                expected: "(string | undefined)",
+                                value: input.title,
+                            })) &&
+                        (undefined === input.description ||
+                            "string" === typeof input.description ||
+                            $guard(_exceptionable, {
+                                path: _path + ".description",
+                                expected: "(string | undefined)",
+                                value: input.description,
+                            })) &&
+                        (undefined === input["x-typia-metaTags"] ||
+                            ((Array.isArray(input["x-typia-metaTags"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                })) &&
+                                input["x-typia-metaTags"].every(
+                                    (elem: any, _index44: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-metaTags"][' +
+                                                    _index44 +
+                                                    "]",
+                                                expected:
+                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                value: elem,
+                                            })) &&
+                                            $au1(
+                                                elem,
+                                                _path +
+                                                    '["x-typia-metaTags"][' +
+                                                    _index44 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-metaTags"][' +
                                                 _index44 +
+                                                "]",
+                                            expected:
+                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-metaTags"]',
+                                expected: "(Array<IMetadataTag> | undefined)",
+                                value: input["x-typia-metaTags"],
+                            })) &&
+                        (undefined === input["x-typia-jsDocTags"] ||
+                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                })) &&
+                                input["x-typia-jsDocTags"].every(
+                                    (elem: any, _index45: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
+                                                    "]",
+                                                expected: "IJsDocTagInfo",
+                                                value: elem,
+                                            })) &&
+                                            $ao17(
+                                                elem,
+                                                _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-jsDocTags"][' +
+                                                _index45 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -5075,41 +5107,17 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input["enum"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["enum"]',
-                                expected: "Array<string>",
-                                value: input["enum"],
-                            })) &&
-                            input["enum"].every(
-                                (elem: any, _index45: number) =>
-                                    "string" === typeof elem ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["enum"][' +
-                                            _index45 +
-                                            "]",
-                                        expected: "string",
-                                        value: elem,
-                                    }),
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["enum"]',
-                                expected: "Array<string>",
-                                value: input["enum"],
-                            })) &&
                         (undefined === input["default"] ||
-                            "string" === typeof input["default"] ||
+                            "boolean" === typeof input["default"] ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(string | undefined)",
+                                expected: "(boolean | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("string" === input.type ||
+                        ("boolean" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"string"',
+                                expected: '"boolean"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5270,17 +5278,75 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (undefined === input.minimum ||
+                            ("number" === typeof input.minimum &&
+                                Number.isFinite(input.minimum) &&
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "(number | undefined)",
+                                value: input.minimum,
+                            })) &&
+                        (undefined === input.maximum ||
+                            ("number" === typeof input.maximum &&
+                                Number.isFinite(input.maximum) &&
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "(number | undefined)",
+                                value: input.maximum,
+                            })) &&
+                        (undefined === input.exclusiveMinimum ||
+                            "boolean" === typeof input.exclusiveMinimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "(boolean | undefined)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (undefined === input.exclusiveMaximum ||
+                            "boolean" === typeof input.exclusiveMaximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMaximum",
+                                expected: "(boolean | undefined)",
+                                value: input.exclusiveMaximum,
+                            })) &&
+                        (undefined === input.multipleOf ||
+                            ("number" === typeof input.multipleOf &&
+                                Number.isFinite(input.multipleOf) &&
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "(number | undefined)",
+                                value: input.multipleOf,
+                            })) &&
                         (undefined === input["default"] ||
-                            "boolean" === typeof input["default"] ||
+                            ("number" === typeof input["default"] &&
+                                Number.isFinite(input["default"])) ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(boolean | undefined)",
+                                expected: "(number | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("boolean" === input.type ||
+                        ("integer" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"boolean"',
+                                expected: '"integer"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5443,13 +5509,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     ): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
-                                Number.isFinite(input.minimum) &&
-                                (parseInt(input.minimum) === input.minimum ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minimum",
-                                        expected: "number (@type int)",
-                                        value: input.minimum,
-                                    }))) ||
+                                Number.isFinite(input.minimum)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -5457,13 +5517,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             })) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
-                                Number.isFinite(input.maximum) &&
-                                (parseInt(input.maximum) === input.maximum ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".maximum",
-                                        expected: "number (@type int)",
-                                        value: input.maximum,
-                                    }))) ||
+                                Number.isFinite(input.maximum)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -5485,14 +5539,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             })) &&
                         (undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
-                                Number.isFinite(input.multipleOf) &&
-                                (parseInt(input.multipleOf) ===
-                                    input.multipleOf ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".multipleOf",
-                                        expected: "number (@type int)",
-                                        value: input.multipleOf,
-                                    }))) ||
+                                Number.isFinite(input.multipleOf)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -5506,10 +5553,10 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: "(number | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("integer" === input.type ||
+                        ("number" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"integer"',
+                                expected: '"number"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5670,56 +5717,73 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (undefined === input.minimum ||
-                            ("number" === typeof input.minimum &&
-                                Number.isFinite(input.minimum)) ||
+                        (undefined === input.minLength ||
+                            ("number" === typeof input.minLength &&
+                                Number.isFinite(input.minLength) &&
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".minimum",
+                                path: _path + ".minLength",
                                 expected: "(number | undefined)",
-                                value: input.minimum,
+                                value: input.minLength,
                             })) &&
-                        (undefined === input.maximum ||
-                            ("number" === typeof input.maximum &&
-                                Number.isFinite(input.maximum)) ||
+                        (undefined === input.maxLength ||
+                            ("number" === typeof input.maxLength &&
+                                Number.isFinite(input.maxLength) &&
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".maximum",
+                                path: _path + ".maxLength",
                                 expected: "(number | undefined)",
-                                value: input.maximum,
+                                value: input.maxLength,
                             })) &&
-                        (undefined === input.exclusiveMinimum ||
-                            "boolean" === typeof input.exclusiveMinimum ||
+                        (undefined === input.pattern ||
+                            "string" === typeof input.pattern ||
                             $guard(_exceptionable, {
-                                path: _path + ".exclusiveMinimum",
-                                expected: "(boolean | undefined)",
-                                value: input.exclusiveMinimum,
+                                path: _path + ".pattern",
+                                expected: "(string | undefined)",
+                                value: input.pattern,
                             })) &&
-                        (undefined === input.exclusiveMaximum ||
-                            "boolean" === typeof input.exclusiveMaximum ||
+                        (undefined === input.format ||
+                            "string" === typeof input.format ||
                             $guard(_exceptionable, {
-                                path: _path + ".exclusiveMaximum",
-                                expected: "(boolean | undefined)",
-                                value: input.exclusiveMaximum,
-                            })) &&
-                        (undefined === input.multipleOf ||
-                            ("number" === typeof input.multipleOf &&
-                                Number.isFinite(input.multipleOf)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".multipleOf",
-                                expected: "(number | undefined)",
-                                value: input.multipleOf,
+                                path: _path + ".format",
+                                expected: "(string | undefined)",
+                                value: input.format,
                             })) &&
                         (undefined === input["default"] ||
-                            ("number" === typeof input["default"] &&
-                                Number.isFinite(input["default"])) ||
+                            "string" === typeof input["default"] ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(number | undefined)",
+                                expected: "(string | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("number" === input.type ||
+                        ("string" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"number"',
+                                expected: '"string"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5880,73 +5944,89 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (undefined === input.minLength ||
-                            ("number" === typeof input.minLength &&
-                                Number.isFinite(input.minLength) &&
-                                (parseInt(input.minLength) ===
-                                    input.minLength ||
+                        (((("object" === typeof input.items &&
+                            null !== input.items &&
+                            false === Array.isArray(input.items)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                value: input.items,
+                            })) &&
+                            $au0(
+                                input.items,
+                                _path + ".items",
+                                true && _exceptionable,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                value: input.items,
+                            })) &&
+                        (undefined === input.minItems ||
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "number (@type uint)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     })) &&
-                                (0 <= input.minLength ||
+                                (0 <= input.minItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "number (@type uint)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".minLength",
+                                path: _path + ".minItems",
                                 expected: "(number | undefined)",
-                                value: input.minLength,
+                                value: input.minItems,
                             })) &&
-                        (undefined === input.maxLength ||
-                            ("number" === typeof input.maxLength &&
-                                Number.isFinite(input.maxLength) &&
-                                (parseInt(input.maxLength) ===
-                                    input.maxLength ||
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                (parseInt(input.maxItems) === input.maxItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "number (@type uint)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     })) &&
-                                (0 <= input.maxLength ||
+                                (0 <= input.maxItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "number (@type uint)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".maxLength",
+                                path: _path + ".maxItems",
                                 expected: "(number | undefined)",
-                                value: input.maxLength,
+                                value: input.maxItems,
                             })) &&
-                        (undefined === input.pattern ||
-                            "string" === typeof input.pattern ||
+                        (undefined === input["x-typia-tuple"] ||
+                            ((("object" === typeof input["x-typia-tuple"] &&
+                                null !== input["x-typia-tuple"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
+                                })) &&
+                                $ao26(
+                                    input["x-typia-tuple"],
+                                    _path + '["x-typia-tuple"]',
+                                    true && _exceptionable,
+                                )) ||
                             $guard(_exceptionable, {
-                                path: _path + ".pattern",
-                                expected: "(string | undefined)",
-                                value: input.pattern,
+                                path: _path + '["x-typia-tuple"]',
+                                expected: "(IJsonSchema.ITuple | undefined)",
+                                value: input["x-typia-tuple"],
                             })) &&
-                        (undefined === input.format ||
-                            "string" === typeof input.format ||
-                            $guard(_exceptionable, {
-                                path: _path + ".format",
-                                expected: "(string | undefined)",
-                                value: input.format,
-                            })) &&
-                        (undefined === input["default"] ||
-                            "string" === typeof input["default"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["default"]',
-                                expected: "(string | undefined)",
-                                value: input["default"],
-                            })) &&
-                        ("string" === input.type ||
+                        ("array" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"string"',
+                                expected: '"array"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -6107,44 +6187,62 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((("object" === typeof input.items &&
-                            null !== input.items &&
-                            false === Array.isArray(input.items)) ||
+                        (((Array.isArray(input.items) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                expected: "Array<IJsonSchema>",
                                 value: input.items,
                             })) &&
-                            $au0(
-                                input.items,
-                                _path + ".items",
-                                true && _exceptionable,
+                            input.items.every(
+                                (elem: any, _index56: number) =>
+                                    ((("object" === typeof elem &&
+                                        null !== elem &&
+                                        false === Array.isArray(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index56 +
+                                                "]",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            value: elem,
+                                        })) &&
+                                        $au0(
+                                            elem,
+                                            _path + ".items[" + _index56 + "]",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".items[" + _index56 + "]",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: elem,
+                                    }),
                             )) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                expected: "Array<IJsonSchema>",
                                 value: input.items,
                             })) &&
-                        (undefined === input.minItems ||
-                            ("number" === typeof input.minItems &&
-                                Number.isFinite(input.minItems) &&
-                                (parseInt(input.minItems) === input.minItems ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minItems",
-                                        expected: "number (@type uint)",
-                                        value: input.minItems,
-                                    })) &&
-                                (0 <= input.minItems ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minItems",
-                                        expected: "number (@type uint)",
-                                        value: input.minItems,
-                                    }))) ||
+                        (("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
-                                expected: "(number | undefined)",
+                                expected: "number",
                                 value: input.minItems,
                             })) &&
                         (undefined === input.maxItems ||
@@ -6166,25 +6264,6 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",
                                 value: input.maxItems,
-                            })) &&
-                        (undefined === input["x-typia-tuple"] ||
-                            ((("object" === typeof input["x-typia-tuple"] &&
-                                null !== input["x-typia-tuple"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
-                                })) &&
-                                $ao26(
-                                    input["x-typia-tuple"],
-                                    _path + '["x-typia-tuple"]',
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-tuple"]',
-                                expected: "(IJsonSchema.ITuple | undefined)",
-                                value: input["x-typia-tuple"],
                             })) &&
                         ("array" === input.type ||
                             $guard(_exceptionable, {
@@ -6229,14 +6308,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index56: number) =>
+                                    (elem: any, _index57: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6246,7 +6325,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6254,7 +6333,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index56 +
+                                                _index57 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6275,14 +6354,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index57: number) =>
+                                    (elem: any, _index58: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6291,7 +6370,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6299,7 +6378,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index57 +
+                                                _index58 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -6350,57 +6429,44 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input.items) ||
+                        (((Array.isArray(input.oneOf) ||
                             $guard(_exceptionable, {
-                                path: _path + ".items",
+                                path: _path + ".oneOf",
                                 expected: "Array<IJsonSchema>",
-                                value: input.items,
+                                value: input.oneOf,
                             })) &&
-                            input.items.every(
-                                (elem: any, _index58: number) =>
+                            input.oneOf.every(
+                                (elem: any, _index59: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem)) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
-                                                ".items[" +
-                                                _index58 +
+                                                ".oneOf[" +
+                                                _index59 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                             true && _exceptionable,
                                         )) ||
                                     $guard(_exceptionable, {
                                         path:
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
                             $guard(_exceptionable, {
-                                path: _path + ".items",
+                                path: _path + ".oneOf",
                                 expected: "Array<IJsonSchema>",
-                                value: input.items,
-                            })) &&
-                        ("array" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"array"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.nullable ||
-                            "boolean" === typeof input.nullable ||
-                            $guard(_exceptionable, {
-                                path: _path + ".nullable",
-                                expected: "(boolean | undefined)",
-                                value: input.nullable,
+                                value: input.oneOf,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6432,14 +6498,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index59: number) =>
+                                    (elem: any, _index60: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6449,7 +6515,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6457,7 +6523,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index59 +
+                                                _index60 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6478,14 +6544,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index60: number) =>
+                                    (elem: any, _index61: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6494,7 +6560,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6502,7 +6568,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index60 +
+                                                _index61 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -6553,44 +6619,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input.oneOf) ||
+                        ("string" === typeof input.$ref ||
                             $guard(_exceptionable, {
-                                path: _path + ".oneOf",
-                                expected: "Array<IJsonSchema>",
-                                value: input.oneOf,
-                            })) &&
-                            input.oneOf.every(
-                                (elem: any, _index61: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem &&
-                                        false === Array.isArray(elem)) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".oneOf[" +
-                                                _index61 +
-                                                "]",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                            value: elem,
-                                        })) &&
-                                        $au0(
-                                            elem,
-                                            _path + ".oneOf[" + _index61 + "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path + ".oneOf[" + _index61 + "]",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                        value: elem,
-                                    }),
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".oneOf",
-                                expected: "Array<IJsonSchema>",
-                                value: input.oneOf,
+                                path: _path + ".$ref",
+                                expected: "string",
+                                value: input.$ref,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6743,11 +6776,11 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$ref ||
+                        ("null" === input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$ref",
-                                expected: "string",
-                                value: input.$ref,
+                                path: _path + ".type",
+                                expected: '"null"',
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6900,11 +6933,17 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$recursiveRef ||
+                        (null !== input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$recursiveRef",
-                                expected: "string",
-                                value: input.$recursiveRef,
+                                path: _path + ".type",
+                                expected: "undefined",
+                                value: input.type,
+                            })) &&
+                        (undefined === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: "undefined",
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -7052,326 +7091,6 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 expected: "(boolean | undefined)",
                                 value: input.$recursiveAnchor,
                             }));
-                    const $ao48 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        ("null" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"null"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index68: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index68 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index69: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index69 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            })) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }));
-                    const $ao49 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        (null !== input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index70: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index70 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index71: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index71 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            })) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }));
                     const $au0 = (
                         input: any,
                         _path: string,
@@ -7402,13 +7121,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
-                                    (elem: any, _index72: number) =>
+                                    (elem: any, _index68: number) =>
                                         "object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index72 + "]",
+                                            _path + ".items[" + _index68 + "]",
                                             false && _exceptionable,
                                         ),
                                 )
@@ -7430,14 +7149,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     _path,
                                     true && _exceptionable,
                                 );
-                            if (undefined !== input.$recursiveRef)
-                                return $ao29(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
                             if ("null" === input.type)
-                                return $ao30(
+                                return $ao29(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7449,7 +7162,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 $ao21(input, _path, false && _exceptionable) ||
                                 $ao23(input, _path, false && _exceptionable) ||
                                 $ao24(input, _path, false && _exceptionable) ||
-                                $ao31(input, _path, false && _exceptionable) ||
+                                $ao30(input, _path, false && _exceptionable) ||
                                 $guard(_exceptionable, {
                                     path: _path,
                                     expected:
@@ -7568,13 +7281,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     ): any =>
                         (() => {
                             if ("object" === input.type)
-                                return $ao34(
+                                return $ao33(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("integer" === input.type)
-                                return $ao40(
+                                return $ao39(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7589,7 +7302,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     false && _exceptionable,
                                 )
                             )
-                                return $ao43(
+                                return $ao42(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7597,54 +7310,48 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
-                                    (elem: any, _index73: number) =>
+                                    (elem: any, _index69: number) =>
                                         "object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index73 + "]",
+                                            _path + ".items[" + _index69 + "]",
                                             false && _exceptionable,
                                         ),
                                 )
                             )
-                                return $ao44(
+                                return $ao43(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.oneOf)
-                                return $ao45(
+                                return $ao44(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.$ref)
-                                return $ao46(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
-                            if (undefined !== input.$recursiveRef)
-                                return $ao47(
+                                return $ao45(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("null" === input.type)
-                                return $ao48(
+                                return $ao46(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             return (
-                                $ao38(input, _path, false && _exceptionable) ||
                                 $ao37(input, _path, false && _exceptionable) ||
                                 $ao36(input, _path, false && _exceptionable) ||
-                                $ao39(input, _path, false && _exceptionable) ||
+                                $ao35(input, _path, false && _exceptionable) ||
+                                $ao38(input, _path, false && _exceptionable) ||
+                                $ao40(input, _path, false && _exceptionable) ||
                                 $ao41(input, _path, false && _exceptionable) ||
-                                $ao42(input, _path, false && _exceptionable) ||
-                                $ao49(input, _path, false && _exceptionable) ||
+                                $ao47(input, _path, false && _exceptionable) ||
                                 $guard(_exceptionable, {
                                     path: _path,
                                     expected:
@@ -8081,6 +7788,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -8180,36 +7894,6 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -8239,7 +7923,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -8270,13 +7954,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -8289,22 +7973,20 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -8330,7 +8012,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -8340,7 +8022,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -8353,7 +8035,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -8392,7 +8074,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "number" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -8431,7 +8113,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -8470,7 +8152,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -8507,7 +8189,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         parseInt(input.minimum) === input.minimum)) &&
@@ -8557,7 +8239,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     "number" === typeof input.minimum) &&
                 (undefined === input.maximum ||
@@ -8604,7 +8286,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         parseInt(input.minLength) === input.minLength &&
@@ -8653,7 +8335,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -8704,7 +8386,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -8713,6 +8395,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -8747,7 +8436,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -8787,7 +8476,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -8820,40 +8509,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -8886,7 +8542,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -8943,8 +8599,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (
                         $io20(input) ||
                         $io19(input) ||
@@ -8952,7 +8607,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         $io21(input) ||
                         $io23(input) ||
                         $io24(input) ||
-                        $io31(input)
+                        $io30(input)
                     );
                 })();
             const $iu1 = (input: any): any =>
@@ -8976,15 +8631,15 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -8995,19 +8650,18 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (
-                        $io38(input) ||
                         $io37(input) ||
                         $io36(input) ||
-                        $io39(input) ||
+                        $io35(input) ||
+                        $io38(input) ||
+                        $io40(input) ||
                         $io41(input) ||
-                        $io42(input) ||
-                        $io49(input)
+                        $io47(input)
                     );
                 })();
             const $join = (typia.createAssertClone as any).join;
@@ -9052,7 +8706,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 components:
                     "object" === typeof input.components &&
                     null !== input.components
-                        ? $co32(input.components)
+                        ? $co31(input.components)
                         : (input.components as any),
                 purpose: input.purpose as any,
             });
@@ -9299,6 +8953,8 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 items: Array.isArray(input.items)
                     ? $cp1(input.items)
                     : (input.items as any),
+                minItems: input.minItems as any,
+                maxItems: input.maxItems as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 deprecated: input.deprecated as any,
@@ -9347,7 +9003,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 "x-typia-rest": input["x-typia-rest"] as any,
             });
             const $co29 = (input: any): any => ({
-                $recursiveRef: input.$recursiveRef as any,
+                type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
                 description: input.description as any,
@@ -9377,27 +9033,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 "x-typia-rest": input["x-typia-rest"] as any,
             });
             const $co31 = (input: any): any => ({
-                type: input.type as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-            });
-            const $co32 = (input: any): any => ({
                 schemas:
                     "object" === typeof input.schemas && null !== input.schemas
-                        ? $co33(input.schemas)
+                        ? $co32(input.schemas)
                         : (input.schemas as any),
             });
-            const $co33 = (input: any): any => {
+            const $co32 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
                     if (RegExp(/(.*)/).test(key)) {
@@ -9410,20 +9051,19 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 }
                 return output;
             };
-            const $co34 = (input: any): any => ({
+            const $co33 = (input: any): any => ({
                 $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 properties:
                     "object" === typeof input.properties &&
                     null !== input.properties
-                        ? $co35(input.properties)
+                        ? $co34(input.properties)
                         : (input.properties as any),
                 patternProperties:
                     "object" === typeof input.patternProperties &&
                     null !== input.patternProperties
-                        ? $co35(input.patternProperties)
+                        ? $co34(input.patternProperties)
                         : (input.patternProperties as any),
                 additionalProperties:
                     "object" === typeof input.additionalProperties &&
@@ -9440,7 +9080,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 "x-typia-patternProperties":
                     "object" === typeof input["x-typia-patternProperties"] &&
                     null !== input["x-typia-patternProperties"]
-                        ? $co35(input["x-typia-patternProperties"])
+                        ? $co34(input["x-typia-patternProperties"])
                         : (input["x-typia-patternProperties"] as any),
                 "x-typia-additionalProperties":
                     "object" === typeof input["x-typia-additionalProperties"] &&
@@ -9448,7 +9088,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         ? $cu0(input["x-typia-additionalProperties"])
                         : (input["x-typia-additionalProperties"] as any),
             });
-            const $co35 = (input: any): any => {
+            const $co34 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
                     if (RegExp(/(.*)/).test(key)) {
@@ -9461,7 +9101,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 }
                 return output;
             };
-            const $co36 = (input: any): any => ({
+            const $co35 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp2(input["enum"])
                     : (input["enum"] as any),
@@ -9483,7 +9123,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co37 = (input: any): any => ({
+            const $co36 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp6(input["enum"])
                     : (input["enum"] as any),
@@ -9505,7 +9145,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co38 = (input: any): any => ({
+            const $co37 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp7(input["enum"])
                     : (input["enum"] as any),
@@ -9527,7 +9167,31 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
+            const $co38 = (input: any): any => ({
+                default: input["default"] as any,
+                type: input.type as any,
+                nullable: input.nullable as any,
+                deprecated: input.deprecated as any,
+                title: input.title as any,
+                description: input.description as any,
+                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
+                    ? $cp3(input["x-typia-metaTags"])
+                    : (input["x-typia-metaTags"] as any),
+                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
+                    ? $cp4(input["x-typia-jsDocTags"])
+                    : (input["x-typia-jsDocTags"] as any),
+                "x-typia-required": input["x-typia-required"] as any,
+                "x-typia-optional": input["x-typia-optional"] as any,
+                "x-typia-rest": input["x-typia-rest"] as any,
+                $id: input.$id as any,
+                $recursiveAnchor: input.$recursiveAnchor as any,
+            });
             const $co39 = (input: any): any => ({
+                minimum: input.minimum as any,
+                maximum: input.maximum as any,
+                exclusiveMinimum: input.exclusiveMinimum as any,
+                exclusiveMaximum: input.exclusiveMaximum as any,
+                multipleOf: input.multipleOf as any,
                 default: input["default"] as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
@@ -9571,30 +9235,6 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
             const $co41 = (input: any): any => ({
-                minimum: input.minimum as any,
-                maximum: input.maximum as any,
-                exclusiveMinimum: input.exclusiveMinimum as any,
-                exclusiveMaximum: input.exclusiveMaximum as any,
-                multipleOf: input.multipleOf as any,
-                default: input["default"] as any,
-                type: input.type as any,
-                nullable: input.nullable as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-                $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
-            });
-            const $co42 = (input: any): any => ({
                 minLength: input.minLength as any,
                 maxLength: input.maxLength as any,
                 pattern: input.pattern as any,
@@ -9617,7 +9257,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co43 = (input: any): any => ({
+            const $co42 = (input: any): any => ({
                 items:
                     "object" === typeof input.items && null !== input.items
                         ? $cu0(input.items)
@@ -9646,10 +9286,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co44 = (input: any): any => ({
+            const $co43 = (input: any): any => ({
                 items: Array.isArray(input.items)
                     ? $cp1(input.items)
                     : (input.items as any),
+                minItems: input.minItems as any,
+                maxItems: input.maxItems as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 deprecated: input.deprecated as any,
@@ -9667,7 +9309,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co45 = (input: any): any => ({
+            const $co44 = (input: any): any => ({
                 oneOf: Array.isArray(input.oneOf)
                     ? $cp1(input.oneOf)
                     : (input.oneOf as any),
@@ -9686,7 +9328,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co46 = (input: any): any => ({
+            const $co45 = (input: any): any => ({
                 $ref: input.$ref as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -9703,24 +9345,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co47 = (input: any): any => ({
-                $recursiveRef: input.$recursiveRef as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-                $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
-            });
-            const $co48 = (input: any): any => ({
+            const $co46 = (input: any): any => ({
                 type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -9737,7 +9362,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co49 = (input: any): any => ({
+            const $co47 = (input: any): any => ({
                 type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -9777,8 +9402,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         return $co26(input);
                     if (undefined !== input.oneOf) return $co27(input);
                     if (undefined !== input.$ref) return $co28(input);
-                    if (undefined !== input.$recursiveRef) return $co29(input);
-                    if ("null" === input.type) return $co30(input);
+                    if ("null" === input.type) return $co29(input);
                     return (() => {
                         if ($io20(input)) return $co20(input);
                         if ($io19(input)) return $co19(input);
@@ -9786,7 +9410,7 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         if ($io21(input)) return $co21(input);
                         if ($io23(input)) return $co23(input);
                         if ($io24(input)) return $co24(input);
-                        if ($io31(input)) return $co31(input);
+                        if ($io30(input)) return $co30(input);
                         $throws({
                             expected:
                                 '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -9819,15 +9443,15 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 })();
             const $cu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $co34(input);
-                    if ("integer" === input.type) return $co40(input);
+                    if ("object" === input.type) return $co33(input);
+                    if ("integer" === input.type) return $co39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $co43(input);
+                        return $co42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -9838,19 +9462,18 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 $iu0(elem),
                         )
                     )
-                        return $co44(input);
-                    if (undefined !== input.oneOf) return $co45(input);
-                    if (undefined !== input.$ref) return $co46(input);
-                    if (undefined !== input.$recursiveRef) return $co47(input);
-                    if ("null" === input.type) return $co48(input);
+                        return $co43(input);
+                    if (undefined !== input.oneOf) return $co44(input);
+                    if (undefined !== input.$ref) return $co45(input);
+                    if ("null" === input.type) return $co46(input);
                     return (() => {
-                        if ($io38(input)) return $co38(input);
                         if ($io37(input)) return $co37(input);
                         if ($io36(input)) return $co36(input);
-                        if ($io39(input)) return $co39(input);
+                        if ($io35(input)) return $co35(input);
+                        if ($io38(input)) return $co38(input);
+                        if ($io40(input)) return $co40(input);
                         if ($io41(input)) return $co41(input);
-                        if ($io42(input)) return $co42(input);
-                        if ($io49(input)) return $co49(input);
+                        if ($io47(input)) return $co47(input);
                         $throws({
                             expected:
                                 '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/createAssertParse/test_createAssertParse_UltimateUnion.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_UltimateUnion.ts
@@ -21,7 +21,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     "object" === typeof input.components &&
                     null !== input.components &&
                     false === Array.isArray(input.components) &&
-                    $io32(input.components) &&
+                    $io31(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose);
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
@@ -454,6 +454,15 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -553,36 +562,6 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -612,7 +591,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -643,13 +622,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -662,23 +641,21 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -708,7 +685,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -718,7 +695,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -731,7 +708,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -773,7 +750,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) =>
@@ -817,7 +794,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -859,7 +836,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -897,7 +874,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
@@ -952,7 +929,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum))) &&
@@ -1004,7 +981,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
@@ -1056,7 +1033,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -1110,7 +1087,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -1119,6 +1096,15 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1154,7 +1140,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -1195,7 +1181,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1229,41 +1215,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1297,7 +1249,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -1355,9 +1307,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (() => {
                             if ($io20(input)) return $io20(input);
                             if ($io19(input)) return $io19(input);
@@ -1365,7 +1315,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             if ($io21(input)) return $io21(input);
                             if ($io23(input)) return $io23(input);
                             if ($io24(input)) return $io24(input);
-                            if ($io31(input)) return $io31(input);
+                            if ($io30(input)) return $io30(input);
                             return false;
                         })();
                     })();
@@ -1392,15 +1342,15 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -1411,20 +1361,18 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (() => {
-                            if ($io38(input)) return $io38(input);
                             if ($io37(input)) return $io37(input);
                             if ($io36(input)) return $io36(input);
-                            if ($io39(input)) return $io39(input);
+                            if ($io35(input)) return $io35(input);
+                            if ($io38(input)) return $io38(input);
+                            if ($io40(input)) return $io40(input);
                             if ($io41(input)) return $io41(input);
-                            if ($io42(input)) return $io42(input);
-                            if ($io49(input)) return $io49(input);
+                            if ($io47(input)) return $io47(input);
                             return false;
                         })();
                     })();
@@ -1469,7 +1417,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 _index2 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -1481,7 +1429,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         path:
                                             _path + ".schemas[" + _index2 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -1498,7 +1446,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: "IJsonComponents",
                                 value: input.components,
                             })) &&
-                            $ao32(
+                            $ao31(
                                 input.components,
                                 _path + ".components",
                                 true && _exceptionable,
@@ -3194,7 +3142,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                 value: input.items,
                             })) &&
                             $au0(
@@ -3205,7 +3153,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                 value: input.items,
                             })) &&
                         (undefined === input.minItems ||
@@ -3435,7 +3383,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 _index23 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -3447,7 +3395,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         path:
                                             _path + ".items[" + _index23 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -3455,6 +3403,45 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 path: _path + ".items",
                                 expected: "Array<IJsonSchema>",
                                 value: input.items,
+                            })) &&
+                        (("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number",
+                                value: input.minItems,
+                            })) &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "(number | undefined)",
+                                value: input.maxItems,
                             })) &&
                         ("array" === input.type ||
                             $guard(_exceptionable, {
@@ -3624,7 +3611,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 _index26 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -3636,7 +3623,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         path:
                                             _path + ".oneOf[" + _index26 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -3925,11 +3912,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$recursiveRef ||
+                        ("null" === input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$recursiveRef",
-                                expected: "string",
-                                value: input.$recursiveRef,
+                                path: _path + ".type",
+                                expected: '"null"',
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -4068,10 +4055,16 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("null" === input.type ||
+                        (null !== input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"null"',
+                                expected: "undefined",
+                                value: input.type,
+                            })) &&
+                        (undefined === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: "undefined",
                                 value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
@@ -4211,31 +4204,174 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (null !== input.type ||
+                        undefined === input.schemas ||
+                        ((("object" === typeof input.schemas &&
+                            null !== input.schemas &&
+                            false === Array.isArray(input.schemas)) ||
                             $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
+                                path: _path + ".schemas",
+                                expected:
+                                    "(Record<string, IObject | IAlias> | undefined)",
+                                value: input.schemas,
                             })) &&
-                        (undefined === input.type ||
+                            $ao32(
+                                input.schemas,
+                                _path + ".schemas",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".schemas",
+                            expected:
+                                "(Record<string, IObject | IAlias> | undefined)",
+                            value: input.schemas,
+                        });
+                    const $ao32 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        false === _exceptionable ||
+                        Object.keys(input).every((key: any) => {
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            if (RegExp(/(.*)/).test(key))
+                                return (
+                                    ((("object" === typeof value &&
+                                        null !== value &&
+                                        false === Array.isArray(value)) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + $join(key),
+                                            expected:
+                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                            value: value,
+                                        })) &&
+                                        $au2(
+                                            value,
+                                            _path + $join(key),
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected:
+                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                        value: value,
+                                    })
+                                );
+                            return true;
+                        });
+                    const $ao33 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.$id ||
+                            "string" === typeof input.$id ||
                             $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
+                                path: _path + ".$id",
                                 expected: "(string | undefined)",
-                                value: input.title,
+                                value: input.$id,
+                            })) &&
+                        ("object" === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: '"object"',
+                                value: input.type,
+                            })) &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
+                            $guard(_exceptionable, {
+                                path: _path + ".nullable",
+                                expected: "(boolean | undefined)",
+                                value: input.nullable,
+                            })) &&
+                        (((("object" === typeof input.properties &&
+                            null !== input.properties &&
+                            false === Array.isArray(input.properties)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".properties",
+                                expected: "Record<string, IJsonSchema>",
+                                value: input.properties,
+                            })) &&
+                            $ao34(
+                                input.properties,
+                                _path + ".properties",
+                                true && _exceptionable,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".properties",
+                                expected: "Record<string, IJsonSchema>",
+                                value: input.properties,
+                            })) &&
+                        (undefined === input.patternProperties ||
+                            ((("object" === typeof input.patternProperties &&
+                                null !== input.patternProperties &&
+                                false ===
+                                    Array.isArray(input.patternProperties)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                })) &&
+                                $ao34(
+                                    input.patternProperties,
+                                    _path + ".patternProperties",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".patternProperties",
+                                expected:
+                                    "(Record<string, IJsonSchema> | undefined)",
+                                value: input.patternProperties,
+                            })) &&
+                        (undefined === input.additionalProperties ||
+                            ((("object" === typeof input.additionalProperties &&
+                                null !== input.additionalProperties &&
+                                false ===
+                                    Array.isArray(
+                                        input.additionalProperties,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                })) &&
+                                $au0(
+                                    input.additionalProperties,
+                                    _path + ".additionalProperties",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".additionalProperties",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                value: input.additionalProperties,
+                            })) &&
+                        (undefined === input.required ||
+                            ((Array.isArray(input.required) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
+                                })) &&
+                                input.required.every(
+                                    (elem: any, _index35: number) =>
+                                        "string" === typeof elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".required[" +
+                                                _index35 +
+                                                "]",
+                                            expected: "string",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".required",
+                                expected: "(Array<string> | undefined)",
+                                value: input.required,
                             })) &&
                         (undefined === input.description ||
                             "string" === typeof input.description ||
@@ -4243,52 +4379,6 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 path: _path + ".description",
                                 expected: "(string | undefined)",
                                 value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index35: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index35 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
                             })) &&
                         (undefined === input["x-typia-jsDocTags"] ||
                             ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4334,259 +4424,6 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: "(Array<IJsDocTagInfo> | undefined)",
                                 value: input["x-typia-jsDocTags"],
                             })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            }));
-                    const $ao32 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        undefined === input.schemas ||
-                        ((("object" === typeof input.schemas &&
-                            null !== input.schemas &&
-                            false === Array.isArray(input.schemas)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".schemas",
-                                expected:
-                                    "(Record<string, IObject | IAlias> | undefined)",
-                                value: input.schemas,
-                            })) &&
-                            $ao33(
-                                input.schemas,
-                                _path + ".schemas",
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".schemas",
-                            expected:
-                                "(Record<string, IObject | IAlias> | undefined)",
-                            value: input.schemas,
-                        });
-                    const $ao33 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        false === _exceptionable ||
-                        Object.keys(input).every((key: any) => {
-                            const value = input[key];
-                            if (undefined === value) return true;
-                            if (RegExp(/(.*)/).test(key))
-                                return (
-                                    ((("object" === typeof value &&
-                                        null !== value &&
-                                        false === Array.isArray(value)) ||
-                                        $guard(_exceptionable, {
-                                            path: _path + $join(key),
-                                            expected:
-                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                            value: value,
-                                        })) &&
-                                        $au2(
-                                            value,
-                                            _path + $join(key),
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + $join(key),
-                                        expected:
-                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                        value: value,
-                                    })
-                                );
-                            return true;
-                        });
-                    const $ao34 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            })) &&
-                        ("object" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"object"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.nullable ||
-                            "boolean" === typeof input.nullable ||
-                            $guard(_exceptionable, {
-                                path: _path + ".nullable",
-                                expected: "(boolean | undefined)",
-                                value: input.nullable,
-                            })) &&
-                        (((("object" === typeof input.properties &&
-                            null !== input.properties &&
-                            false === Array.isArray(input.properties)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".properties",
-                                expected: "Record<string, IJsonSchema>",
-                                value: input.properties,
-                            })) &&
-                            $ao35(
-                                input.properties,
-                                _path + ".properties",
-                                true && _exceptionable,
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".properties",
-                                expected: "Record<string, IJsonSchema>",
-                                value: input.properties,
-                            })) &&
-                        (undefined === input.patternProperties ||
-                            ((("object" === typeof input.patternProperties &&
-                                null !== input.patternProperties &&
-                                false ===
-                                    Array.isArray(input.patternProperties)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                })) &&
-                                $ao35(
-                                    input.patternProperties,
-                                    _path + ".patternProperties",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".patternProperties",
-                                expected:
-                                    "(Record<string, IJsonSchema> | undefined)",
-                                value: input.patternProperties,
-                            })) &&
-                        (undefined === input.additionalProperties ||
-                            ((("object" === typeof input.additionalProperties &&
-                                null !== input.additionalProperties &&
-                                false ===
-                                    Array.isArray(
-                                        input.additionalProperties,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                })) &&
-                                $au0(
-                                    input.additionalProperties,
-                                    _path + ".additionalProperties",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".additionalProperties",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                value: input.additionalProperties,
-                            })) &&
-                        (undefined === input.required ||
-                            ((Array.isArray(input.required) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                })) &&
-                                input.required.every(
-                                    (elem: any, _index37: number) =>
-                                        "string" === typeof elem ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".required[" +
-                                                _index37 +
-                                                "]",
-                                            expected: "string",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".required",
-                                expected: "(Array<string> | undefined)",
-                                value: input.required,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index38: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index38 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
                         (undefined === input["x-typia-patternProperties"] ||
                             ((("object" ===
                                 typeof input["x-typia-patternProperties"] &&
@@ -4602,7 +4439,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         "(Record<string, IJsonSchema> | undefined)",
                                     value: input["x-typia-patternProperties"],
                                 })) &&
-                                $ao35(
+                                $ao34(
                                     input["x-typia-patternProperties"],
                                     _path + '["x-typia-patternProperties"]',
                                     true && _exceptionable,
@@ -4627,7 +4464,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
@@ -4641,10 +4478,10 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 path:
                                     _path + '["x-typia-additionalProperties"]',
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                 value: input["x-typia-additionalProperties"],
                             }));
-                    const $ao35 = (
+                    const $ao34 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4661,7 +4498,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         $guard(_exceptionable, {
                                             path: _path + $join(key),
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: value,
                                         })) &&
                                         $au0(
@@ -4672,13 +4509,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     $guard(_exceptionable, {
                                         path: _path + $join(key),
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: value,
                                     })
                                 );
                             return true;
                         });
-                    const $ao36 = (
+                    const $ao35 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4690,13 +4527,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 value: input["enum"],
                             })) &&
                             input["enum"].every(
-                                (elem: any, _index39: number) =>
+                                (elem: any, _index37: number) =>
                                     "boolean" === typeof elem ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +
                                             '["enum"][' +
-                                            _index39 +
+                                            _index37 +
                                             "]",
                                         expected: "boolean",
                                         value: elem,
@@ -4757,14 +4594,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index40: number) =>
+                                    (elem: any, _index38: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4774,7 +4611,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4782,7 +4619,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index40 +
+                                                _index38 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4803,14 +4640,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index41: number) =>
+                                    (elem: any, _index39: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -4819,7 +4656,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4827,7 +4664,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index41 +
+                                                _index39 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -4873,7 +4710,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: "(boolean | undefined)",
                                 value: input.$recursiveAnchor,
                             }));
-                    const $ao37 = (
+                    const $ao36 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4885,14 +4722,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 value: input["enum"],
                             })) &&
                             input["enum"].every(
-                                (elem: any, _index42: number) =>
+                                (elem: any, _index40: number) =>
                                     ("number" === typeof elem &&
                                         Number.isFinite(elem)) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +
                                             '["enum"][' +
-                                            _index42 +
+                                            _index40 +
                                             "]",
                                         expected: "number",
                                         value: elem,
@@ -4954,14 +4791,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index43: number) =>
+                                    (elem: any, _index41: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4971,7 +4808,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4979,7 +4816,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index43 +
+                                                _index41 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5000,14 +4837,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index44: number) =>
+                                    (elem: any, _index42: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index44 +
+                                                    _index42 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -5016,7 +4853,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index44 +
+                                                    _index42 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -5024,7 +4861,202 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
+                                                _index42 +
+                                                "]",
+                                            expected: "IJsDocTagInfo",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-jsDocTags"]',
+                                expected: "(Array<IJsDocTagInfo> | undefined)",
+                                value: input["x-typia-jsDocTags"],
+                            })) &&
+                        (undefined === input["x-typia-required"] ||
+                            "boolean" === typeof input["x-typia-required"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-required"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-required"],
+                            })) &&
+                        (undefined === input["x-typia-optional"] ||
+                            "boolean" === typeof input["x-typia-optional"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-optional"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-optional"],
+                            })) &&
+                        (undefined === input["x-typia-rest"] ||
+                            "boolean" === typeof input["x-typia-rest"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-rest"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-rest"],
+                            })) &&
+                        (undefined === input.$id ||
+                            "string" === typeof input.$id ||
+                            $guard(_exceptionable, {
+                                path: _path + ".$id",
+                                expected: "(string | undefined)",
+                                value: input.$id,
+                            })) &&
+                        (undefined === input.$recursiveAnchor ||
+                            "boolean" === typeof input.$recursiveAnchor ||
+                            $guard(_exceptionable, {
+                                path: _path + ".$recursiveAnchor",
+                                expected: "(boolean | undefined)",
+                                value: input.$recursiveAnchor,
+                            }));
+                    const $ao37 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (((Array.isArray(input["enum"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["enum"]',
+                                expected: "Array<string>",
+                                value: input["enum"],
+                            })) &&
+                            input["enum"].every(
+                                (elem: any, _index43: number) =>
+                                    "string" === typeof elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            '["enum"][' +
+                                            _index43 +
+                                            "]",
+                                        expected: "string",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["enum"]',
+                                expected: "Array<string>",
+                                value: input["enum"],
+                            })) &&
+                        (undefined === input["default"] ||
+                            "string" === typeof input["default"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["default"]',
+                                expected: "(string | undefined)",
+                                value: input["default"],
+                            })) &&
+                        ("string" === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: '"string"',
+                                value: input.type,
+                            })) &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
+                            $guard(_exceptionable, {
+                                path: _path + ".nullable",
+                                expected: "(boolean | undefined)",
+                                value: input.nullable,
+                            })) &&
+                        (undefined === input.deprecated ||
+                            "boolean" === typeof input.deprecated ||
+                            $guard(_exceptionable, {
+                                path: _path + ".deprecated",
+                                expected: "(boolean | undefined)",
+                                value: input.deprecated,
+                            })) &&
+                        (undefined === input.title ||
+                            "string" === typeof input.title ||
+                            $guard(_exceptionable, {
+                                path: _path + ".title",
+                                expected: "(string | undefined)",
+                                value: input.title,
+                            })) &&
+                        (undefined === input.description ||
+                            "string" === typeof input.description ||
+                            $guard(_exceptionable, {
+                                path: _path + ".description",
+                                expected: "(string | undefined)",
+                                value: input.description,
+                            })) &&
+                        (undefined === input["x-typia-metaTags"] ||
+                            ((Array.isArray(input["x-typia-metaTags"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                })) &&
+                                input["x-typia-metaTags"].every(
+                                    (elem: any, _index44: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-metaTags"][' +
+                                                    _index44 +
+                                                    "]",
+                                                expected:
+                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                value: elem,
+                                            })) &&
+                                            $au1(
+                                                elem,
+                                                _path +
+                                                    '["x-typia-metaTags"][' +
+                                                    _index44 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-metaTags"][' +
                                                 _index44 +
+                                                "]",
+                                            expected:
+                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-metaTags"]',
+                                expected: "(Array<IMetadataTag> | undefined)",
+                                value: input["x-typia-metaTags"],
+                            })) &&
+                        (undefined === input["x-typia-jsDocTags"] ||
+                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                })) &&
+                                input["x-typia-jsDocTags"].every(
+                                    (elem: any, _index45: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
+                                                    "]",
+                                                expected: "IJsDocTagInfo",
+                                                value: elem,
+                                            })) &&
+                                            $ao17(
+                                                elem,
+                                                _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-jsDocTags"][' +
+                                                _index45 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -5075,41 +5107,17 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input["enum"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["enum"]',
-                                expected: "Array<string>",
-                                value: input["enum"],
-                            })) &&
-                            input["enum"].every(
-                                (elem: any, _index45: number) =>
-                                    "string" === typeof elem ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["enum"][' +
-                                            _index45 +
-                                            "]",
-                                        expected: "string",
-                                        value: elem,
-                                    }),
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["enum"]',
-                                expected: "Array<string>",
-                                value: input["enum"],
-                            })) &&
                         (undefined === input["default"] ||
-                            "string" === typeof input["default"] ||
+                            "boolean" === typeof input["default"] ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(string | undefined)",
+                                expected: "(boolean | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("string" === input.type ||
+                        ("boolean" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"string"',
+                                expected: '"boolean"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5270,17 +5278,75 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (undefined === input.minimum ||
+                            ("number" === typeof input.minimum &&
+                                Number.isFinite(input.minimum) &&
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "(number | undefined)",
+                                value: input.minimum,
+                            })) &&
+                        (undefined === input.maximum ||
+                            ("number" === typeof input.maximum &&
+                                Number.isFinite(input.maximum) &&
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "(number | undefined)",
+                                value: input.maximum,
+                            })) &&
+                        (undefined === input.exclusiveMinimum ||
+                            "boolean" === typeof input.exclusiveMinimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "(boolean | undefined)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (undefined === input.exclusiveMaximum ||
+                            "boolean" === typeof input.exclusiveMaximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMaximum",
+                                expected: "(boolean | undefined)",
+                                value: input.exclusiveMaximum,
+                            })) &&
+                        (undefined === input.multipleOf ||
+                            ("number" === typeof input.multipleOf &&
+                                Number.isFinite(input.multipleOf) &&
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "(number | undefined)",
+                                value: input.multipleOf,
+                            })) &&
                         (undefined === input["default"] ||
-                            "boolean" === typeof input["default"] ||
+                            ("number" === typeof input["default"] &&
+                                Number.isFinite(input["default"])) ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(boolean | undefined)",
+                                expected: "(number | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("boolean" === input.type ||
+                        ("integer" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"boolean"',
+                                expected: '"integer"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5443,13 +5509,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     ): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
-                                Number.isFinite(input.minimum) &&
-                                (parseInt(input.minimum) === input.minimum ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minimum",
-                                        expected: "number (@type int)",
-                                        value: input.minimum,
-                                    }))) ||
+                                Number.isFinite(input.minimum)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -5457,13 +5517,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             })) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
-                                Number.isFinite(input.maximum) &&
-                                (parseInt(input.maximum) === input.maximum ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".maximum",
-                                        expected: "number (@type int)",
-                                        value: input.maximum,
-                                    }))) ||
+                                Number.isFinite(input.maximum)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -5485,14 +5539,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             })) &&
                         (undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
-                                Number.isFinite(input.multipleOf) &&
-                                (parseInt(input.multipleOf) ===
-                                    input.multipleOf ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".multipleOf",
-                                        expected: "number (@type int)",
-                                        value: input.multipleOf,
-                                    }))) ||
+                                Number.isFinite(input.multipleOf)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -5506,10 +5553,10 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: "(number | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("integer" === input.type ||
+                        ("number" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"integer"',
+                                expected: '"number"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5670,56 +5717,73 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (undefined === input.minimum ||
-                            ("number" === typeof input.minimum &&
-                                Number.isFinite(input.minimum)) ||
+                        (undefined === input.minLength ||
+                            ("number" === typeof input.minLength &&
+                                Number.isFinite(input.minLength) &&
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".minimum",
+                                path: _path + ".minLength",
                                 expected: "(number | undefined)",
-                                value: input.minimum,
+                                value: input.minLength,
                             })) &&
-                        (undefined === input.maximum ||
-                            ("number" === typeof input.maximum &&
-                                Number.isFinite(input.maximum)) ||
+                        (undefined === input.maxLength ||
+                            ("number" === typeof input.maxLength &&
+                                Number.isFinite(input.maxLength) &&
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".maximum",
+                                path: _path + ".maxLength",
                                 expected: "(number | undefined)",
-                                value: input.maximum,
+                                value: input.maxLength,
                             })) &&
-                        (undefined === input.exclusiveMinimum ||
-                            "boolean" === typeof input.exclusiveMinimum ||
+                        (undefined === input.pattern ||
+                            "string" === typeof input.pattern ||
                             $guard(_exceptionable, {
-                                path: _path + ".exclusiveMinimum",
-                                expected: "(boolean | undefined)",
-                                value: input.exclusiveMinimum,
+                                path: _path + ".pattern",
+                                expected: "(string | undefined)",
+                                value: input.pattern,
                             })) &&
-                        (undefined === input.exclusiveMaximum ||
-                            "boolean" === typeof input.exclusiveMaximum ||
+                        (undefined === input.format ||
+                            "string" === typeof input.format ||
                             $guard(_exceptionable, {
-                                path: _path + ".exclusiveMaximum",
-                                expected: "(boolean | undefined)",
-                                value: input.exclusiveMaximum,
-                            })) &&
-                        (undefined === input.multipleOf ||
-                            ("number" === typeof input.multipleOf &&
-                                Number.isFinite(input.multipleOf)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".multipleOf",
-                                expected: "(number | undefined)",
-                                value: input.multipleOf,
+                                path: _path + ".format",
+                                expected: "(string | undefined)",
+                                value: input.format,
                             })) &&
                         (undefined === input["default"] ||
-                            ("number" === typeof input["default"] &&
-                                Number.isFinite(input["default"])) ||
+                            "string" === typeof input["default"] ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(number | undefined)",
+                                expected: "(string | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("number" === input.type ||
+                        ("string" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"number"',
+                                expected: '"string"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5880,73 +5944,89 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (undefined === input.minLength ||
-                            ("number" === typeof input.minLength &&
-                                Number.isFinite(input.minLength) &&
-                                (parseInt(input.minLength) ===
-                                    input.minLength ||
+                        (((("object" === typeof input.items &&
+                            null !== input.items &&
+                            false === Array.isArray(input.items)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                value: input.items,
+                            })) &&
+                            $au0(
+                                input.items,
+                                _path + ".items",
+                                true && _exceptionable,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                value: input.items,
+                            })) &&
+                        (undefined === input.minItems ||
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "number (@type uint)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     })) &&
-                                (0 <= input.minLength ||
+                                (0 <= input.minItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "number (@type uint)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".minLength",
+                                path: _path + ".minItems",
                                 expected: "(number | undefined)",
-                                value: input.minLength,
+                                value: input.minItems,
                             })) &&
-                        (undefined === input.maxLength ||
-                            ("number" === typeof input.maxLength &&
-                                Number.isFinite(input.maxLength) &&
-                                (parseInt(input.maxLength) ===
-                                    input.maxLength ||
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                (parseInt(input.maxItems) === input.maxItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "number (@type uint)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     })) &&
-                                (0 <= input.maxLength ||
+                                (0 <= input.maxItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "number (@type uint)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".maxLength",
+                                path: _path + ".maxItems",
                                 expected: "(number | undefined)",
-                                value: input.maxLength,
+                                value: input.maxItems,
                             })) &&
-                        (undefined === input.pattern ||
-                            "string" === typeof input.pattern ||
+                        (undefined === input["x-typia-tuple"] ||
+                            ((("object" === typeof input["x-typia-tuple"] &&
+                                null !== input["x-typia-tuple"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
+                                })) &&
+                                $ao26(
+                                    input["x-typia-tuple"],
+                                    _path + '["x-typia-tuple"]',
+                                    true && _exceptionable,
+                                )) ||
                             $guard(_exceptionable, {
-                                path: _path + ".pattern",
-                                expected: "(string | undefined)",
-                                value: input.pattern,
+                                path: _path + '["x-typia-tuple"]',
+                                expected: "(IJsonSchema.ITuple | undefined)",
+                                value: input["x-typia-tuple"],
                             })) &&
-                        (undefined === input.format ||
-                            "string" === typeof input.format ||
-                            $guard(_exceptionable, {
-                                path: _path + ".format",
-                                expected: "(string | undefined)",
-                                value: input.format,
-                            })) &&
-                        (undefined === input["default"] ||
-                            "string" === typeof input["default"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["default"]',
-                                expected: "(string | undefined)",
-                                value: input["default"],
-                            })) &&
-                        ("string" === input.type ||
+                        ("array" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"string"',
+                                expected: '"array"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -6107,44 +6187,62 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((("object" === typeof input.items &&
-                            null !== input.items &&
-                            false === Array.isArray(input.items)) ||
+                        (((Array.isArray(input.items) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                expected: "Array<IJsonSchema>",
                                 value: input.items,
                             })) &&
-                            $au0(
-                                input.items,
-                                _path + ".items",
-                                true && _exceptionable,
+                            input.items.every(
+                                (elem: any, _index56: number) =>
+                                    ((("object" === typeof elem &&
+                                        null !== elem &&
+                                        false === Array.isArray(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index56 +
+                                                "]",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            value: elem,
+                                        })) &&
+                                        $au0(
+                                            elem,
+                                            _path + ".items[" + _index56 + "]",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".items[" + _index56 + "]",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: elem,
+                                    }),
                             )) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                expected: "Array<IJsonSchema>",
                                 value: input.items,
                             })) &&
-                        (undefined === input.minItems ||
-                            ("number" === typeof input.minItems &&
-                                Number.isFinite(input.minItems) &&
-                                (parseInt(input.minItems) === input.minItems ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minItems",
-                                        expected: "number (@type uint)",
-                                        value: input.minItems,
-                                    })) &&
-                                (0 <= input.minItems ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minItems",
-                                        expected: "number (@type uint)",
-                                        value: input.minItems,
-                                    }))) ||
+                        (("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
-                                expected: "(number | undefined)",
+                                expected: "number",
                                 value: input.minItems,
                             })) &&
                         (undefined === input.maxItems ||
@@ -6166,25 +6264,6 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",
                                 value: input.maxItems,
-                            })) &&
-                        (undefined === input["x-typia-tuple"] ||
-                            ((("object" === typeof input["x-typia-tuple"] &&
-                                null !== input["x-typia-tuple"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
-                                })) &&
-                                $ao26(
-                                    input["x-typia-tuple"],
-                                    _path + '["x-typia-tuple"]',
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-tuple"]',
-                                expected: "(IJsonSchema.ITuple | undefined)",
-                                value: input["x-typia-tuple"],
                             })) &&
                         ("array" === input.type ||
                             $guard(_exceptionable, {
@@ -6229,14 +6308,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index56: number) =>
+                                    (elem: any, _index57: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6246,7 +6325,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6254,7 +6333,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index56 +
+                                                _index57 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6275,14 +6354,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index57: number) =>
+                                    (elem: any, _index58: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6291,7 +6370,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6299,7 +6378,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index57 +
+                                                _index58 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -6350,57 +6429,44 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input.items) ||
+                        (((Array.isArray(input.oneOf) ||
                             $guard(_exceptionable, {
-                                path: _path + ".items",
+                                path: _path + ".oneOf",
                                 expected: "Array<IJsonSchema>",
-                                value: input.items,
+                                value: input.oneOf,
                             })) &&
-                            input.items.every(
-                                (elem: any, _index58: number) =>
+                            input.oneOf.every(
+                                (elem: any, _index59: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem)) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
-                                                ".items[" +
-                                                _index58 +
+                                                ".oneOf[" +
+                                                _index59 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                             true && _exceptionable,
                                         )) ||
                                     $guard(_exceptionable, {
                                         path:
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
                             $guard(_exceptionable, {
-                                path: _path + ".items",
+                                path: _path + ".oneOf",
                                 expected: "Array<IJsonSchema>",
-                                value: input.items,
-                            })) &&
-                        ("array" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"array"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.nullable ||
-                            "boolean" === typeof input.nullable ||
-                            $guard(_exceptionable, {
-                                path: _path + ".nullable",
-                                expected: "(boolean | undefined)",
-                                value: input.nullable,
+                                value: input.oneOf,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6432,14 +6498,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index59: number) =>
+                                    (elem: any, _index60: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6449,7 +6515,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6457,7 +6523,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index59 +
+                                                _index60 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6478,14 +6544,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index60: number) =>
+                                    (elem: any, _index61: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6494,7 +6560,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6502,7 +6568,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index60 +
+                                                _index61 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -6553,44 +6619,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input.oneOf) ||
+                        ("string" === typeof input.$ref ||
                             $guard(_exceptionable, {
-                                path: _path + ".oneOf",
-                                expected: "Array<IJsonSchema>",
-                                value: input.oneOf,
-                            })) &&
-                            input.oneOf.every(
-                                (elem: any, _index61: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem &&
-                                        false === Array.isArray(elem)) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".oneOf[" +
-                                                _index61 +
-                                                "]",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                            value: elem,
-                                        })) &&
-                                        $au0(
-                                            elem,
-                                            _path + ".oneOf[" + _index61 + "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path + ".oneOf[" + _index61 + "]",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                        value: elem,
-                                    }),
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".oneOf",
-                                expected: "Array<IJsonSchema>",
-                                value: input.oneOf,
+                                path: _path + ".$ref",
+                                expected: "string",
+                                value: input.$ref,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6743,11 +6776,11 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$ref ||
+                        ("null" === input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$ref",
-                                expected: "string",
-                                value: input.$ref,
+                                path: _path + ".type",
+                                expected: '"null"',
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6900,11 +6933,17 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$recursiveRef ||
+                        (null !== input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$recursiveRef",
-                                expected: "string",
-                                value: input.$recursiveRef,
+                                path: _path + ".type",
+                                expected: "undefined",
+                                value: input.type,
+                            })) &&
+                        (undefined === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: "undefined",
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -7052,326 +7091,6 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 expected: "(boolean | undefined)",
                                 value: input.$recursiveAnchor,
                             }));
-                    const $ao48 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        ("null" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"null"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index68: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index68 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index69: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index69 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            })) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }));
-                    const $ao49 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        (null !== input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index70: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index70 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index71: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index71 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            })) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }));
                     const $au0 = (
                         input: any,
                         _path: string,
@@ -7402,13 +7121,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
-                                    (elem: any, _index72: number) =>
+                                    (elem: any, _index68: number) =>
                                         "object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index72 + "]",
+                                            _path + ".items[" + _index68 + "]",
                                             false && _exceptionable,
                                         ),
                                 )
@@ -7430,14 +7149,8 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     _path,
                                     true && _exceptionable,
                                 );
-                            if (undefined !== input.$recursiveRef)
-                                return $ao29(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
                             if ("null" === input.type)
-                                return $ao30(
+                                return $ao29(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7449,7 +7162,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 $ao21(input, _path, false && _exceptionable) ||
                                 $ao23(input, _path, false && _exceptionable) ||
                                 $ao24(input, _path, false && _exceptionable) ||
-                                $ao31(input, _path, false && _exceptionable) ||
+                                $ao30(input, _path, false && _exceptionable) ||
                                 $guard(_exceptionable, {
                                     path: _path,
                                     expected:
@@ -7568,13 +7281,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     ): any =>
                         (() => {
                             if ("object" === input.type)
-                                return $ao34(
+                                return $ao33(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("integer" === input.type)
-                                return $ao40(
+                                return $ao39(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7589,7 +7302,7 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     false && _exceptionable,
                                 )
                             )
-                                return $ao43(
+                                return $ao42(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7597,54 +7310,48 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
-                                    (elem: any, _index73: number) =>
+                                    (elem: any, _index69: number) =>
                                         "object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index73 + "]",
+                                            _path + ".items[" + _index69 + "]",
                                             false && _exceptionable,
                                         ),
                                 )
                             )
-                                return $ao44(
+                                return $ao43(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.oneOf)
-                                return $ao45(
+                                return $ao44(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.$ref)
-                                return $ao46(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
-                            if (undefined !== input.$recursiveRef)
-                                return $ao47(
+                                return $ao45(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("null" === input.type)
-                                return $ao48(
+                                return $ao46(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             return (
-                                $ao38(input, _path, false && _exceptionable) ||
                                 $ao37(input, _path, false && _exceptionable) ||
                                 $ao36(input, _path, false && _exceptionable) ||
-                                $ao39(input, _path, false && _exceptionable) ||
+                                $ao35(input, _path, false && _exceptionable) ||
+                                $ao38(input, _path, false && _exceptionable) ||
+                                $ao40(input, _path, false && _exceptionable) ||
                                 $ao41(input, _path, false && _exceptionable) ||
-                                $ao42(input, _path, false && _exceptionable) ||
-                                $ao49(input, _path, false && _exceptionable) ||
+                                $ao47(input, _path, false && _exceptionable) ||
                                 $guard(_exceptionable, {
                                     path: _path,
                                     expected:

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_UltimateUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_UltimateUnion.ts
@@ -21,7 +21,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     "object" === typeof input.components &&
                     null !== input.components &&
                     false === Array.isArray(input.components) &&
-                    $io32(input.components) &&
+                    $io31(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose);
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
@@ -454,6 +454,15 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -553,36 +562,6 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -612,7 +591,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -643,13 +622,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -662,23 +641,21 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -708,7 +685,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -718,7 +695,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -731,7 +708,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -773,7 +750,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) =>
@@ -817,7 +794,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -859,7 +836,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -897,7 +874,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
@@ -952,7 +929,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum))) &&
@@ -1004,7 +981,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
@@ -1056,7 +1033,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -1110,7 +1087,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -1119,6 +1096,15 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1154,7 +1140,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -1195,7 +1181,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1229,41 +1215,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1297,7 +1249,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -1355,9 +1307,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (() => {
                             if ($io20(input)) return $io20(input);
                             if ($io19(input)) return $io19(input);
@@ -1365,7 +1315,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             if ($io21(input)) return $io21(input);
                             if ($io23(input)) return $io23(input);
                             if ($io24(input)) return $io24(input);
-                            if ($io31(input)) return $io31(input);
+                            if ($io30(input)) return $io30(input);
                             return false;
                         })();
                     })();
@@ -1392,15 +1342,15 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -1411,20 +1361,18 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (() => {
-                            if ($io38(input)) return $io38(input);
                             if ($io37(input)) return $io37(input);
                             if ($io36(input)) return $io36(input);
-                            if ($io39(input)) return $io39(input);
+                            if ($io35(input)) return $io35(input);
+                            if ($io38(input)) return $io38(input);
+                            if ($io40(input)) return $io40(input);
                             if ($io41(input)) return $io41(input);
-                            if ($io42(input)) return $io42(input);
-                            if ($io49(input)) return $io49(input);
+                            if ($io47(input)) return $io47(input);
                             return false;
                         })();
                     })();
@@ -1469,7 +1417,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 _index2 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -1481,7 +1429,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         path:
                                             _path + ".schemas[" + _index2 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -1498,7 +1446,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: "IJsonComponents",
                                 value: input.components,
                             })) &&
-                            $ao32(
+                            $ao31(
                                 input.components,
                                 _path + ".components",
                                 true && _exceptionable,
@@ -3194,7 +3142,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                 value: input.items,
                             })) &&
                             $au0(
@@ -3205,7 +3153,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             $guard(_exceptionable, {
                                 path: _path + ".items",
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                 value: input.items,
                             })) &&
                         (undefined === input.minItems ||
@@ -3435,7 +3383,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 _index23 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -3447,7 +3395,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         path:
                                             _path + ".items[" + _index23 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -3455,6 +3403,45 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 path: _path + ".items",
                                 expected: "Array<IJsonSchema>",
                                 value: input.items,
+                            })) &&
+                        (("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number",
+                                value: input.minItems,
+                            })) &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "(number | undefined)",
+                                value: input.maxItems,
                             })) &&
                         ("array" === input.type ||
                             $guard(_exceptionable, {
@@ -3624,7 +3611,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 _index26 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
@@ -3636,7 +3623,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         path:
                                             _path + ".oneOf[" + _index26 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
@@ -3925,11 +3912,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$recursiveRef ||
+                        ("null" === input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$recursiveRef",
-                                expected: "string",
-                                value: input.$recursiveRef,
+                                path: _path + ".type",
+                                expected: '"null"',
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -4068,10 +4055,16 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("null" === input.type ||
+                        (null !== input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"null"',
+                                expected: "undefined",
+                                value: input.type,
+                            })) &&
+                        (undefined === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: "undefined",
                                 value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
@@ -4211,31 +4204,174 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (null !== input.type ||
+                        undefined === input.schemas ||
+                        ((("object" === typeof input.schemas &&
+                            null !== input.schemas &&
+                            false === Array.isArray(input.schemas)) ||
                             $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
+                                path: _path + ".schemas",
+                                expected:
+                                    "(Record<string, IObject | IAlias> | undefined)",
+                                value: input.schemas,
                             })) &&
-                        (undefined === input.type ||
+                            $ao32(
+                                input.schemas,
+                                _path + ".schemas",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".schemas",
+                            expected:
+                                "(Record<string, IObject | IAlias> | undefined)",
+                            value: input.schemas,
+                        });
+                    const $ao32 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        false === _exceptionable ||
+                        Object.keys(input).every((key: any) => {
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            if (RegExp(/(.*)/).test(key))
+                                return (
+                                    ((("object" === typeof value &&
+                                        null !== value &&
+                                        false === Array.isArray(value)) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + $join(key),
+                                            expected:
+                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                            value: value,
+                                        })) &&
+                                        $au2(
+                                            value,
+                                            _path + $join(key),
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected:
+                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                        value: value,
+                                    })
+                                );
+                            return true;
+                        });
+                    const $ao33 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.$id ||
+                            "string" === typeof input.$id ||
                             $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
+                                path: _path + ".$id",
                                 expected: "(string | undefined)",
-                                value: input.title,
+                                value: input.$id,
+                            })) &&
+                        ("object" === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: '"object"',
+                                value: input.type,
+                            })) &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
+                            $guard(_exceptionable, {
+                                path: _path + ".nullable",
+                                expected: "(boolean | undefined)",
+                                value: input.nullable,
+                            })) &&
+                        (((("object" === typeof input.properties &&
+                            null !== input.properties &&
+                            false === Array.isArray(input.properties)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".properties",
+                                expected: "Record<string, IJsonSchema>",
+                                value: input.properties,
+                            })) &&
+                            $ao34(
+                                input.properties,
+                                _path + ".properties",
+                                true && _exceptionable,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".properties",
+                                expected: "Record<string, IJsonSchema>",
+                                value: input.properties,
+                            })) &&
+                        (undefined === input.patternProperties ||
+                            ((("object" === typeof input.patternProperties &&
+                                null !== input.patternProperties &&
+                                false ===
+                                    Array.isArray(input.patternProperties)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                })) &&
+                                $ao34(
+                                    input.patternProperties,
+                                    _path + ".patternProperties",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".patternProperties",
+                                expected:
+                                    "(Record<string, IJsonSchema> | undefined)",
+                                value: input.patternProperties,
+                            })) &&
+                        (undefined === input.additionalProperties ||
+                            ((("object" === typeof input.additionalProperties &&
+                                null !== input.additionalProperties &&
+                                false ===
+                                    Array.isArray(
+                                        input.additionalProperties,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                })) &&
+                                $au0(
+                                    input.additionalProperties,
+                                    _path + ".additionalProperties",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".additionalProperties",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                value: input.additionalProperties,
+                            })) &&
+                        (undefined === input.required ||
+                            ((Array.isArray(input.required) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
+                                })) &&
+                                input.required.every(
+                                    (elem: any, _index35: number) =>
+                                        "string" === typeof elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".required[" +
+                                                _index35 +
+                                                "]",
+                                            expected: "string",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".required",
+                                expected: "(Array<string> | undefined)",
+                                value: input.required,
                             })) &&
                         (undefined === input.description ||
                             "string" === typeof input.description ||
@@ -4243,52 +4379,6 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 path: _path + ".description",
                                 expected: "(string | undefined)",
                                 value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index35: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index35 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
                             })) &&
                         (undefined === input["x-typia-jsDocTags"] ||
                             ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4334,259 +4424,6 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: "(Array<IJsDocTagInfo> | undefined)",
                                 value: input["x-typia-jsDocTags"],
                             })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            }));
-                    const $ao32 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        undefined === input.schemas ||
-                        ((("object" === typeof input.schemas &&
-                            null !== input.schemas &&
-                            false === Array.isArray(input.schemas)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".schemas",
-                                expected:
-                                    "(Record<string, IObject | IAlias> | undefined)",
-                                value: input.schemas,
-                            })) &&
-                            $ao33(
-                                input.schemas,
-                                _path + ".schemas",
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".schemas",
-                            expected:
-                                "(Record<string, IObject | IAlias> | undefined)",
-                            value: input.schemas,
-                        });
-                    const $ao33 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        false === _exceptionable ||
-                        Object.keys(input).every((key: any) => {
-                            const value = input[key];
-                            if (undefined === value) return true;
-                            if (RegExp(/(.*)/).test(key))
-                                return (
-                                    ((("object" === typeof value &&
-                                        null !== value &&
-                                        false === Array.isArray(value)) ||
-                                        $guard(_exceptionable, {
-                                            path: _path + $join(key),
-                                            expected:
-                                                '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                            value: value,
-                                        })) &&
-                                        $au2(
-                                            value,
-                                            _path + $join(key),
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + $join(key),
-                                        expected:
-                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                        value: value,
-                                    })
-                                );
-                            return true;
-                        });
-                    const $ao34 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            })) &&
-                        ("object" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"object"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.nullable ||
-                            "boolean" === typeof input.nullable ||
-                            $guard(_exceptionable, {
-                                path: _path + ".nullable",
-                                expected: "(boolean | undefined)",
-                                value: input.nullable,
-                            })) &&
-                        (((("object" === typeof input.properties &&
-                            null !== input.properties &&
-                            false === Array.isArray(input.properties)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".properties",
-                                expected: "Record<string, IJsonSchema>",
-                                value: input.properties,
-                            })) &&
-                            $ao35(
-                                input.properties,
-                                _path + ".properties",
-                                true && _exceptionable,
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".properties",
-                                expected: "Record<string, IJsonSchema>",
-                                value: input.properties,
-                            })) &&
-                        (undefined === input.patternProperties ||
-                            ((("object" === typeof input.patternProperties &&
-                                null !== input.patternProperties &&
-                                false ===
-                                    Array.isArray(input.patternProperties)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                })) &&
-                                $ao35(
-                                    input.patternProperties,
-                                    _path + ".patternProperties",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".patternProperties",
-                                expected:
-                                    "(Record<string, IJsonSchema> | undefined)",
-                                value: input.patternProperties,
-                            })) &&
-                        (undefined === input.additionalProperties ||
-                            ((("object" === typeof input.additionalProperties &&
-                                null !== input.additionalProperties &&
-                                false ===
-                                    Array.isArray(
-                                        input.additionalProperties,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                })) &&
-                                $au0(
-                                    input.additionalProperties,
-                                    _path + ".additionalProperties",
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".additionalProperties",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                value: input.additionalProperties,
-                            })) &&
-                        (undefined === input.required ||
-                            ((Array.isArray(input.required) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                })) &&
-                                input.required.every(
-                                    (elem: any, _index37: number) =>
-                                        "string" === typeof elem ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".required[" +
-                                                _index37 +
-                                                "]",
-                                            expected: "string",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".required",
-                                expected: "(Array<string> | undefined)",
-                                value: input.required,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index38: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index38 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
                         (undefined === input["x-typia-patternProperties"] ||
                             ((("object" ===
                                 typeof input["x-typia-patternProperties"] &&
@@ -4602,7 +4439,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         "(Record<string, IJsonSchema> | undefined)",
                                     value: input["x-typia-patternProperties"],
                                 })) &&
-                                $ao35(
+                                $ao34(
                                     input["x-typia-patternProperties"],
                                     _path + '["x-typia-patternProperties"]',
                                     true && _exceptionable,
@@ -4627,7 +4464,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
@@ -4641,10 +4478,10 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 path:
                                     _path + '["x-typia-additionalProperties"]',
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                 value: input["x-typia-additionalProperties"],
                             }));
-                    const $ao35 = (
+                    const $ao34 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4661,7 +4498,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         $guard(_exceptionable, {
                                             path: _path + $join(key),
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: value,
                                         })) &&
                                         $au0(
@@ -4672,13 +4509,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     $guard(_exceptionable, {
                                         path: _path + $join(key),
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: value,
                                     })
                                 );
                             return true;
                         });
-                    const $ao36 = (
+                    const $ao35 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4690,13 +4527,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 value: input["enum"],
                             })) &&
                             input["enum"].every(
-                                (elem: any, _index39: number) =>
+                                (elem: any, _index37: number) =>
                                     "boolean" === typeof elem ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +
                                             '["enum"][' +
-                                            _index39 +
+                                            _index37 +
                                             "]",
                                         expected: "boolean",
                                         value: elem,
@@ -4757,14 +4594,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index40: number) =>
+                                    (elem: any, _index38: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4774,7 +4611,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4782,7 +4619,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index40 +
+                                                _index38 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4803,14 +4640,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index41: number) =>
+                                    (elem: any, _index39: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -4819,7 +4656,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4827,7 +4664,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index41 +
+                                                _index39 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -4873,7 +4710,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: "(boolean | undefined)",
                                 value: input.$recursiveAnchor,
                             }));
-                    const $ao37 = (
+                    const $ao36 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4885,14 +4722,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 value: input["enum"],
                             })) &&
                             input["enum"].every(
-                                (elem: any, _index42: number) =>
+                                (elem: any, _index40: number) =>
                                     ("number" === typeof elem &&
                                         Number.isFinite(elem)) ||
                                     $guard(_exceptionable, {
                                         path:
                                             _path +
                                             '["enum"][' +
-                                            _index42 +
+                                            _index40 +
                                             "]",
                                         expected: "number",
                                         value: elem,
@@ -4954,14 +4791,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index43: number) =>
+                                    (elem: any, _index41: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4971,7 +4808,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -4979,7 +4816,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index43 +
+                                                _index41 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5000,14 +4837,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index44: number) =>
+                                    (elem: any, _index42: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index44 +
+                                                    _index42 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -5016,7 +4853,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index44 +
+                                                    _index42 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -5024,7 +4861,202 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
+                                                _index42 +
+                                                "]",
+                                            expected: "IJsDocTagInfo",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-jsDocTags"]',
+                                expected: "(Array<IJsDocTagInfo> | undefined)",
+                                value: input["x-typia-jsDocTags"],
+                            })) &&
+                        (undefined === input["x-typia-required"] ||
+                            "boolean" === typeof input["x-typia-required"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-required"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-required"],
+                            })) &&
+                        (undefined === input["x-typia-optional"] ||
+                            "boolean" === typeof input["x-typia-optional"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-optional"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-optional"],
+                            })) &&
+                        (undefined === input["x-typia-rest"] ||
+                            "boolean" === typeof input["x-typia-rest"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-rest"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-rest"],
+                            })) &&
+                        (undefined === input.$id ||
+                            "string" === typeof input.$id ||
+                            $guard(_exceptionable, {
+                                path: _path + ".$id",
+                                expected: "(string | undefined)",
+                                value: input.$id,
+                            })) &&
+                        (undefined === input.$recursiveAnchor ||
+                            "boolean" === typeof input.$recursiveAnchor ||
+                            $guard(_exceptionable, {
+                                path: _path + ".$recursiveAnchor",
+                                expected: "(boolean | undefined)",
+                                value: input.$recursiveAnchor,
+                            }));
+                    const $ao37 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (((Array.isArray(input["enum"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["enum"]',
+                                expected: "Array<string>",
+                                value: input["enum"],
+                            })) &&
+                            input["enum"].every(
+                                (elem: any, _index43: number) =>
+                                    "string" === typeof elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            '["enum"][' +
+                                            _index43 +
+                                            "]",
+                                        expected: "string",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["enum"]',
+                                expected: "Array<string>",
+                                value: input["enum"],
+                            })) &&
+                        (undefined === input["default"] ||
+                            "string" === typeof input["default"] ||
+                            $guard(_exceptionable, {
+                                path: _path + '["default"]',
+                                expected: "(string | undefined)",
+                                value: input["default"],
+                            })) &&
+                        ("string" === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: '"string"',
+                                value: input.type,
+                            })) &&
+                        (undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
+                            $guard(_exceptionable, {
+                                path: _path + ".nullable",
+                                expected: "(boolean | undefined)",
+                                value: input.nullable,
+                            })) &&
+                        (undefined === input.deprecated ||
+                            "boolean" === typeof input.deprecated ||
+                            $guard(_exceptionable, {
+                                path: _path + ".deprecated",
+                                expected: "(boolean | undefined)",
+                                value: input.deprecated,
+                            })) &&
+                        (undefined === input.title ||
+                            "string" === typeof input.title ||
+                            $guard(_exceptionable, {
+                                path: _path + ".title",
+                                expected: "(string | undefined)",
+                                value: input.title,
+                            })) &&
+                        (undefined === input.description ||
+                            "string" === typeof input.description ||
+                            $guard(_exceptionable, {
+                                path: _path + ".description",
+                                expected: "(string | undefined)",
+                                value: input.description,
+                            })) &&
+                        (undefined === input["x-typia-metaTags"] ||
+                            ((Array.isArray(input["x-typia-metaTags"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                })) &&
+                                input["x-typia-metaTags"].every(
+                                    (elem: any, _index44: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-metaTags"][' +
+                                                    _index44 +
+                                                    "]",
+                                                expected:
+                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                value: elem,
+                                            })) &&
+                                            $au1(
+                                                elem,
+                                                _path +
+                                                    '["x-typia-metaTags"][' +
+                                                    _index44 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-metaTags"][' +
                                                 _index44 +
+                                                "]",
+                                            expected:
+                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-metaTags"]',
+                                expected: "(Array<IMetadataTag> | undefined)",
+                                value: input["x-typia-metaTags"],
+                            })) &&
+                        (undefined === input["x-typia-jsDocTags"] ||
+                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                })) &&
+                                input["x-typia-jsDocTags"].every(
+                                    (elem: any, _index45: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
+                                                    "]",
+                                                expected: "IJsDocTagInfo",
+                                                value: elem,
+                                            })) &&
+                                            $ao17(
+                                                elem,
+                                                _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-jsDocTags"][' +
+                                                _index45 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -5075,41 +5107,17 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input["enum"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["enum"]',
-                                expected: "Array<string>",
-                                value: input["enum"],
-                            })) &&
-                            input["enum"].every(
-                                (elem: any, _index45: number) =>
-                                    "string" === typeof elem ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["enum"][' +
-                                            _index45 +
-                                            "]",
-                                        expected: "string",
-                                        value: elem,
-                                    }),
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["enum"]',
-                                expected: "Array<string>",
-                                value: input["enum"],
-                            })) &&
                         (undefined === input["default"] ||
-                            "string" === typeof input["default"] ||
+                            "boolean" === typeof input["default"] ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(string | undefined)",
+                                expected: "(boolean | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("string" === input.type ||
+                        ("boolean" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"string"',
+                                expected: '"boolean"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5270,17 +5278,75 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (undefined === input.minimum ||
+                            ("number" === typeof input.minimum &&
+                                Number.isFinite(input.minimum) &&
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "(number | undefined)",
+                                value: input.minimum,
+                            })) &&
+                        (undefined === input.maximum ||
+                            ("number" === typeof input.maximum &&
+                                Number.isFinite(input.maximum) &&
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "(number | undefined)",
+                                value: input.maximum,
+                            })) &&
+                        (undefined === input.exclusiveMinimum ||
+                            "boolean" === typeof input.exclusiveMinimum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "(boolean | undefined)",
+                                value: input.exclusiveMinimum,
+                            })) &&
+                        (undefined === input.exclusiveMaximum ||
+                            "boolean" === typeof input.exclusiveMaximum ||
+                            $guard(_exceptionable, {
+                                path: _path + ".exclusiveMaximum",
+                                expected: "(boolean | undefined)",
+                                value: input.exclusiveMaximum,
+                            })) &&
+                        (undefined === input.multipleOf ||
+                            ("number" === typeof input.multipleOf &&
+                                Number.isFinite(input.multipleOf) &&
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "(number | undefined)",
+                                value: input.multipleOf,
+                            })) &&
                         (undefined === input["default"] ||
-                            "boolean" === typeof input["default"] ||
+                            ("number" === typeof input["default"] &&
+                                Number.isFinite(input["default"])) ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(boolean | undefined)",
+                                expected: "(number | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("boolean" === input.type ||
+                        ("integer" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"boolean"',
+                                expected: '"integer"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5443,13 +5509,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     ): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
-                                Number.isFinite(input.minimum) &&
-                                (parseInt(input.minimum) === input.minimum ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minimum",
-                                        expected: "number (@type int)",
-                                        value: input.minimum,
-                                    }))) ||
+                                Number.isFinite(input.minimum)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -5457,13 +5517,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             })) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
-                                Number.isFinite(input.maximum) &&
-                                (parseInt(input.maximum) === input.maximum ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".maximum",
-                                        expected: "number (@type int)",
-                                        value: input.maximum,
-                                    }))) ||
+                                Number.isFinite(input.maximum)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -5485,14 +5539,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             })) &&
                         (undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
-                                Number.isFinite(input.multipleOf) &&
-                                (parseInt(input.multipleOf) ===
-                                    input.multipleOf ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".multipleOf",
-                                        expected: "number (@type int)",
-                                        value: input.multipleOf,
-                                    }))) ||
+                                Number.isFinite(input.multipleOf)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -5506,10 +5553,10 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: "(number | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("integer" === input.type ||
+                        ("number" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"integer"',
+                                expected: '"number"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5670,56 +5717,73 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (undefined === input.minimum ||
-                            ("number" === typeof input.minimum &&
-                                Number.isFinite(input.minimum)) ||
+                        (undefined === input.minLength ||
+                            ("number" === typeof input.minLength &&
+                                Number.isFinite(input.minLength) &&
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".minimum",
+                                path: _path + ".minLength",
                                 expected: "(number | undefined)",
-                                value: input.minimum,
+                                value: input.minLength,
                             })) &&
-                        (undefined === input.maximum ||
-                            ("number" === typeof input.maximum &&
-                                Number.isFinite(input.maximum)) ||
+                        (undefined === input.maxLength ||
+                            ("number" === typeof input.maxLength &&
+                                Number.isFinite(input.maxLength) &&
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".maximum",
+                                path: _path + ".maxLength",
                                 expected: "(number | undefined)",
-                                value: input.maximum,
+                                value: input.maxLength,
                             })) &&
-                        (undefined === input.exclusiveMinimum ||
-                            "boolean" === typeof input.exclusiveMinimum ||
+                        (undefined === input.pattern ||
+                            "string" === typeof input.pattern ||
                             $guard(_exceptionable, {
-                                path: _path + ".exclusiveMinimum",
-                                expected: "(boolean | undefined)",
-                                value: input.exclusiveMinimum,
+                                path: _path + ".pattern",
+                                expected: "(string | undefined)",
+                                value: input.pattern,
                             })) &&
-                        (undefined === input.exclusiveMaximum ||
-                            "boolean" === typeof input.exclusiveMaximum ||
+                        (undefined === input.format ||
+                            "string" === typeof input.format ||
                             $guard(_exceptionable, {
-                                path: _path + ".exclusiveMaximum",
-                                expected: "(boolean | undefined)",
-                                value: input.exclusiveMaximum,
-                            })) &&
-                        (undefined === input.multipleOf ||
-                            ("number" === typeof input.multipleOf &&
-                                Number.isFinite(input.multipleOf)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".multipleOf",
-                                expected: "(number | undefined)",
-                                value: input.multipleOf,
+                                path: _path + ".format",
+                                expected: "(string | undefined)",
+                                value: input.format,
                             })) &&
                         (undefined === input["default"] ||
-                            ("number" === typeof input["default"] &&
-                                Number.isFinite(input["default"])) ||
+                            "string" === typeof input["default"] ||
                             $guard(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(number | undefined)",
+                                expected: "(string | undefined)",
                                 value: input["default"],
                             })) &&
-                        ("number" === input.type ||
+                        ("string" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"number"',
+                                expected: '"string"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -5880,73 +5944,89 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (undefined === input.minLength ||
-                            ("number" === typeof input.minLength &&
-                                Number.isFinite(input.minLength) &&
-                                (parseInt(input.minLength) ===
-                                    input.minLength ||
+                        (((("object" === typeof input.items &&
+                            null !== input.items &&
+                            false === Array.isArray(input.items)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                value: input.items,
+                            })) &&
+                            $au0(
+                                input.items,
+                                _path + ".items",
+                                true && _exceptionable,
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".items",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                value: input.items,
+                            })) &&
+                        (undefined === input.minItems ||
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "number (@type uint)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     })) &&
-                                (0 <= input.minLength ||
+                                (0 <= input.minItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "number (@type uint)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".minLength",
+                                path: _path + ".minItems",
                                 expected: "(number | undefined)",
-                                value: input.minLength,
+                                value: input.minItems,
                             })) &&
-                        (undefined === input.maxLength ||
-                            ("number" === typeof input.maxLength &&
-                                Number.isFinite(input.maxLength) &&
-                                (parseInt(input.maxLength) ===
-                                    input.maxLength ||
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                (parseInt(input.maxItems) === input.maxItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "number (@type uint)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     })) &&
-                                (0 <= input.maxLength ||
+                                (0 <= input.maxItems ||
                                     $guard(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "number (@type uint)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     }))) ||
                             $guard(_exceptionable, {
-                                path: _path + ".maxLength",
+                                path: _path + ".maxItems",
                                 expected: "(number | undefined)",
-                                value: input.maxLength,
+                                value: input.maxItems,
                             })) &&
-                        (undefined === input.pattern ||
-                            "string" === typeof input.pattern ||
+                        (undefined === input["x-typia-tuple"] ||
+                            ((("object" === typeof input["x-typia-tuple"] &&
+                                null !== input["x-typia-tuple"]) ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
+                                })) &&
+                                $ao26(
+                                    input["x-typia-tuple"],
+                                    _path + '["x-typia-tuple"]',
+                                    true && _exceptionable,
+                                )) ||
                             $guard(_exceptionable, {
-                                path: _path + ".pattern",
-                                expected: "(string | undefined)",
-                                value: input.pattern,
+                                path: _path + '["x-typia-tuple"]',
+                                expected: "(IJsonSchema.ITuple | undefined)",
+                                value: input["x-typia-tuple"],
                             })) &&
-                        (undefined === input.format ||
-                            "string" === typeof input.format ||
-                            $guard(_exceptionable, {
-                                path: _path + ".format",
-                                expected: "(string | undefined)",
-                                value: input.format,
-                            })) &&
-                        (undefined === input["default"] ||
-                            "string" === typeof input["default"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["default"]',
-                                expected: "(string | undefined)",
-                                value: input["default"],
-                            })) &&
-                        ("string" === input.type ||
+                        ("array" === input.type ||
                             $guard(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"string"',
+                                expected: '"array"',
                                 value: input.type,
                             })) &&
                         (undefined === input.nullable ||
@@ -6107,44 +6187,62 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((("object" === typeof input.items &&
-                            null !== input.items &&
-                            false === Array.isArray(input.items)) ||
+                        (((Array.isArray(input.items) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                expected: "Array<IJsonSchema>",
                                 value: input.items,
                             })) &&
-                            $au0(
-                                input.items,
-                                _path + ".items",
-                                true && _exceptionable,
+                            input.items.every(
+                                (elem: any, _index56: number) =>
+                                    ((("object" === typeof elem &&
+                                        null !== elem &&
+                                        false === Array.isArray(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index56 +
+                                                "]",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            value: elem,
+                                        })) &&
+                                        $au0(
+                                            elem,
+                                            _path + ".items[" + _index56 + "]",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".items[" + _index56 + "]",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: elem,
+                                    }),
                             )) ||
                             $guard(_exceptionable, {
                                 path: _path + ".items",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                expected: "Array<IJsonSchema>",
                                 value: input.items,
                             })) &&
-                        (undefined === input.minItems ||
-                            ("number" === typeof input.minItems &&
-                                Number.isFinite(input.minItems) &&
-                                (parseInt(input.minItems) === input.minItems ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minItems",
-                                        expected: "number (@type uint)",
-                                        value: input.minItems,
-                                    })) &&
-                                (0 <= input.minItems ||
-                                    $guard(_exceptionable, {
-                                        path: _path + ".minItems",
-                                        expected: "number (@type uint)",
-                                        value: input.minItems,
-                                    }))) ||
+                        (("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
-                                expected: "(number | undefined)",
+                                expected: "number",
                                 value: input.minItems,
                             })) &&
                         (undefined === input.maxItems ||
@@ -6166,25 +6264,6 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",
                                 value: input.maxItems,
-                            })) &&
-                        (undefined === input["x-typia-tuple"] ||
-                            ((("object" === typeof input["x-typia-tuple"] &&
-                                null !== input["x-typia-tuple"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
-                                })) &&
-                                $ao26(
-                                    input["x-typia-tuple"],
-                                    _path + '["x-typia-tuple"]',
-                                    true && _exceptionable,
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-tuple"]',
-                                expected: "(IJsonSchema.ITuple | undefined)",
-                                value: input["x-typia-tuple"],
                             })) &&
                         ("array" === input.type ||
                             $guard(_exceptionable, {
@@ -6229,14 +6308,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index56: number) =>
+                                    (elem: any, _index57: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6246,7 +6325,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6254,7 +6333,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index56 +
+                                                _index57 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6275,14 +6354,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index57: number) =>
+                                    (elem: any, _index58: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6291,7 +6370,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6299,7 +6378,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index57 +
+                                                _index58 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -6350,57 +6429,44 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input.items) ||
+                        (((Array.isArray(input.oneOf) ||
                             $guard(_exceptionable, {
-                                path: _path + ".items",
+                                path: _path + ".oneOf",
                                 expected: "Array<IJsonSchema>",
-                                value: input.items,
+                                value: input.oneOf,
                             })) &&
-                            input.items.every(
-                                (elem: any, _index58: number) =>
+                            input.oneOf.every(
+                                (elem: any, _index59: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem)) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
-                                                ".items[" +
-                                                _index58 +
+                                                ".oneOf[" +
+                                                _index59 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         })) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                             true && _exceptionable,
                                         )) ||
                                     $guard(_exceptionable, {
                                         path:
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     }),
                             )) ||
                             $guard(_exceptionable, {
-                                path: _path + ".items",
+                                path: _path + ".oneOf",
                                 expected: "Array<IJsonSchema>",
-                                value: input.items,
-                            })) &&
-                        ("array" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"array"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.nullable ||
-                            "boolean" === typeof input.nullable ||
-                            $guard(_exceptionable, {
-                                path: _path + ".nullable",
-                                expected: "(boolean | undefined)",
-                                value: input.nullable,
+                                value: input.oneOf,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6432,14 +6498,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     value: input["x-typia-metaTags"],
                                 })) &&
                                 input["x-typia-metaTags"].every(
-                                    (elem: any, _index59: number) =>
+                                    (elem: any, _index60: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6449,7 +6515,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 elem,
                                                 _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6457,7 +6523,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index59 +
+                                                _index60 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6478,14 +6544,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     value: input["x-typia-jsDocTags"],
                                 })) &&
                                 input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index60: number) =>
+                                    (elem: any, _index61: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem) ||
                                             $guard(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6494,7 +6560,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                                 elem,
                                                 _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
@@ -6502,7 +6568,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index60 +
+                                                _index61 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -6553,44 +6619,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        (((Array.isArray(input.oneOf) ||
+                        ("string" === typeof input.$ref ||
                             $guard(_exceptionable, {
-                                path: _path + ".oneOf",
-                                expected: "Array<IJsonSchema>",
-                                value: input.oneOf,
-                            })) &&
-                            input.oneOf.every(
-                                (elem: any, _index61: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem &&
-                                        false === Array.isArray(elem)) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".oneOf[" +
-                                                _index61 +
-                                                "]",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                            value: elem,
-                                        })) &&
-                                        $au0(
-                                            elem,
-                                            _path + ".oneOf[" + _index61 + "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path + ".oneOf[" + _index61 + "]",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                        value: elem,
-                                    }),
-                            )) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".oneOf",
-                                expected: "Array<IJsonSchema>",
-                                value: input.oneOf,
+                                path: _path + ".$ref",
+                                expected: "string",
+                                value: input.$ref,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6743,11 +6776,11 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$ref ||
+                        ("null" === input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$ref",
-                                expected: "string",
-                                value: input.$ref,
+                                path: _path + ".type",
+                                expected: '"null"',
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6900,11 +6933,17 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
-                        ("string" === typeof input.$recursiveRef ||
+                        (null !== input.type ||
                             $guard(_exceptionable, {
-                                path: _path + ".$recursiveRef",
-                                expected: "string",
-                                value: input.$recursiveRef,
+                                path: _path + ".type",
+                                expected: "undefined",
+                                value: input.type,
+                            })) &&
+                        (undefined === input.type ||
+                            $guard(_exceptionable, {
+                                path: _path + ".type",
+                                expected: "undefined",
+                                value: input.type,
                             })) &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -7052,326 +7091,6 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 expected: "(boolean | undefined)",
                                 value: input.$recursiveAnchor,
                             }));
-                    const $ao48 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        ("null" === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"null"',
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index68: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index68 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index69: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index69 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            })) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }));
-                    const $ao49 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        (null !== input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.type ||
-                            $guard(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $guard(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            })) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $guard(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
-                            })) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $guard(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            })) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any, _index70: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            })) &&
-                                            $au1(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index70 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any, _index71: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem) ||
-                                            $guard(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            })) &&
-                                            $ao17(
-                                                elem,
-                                                _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index71 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        }),
-                                )) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            })) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            })) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            })) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            })) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $guard(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }));
                     const $au0 = (
                         input: any,
                         _path: string,
@@ -7402,13 +7121,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
-                                    (elem: any, _index72: number) =>
+                                    (elem: any, _index68: number) =>
                                         "object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index72 + "]",
+                                            _path + ".items[" + _index68 + "]",
                                             false && _exceptionable,
                                         ),
                                 )
@@ -7430,14 +7149,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     _path,
                                     true && _exceptionable,
                                 );
-                            if (undefined !== input.$recursiveRef)
-                                return $ao29(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
                             if ("null" === input.type)
-                                return $ao30(
+                                return $ao29(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7449,7 +7162,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 $ao21(input, _path, false && _exceptionable) ||
                                 $ao23(input, _path, false && _exceptionable) ||
                                 $ao24(input, _path, false && _exceptionable) ||
-                                $ao31(input, _path, false && _exceptionable) ||
+                                $ao30(input, _path, false && _exceptionable) ||
                                 $guard(_exceptionable, {
                                     path: _path,
                                     expected:
@@ -7568,13 +7281,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     ): any =>
                         (() => {
                             if ("object" === input.type)
-                                return $ao34(
+                                return $ao33(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("integer" === input.type)
-                                return $ao40(
+                                return $ao39(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7589,7 +7302,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     false && _exceptionable,
                                 )
                             )
-                                return $ao43(
+                                return $ao42(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7597,54 +7310,48 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
-                                    (elem: any, _index73: number) =>
+                                    (elem: any, _index69: number) =>
                                         "object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem) &&
                                         $au0(
                                             elem,
-                                            _path + ".items[" + _index73 + "]",
+                                            _path + ".items[" + _index69 + "]",
                                             false && _exceptionable,
                                         ),
                                 )
                             )
-                                return $ao44(
+                                return $ao43(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.oneOf)
-                                return $ao45(
+                                return $ao44(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.$ref)
-                                return $ao46(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
-                            if (undefined !== input.$recursiveRef)
-                                return $ao47(
+                                return $ao45(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("null" === input.type)
-                                return $ao48(
+                                return $ao46(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             return (
-                                $ao38(input, _path, false && _exceptionable) ||
                                 $ao37(input, _path, false && _exceptionable) ||
                                 $ao36(input, _path, false && _exceptionable) ||
-                                $ao39(input, _path, false && _exceptionable) ||
+                                $ao35(input, _path, false && _exceptionable) ||
+                                $ao38(input, _path, false && _exceptionable) ||
+                                $ao40(input, _path, false && _exceptionable) ||
                                 $ao41(input, _path, false && _exceptionable) ||
-                                $ao42(input, _path, false && _exceptionable) ||
-                                $ao49(input, _path, false && _exceptionable) ||
+                                $ao47(input, _path, false && _exceptionable) ||
                                 $guard(_exceptionable, {
                                     path: _path,
                                     expected:
@@ -8079,6 +7786,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -8178,36 +7892,6 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -8237,7 +7921,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -8268,13 +7952,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -8287,22 +7971,20 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -8328,7 +8010,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -8338,7 +8020,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -8351,7 +8033,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -8390,7 +8072,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "number" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -8429,7 +8111,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -8468,7 +8150,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -8505,7 +8187,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         parseInt(input.minimum) === input.minimum)) &&
@@ -8555,7 +8237,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     "number" === typeof input.minimum) &&
                 (undefined === input.maximum ||
@@ -8602,7 +8284,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         parseInt(input.minLength) === input.minLength &&
@@ -8651,7 +8333,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -8702,7 +8384,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -8711,6 +8393,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -8745,7 +8434,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -8785,7 +8474,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -8818,40 +8507,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -8884,7 +8540,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -8941,8 +8597,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (
                         $io20(input) ||
                         $io19(input) ||
@@ -8950,7 +8605,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         $io21(input) ||
                         $io23(input) ||
                         $io24(input) ||
-                        $io31(input)
+                        $io30(input)
                     );
                 })();
             const $iu1 = (input: any): any =>
@@ -8974,15 +8629,15 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -8993,19 +8648,18 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (
-                        $io38(input) ||
                         $io37(input) ||
                         $io36(input) ||
-                        $io39(input) ||
+                        $io35(input) ||
+                        $io38(input) ||
+                        $io40(input) ||
                         $io41(input) ||
-                        $io42(input) ||
-                        $io49(input)
+                        $io47(input)
                     );
                 })();
             const $string = (typia.createAssertStringify as any).string;
@@ -9016,7 +8670,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
             const $so0 = (input: any): any =>
                 `{"schemas":${`[${input.schemas
                     .map((elem: any) => $su0(elem))
-                    .join(",")}]`},"components":${$so32(
+                    .join(",")}]`},"components":${$so31(
                     input.components,
                 )},"purpose":${(() => {
                     if ("string" === typeof input.purpose)
@@ -10127,6 +9781,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 })()}}`;
             const $so26 = (input: any): any =>
                 `{${
+                    undefined === input.maxItems
+                        ? ""
+                        : `"maxItems":${
+                              undefined !== input.maxItems
+                                  ? $number(input.maxItems)
+                                  : undefined
+                          },`
+                }${
                     undefined === input.nullable
                         ? ""
                         : `"nullable":${
@@ -10204,7 +9866,9 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                           },`
                 }"items":${`[${input.items
                     .map((elem: any) => $su0(elem))
-                    .join(",")}]`},"type":${(() => {
+                    .join(",")}]`},"minItems":${$number(
+                    input.minItems,
+                )},"type":${(() => {
                     if ("string" === typeof input.type)
                         return $string(input.type);
                     if ("string" === typeof input.type)
@@ -10425,76 +10089,6 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                   ? input["x-typia-rest"]
                                   : undefined
                           },`
-                }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-            const $so30 = (input: any): any =>
-                `{${
-                    undefined === input.deprecated
-                        ? ""
-                        : `"deprecated":${
-                              undefined !== input.deprecated
-                                  ? input.deprecated
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.title
-                        ? ""
-                        : `"title":${
-                              undefined !== input.title
-                                  ? $string(input.title)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.description
-                        ? ""
-                        : `"description":${
-                              undefined !== input.description
-                                  ? $string(input.description)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-metaTags"]
-                        ? ""
-                        : `"x-typia-metaTags":${
-                              undefined !== input["x-typia-metaTags"]
-                                  ? `[${input["x-typia-metaTags"]
-                                        .map((elem: any) => $su1(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-jsDocTags"]
-                        ? ""
-                        : `"x-typia-jsDocTags":${
-                              undefined !== input["x-typia-jsDocTags"]
-                                  ? `[${input["x-typia-jsDocTags"]
-                                        .map((elem: any) => $so17(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-required"]
-                        ? ""
-                        : `"x-typia-required":${
-                              undefined !== input["x-typia-required"]
-                                  ? input["x-typia-required"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-optional"]
-                        ? ""
-                        : `"x-typia-optional":${
-                              undefined !== input["x-typia-optional"]
-                                  ? input["x-typia-optional"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-rest"]
-                        ? ""
-                        : `"x-typia-rest":${
-                              undefined !== input["x-typia-rest"]
-                                  ? input["x-typia-rest"]
-                                  : undefined
-                          },`
                 }"type":${(() => {
                     if ("string" === typeof input.type)
                         return $string(input.type);
@@ -10505,7 +10099,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so31 = (input: any): any =>
+            const $so30 = (input: any): any =>
                 `{${$tail(
                     `${
                         undefined === input.deprecated
@@ -10577,19 +10171,19 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                               }`
                     }`,
                 )}}`;
-            const $so32 = (input: any): any =>
+            const $so31 = (input: any): any =>
                 `{${$tail(
                     `${
                         undefined === input.schemas
                             ? ""
                             : `"schemas":${
                                   undefined !== input.schemas
-                                      ? $so33(input.schemas)
+                                      ? $so32(input.schemas)
                                       : undefined
                               }`
                     }`,
                 )}}`;
-            const $so33 = (input: any): any =>
+            const $so32 = (input: any): any =>
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {
                         if (undefined === value) return "";
@@ -10597,21 +10191,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;
-            const $so34 = (input: any): any =>
+            const $so33 = (input: any): any =>
                 `{${
                     undefined === input.$id
                         ? ""
                         : `"$id":${
                               undefined !== input.$id
                                   ? $string(input.$id)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.$recursiveAnchor
-                        ? ""
-                        : `"$recursiveAnchor":${
-                              undefined !== input.$recursiveAnchor
-                                  ? input.$recursiveAnchor
                                   : undefined
                           },`
                 }${
@@ -10627,7 +10213,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         ? ""
                         : `"patternProperties":${
                               undefined !== input.patternProperties
-                                  ? $so35(input.patternProperties)
+                                  ? $so34(input.patternProperties)
                                   : undefined
                           },`
                 }${
@@ -10671,7 +10257,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         ? ""
                         : `"x-typia-patternProperties":${
                               undefined !== input["x-typia-patternProperties"]
-                                  ? $so35(input["x-typia-patternProperties"])
+                                  ? $so34(input["x-typia-patternProperties"])
                                   : undefined
                           },`
                 }${
@@ -10692,8 +10278,8 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         expected: '"object"',
                         value: input.type,
                     });
-                })()},"properties":${$so35(input.properties)}}`;
-            const $so35 = (input: any): any =>
+                })()},"properties":${$so34(input.properties)}}`;
+            const $so34 = (input: any): any =>
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {
                         if (undefined === value) return "";
@@ -10701,7 +10287,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;
-            const $so36 = (input: any): any =>
+            const $so35 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -10814,7 +10400,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so37 = (input: any): any =>
+            const $so36 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -10927,7 +10513,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so38 = (input: any): any =>
+            const $so37 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -11040,7 +10626,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so39 = (input: any): any =>
+            const $so38 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -11151,7 +10737,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so40 = (input: any): any =>
+            const $so39 = (input: any): any =>
                 `{${
                     undefined === input.minimum
                         ? ""
@@ -11302,7 +10888,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so41 = (input: any): any =>
+            const $so40 = (input: any): any =>
                 `{${
                     undefined === input.minimum
                         ? ""
@@ -11453,7 +11039,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so42 = (input: any): any =>
+            const $so41 = (input: any): any =>
                 `{${
                     undefined === input.minLength
                         ? ""
@@ -11596,7 +11182,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so43 = (input: any): any =>
+            const $so42 = (input: any): any =>
                 `{${
                     undefined === input.minItems
                         ? ""
@@ -11723,8 +11309,16 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so44 = (input: any): any =>
+            const $so43 = (input: any): any =>
                 `{${
+                    undefined === input.maxItems
+                        ? ""
+                        : `"maxItems":${
+                              undefined !== input.maxItems
+                                  ? $number(input.maxItems)
+                                  : undefined
+                          },`
+                }${
                     undefined === input.nullable
                         ? ""
                         : `"nullable":${
@@ -11818,7 +11412,9 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                           },`
                 }"items":${`[${input.items
                     .map((elem: any) => $su0(elem))
-                    .join(",")}]`},"type":${(() => {
+                    .join(",")}]`},"minItems":${$number(
+                    input.minItems,
+                )},"type":${(() => {
                     if ("string" === typeof input.type)
                         return $string(input.type);
                     if ("string" === typeof input.type)
@@ -11828,7 +11424,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so45 = (input: any): any =>
+            const $so44 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
                         ? ""
@@ -11916,7 +11512,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 }"oneOf":${`[${input.oneOf
                     .map((elem: any) => $su0(elem))
                     .join(",")}]`}}`;
-            const $so46 = (input: any): any =>
+            const $so45 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
                         ? ""
@@ -12002,93 +11598,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                   : undefined
                           },`
                 }"$ref":${$string(input.$ref)}}`;
-            const $so47 = (input: any): any =>
-                `{${
-                    undefined === input.deprecated
-                        ? ""
-                        : `"deprecated":${
-                              undefined !== input.deprecated
-                                  ? input.deprecated
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.title
-                        ? ""
-                        : `"title":${
-                              undefined !== input.title
-                                  ? $string(input.title)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.description
-                        ? ""
-                        : `"description":${
-                              undefined !== input.description
-                                  ? $string(input.description)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-metaTags"]
-                        ? ""
-                        : `"x-typia-metaTags":${
-                              undefined !== input["x-typia-metaTags"]
-                                  ? `[${input["x-typia-metaTags"]
-                                        .map((elem: any) => $su1(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-jsDocTags"]
-                        ? ""
-                        : `"x-typia-jsDocTags":${
-                              undefined !== input["x-typia-jsDocTags"]
-                                  ? `[${input["x-typia-jsDocTags"]
-                                        .map((elem: any) => $so17(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-required"]
-                        ? ""
-                        : `"x-typia-required":${
-                              undefined !== input["x-typia-required"]
-                                  ? input["x-typia-required"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-optional"]
-                        ? ""
-                        : `"x-typia-optional":${
-                              undefined !== input["x-typia-optional"]
-                                  ? input["x-typia-optional"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-rest"]
-                        ? ""
-                        : `"x-typia-rest":${
-                              undefined !== input["x-typia-rest"]
-                                  ? input["x-typia-rest"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.$id
-                        ? ""
-                        : `"$id":${
-                              undefined !== input.$id
-                                  ? $string(input.$id)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.$recursiveAnchor
-                        ? ""
-                        : `"$recursiveAnchor":${
-                              undefined !== input.$recursiveAnchor
-                                  ? input.$recursiveAnchor
-                                  : undefined
-                          },`
-                }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-            const $so48 = (input: any): any =>
+            const $so46 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
                         ? ""
@@ -12183,7 +11693,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so49 = (input: any): any =>
+            const $so47 = (input: any): any =>
                 `{${$tail(
                     `${
                         undefined === input.deprecated
@@ -12294,8 +11804,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         return $so26(input);
                     if (undefined !== input.oneOf) return $so27(input);
                     if (undefined !== input.$ref) return $so28(input);
-                    if (undefined !== input.$recursiveRef) return $so29(input);
-                    if ("null" === input.type) return $so30(input);
+                    if ("null" === input.type) return $so29(input);
                     return (() => {
                         if ($io20(input)) return $so20(input);
                         if ($io19(input)) return $so19(input);
@@ -12303,7 +11812,7 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         if ($io21(input)) return $so21(input);
                         if ($io23(input)) return $so23(input);
                         if ($io24(input)) return $so24(input);
-                        if ($io31(input)) return $so31(input);
+                        if ($io30(input)) return $so30(input);
                         $throws({
                             expected:
                                 '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -12336,15 +11845,15 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 })();
             const $su2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $so34(input);
-                    if ("integer" === input.type) return $so40(input);
+                    if ("object" === input.type) return $so33(input);
+                    if ("integer" === input.type) return $so39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $so43(input);
+                        return $so42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -12355,19 +11864,18 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 $iu0(elem),
                         )
                     )
-                        return $so44(input);
-                    if (undefined !== input.oneOf) return $so45(input);
-                    if (undefined !== input.$ref) return $so46(input);
-                    if (undefined !== input.$recursiveRef) return $so47(input);
-                    if ("null" === input.type) return $so48(input);
+                        return $so43(input);
+                    if (undefined !== input.oneOf) return $so44(input);
+                    if (undefined !== input.$ref) return $so45(input);
+                    if ("null" === input.type) return $so46(input);
                     return (() => {
-                        if ($io38(input)) return $so38(input);
                         if ($io37(input)) return $so37(input);
                         if ($io36(input)) return $so36(input);
-                        if ($io39(input)) return $so39(input);
+                        if ($io35(input)) return $so35(input);
+                        if ($io38(input)) return $so38(input);
+                        if ($io40(input)) return $so40(input);
                         if ($io41(input)) return $so41(input);
-                        if ($io42(input)) return $so42(input);
-                        if ($io49(input)) return $so49(input);
+                        if ($io47(input)) return $so47(input);
                         $throws({
                             expected:
                                 '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/createClone/test_createClone_UltimateUnion.ts
+++ b/test/generated/output/createClone/test_createClone_UltimateUnion.ts
@@ -385,6 +385,13 @@ export const test_createClone_UltimateUnion = _test_clone(
                     false === Array.isArray(elem) &&
                     $iu0(elem),
             ) &&
+            "number" === typeof input.minItems &&
+            parseInt(input.minItems) === input.minItems &&
+            0 <= input.minItems &&
+            (undefined === input.maxItems ||
+                ("number" === typeof input.maxItems &&
+                    parseInt(input.maxItems) === input.maxItems &&
+                    0 <= input.maxItems)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
@@ -481,35 +488,6 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input["x-typia-rest"] ||
                 "boolean" === typeof input["x-typia-rest"]);
         const $io29 = (input: any): boolean =>
-            "string" === typeof input.$recursiveRef &&
-            (undefined === input.deprecated ||
-                "boolean" === typeof input.deprecated) &&
-            (undefined === input.title || "string" === typeof input.title) &&
-            (undefined === input.description ||
-                "string" === typeof input.description) &&
-            (undefined === input["x-typia-metaTags"] ||
-                (Array.isArray(input["x-typia-metaTags"]) &&
-                    input["x-typia-metaTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $iu1(elem),
-                    ))) &&
-            (undefined === input["x-typia-jsDocTags"] ||
-                (Array.isArray(input["x-typia-jsDocTags"]) &&
-                    input["x-typia-jsDocTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $io17(elem),
-                    ))) &&
-            (undefined === input["x-typia-required"] ||
-                "boolean" === typeof input["x-typia-required"]) &&
-            (undefined === input["x-typia-optional"] ||
-                "boolean" === typeof input["x-typia-optional"]) &&
-            (undefined === input["x-typia-rest"] ||
-                "boolean" === typeof input["x-typia-rest"]);
-        const $io30 = (input: any): boolean =>
             "null" === input.type &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
@@ -538,7 +516,7 @@ export const test_createClone_UltimateUnion = _test_clone(
                 "boolean" === typeof input["x-typia-optional"]) &&
             (undefined === input["x-typia-rest"] ||
                 "boolean" === typeof input["x-typia-rest"]);
-        const $io31 = (input: any): boolean =>
+        const $io30 = (input: any): boolean =>
             null !== input.type &&
             undefined === input.type &&
             (undefined === input.deprecated ||
@@ -568,13 +546,13 @@ export const test_createClone_UltimateUnion = _test_clone(
                 "boolean" === typeof input["x-typia-optional"]) &&
             (undefined === input["x-typia-rest"] ||
                 "boolean" === typeof input["x-typia-rest"]);
-        const $io32 = (input: any): boolean =>
+        const $io31 = (input: any): boolean =>
             undefined === input.schemas ||
             ("object" === typeof input.schemas &&
                 null !== input.schemas &&
                 false === Array.isArray(input.schemas) &&
-                $io33(input.schemas));
-        const $io33 = (input: any): boolean =>
+                $io32(input.schemas));
+        const $io32 = (input: any): boolean =>
             Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
@@ -587,22 +565,20 @@ export const test_createClone_UltimateUnion = _test_clone(
                     );
                 return true;
             });
-        const $io34 = (input: any): boolean =>
+        const $io33 = (input: any): boolean =>
             (undefined === input.$id || "string" === typeof input.$id) &&
-            (undefined === input.$recursiveAnchor ||
-                "boolean" === typeof input.$recursiveAnchor) &&
             "object" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
             "object" === typeof input.properties &&
             null !== input.properties &&
             false === Array.isArray(input.properties) &&
-            $io35(input.properties) &&
+            $io34(input.properties) &&
             (undefined === input.patternProperties ||
                 ("object" === typeof input.patternProperties &&
                     null !== input.patternProperties &&
                     false === Array.isArray(input.patternProperties) &&
-                    $io35(input.patternProperties))) &&
+                    $io34(input.patternProperties))) &&
             (undefined === input.additionalProperties ||
                 ("object" === typeof input.additionalProperties &&
                     null !== input.additionalProperties &&
@@ -628,14 +604,14 @@ export const test_createClone_UltimateUnion = _test_clone(
                     null !== input["x-typia-patternProperties"] &&
                     false ===
                         Array.isArray(input["x-typia-patternProperties"]) &&
-                    $io35(input["x-typia-patternProperties"]))) &&
+                    $io34(input["x-typia-patternProperties"]))) &&
             (undefined === input["x-typia-additionalProperties"] ||
                 ("object" === typeof input["x-typia-additionalProperties"] &&
                     null !== input["x-typia-additionalProperties"] &&
                     false ===
                         Array.isArray(input["x-typia-additionalProperties"]) &&
                     $iu0(input["x-typia-additionalProperties"])));
-        const $io35 = (input: any): boolean =>
+        const $io34 = (input: any): boolean =>
             Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
@@ -648,7 +624,7 @@ export const test_createClone_UltimateUnion = _test_clone(
                     );
                 return true;
             });
-        const $io36 = (input: any): boolean =>
+        const $io35 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "boolean" === typeof elem) &&
             (undefined === input["default"] ||
@@ -686,7 +662,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io37 = (input: any): boolean =>
+        const $io36 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "number" === typeof elem) &&
             (undefined === input["default"] ||
@@ -724,7 +700,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io38 = (input: any): boolean =>
+        const $io37 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "string" === typeof elem) &&
             (undefined === input["default"] ||
@@ -762,7 +738,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io39 = (input: any): boolean =>
+        const $io38 = (input: any): boolean =>
             (undefined === input["default"] ||
                 "boolean" === typeof input["default"]) &&
             "boolean" === input.type &&
@@ -798,7 +774,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io40 = (input: any): boolean =>
+        const $io39 = (input: any): boolean =>
             (undefined === input.minimum ||
                 ("number" === typeof input.minimum &&
                     parseInt(input.minimum) === input.minimum)) &&
@@ -847,7 +823,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io41 = (input: any): boolean =>
+        const $io40 = (input: any): boolean =>
             (undefined === input.minimum ||
                 "number" === typeof input.minimum) &&
             (undefined === input.maximum ||
@@ -893,7 +869,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io42 = (input: any): boolean =>
+        const $io41 = (input: any): boolean =>
             (undefined === input.minLength ||
                 ("number" === typeof input.minLength &&
                     parseInt(input.minLength) === input.minLength &&
@@ -940,7 +916,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io43 = (input: any): boolean =>
+        const $io42 = (input: any): boolean =>
             "object" === typeof input.items &&
             null !== input.items &&
             false === Array.isArray(input.items) &&
@@ -990,7 +966,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io44 = (input: any): boolean =>
+        const $io43 = (input: any): boolean =>
             Array.isArray(input.items) &&
             input.items.every(
                 (elem: any) =>
@@ -999,6 +975,13 @@ export const test_createClone_UltimateUnion = _test_clone(
                     false === Array.isArray(elem) &&
                     $iu0(elem),
             ) &&
+            "number" === typeof input.minItems &&
+            parseInt(input.minItems) === input.minItems &&
+            0 <= input.minItems &&
+            (undefined === input.maxItems ||
+                ("number" === typeof input.maxItems &&
+                    parseInt(input.maxItems) === input.maxItems &&
+                    0 <= input.maxItems)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
@@ -1032,7 +1015,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io45 = (input: any): boolean =>
+        const $io44 = (input: any): boolean =>
             Array.isArray(input.oneOf) &&
             input.oneOf.every(
                 (elem: any) =>
@@ -1071,7 +1054,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io46 = (input: any): boolean =>
+        const $io45 = (input: any): boolean =>
             "string" === typeof input.$ref &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
@@ -1103,39 +1086,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io47 = (input: any): boolean =>
-            "string" === typeof input.$recursiveRef &&
-            (undefined === input.deprecated ||
-                "boolean" === typeof input.deprecated) &&
-            (undefined === input.title || "string" === typeof input.title) &&
-            (undefined === input.description ||
-                "string" === typeof input.description) &&
-            (undefined === input["x-typia-metaTags"] ||
-                (Array.isArray(input["x-typia-metaTags"]) &&
-                    input["x-typia-metaTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $iu1(elem),
-                    ))) &&
-            (undefined === input["x-typia-jsDocTags"] ||
-                (Array.isArray(input["x-typia-jsDocTags"]) &&
-                    input["x-typia-jsDocTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $io17(elem),
-                    ))) &&
-            (undefined === input["x-typia-required"] ||
-                "boolean" === typeof input["x-typia-required"]) &&
-            (undefined === input["x-typia-optional"] ||
-                "boolean" === typeof input["x-typia-optional"]) &&
-            (undefined === input["x-typia-rest"] ||
-                "boolean" === typeof input["x-typia-rest"]) &&
-            (undefined === input.$id || "string" === typeof input.$id) &&
-            (undefined === input.$recursiveAnchor ||
-                "boolean" === typeof input.$recursiveAnchor);
-        const $io48 = (input: any): boolean =>
+        const $io46 = (input: any): boolean =>
             "null" === input.type &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
@@ -1167,7 +1118,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io49 = (input: any): boolean =>
+        const $io47 = (input: any): boolean =>
             null !== input.type &&
             undefined === input.type &&
             (undefined === input.deprecated ||
@@ -1223,8 +1174,7 @@ export const test_createClone_UltimateUnion = _test_clone(
                     return $io26(input);
                 if (undefined !== input.oneOf) return $io27(input);
                 if (undefined !== input.$ref) return $io28(input);
-                if (undefined !== input.$recursiveRef) return $io29(input);
-                if ("null" === input.type) return $io30(input);
+                if ("null" === input.type) return $io29(input);
                 return (
                     $io20(input) ||
                     $io19(input) ||
@@ -1232,7 +1182,7 @@ export const test_createClone_UltimateUnion = _test_clone(
                     $io21(input) ||
                     $io23(input) ||
                     $io24(input) ||
-                    $io31(input)
+                    $io30(input)
                 );
             })();
         const $iu1 = (input: any): any =>
@@ -1256,15 +1206,15 @@ export const test_createClone_UltimateUnion = _test_clone(
             })();
         const $iu2 = (input: any): any =>
             (() => {
-                if ("object" === input.type) return $io34(input);
-                if ("integer" === input.type) return $io40(input);
+                if ("object" === input.type) return $io33(input);
+                if ("integer" === input.type) return $io39(input);
                 if (
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
                     $iu0(input.items)
                 )
-                    return $io43(input);
+                    return $io42(input);
                 if (
                     Array.isArray(input.items) &&
                     input.items.every(
@@ -1275,19 +1225,18 @@ export const test_createClone_UltimateUnion = _test_clone(
                             $iu0(elem),
                     )
                 )
-                    return $io44(input);
-                if (undefined !== input.oneOf) return $io45(input);
-                if (undefined !== input.$ref) return $io46(input);
-                if (undefined !== input.$recursiveRef) return $io47(input);
-                if ("null" === input.type) return $io48(input);
+                    return $io43(input);
+                if (undefined !== input.oneOf) return $io44(input);
+                if (undefined !== input.$ref) return $io45(input);
+                if ("null" === input.type) return $io46(input);
                 return (
-                    $io38(input) ||
                     $io37(input) ||
                     $io36(input) ||
-                    $io39(input) ||
+                    $io35(input) ||
+                    $io38(input) ||
+                    $io40(input) ||
                     $io41(input) ||
-                    $io42(input) ||
-                    $io49(input)
+                    $io47(input)
                 );
             })();
         const $join = (typia.createClone as any).join;
@@ -1332,7 +1281,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             components:
                 "object" === typeof input.components &&
                 null !== input.components
-                    ? $co32(input.components)
+                    ? $co31(input.components)
                     : (input.components as any),
             purpose: input.purpose as any,
         });
@@ -1579,6 +1528,8 @@ export const test_createClone_UltimateUnion = _test_clone(
             items: Array.isArray(input.items)
                 ? $cp1(input.items)
                 : (input.items as any),
+            minItems: input.minItems as any,
+            maxItems: input.maxItems as any,
             type: input.type as any,
             nullable: input.nullable as any,
             deprecated: input.deprecated as any,
@@ -1627,7 +1578,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             "x-typia-rest": input["x-typia-rest"] as any,
         });
         const $co29 = (input: any): any => ({
-            $recursiveRef: input.$recursiveRef as any,
+            type: input.type as any,
             deprecated: input.deprecated as any,
             title: input.title as any,
             description: input.description as any,
@@ -1657,27 +1608,12 @@ export const test_createClone_UltimateUnion = _test_clone(
             "x-typia-rest": input["x-typia-rest"] as any,
         });
         const $co31 = (input: any): any => ({
-            type: input.type as any,
-            deprecated: input.deprecated as any,
-            title: input.title as any,
-            description: input.description as any,
-            "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                ? $cp3(input["x-typia-metaTags"])
-                : (input["x-typia-metaTags"] as any),
-            "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                ? $cp4(input["x-typia-jsDocTags"])
-                : (input["x-typia-jsDocTags"] as any),
-            "x-typia-required": input["x-typia-required"] as any,
-            "x-typia-optional": input["x-typia-optional"] as any,
-            "x-typia-rest": input["x-typia-rest"] as any,
-        });
-        const $co32 = (input: any): any => ({
             schemas:
                 "object" === typeof input.schemas && null !== input.schemas
-                    ? $co33(input.schemas)
+                    ? $co32(input.schemas)
                     : (input.schemas as any),
         });
-        const $co33 = (input: any): any => {
+        const $co32 = (input: any): any => {
             const output = {} as any;
             for (const [key, value] of Object.entries(input)) {
                 if (RegExp(/(.*)/).test(key)) {
@@ -1690,20 +1626,19 @@ export const test_createClone_UltimateUnion = _test_clone(
             }
             return output;
         };
-        const $co34 = (input: any): any => ({
+        const $co33 = (input: any): any => ({
             $id: input.$id as any,
-            $recursiveAnchor: input.$recursiveAnchor as any,
             type: input.type as any,
             nullable: input.nullable as any,
             properties:
                 "object" === typeof input.properties &&
                 null !== input.properties
-                    ? $co35(input.properties)
+                    ? $co34(input.properties)
                     : (input.properties as any),
             patternProperties:
                 "object" === typeof input.patternProperties &&
                 null !== input.patternProperties
-                    ? $co35(input.patternProperties)
+                    ? $co34(input.patternProperties)
                     : (input.patternProperties as any),
             additionalProperties:
                 "object" === typeof input.additionalProperties &&
@@ -1720,7 +1655,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             "x-typia-patternProperties":
                 "object" === typeof input["x-typia-patternProperties"] &&
                 null !== input["x-typia-patternProperties"]
-                    ? $co35(input["x-typia-patternProperties"])
+                    ? $co34(input["x-typia-patternProperties"])
                     : (input["x-typia-patternProperties"] as any),
             "x-typia-additionalProperties":
                 "object" === typeof input["x-typia-additionalProperties"] &&
@@ -1728,7 +1663,7 @@ export const test_createClone_UltimateUnion = _test_clone(
                     ? $cu0(input["x-typia-additionalProperties"])
                     : (input["x-typia-additionalProperties"] as any),
         });
-        const $co35 = (input: any): any => {
+        const $co34 = (input: any): any => {
             const output = {} as any;
             for (const [key, value] of Object.entries(input)) {
                 if (RegExp(/(.*)/).test(key)) {
@@ -1741,7 +1676,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             }
             return output;
         };
-        const $co36 = (input: any): any => ({
+        const $co35 = (input: any): any => ({
             enum: Array.isArray(input["enum"])
                 ? $cp2(input["enum"])
                 : (input["enum"] as any),
@@ -1763,7 +1698,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             $id: input.$id as any,
             $recursiveAnchor: input.$recursiveAnchor as any,
         });
-        const $co37 = (input: any): any => ({
+        const $co36 = (input: any): any => ({
             enum: Array.isArray(input["enum"])
                 ? $cp6(input["enum"])
                 : (input["enum"] as any),
@@ -1785,7 +1720,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             $id: input.$id as any,
             $recursiveAnchor: input.$recursiveAnchor as any,
         });
-        const $co38 = (input: any): any => ({
+        const $co37 = (input: any): any => ({
             enum: Array.isArray(input["enum"])
                 ? $cp7(input["enum"])
                 : (input["enum"] as any),
@@ -1807,7 +1742,31 @@ export const test_createClone_UltimateUnion = _test_clone(
             $id: input.$id as any,
             $recursiveAnchor: input.$recursiveAnchor as any,
         });
+        const $co38 = (input: any): any => ({
+            default: input["default"] as any,
+            type: input.type as any,
+            nullable: input.nullable as any,
+            deprecated: input.deprecated as any,
+            title: input.title as any,
+            description: input.description as any,
+            "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
+                ? $cp3(input["x-typia-metaTags"])
+                : (input["x-typia-metaTags"] as any),
+            "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
+                ? $cp4(input["x-typia-jsDocTags"])
+                : (input["x-typia-jsDocTags"] as any),
+            "x-typia-required": input["x-typia-required"] as any,
+            "x-typia-optional": input["x-typia-optional"] as any,
+            "x-typia-rest": input["x-typia-rest"] as any,
+            $id: input.$id as any,
+            $recursiveAnchor: input.$recursiveAnchor as any,
+        });
         const $co39 = (input: any): any => ({
+            minimum: input.minimum as any,
+            maximum: input.maximum as any,
+            exclusiveMinimum: input.exclusiveMinimum as any,
+            exclusiveMaximum: input.exclusiveMaximum as any,
+            multipleOf: input.multipleOf as any,
             default: input["default"] as any,
             type: input.type as any,
             nullable: input.nullable as any,
@@ -1851,30 +1810,6 @@ export const test_createClone_UltimateUnion = _test_clone(
             $recursiveAnchor: input.$recursiveAnchor as any,
         });
         const $co41 = (input: any): any => ({
-            minimum: input.minimum as any,
-            maximum: input.maximum as any,
-            exclusiveMinimum: input.exclusiveMinimum as any,
-            exclusiveMaximum: input.exclusiveMaximum as any,
-            multipleOf: input.multipleOf as any,
-            default: input["default"] as any,
-            type: input.type as any,
-            nullable: input.nullable as any,
-            deprecated: input.deprecated as any,
-            title: input.title as any,
-            description: input.description as any,
-            "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                ? $cp3(input["x-typia-metaTags"])
-                : (input["x-typia-metaTags"] as any),
-            "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                ? $cp4(input["x-typia-jsDocTags"])
-                : (input["x-typia-jsDocTags"] as any),
-            "x-typia-required": input["x-typia-required"] as any,
-            "x-typia-optional": input["x-typia-optional"] as any,
-            "x-typia-rest": input["x-typia-rest"] as any,
-            $id: input.$id as any,
-            $recursiveAnchor: input.$recursiveAnchor as any,
-        });
-        const $co42 = (input: any): any => ({
             minLength: input.minLength as any,
             maxLength: input.maxLength as any,
             pattern: input.pattern as any,
@@ -1897,7 +1832,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             $id: input.$id as any,
             $recursiveAnchor: input.$recursiveAnchor as any,
         });
-        const $co43 = (input: any): any => ({
+        const $co42 = (input: any): any => ({
             items:
                 "object" === typeof input.items && null !== input.items
                     ? $cu0(input.items)
@@ -1926,10 +1861,12 @@ export const test_createClone_UltimateUnion = _test_clone(
             $id: input.$id as any,
             $recursiveAnchor: input.$recursiveAnchor as any,
         });
-        const $co44 = (input: any): any => ({
+        const $co43 = (input: any): any => ({
             items: Array.isArray(input.items)
                 ? $cp1(input.items)
                 : (input.items as any),
+            minItems: input.minItems as any,
+            maxItems: input.maxItems as any,
             type: input.type as any,
             nullable: input.nullable as any,
             deprecated: input.deprecated as any,
@@ -1947,7 +1884,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             $id: input.$id as any,
             $recursiveAnchor: input.$recursiveAnchor as any,
         });
-        const $co45 = (input: any): any => ({
+        const $co44 = (input: any): any => ({
             oneOf: Array.isArray(input.oneOf)
                 ? $cp1(input.oneOf)
                 : (input.oneOf as any),
@@ -1966,7 +1903,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             $id: input.$id as any,
             $recursiveAnchor: input.$recursiveAnchor as any,
         });
-        const $co46 = (input: any): any => ({
+        const $co45 = (input: any): any => ({
             $ref: input.$ref as any,
             deprecated: input.deprecated as any,
             title: input.title as any,
@@ -1983,24 +1920,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             $id: input.$id as any,
             $recursiveAnchor: input.$recursiveAnchor as any,
         });
-        const $co47 = (input: any): any => ({
-            $recursiveRef: input.$recursiveRef as any,
-            deprecated: input.deprecated as any,
-            title: input.title as any,
-            description: input.description as any,
-            "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                ? $cp3(input["x-typia-metaTags"])
-                : (input["x-typia-metaTags"] as any),
-            "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                ? $cp4(input["x-typia-jsDocTags"])
-                : (input["x-typia-jsDocTags"] as any),
-            "x-typia-required": input["x-typia-required"] as any,
-            "x-typia-optional": input["x-typia-optional"] as any,
-            "x-typia-rest": input["x-typia-rest"] as any,
-            $id: input.$id as any,
-            $recursiveAnchor: input.$recursiveAnchor as any,
-        });
-        const $co48 = (input: any): any => ({
+        const $co46 = (input: any): any => ({
             type: input.type as any,
             deprecated: input.deprecated as any,
             title: input.title as any,
@@ -2017,7 +1937,7 @@ export const test_createClone_UltimateUnion = _test_clone(
             $id: input.$id as any,
             $recursiveAnchor: input.$recursiveAnchor as any,
         });
-        const $co49 = (input: any): any => ({
+        const $co47 = (input: any): any => ({
             type: input.type as any,
             deprecated: input.deprecated as any,
             title: input.title as any,
@@ -2057,8 +1977,7 @@ export const test_createClone_UltimateUnion = _test_clone(
                     return $co26(input);
                 if (undefined !== input.oneOf) return $co27(input);
                 if (undefined !== input.$ref) return $co28(input);
-                if (undefined !== input.$recursiveRef) return $co29(input);
-                if ("null" === input.type) return $co30(input);
+                if ("null" === input.type) return $co29(input);
                 return (() => {
                     if ($io20(input)) return $co20(input);
                     if ($io19(input)) return $co19(input);
@@ -2066,7 +1985,7 @@ export const test_createClone_UltimateUnion = _test_clone(
                     if ($io21(input)) return $co21(input);
                     if ($io23(input)) return $co23(input);
                     if ($io24(input)) return $co24(input);
-                    if ($io31(input)) return $co31(input);
+                    if ($io30(input)) return $co30(input);
                     $throws({
                         expected:
                             '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -2099,15 +2018,15 @@ export const test_createClone_UltimateUnion = _test_clone(
             })();
         const $cu2 = (input: any): any =>
             (() => {
-                if ("object" === input.type) return $co34(input);
-                if ("integer" === input.type) return $co40(input);
+                if ("object" === input.type) return $co33(input);
+                if ("integer" === input.type) return $co39(input);
                 if (
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
                     $iu0(input.items)
                 )
-                    return $co43(input);
+                    return $co42(input);
                 if (
                     Array.isArray(input.items) &&
                     input.items.every(
@@ -2118,19 +2037,18 @@ export const test_createClone_UltimateUnion = _test_clone(
                             $iu0(elem),
                     )
                 )
-                    return $co44(input);
-                if (undefined !== input.oneOf) return $co45(input);
-                if (undefined !== input.$ref) return $co46(input);
-                if (undefined !== input.$recursiveRef) return $co47(input);
-                if ("null" === input.type) return $co48(input);
+                    return $co43(input);
+                if (undefined !== input.oneOf) return $co44(input);
+                if (undefined !== input.$ref) return $co45(input);
+                if ("null" === input.type) return $co46(input);
                 return (() => {
-                    if ($io38(input)) return $co38(input);
                     if ($io37(input)) return $co37(input);
                     if ($io36(input)) return $co36(input);
-                    if ($io39(input)) return $co39(input);
+                    if ($io35(input)) return $co35(input);
+                    if ($io38(input)) return $co38(input);
+                    if ($io40(input)) return $co40(input);
                     if ($io41(input)) return $co41(input);
-                    if ($io42(input)) return $co42(input);
-                    if ($io49(input)) return $co49(input);
+                    if ($io47(input)) return $co47(input);
                     $throws({
                         expected:
                             '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/createIs/test_createIs_UltimateUnion.ts
+++ b/test/generated/output/createIs/test_createIs_UltimateUnion.ts
@@ -19,7 +19,7 @@ export const test_createIs_UltimateUnion = _test_is(
             "object" === typeof input.components &&
             null !== input.components &&
             false === Array.isArray(input.components) &&
-            $io32(input.components) &&
+            $io31(input.components) &&
             ("ajv" === input.purpose || "swagger" === input.purpose);
         const $io1 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
@@ -438,6 +438,15 @@ export const test_createIs_UltimateUnion = _test_is(
                     false === Array.isArray(elem) &&
                     $iu0(elem),
             ) &&
+            "number" === typeof input.minItems &&
+            Number.isFinite(input.minItems) &&
+            parseInt(input.minItems) === input.minItems &&
+            0 <= input.minItems &&
+            (undefined === input.maxItems ||
+                ("number" === typeof input.maxItems &&
+                    Number.isFinite(input.maxItems) &&
+                    parseInt(input.maxItems) === input.maxItems &&
+                    0 <= input.maxItems)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
@@ -534,35 +543,6 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input["x-typia-rest"] ||
                 "boolean" === typeof input["x-typia-rest"]);
         const $io29 = (input: any): boolean =>
-            "string" === typeof input.$recursiveRef &&
-            (undefined === input.deprecated ||
-                "boolean" === typeof input.deprecated) &&
-            (undefined === input.title || "string" === typeof input.title) &&
-            (undefined === input.description ||
-                "string" === typeof input.description) &&
-            (undefined === input["x-typia-metaTags"] ||
-                (Array.isArray(input["x-typia-metaTags"]) &&
-                    input["x-typia-metaTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $iu1(elem),
-                    ))) &&
-            (undefined === input["x-typia-jsDocTags"] ||
-                (Array.isArray(input["x-typia-jsDocTags"]) &&
-                    input["x-typia-jsDocTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $io17(elem),
-                    ))) &&
-            (undefined === input["x-typia-required"] ||
-                "boolean" === typeof input["x-typia-required"]) &&
-            (undefined === input["x-typia-optional"] ||
-                "boolean" === typeof input["x-typia-optional"]) &&
-            (undefined === input["x-typia-rest"] ||
-                "boolean" === typeof input["x-typia-rest"]);
-        const $io30 = (input: any): boolean =>
             "null" === input.type &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
@@ -591,7 +571,7 @@ export const test_createIs_UltimateUnion = _test_is(
                 "boolean" === typeof input["x-typia-optional"]) &&
             (undefined === input["x-typia-rest"] ||
                 "boolean" === typeof input["x-typia-rest"]);
-        const $io31 = (input: any): boolean =>
+        const $io30 = (input: any): boolean =>
             null !== input.type &&
             undefined === input.type &&
             (undefined === input.deprecated ||
@@ -621,13 +601,13 @@ export const test_createIs_UltimateUnion = _test_is(
                 "boolean" === typeof input["x-typia-optional"]) &&
             (undefined === input["x-typia-rest"] ||
                 "boolean" === typeof input["x-typia-rest"]);
-        const $io32 = (input: any): boolean =>
+        const $io31 = (input: any): boolean =>
             undefined === input.schemas ||
             ("object" === typeof input.schemas &&
                 null !== input.schemas &&
                 false === Array.isArray(input.schemas) &&
-                $io33(input.schemas));
-        const $io33 = (input: any): boolean =>
+                $io32(input.schemas));
+        const $io32 = (input: any): boolean =>
             Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
@@ -640,22 +620,20 @@ export const test_createIs_UltimateUnion = _test_is(
                     );
                 return true;
             });
-        const $io34 = (input: any): boolean =>
+        const $io33 = (input: any): boolean =>
             (undefined === input.$id || "string" === typeof input.$id) &&
-            (undefined === input.$recursiveAnchor ||
-                "boolean" === typeof input.$recursiveAnchor) &&
             "object" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
             "object" === typeof input.properties &&
             null !== input.properties &&
             false === Array.isArray(input.properties) &&
-            $io35(input.properties) &&
+            $io34(input.properties) &&
             (undefined === input.patternProperties ||
                 ("object" === typeof input.patternProperties &&
                     null !== input.patternProperties &&
                     false === Array.isArray(input.patternProperties) &&
-                    $io35(input.patternProperties))) &&
+                    $io34(input.patternProperties))) &&
             (undefined === input.additionalProperties ||
                 ("object" === typeof input.additionalProperties &&
                     null !== input.additionalProperties &&
@@ -681,14 +659,14 @@ export const test_createIs_UltimateUnion = _test_is(
                     null !== input["x-typia-patternProperties"] &&
                     false ===
                         Array.isArray(input["x-typia-patternProperties"]) &&
-                    $io35(input["x-typia-patternProperties"]))) &&
+                    $io34(input["x-typia-patternProperties"]))) &&
             (undefined === input["x-typia-additionalProperties"] ||
                 ("object" === typeof input["x-typia-additionalProperties"] &&
                     null !== input["x-typia-additionalProperties"] &&
                     false ===
                         Array.isArray(input["x-typia-additionalProperties"]) &&
                     $iu0(input["x-typia-additionalProperties"])));
-        const $io35 = (input: any): boolean =>
+        const $io34 = (input: any): boolean =>
             Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
@@ -701,7 +679,7 @@ export const test_createIs_UltimateUnion = _test_is(
                     );
                 return true;
             });
-        const $io36 = (input: any): boolean =>
+        const $io35 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "boolean" === typeof elem) &&
             (undefined === input["default"] ||
@@ -739,7 +717,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io37 = (input: any): boolean =>
+        const $io36 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every(
                 (elem: any) =>
@@ -781,7 +759,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io38 = (input: any): boolean =>
+        const $io37 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "string" === typeof elem) &&
             (undefined === input["default"] ||
@@ -819,7 +797,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io39 = (input: any): boolean =>
+        const $io38 = (input: any): boolean =>
             (undefined === input["default"] ||
                 "boolean" === typeof input["default"]) &&
             "boolean" === input.type &&
@@ -855,7 +833,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io40 = (input: any): boolean =>
+        const $io39 = (input: any): boolean =>
             (undefined === input.minimum ||
                 ("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
@@ -908,7 +886,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io41 = (input: any): boolean =>
+        const $io40 = (input: any): boolean =>
             (undefined === input.minimum ||
                 ("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum))) &&
@@ -958,7 +936,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io42 = (input: any): boolean =>
+        const $io41 = (input: any): boolean =>
             (undefined === input.minLength ||
                 ("number" === typeof input.minLength &&
                     Number.isFinite(input.minLength) &&
@@ -1007,7 +985,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io43 = (input: any): boolean =>
+        const $io42 = (input: any): boolean =>
             "object" === typeof input.items &&
             null !== input.items &&
             false === Array.isArray(input.items) &&
@@ -1059,7 +1037,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io44 = (input: any): boolean =>
+        const $io43 = (input: any): boolean =>
             Array.isArray(input.items) &&
             input.items.every(
                 (elem: any) =>
@@ -1068,6 +1046,15 @@ export const test_createIs_UltimateUnion = _test_is(
                     false === Array.isArray(elem) &&
                     $iu0(elem),
             ) &&
+            "number" === typeof input.minItems &&
+            Number.isFinite(input.minItems) &&
+            parseInt(input.minItems) === input.minItems &&
+            0 <= input.minItems &&
+            (undefined === input.maxItems ||
+                ("number" === typeof input.maxItems &&
+                    Number.isFinite(input.maxItems) &&
+                    parseInt(input.maxItems) === input.maxItems &&
+                    0 <= input.maxItems)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
@@ -1101,7 +1088,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io45 = (input: any): boolean =>
+        const $io44 = (input: any): boolean =>
             Array.isArray(input.oneOf) &&
             input.oneOf.every(
                 (elem: any) =>
@@ -1140,7 +1127,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io46 = (input: any): boolean =>
+        const $io45 = (input: any): boolean =>
             "string" === typeof input.$ref &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
@@ -1172,39 +1159,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io47 = (input: any): boolean =>
-            "string" === typeof input.$recursiveRef &&
-            (undefined === input.deprecated ||
-                "boolean" === typeof input.deprecated) &&
-            (undefined === input.title || "string" === typeof input.title) &&
-            (undefined === input.description ||
-                "string" === typeof input.description) &&
-            (undefined === input["x-typia-metaTags"] ||
-                (Array.isArray(input["x-typia-metaTags"]) &&
-                    input["x-typia-metaTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $iu1(elem),
-                    ))) &&
-            (undefined === input["x-typia-jsDocTags"] ||
-                (Array.isArray(input["x-typia-jsDocTags"]) &&
-                    input["x-typia-jsDocTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $io17(elem),
-                    ))) &&
-            (undefined === input["x-typia-required"] ||
-                "boolean" === typeof input["x-typia-required"]) &&
-            (undefined === input["x-typia-optional"] ||
-                "boolean" === typeof input["x-typia-optional"]) &&
-            (undefined === input["x-typia-rest"] ||
-                "boolean" === typeof input["x-typia-rest"]) &&
-            (undefined === input.$id || "string" === typeof input.$id) &&
-            (undefined === input.$recursiveAnchor ||
-                "boolean" === typeof input.$recursiveAnchor);
-        const $io48 = (input: any): boolean =>
+        const $io46 = (input: any): boolean =>
             "null" === input.type &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
@@ -1236,7 +1191,7 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io49 = (input: any): boolean =>
+        const $io47 = (input: any): boolean =>
             null !== input.type &&
             undefined === input.type &&
             (undefined === input.deprecated ||
@@ -1292,8 +1247,7 @@ export const test_createIs_UltimateUnion = _test_is(
                     return $io26(input);
                 if (undefined !== input.oneOf) return $io27(input);
                 if (undefined !== input.$ref) return $io28(input);
-                if (undefined !== input.$recursiveRef) return $io29(input);
-                if ("null" === input.type) return $io30(input);
+                if ("null" === input.type) return $io29(input);
                 return (() => {
                     if ($io20(input)) return $io20(input);
                     if ($io19(input)) return $io19(input);
@@ -1301,7 +1255,7 @@ export const test_createIs_UltimateUnion = _test_is(
                     if ($io21(input)) return $io21(input);
                     if ($io23(input)) return $io23(input);
                     if ($io24(input)) return $io24(input);
-                    if ($io31(input)) return $io31(input);
+                    if ($io30(input)) return $io30(input);
                     return false;
                 })();
             })();
@@ -1326,15 +1280,15 @@ export const test_createIs_UltimateUnion = _test_is(
             })();
         const $iu2 = (input: any): any =>
             (() => {
-                if ("object" === input.type) return $io34(input);
-                if ("integer" === input.type) return $io40(input);
+                if ("object" === input.type) return $io33(input);
+                if ("integer" === input.type) return $io39(input);
                 if (
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
                     $iu0(input.items)
                 )
-                    return $io43(input);
+                    return $io42(input);
                 if (
                     Array.isArray(input.items) &&
                     input.items.every(
@@ -1345,19 +1299,18 @@ export const test_createIs_UltimateUnion = _test_is(
                             $iu0(elem),
                     )
                 )
-                    return $io44(input);
-                if (undefined !== input.oneOf) return $io45(input);
-                if (undefined !== input.$ref) return $io46(input);
-                if (undefined !== input.$recursiveRef) return $io47(input);
-                if ("null" === input.type) return $io48(input);
+                    return $io43(input);
+                if (undefined !== input.oneOf) return $io44(input);
+                if (undefined !== input.$ref) return $io45(input);
+                if ("null" === input.type) return $io46(input);
                 return (() => {
-                    if ($io38(input)) return $io38(input);
                     if ($io37(input)) return $io37(input);
                     if ($io36(input)) return $io36(input);
-                    if ($io39(input)) return $io39(input);
+                    if ($io35(input)) return $io35(input);
+                    if ($io38(input)) return $io38(input);
+                    if ($io40(input)) return $io40(input);
                     if ($io41(input)) return $io41(input);
-                    if ($io42(input)) return $io42(input);
-                    if ($io49(input)) return $io49(input);
+                    if ($io47(input)) return $io47(input);
                     return false;
                 })();
             })();

--- a/test/generated/output/createIsClone/test_createIsClone_UltimateUnion.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_UltimateUnion.ts
@@ -20,7 +20,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 "object" === typeof input.components &&
                 null !== input.components &&
                 false === Array.isArray(input.components) &&
-                $io32(input.components) &&
+                $io31(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose);
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
@@ -449,6 +449,15 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -548,36 +557,6 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -607,7 +586,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -638,13 +617,13 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -657,22 +636,20 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -698,7 +675,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -708,7 +685,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -721,7 +698,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -760,7 +737,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every(
                     (elem: any) =>
@@ -803,7 +780,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -842,7 +819,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -879,7 +856,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
@@ -933,7 +910,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum))) &&
@@ -984,7 +961,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
@@ -1035,7 +1012,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -1088,7 +1065,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -1097,6 +1074,15 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1131,7 +1117,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -1171,7 +1157,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1204,40 +1190,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1270,7 +1223,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -1327,8 +1280,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (() => {
                         if ($io20(input)) return $io20(input);
                         if ($io19(input)) return $io19(input);
@@ -1336,7 +1288,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         if ($io21(input)) return $io21(input);
                         if ($io23(input)) return $io23(input);
                         if ($io24(input)) return $io24(input);
-                        if ($io31(input)) return $io31(input);
+                        if ($io30(input)) return $io30(input);
                         return false;
                     })();
                 })();
@@ -1361,15 +1313,15 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -1380,19 +1332,18 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (() => {
-                        if ($io38(input)) return $io38(input);
                         if ($io37(input)) return $io37(input);
                         if ($io36(input)) return $io36(input);
-                        if ($io39(input)) return $io39(input);
+                        if ($io35(input)) return $io35(input);
+                        if ($io38(input)) return $io38(input);
+                        if ($io40(input)) return $io40(input);
                         if ($io41(input)) return $io41(input);
-                        if ($io42(input)) return $io42(input);
-                        if ($io49(input)) return $io49(input);
+                        if ($io47(input)) return $io47(input);
                         return false;
                     })();
                 })();
@@ -1796,6 +1747,13 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1895,36 +1853,6 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1954,7 +1882,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -1985,13 +1913,13 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -2004,22 +1932,20 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -2045,7 +1971,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -2055,7 +1981,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -2068,7 +1994,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -2107,7 +2033,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "number" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -2146,7 +2072,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -2185,7 +2111,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -2222,7 +2148,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         parseInt(input.minimum) === input.minimum)) &&
@@ -2272,7 +2198,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     "number" === typeof input.minimum) &&
                 (undefined === input.maximum ||
@@ -2319,7 +2245,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         parseInt(input.minLength) === input.minLength &&
@@ -2368,7 +2294,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -2419,7 +2345,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -2428,6 +2354,13 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -2462,7 +2395,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -2502,7 +2435,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -2535,40 +2468,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -2601,7 +2501,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -2658,8 +2558,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (
                         $io20(input) ||
                         $io19(input) ||
@@ -2667,7 +2566,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         $io21(input) ||
                         $io23(input) ||
                         $io24(input) ||
-                        $io31(input)
+                        $io30(input)
                     );
                 })();
             const $iu1 = (input: any): any =>
@@ -2691,15 +2590,15 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -2710,19 +2609,18 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (
-                        $io38(input) ||
                         $io37(input) ||
                         $io36(input) ||
-                        $io39(input) ||
+                        $io35(input) ||
+                        $io38(input) ||
+                        $io40(input) ||
                         $io41(input) ||
-                        $io42(input) ||
-                        $io49(input)
+                        $io47(input)
                     );
                 })();
             const $join = (typia.createIsClone as any).join;
@@ -2767,7 +2665,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 components:
                     "object" === typeof input.components &&
                     null !== input.components
-                        ? $co32(input.components)
+                        ? $co31(input.components)
                         : (input.components as any),
                 purpose: input.purpose as any,
             });
@@ -3014,6 +2912,8 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 items: Array.isArray(input.items)
                     ? $cp1(input.items)
                     : (input.items as any),
+                minItems: input.minItems as any,
+                maxItems: input.maxItems as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 deprecated: input.deprecated as any,
@@ -3062,7 +2962,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 "x-typia-rest": input["x-typia-rest"] as any,
             });
             const $co29 = (input: any): any => ({
-                $recursiveRef: input.$recursiveRef as any,
+                type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
                 description: input.description as any,
@@ -3092,27 +2992,12 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 "x-typia-rest": input["x-typia-rest"] as any,
             });
             const $co31 = (input: any): any => ({
-                type: input.type as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-            });
-            const $co32 = (input: any): any => ({
                 schemas:
                     "object" === typeof input.schemas && null !== input.schemas
-                        ? $co33(input.schemas)
+                        ? $co32(input.schemas)
                         : (input.schemas as any),
             });
-            const $co33 = (input: any): any => {
+            const $co32 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
                     if (RegExp(/(.*)/).test(key)) {
@@ -3125,20 +3010,19 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 }
                 return output;
             };
-            const $co34 = (input: any): any => ({
+            const $co33 = (input: any): any => ({
                 $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 properties:
                     "object" === typeof input.properties &&
                     null !== input.properties
-                        ? $co35(input.properties)
+                        ? $co34(input.properties)
                         : (input.properties as any),
                 patternProperties:
                     "object" === typeof input.patternProperties &&
                     null !== input.patternProperties
-                        ? $co35(input.patternProperties)
+                        ? $co34(input.patternProperties)
                         : (input.patternProperties as any),
                 additionalProperties:
                     "object" === typeof input.additionalProperties &&
@@ -3155,7 +3039,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 "x-typia-patternProperties":
                     "object" === typeof input["x-typia-patternProperties"] &&
                     null !== input["x-typia-patternProperties"]
-                        ? $co35(input["x-typia-patternProperties"])
+                        ? $co34(input["x-typia-patternProperties"])
                         : (input["x-typia-patternProperties"] as any),
                 "x-typia-additionalProperties":
                     "object" === typeof input["x-typia-additionalProperties"] &&
@@ -3163,7 +3047,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         ? $cu0(input["x-typia-additionalProperties"])
                         : (input["x-typia-additionalProperties"] as any),
             });
-            const $co35 = (input: any): any => {
+            const $co34 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
                     if (RegExp(/(.*)/).test(key)) {
@@ -3176,7 +3060,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 }
                 return output;
             };
-            const $co36 = (input: any): any => ({
+            const $co35 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp2(input["enum"])
                     : (input["enum"] as any),
@@ -3198,7 +3082,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co37 = (input: any): any => ({
+            const $co36 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp6(input["enum"])
                     : (input["enum"] as any),
@@ -3220,7 +3104,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co38 = (input: any): any => ({
+            const $co37 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp7(input["enum"])
                     : (input["enum"] as any),
@@ -3242,7 +3126,31 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
+            const $co38 = (input: any): any => ({
+                default: input["default"] as any,
+                type: input.type as any,
+                nullable: input.nullable as any,
+                deprecated: input.deprecated as any,
+                title: input.title as any,
+                description: input.description as any,
+                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
+                    ? $cp3(input["x-typia-metaTags"])
+                    : (input["x-typia-metaTags"] as any),
+                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
+                    ? $cp4(input["x-typia-jsDocTags"])
+                    : (input["x-typia-jsDocTags"] as any),
+                "x-typia-required": input["x-typia-required"] as any,
+                "x-typia-optional": input["x-typia-optional"] as any,
+                "x-typia-rest": input["x-typia-rest"] as any,
+                $id: input.$id as any,
+                $recursiveAnchor: input.$recursiveAnchor as any,
+            });
             const $co39 = (input: any): any => ({
+                minimum: input.minimum as any,
+                maximum: input.maximum as any,
+                exclusiveMinimum: input.exclusiveMinimum as any,
+                exclusiveMaximum: input.exclusiveMaximum as any,
+                multipleOf: input.multipleOf as any,
                 default: input["default"] as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
@@ -3286,30 +3194,6 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
             const $co41 = (input: any): any => ({
-                minimum: input.minimum as any,
-                maximum: input.maximum as any,
-                exclusiveMinimum: input.exclusiveMinimum as any,
-                exclusiveMaximum: input.exclusiveMaximum as any,
-                multipleOf: input.multipleOf as any,
-                default: input["default"] as any,
-                type: input.type as any,
-                nullable: input.nullable as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-                $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
-            });
-            const $co42 = (input: any): any => ({
                 minLength: input.minLength as any,
                 maxLength: input.maxLength as any,
                 pattern: input.pattern as any,
@@ -3332,7 +3216,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co43 = (input: any): any => ({
+            const $co42 = (input: any): any => ({
                 items:
                     "object" === typeof input.items && null !== input.items
                         ? $cu0(input.items)
@@ -3361,10 +3245,12 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co44 = (input: any): any => ({
+            const $co43 = (input: any): any => ({
                 items: Array.isArray(input.items)
                     ? $cp1(input.items)
                     : (input.items as any),
+                minItems: input.minItems as any,
+                maxItems: input.maxItems as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 deprecated: input.deprecated as any,
@@ -3382,7 +3268,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co45 = (input: any): any => ({
+            const $co44 = (input: any): any => ({
                 oneOf: Array.isArray(input.oneOf)
                     ? $cp1(input.oneOf)
                     : (input.oneOf as any),
@@ -3401,7 +3287,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co46 = (input: any): any => ({
+            const $co45 = (input: any): any => ({
                 $ref: input.$ref as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -3418,24 +3304,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co47 = (input: any): any => ({
-                $recursiveRef: input.$recursiveRef as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-                $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
-            });
-            const $co48 = (input: any): any => ({
+            const $co46 = (input: any): any => ({
                 type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -3452,7 +3321,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co49 = (input: any): any => ({
+            const $co47 = (input: any): any => ({
                 type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -3492,8 +3361,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         return $co26(input);
                     if (undefined !== input.oneOf) return $co27(input);
                     if (undefined !== input.$ref) return $co28(input);
-                    if (undefined !== input.$recursiveRef) return $co29(input);
-                    if ("null" === input.type) return $co30(input);
+                    if ("null" === input.type) return $co29(input);
                     return (() => {
                         if ($io20(input)) return $co20(input);
                         if ($io19(input)) return $co19(input);
@@ -3501,7 +3369,7 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                         if ($io21(input)) return $co21(input);
                         if ($io23(input)) return $co23(input);
                         if ($io24(input)) return $co24(input);
-                        if ($io31(input)) return $co31(input);
+                        if ($io30(input)) return $co30(input);
                         $throws({
                             expected:
                                 '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -3534,15 +3402,15 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 })();
             const $cu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $co34(input);
-                    if ("integer" === input.type) return $co40(input);
+                    if ("object" === input.type) return $co33(input);
+                    if ("integer" === input.type) return $co39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $co43(input);
+                        return $co42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -3553,19 +3421,18 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                                 $iu0(elem),
                         )
                     )
-                        return $co44(input);
-                    if (undefined !== input.oneOf) return $co45(input);
-                    if (undefined !== input.$ref) return $co46(input);
-                    if (undefined !== input.$recursiveRef) return $co47(input);
-                    if ("null" === input.type) return $co48(input);
+                        return $co43(input);
+                    if (undefined !== input.oneOf) return $co44(input);
+                    if (undefined !== input.$ref) return $co45(input);
+                    if ("null" === input.type) return $co46(input);
                     return (() => {
-                        if ($io38(input)) return $co38(input);
                         if ($io37(input)) return $co37(input);
                         if ($io36(input)) return $co36(input);
-                        if ($io39(input)) return $co39(input);
+                        if ($io35(input)) return $co35(input);
+                        if ($io38(input)) return $co38(input);
+                        if ($io40(input)) return $co40(input);
                         if ($io41(input)) return $co41(input);
-                        if ($io42(input)) return $co42(input);
-                        if ($io49(input)) return $co49(input);
+                        if ($io47(input)) return $co47(input);
                         $throws({
                             expected:
                                 '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/createIsParse/test_createIsParse_UltimateUnion.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_UltimateUnion.ts
@@ -20,7 +20,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 "object" === typeof input.components &&
                 null !== input.components &&
                 false === Array.isArray(input.components) &&
-                $io32(input.components) &&
+                $io31(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose);
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
@@ -449,6 +449,15 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -548,36 +557,6 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -607,7 +586,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -638,13 +617,13 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -657,22 +636,20 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -698,7 +675,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -708,7 +685,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -721,7 +698,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -760,7 +737,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every(
                     (elem: any) =>
@@ -803,7 +780,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -842,7 +819,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -879,7 +856,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
@@ -933,7 +910,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum))) &&
@@ -984,7 +961,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
@@ -1035,7 +1012,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -1088,7 +1065,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -1097,6 +1074,15 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1131,7 +1117,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -1171,7 +1157,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1204,40 +1190,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1270,7 +1223,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -1327,8 +1280,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (() => {
                         if ($io20(input)) return $io20(input);
                         if ($io19(input)) return $io19(input);
@@ -1336,7 +1288,7 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                         if ($io21(input)) return $io21(input);
                         if ($io23(input)) return $io23(input);
                         if ($io24(input)) return $io24(input);
-                        if ($io31(input)) return $io31(input);
+                        if ($io30(input)) return $io30(input);
                         return false;
                     })();
                 })();
@@ -1361,15 +1313,15 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -1380,19 +1332,18 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (() => {
-                        if ($io38(input)) return $io38(input);
                         if ($io37(input)) return $io37(input);
                         if ($io36(input)) return $io36(input);
-                        if ($io39(input)) return $io39(input);
+                        if ($io35(input)) return $io35(input);
+                        if ($io38(input)) return $io38(input);
+                        if ($io40(input)) return $io40(input);
                         if ($io41(input)) return $io41(input);
-                        if ($io42(input)) return $io42(input);
-                        if ($io49(input)) return $io49(input);
+                        if ($io47(input)) return $io47(input);
                         return false;
                     })();
                 })();

--- a/test/generated/output/createIsStringify/test_createIsStringify_UltimateUnion.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_UltimateUnion.ts
@@ -20,7 +20,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 "object" === typeof input.components &&
                 null !== input.components &&
                 false === Array.isArray(input.components) &&
-                $io32(input.components) &&
+                $io31(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose);
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
@@ -449,6 +449,15 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -548,36 +557,6 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -607,7 +586,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -638,13 +617,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -657,22 +636,20 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -698,7 +675,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -708,7 +685,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -721,7 +698,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -760,7 +737,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every(
                     (elem: any) =>
@@ -803,7 +780,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -842,7 +819,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -879,7 +856,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
@@ -933,7 +910,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum))) &&
@@ -984,7 +961,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
@@ -1035,7 +1012,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -1088,7 +1065,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -1097,6 +1074,15 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1131,7 +1117,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -1171,7 +1157,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1204,40 +1190,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1270,7 +1223,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -1327,8 +1280,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (() => {
                         if ($io20(input)) return $io20(input);
                         if ($io19(input)) return $io19(input);
@@ -1336,7 +1288,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         if ($io21(input)) return $io21(input);
                         if ($io23(input)) return $io23(input);
                         if ($io24(input)) return $io24(input);
-                        if ($io31(input)) return $io31(input);
+                        if ($io30(input)) return $io30(input);
                         return false;
                     })();
                 })();
@@ -1361,15 +1313,15 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -1380,19 +1332,18 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (() => {
-                        if ($io38(input)) return $io38(input);
                         if ($io37(input)) return $io37(input);
                         if ($io36(input)) return $io36(input);
-                        if ($io39(input)) return $io39(input);
+                        if ($io35(input)) return $io35(input);
+                        if ($io38(input)) return $io38(input);
+                        if ($io40(input)) return $io40(input);
                         if ($io41(input)) return $io41(input);
-                        if ($io42(input)) return $io42(input);
-                        if ($io49(input)) return $io49(input);
+                        if ($io47(input)) return $io47(input);
                         return false;
                     })();
                 })();
@@ -1794,6 +1745,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1893,36 +1851,6 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1952,7 +1880,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -1983,13 +1911,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -2002,22 +1930,20 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -2043,7 +1969,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -2053,7 +1979,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -2066,7 +1992,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -2105,7 +2031,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "number" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -2144,7 +2070,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -2183,7 +2109,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -2220,7 +2146,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         parseInt(input.minimum) === input.minimum)) &&
@@ -2270,7 +2196,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     "number" === typeof input.minimum) &&
                 (undefined === input.maximum ||
@@ -2317,7 +2243,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         parseInt(input.minLength) === input.minLength &&
@@ -2366,7 +2292,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -2417,7 +2343,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -2426,6 +2352,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -2460,7 +2393,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -2500,7 +2433,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -2533,40 +2466,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -2599,7 +2499,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -2656,8 +2556,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (
                         $io20(input) ||
                         $io19(input) ||
@@ -2665,7 +2564,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         $io21(input) ||
                         $io23(input) ||
                         $io24(input) ||
-                        $io31(input)
+                        $io30(input)
                     );
                 })();
             const $iu1 = (input: any): any =>
@@ -2689,15 +2588,15 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -2708,19 +2607,18 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (
-                        $io38(input) ||
                         $io37(input) ||
                         $io36(input) ||
-                        $io39(input) ||
+                        $io35(input) ||
+                        $io38(input) ||
+                        $io40(input) ||
                         $io41(input) ||
-                        $io42(input) ||
-                        $io49(input)
+                        $io47(input)
                     );
                 })();
             const $string = (typia.createIsStringify as any).string;
@@ -2731,7 +2629,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
             const $so0 = (input: any): any =>
                 `{"schemas":${`[${input.schemas
                     .map((elem: any) => $su0(elem))
-                    .join(",")}]`},"components":${$so32(
+                    .join(",")}]`},"components":${$so31(
                     input.components,
                 )},"purpose":${(() => {
                     if ("string" === typeof input.purpose)
@@ -3842,6 +3740,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 })()}}`;
             const $so26 = (input: any): any =>
                 `{${
+                    undefined === input.maxItems
+                        ? ""
+                        : `"maxItems":${
+                              undefined !== input.maxItems
+                                  ? $number(input.maxItems)
+                                  : undefined
+                          },`
+                }${
                     undefined === input.nullable
                         ? ""
                         : `"nullable":${
@@ -3919,7 +3825,9 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                           },`
                 }"items":${`[${input.items
                     .map((elem: any) => $su0(elem))
-                    .join(",")}]`},"type":${(() => {
+                    .join(",")}]`},"minItems":${$number(
+                    input.minItems,
+                )},"type":${(() => {
                     if ("string" === typeof input.type)
                         return $string(input.type);
                     if ("string" === typeof input.type)
@@ -4140,76 +4048,6 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                                   ? input["x-typia-rest"]
                                   : undefined
                           },`
-                }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-            const $so30 = (input: any): any =>
-                `{${
-                    undefined === input.deprecated
-                        ? ""
-                        : `"deprecated":${
-                              undefined !== input.deprecated
-                                  ? input.deprecated
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.title
-                        ? ""
-                        : `"title":${
-                              undefined !== input.title
-                                  ? $string(input.title)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.description
-                        ? ""
-                        : `"description":${
-                              undefined !== input.description
-                                  ? $string(input.description)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-metaTags"]
-                        ? ""
-                        : `"x-typia-metaTags":${
-                              undefined !== input["x-typia-metaTags"]
-                                  ? `[${input["x-typia-metaTags"]
-                                        .map((elem: any) => $su1(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-jsDocTags"]
-                        ? ""
-                        : `"x-typia-jsDocTags":${
-                              undefined !== input["x-typia-jsDocTags"]
-                                  ? `[${input["x-typia-jsDocTags"]
-                                        .map((elem: any) => $so17(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-required"]
-                        ? ""
-                        : `"x-typia-required":${
-                              undefined !== input["x-typia-required"]
-                                  ? input["x-typia-required"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-optional"]
-                        ? ""
-                        : `"x-typia-optional":${
-                              undefined !== input["x-typia-optional"]
-                                  ? input["x-typia-optional"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-rest"]
-                        ? ""
-                        : `"x-typia-rest":${
-                              undefined !== input["x-typia-rest"]
-                                  ? input["x-typia-rest"]
-                                  : undefined
-                          },`
                 }"type":${(() => {
                     if ("string" === typeof input.type)
                         return $string(input.type);
@@ -4220,7 +4058,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so31 = (input: any): any =>
+            const $so30 = (input: any): any =>
                 `{${$tail(
                     `${
                         undefined === input.deprecated
@@ -4292,19 +4130,19 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                               }`
                     }`,
                 )}}`;
-            const $so32 = (input: any): any =>
+            const $so31 = (input: any): any =>
                 `{${$tail(
                     `${
                         undefined === input.schemas
                             ? ""
                             : `"schemas":${
                                   undefined !== input.schemas
-                                      ? $so33(input.schemas)
+                                      ? $so32(input.schemas)
                                       : undefined
                               }`
                     }`,
                 )}}`;
-            const $so33 = (input: any): any =>
+            const $so32 = (input: any): any =>
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {
                         if (undefined === value) return "";
@@ -4312,21 +4150,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;
-            const $so34 = (input: any): any =>
+            const $so33 = (input: any): any =>
                 `{${
                     undefined === input.$id
                         ? ""
                         : `"$id":${
                               undefined !== input.$id
                                   ? $string(input.$id)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.$recursiveAnchor
-                        ? ""
-                        : `"$recursiveAnchor":${
-                              undefined !== input.$recursiveAnchor
-                                  ? input.$recursiveAnchor
                                   : undefined
                           },`
                 }${
@@ -4342,7 +4172,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         ? ""
                         : `"patternProperties":${
                               undefined !== input.patternProperties
-                                  ? $so35(input.patternProperties)
+                                  ? $so34(input.patternProperties)
                                   : undefined
                           },`
                 }${
@@ -4386,7 +4216,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         ? ""
                         : `"x-typia-patternProperties":${
                               undefined !== input["x-typia-patternProperties"]
-                                  ? $so35(input["x-typia-patternProperties"])
+                                  ? $so34(input["x-typia-patternProperties"])
                                   : undefined
                           },`
                 }${
@@ -4407,8 +4237,8 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         expected: '"object"',
                         value: input.type,
                     });
-                })()},"properties":${$so35(input.properties)}}`;
-            const $so35 = (input: any): any =>
+                })()},"properties":${$so34(input.properties)}}`;
+            const $so34 = (input: any): any =>
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {
                         if (undefined === value) return "";
@@ -4416,7 +4246,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;
-            const $so36 = (input: any): any =>
+            const $so35 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -4529,7 +4359,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so37 = (input: any): any =>
+            const $so36 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -4642,7 +4472,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so38 = (input: any): any =>
+            const $so37 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -4755,7 +4585,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so39 = (input: any): any =>
+            const $so38 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -4866,7 +4696,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so40 = (input: any): any =>
+            const $so39 = (input: any): any =>
                 `{${
                     undefined === input.minimum
                         ? ""
@@ -5017,7 +4847,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so41 = (input: any): any =>
+            const $so40 = (input: any): any =>
                 `{${
                     undefined === input.minimum
                         ? ""
@@ -5168,7 +4998,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so42 = (input: any): any =>
+            const $so41 = (input: any): any =>
                 `{${
                     undefined === input.minLength
                         ? ""
@@ -5311,7 +5141,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so43 = (input: any): any =>
+            const $so42 = (input: any): any =>
                 `{${
                     undefined === input.minItems
                         ? ""
@@ -5438,8 +5268,16 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so44 = (input: any): any =>
+            const $so43 = (input: any): any =>
                 `{${
+                    undefined === input.maxItems
+                        ? ""
+                        : `"maxItems":${
+                              undefined !== input.maxItems
+                                  ? $number(input.maxItems)
+                                  : undefined
+                          },`
+                }${
                     undefined === input.nullable
                         ? ""
                         : `"nullable":${
@@ -5533,7 +5371,9 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                           },`
                 }"items":${`[${input.items
                     .map((elem: any) => $su0(elem))
-                    .join(",")}]`},"type":${(() => {
+                    .join(",")}]`},"minItems":${$number(
+                    input.minItems,
+                )},"type":${(() => {
                     if ("string" === typeof input.type)
                         return $string(input.type);
                     if ("string" === typeof input.type)
@@ -5543,7 +5383,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so45 = (input: any): any =>
+            const $so44 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
                         ? ""
@@ -5631,7 +5471,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 }"oneOf":${`[${input.oneOf
                     .map((elem: any) => $su0(elem))
                     .join(",")}]`}}`;
-            const $so46 = (input: any): any =>
+            const $so45 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
                         ? ""
@@ -5717,93 +5557,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                                   : undefined
                           },`
                 }"$ref":${$string(input.$ref)}}`;
-            const $so47 = (input: any): any =>
-                `{${
-                    undefined === input.deprecated
-                        ? ""
-                        : `"deprecated":${
-                              undefined !== input.deprecated
-                                  ? input.deprecated
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.title
-                        ? ""
-                        : `"title":${
-                              undefined !== input.title
-                                  ? $string(input.title)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.description
-                        ? ""
-                        : `"description":${
-                              undefined !== input.description
-                                  ? $string(input.description)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-metaTags"]
-                        ? ""
-                        : `"x-typia-metaTags":${
-                              undefined !== input["x-typia-metaTags"]
-                                  ? `[${input["x-typia-metaTags"]
-                                        .map((elem: any) => $su1(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-jsDocTags"]
-                        ? ""
-                        : `"x-typia-jsDocTags":${
-                              undefined !== input["x-typia-jsDocTags"]
-                                  ? `[${input["x-typia-jsDocTags"]
-                                        .map((elem: any) => $so17(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-required"]
-                        ? ""
-                        : `"x-typia-required":${
-                              undefined !== input["x-typia-required"]
-                                  ? input["x-typia-required"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-optional"]
-                        ? ""
-                        : `"x-typia-optional":${
-                              undefined !== input["x-typia-optional"]
-                                  ? input["x-typia-optional"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-rest"]
-                        ? ""
-                        : `"x-typia-rest":${
-                              undefined !== input["x-typia-rest"]
-                                  ? input["x-typia-rest"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.$id
-                        ? ""
-                        : `"$id":${
-                              undefined !== input.$id
-                                  ? $string(input.$id)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.$recursiveAnchor
-                        ? ""
-                        : `"$recursiveAnchor":${
-                              undefined !== input.$recursiveAnchor
-                                  ? input.$recursiveAnchor
-                                  : undefined
-                          },`
-                }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-            const $so48 = (input: any): any =>
+            const $so46 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
                         ? ""
@@ -5898,7 +5652,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so49 = (input: any): any =>
+            const $so47 = (input: any): any =>
                 `{${$tail(
                     `${
                         undefined === input.deprecated
@@ -6009,8 +5763,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         return $so26(input);
                     if (undefined !== input.oneOf) return $so27(input);
                     if (undefined !== input.$ref) return $so28(input);
-                    if (undefined !== input.$recursiveRef) return $so29(input);
-                    if ("null" === input.type) return $so30(input);
+                    if ("null" === input.type) return $so29(input);
                     return (() => {
                         if ($io20(input)) return $so20(input);
                         if ($io19(input)) return $so19(input);
@@ -6018,7 +5771,7 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                         if ($io21(input)) return $so21(input);
                         if ($io23(input)) return $so23(input);
                         if ($io24(input)) return $so24(input);
-                        if ($io31(input)) return $so31(input);
+                        if ($io30(input)) return $so30(input);
                         $throws({
                             expected:
                                 '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -6051,15 +5804,15 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 })();
             const $su2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $so34(input);
-                    if ("integer" === input.type) return $so40(input);
+                    if ("object" === input.type) return $so33(input);
+                    if ("integer" === input.type) return $so39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $so43(input);
+                        return $so42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -6070,19 +5823,18 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                                 $iu0(elem),
                         )
                     )
-                        return $so44(input);
-                    if (undefined !== input.oneOf) return $so45(input);
-                    if (undefined !== input.$ref) return $so46(input);
-                    if (undefined !== input.$recursiveRef) return $so47(input);
-                    if ("null" === input.type) return $so48(input);
+                        return $so43(input);
+                    if (undefined !== input.oneOf) return $so44(input);
+                    if (undefined !== input.$ref) return $so45(input);
+                    if ("null" === input.type) return $so46(input);
                     return (() => {
-                        if ($io38(input)) return $so38(input);
                         if ($io37(input)) return $so37(input);
                         if ($io36(input)) return $so36(input);
-                        if ($io39(input)) return $so39(input);
+                        if ($io35(input)) return $so35(input);
+                        if ($io38(input)) return $so38(input);
+                        if ($io40(input)) return $so40(input);
                         if ($io41(input)) return $so41(input);
-                        if ($io42(input)) return $so42(input);
-                        if ($io49(input)) return $so49(input);
+                        if ($io47(input)) return $so47(input);
                         $throws({
                             expected:
                                 '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/createRandom/test_createRandom_UltimateUnion.ts
+++ b/test/generated/output/createRandom/test_createRandom_UltimateUnion.ts
@@ -26,12 +26,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                     () => $ro26(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro27(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro28(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro31(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
                 ])(),
             ),
-            components: $ro32(_recursive, _recursive ? 1 + _depth : _depth),
+            components: $ro31(_recursive, _recursive ? 1 + _depth : _depth),
             purpose: $pick([() => "ajv", () => "swagger"])(),
         });
         const $ro1 = (
@@ -1258,9 +1257,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => $ro26(true, _recursive ? 1 + _depth : _depth),
                 () => $ro27(true, _recursive ? 1 + _depth : _depth),
                 () => $ro28(true, _recursive ? 1 + _depth : _depth),
-                () => $ro29(true, _recursive ? 1 + _depth : _depth),
-                () => $ro31(true, _recursive ? 1 + _depth : _depth),
                 () => $ro30(true, _recursive ? 1 + _depth : _depth),
+                () => $ro29(true, _recursive ? 1 + _depth : _depth),
             ])(),
             minItems: $pick([
                 () => undefined,
@@ -1451,14 +1449,29 @@ export const test_createRandom_UltimateUnion = _test_random(
                               () =>
                                   $ro28(true, _recursive ? 1 + _depth : _depth),
                               () =>
-                                  $ro29(true, _recursive ? 1 + _depth : _depth),
-                              () =>
-                                  $ro31(true, _recursive ? 1 + _depth : _depth),
-                              () =>
                                   $ro30(true, _recursive ? 1 + _depth : _depth),
+                              () =>
+                                  $ro29(true, _recursive ? 1 + _depth : _depth),
                           ])(),
                       )
                     : [],
+            minItems:
+                (generator?.customs ?? $generator.customs)?.number?.([
+                    {
+                        name: "type",
+                        value: "uint",
+                    },
+                ]) ?? (generator?.integer ?? $generator.integer)(0, 10),
+            maxItems: $pick([
+                () => undefined,
+                () =>
+                    (generator?.customs ?? $generator.customs)?.number?.([
+                        {
+                            name: "type",
+                            value: "uint",
+                        },
+                    ]) ?? (generator?.integer ?? $generator.integer)(0, 10),
+            ])(),
             type: "array",
             nullable: $pick([
                 () => undefined,
@@ -1624,11 +1637,9 @@ export const test_createRandom_UltimateUnion = _test_random(
                               () =>
                                   $ro28(true, _recursive ? 1 + _depth : _depth),
                               () =>
-                                  $ro29(true, _recursive ? 1 + _depth : _depth),
-                              () =>
-                                  $ro31(true, _recursive ? 1 + _depth : _depth),
-                              () =>
                                   $ro30(true, _recursive ? 1 + _depth : _depth),
+                              () =>
+                                  $ro29(true, _recursive ? 1 + _depth : _depth),
                           ])(),
                       )
                     : [],
@@ -1889,9 +1900,7 @@ export const test_createRandom_UltimateUnion = _test_random(
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
-            $recursiveRef:
-                (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                (generator?.string ?? $generator.string)(),
+            type: "null",
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -2015,7 +2024,7 @@ export const test_createRandom_UltimateUnion = _test_random(
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
-            type: "null",
+            type: undefined,
             deprecated: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
@@ -2139,136 +2148,12 @@ export const test_createRandom_UltimateUnion = _test_random(
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
-            type: undefined,
-            deprecated: $pick([
+            schemas: $pick([
                 () => undefined,
-                () => (generator?.boolean ?? $generator.boolean)(),
-            ])(),
-            title: $pick([
-                () => undefined,
-                () =>
-                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                    (generator?.string ?? $generator.string)(),
-            ])(),
-            description: $pick([
-                () => undefined,
-                () =>
-                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                    (generator?.string ?? $generator.string)(),
-            ])(),
-            "x-typia-metaTags": $pick([
-                () => undefined,
-                () =>
-                    (generator?.array ?? $generator.array)(() =>
-                        $pick([
-                            () =>
-                                $ro16(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro15(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro14(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro13(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro12(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro11(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro10(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro9(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro8(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro7(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro6(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro5(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro4(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro3(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro2(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                        ])(),
-                    ),
-            ])(),
-            "x-typia-jsDocTags": $pick([
-                () => undefined,
-                () =>
-                    (generator?.array ?? $generator.array)(() =>
-                        $ro17(_recursive, _recursive ? 1 + _depth : _depth),
-                    ),
-            ])(),
-            "x-typia-required": $pick([
-                () => undefined,
-                () => (generator?.boolean ?? $generator.boolean)(),
-            ])(),
-            "x-typia-optional": $pick([
-                () => undefined,
-                () => (generator?.boolean ?? $generator.boolean)(),
-            ])(),
-            "x-typia-rest": $pick([
-                () => undefined,
-                () => (generator?.boolean ?? $generator.boolean)(),
+                () => $ro32(_recursive, _recursive ? 1 + _depth : _depth),
             ])(),
         });
         const $ro32 = (
-            _recursive: boolean = false,
-            _depth: number = 0,
-        ): any => ({
-            schemas: $pick([
-                () => undefined,
-                () => $ro33(_recursive, _recursive ? 1 + _depth : _depth),
-            ])(),
-        });
-        const $ro33 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => {
@@ -2281,19 +2166,21 @@ export const test_createRandom_UltimateUnion = _test_random(
                         ) ?? (generator?.string ?? $generator.string)()
                     ] = $pick([
                         () =>
-                            $ro34(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
-                            $ro38(_recursive, _recursive ? 1 + _depth : _depth),
+                            $ro33(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
                             $ro37(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
                             $ro36(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
+                            $ro35(_recursive, _recursive ? 1 + _depth : _depth),
+                        () =>
+                            $ro38(_recursive, _recursive ? 1 + _depth : _depth),
+                        () =>
+                            $ro40(_recursive, _recursive ? 1 + _depth : _depth),
+                        () =>
                             $ro39(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
                             $ro41(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
-                            $ro40(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
                             $ro42(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
@@ -2303,19 +2190,15 @@ export const test_createRandom_UltimateUnion = _test_random(
                         () =>
                             $ro45(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
-                            $ro46(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
                             $ro47(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
-                            $ro49(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
-                            $ro48(_recursive, _recursive ? 1 + _depth : _depth),
+                            $ro46(_recursive, _recursive ? 1 + _depth : _depth),
                     ])()),
                 (generator?.integer ?? $generator.integer)(0, 3),
             );
             return output;
         };
-        const $ro34 = (
+        const $ro33 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -2325,19 +2208,15 @@ export const test_createRandom_UltimateUnion = _test_random(
                     (generator?.customs ?? $generator.customs)?.string?.([]) ??
                     (generator?.string ?? $generator.string)(),
             ])(),
-            $recursiveAnchor: $pick([
-                () => undefined,
-                () => (generator?.boolean ?? $generator.boolean)(),
-            ])(),
             type: "object",
             nullable: $pick([
                 () => undefined,
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
-            properties: $ro35(_recursive, _recursive ? 1 + _depth : _depth),
+            properties: $ro34(_recursive, _recursive ? 1 + _depth : _depth),
             patternProperties: $pick([
                 () => undefined,
-                () => $ro35(_recursive, _recursive ? 1 + _depth : _depth),
+                () => $ro34(_recursive, _recursive ? 1 + _depth : _depth),
             ])(),
             additionalProperties: $pick([
                 () => undefined,
@@ -2352,9 +2231,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => $ro26(_recursive, _recursive ? 1 + _depth : _depth),
                 () => $ro27(_recursive, _recursive ? 1 + _depth : _depth),
                 () => $ro28(_recursive, _recursive ? 1 + _depth : _depth),
-                () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                () => $ro31(_recursive, _recursive ? 1 + _depth : _depth),
                 () => $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
             ])(),
             required: $pick([
                 () => undefined,
@@ -2382,7 +2260,7 @@ export const test_createRandom_UltimateUnion = _test_random(
             ])(),
             "x-typia-patternProperties": $pick([
                 () => undefined,
-                () => $ro35(_recursive, _recursive ? 1 + _depth : _depth),
+                () => $ro34(_recursive, _recursive ? 1 + _depth : _depth),
             ])(),
             "x-typia-additionalProperties": $pick([
                 () => undefined,
@@ -2397,12 +2275,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => $ro26(_recursive, _recursive ? 1 + _depth : _depth),
                 () => $ro27(_recursive, _recursive ? 1 + _depth : _depth),
                 () => $ro28(_recursive, _recursive ? 1 + _depth : _depth),
-                () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                () => $ro31(_recursive, _recursive ? 1 + _depth : _depth),
                 () => $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
             ])(),
         });
-        const $ro35 = (
+        const $ro34 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => {
@@ -2437,17 +2314,15 @@ export const test_createRandom_UltimateUnion = _test_random(
                         () =>
                             $ro28(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
-                            $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
-                            $ro31(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
                             $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                        () =>
+                            $ro29(_recursive, _recursive ? 1 + _depth : _depth),
                     ])()),
                 (generator?.integer ?? $generator.integer)(0, 3),
             );
             return output;
         };
-        const $ro36 = (
+        const $ro35 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -2592,7 +2467,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro37 = (
+        const $ro36 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -2741,7 +2616,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro38 = (
+        const $ro37 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -2890,7 +2765,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro39 = (
+        const $ro38 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -3032,7 +2907,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro40 = (
+        const $ro39 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -3214,7 +3089,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro41 = (
+        const $ro40 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -3384,7 +3259,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro42 = (
+        const $ro41 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -3560,7 +3435,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro43 = (
+        const $ro42 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -3576,9 +3451,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => $ro26(_recursive, _recursive ? 1 + _depth : _depth),
                 () => $ro27(_recursive, _recursive ? 1 + _depth : _depth),
                 () => $ro28(_recursive, _recursive ? 1 + _depth : _depth),
-                () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                () => $ro31(_recursive, _recursive ? 1 + _depth : _depth),
                 () => $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
             ])(),
             minItems: $pick([
                 () => undefined,
@@ -3738,7 +3612,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro44 = (
+        const $ro43 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -3755,11 +3629,27 @@ export const test_createRandom_UltimateUnion = _test_random(
                     () => $ro26(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro27(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro28(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro31(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
                 ])(),
             ),
+            minItems:
+                (generator?.customs ?? $generator.customs)?.number?.([
+                    {
+                        name: "type",
+                        value: "uint",
+                    },
+                ]) ?? (generator?.integer ?? $generator.integer)(0, 10),
+            maxItems: $pick([
+                () => undefined,
+                () =>
+                    (generator?.customs ?? $generator.customs)?.number?.([
+                        {
+                            name: "type",
+                            value: "uint",
+                        },
+                    ]) ?? (generator?.integer ?? $generator.integer)(0, 10),
+            ])(),
             type: "array",
             nullable: $pick([
                 () => undefined,
@@ -3894,7 +3784,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro45 = (
+        const $ro44 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -3911,9 +3801,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                     () => $ro26(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro27(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro28(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro31(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
                 ])(),
             ),
             deprecated: $pick([
@@ -4045,7 +3934,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro46 = (
+        const $ro45 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -4181,143 +4070,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro47 = (
-            _recursive: boolean = false,
-            _depth: number = 0,
-        ): any => ({
-            $recursiveRef:
-                (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                (generator?.string ?? $generator.string)(),
-            deprecated: $pick([
-                () => undefined,
-                () => (generator?.boolean ?? $generator.boolean)(),
-            ])(),
-            title: $pick([
-                () => undefined,
-                () =>
-                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                    (generator?.string ?? $generator.string)(),
-            ])(),
-            description: $pick([
-                () => undefined,
-                () =>
-                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                    (generator?.string ?? $generator.string)(),
-            ])(),
-            "x-typia-metaTags": $pick([
-                () => undefined,
-                () =>
-                    (generator?.array ?? $generator.array)(() =>
-                        $pick([
-                            () =>
-                                $ro16(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro15(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro14(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro13(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro12(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro11(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro10(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro9(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro8(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro7(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro6(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro5(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro4(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro3(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro2(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                        ])(),
-                    ),
-            ])(),
-            "x-typia-jsDocTags": $pick([
-                () => undefined,
-                () =>
-                    (generator?.array ?? $generator.array)(() =>
-                        $ro17(_recursive, _recursive ? 1 + _depth : _depth),
-                    ),
-            ])(),
-            "x-typia-required": $pick([
-                () => undefined,
-                () => (generator?.boolean ?? $generator.boolean)(),
-            ])(),
-            "x-typia-optional": $pick([
-                () => undefined,
-                () => (generator?.boolean ?? $generator.boolean)(),
-            ])(),
-            "x-typia-rest": $pick([
-                () => undefined,
-                () => (generator?.boolean ?? $generator.boolean)(),
-            ])(),
-            $id: $pick([
-                () => undefined,
-                () =>
-                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                    (generator?.string ?? $generator.string)(),
-            ])(),
-            $recursiveAnchor: $pick([
-                () => undefined,
-                () => (generator?.boolean ?? $generator.boolean)(),
-            ])(),
-        });
-        const $ro48 = (
+        const $ro46 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -4451,7 +4204,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 () => (generator?.boolean ?? $generator.boolean)(),
             ])(),
         });
-        const $ro49 = (
+        const $ro47 = (
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
@@ -4602,7 +4355,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 "object" === typeof input.components &&
                 null !== input.components &&
                 false === Array.isArray(input.components) &&
-                $io32(input.components) &&
+                $io31(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose);
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
@@ -5031,6 +4784,15 @@ export const test_createRandom_UltimateUnion = _test_random(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -5130,36 +4892,6 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -5189,7 +4921,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -5220,13 +4952,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -5239,22 +4971,20 @@ export const test_createRandom_UltimateUnion = _test_random(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -5280,7 +5010,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -5290,7 +5020,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -5303,7 +5033,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -5342,7 +5072,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every(
                     (elem: any) =>
@@ -5385,7 +5115,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -5424,7 +5154,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -5461,7 +5191,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
@@ -5515,7 +5245,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum))) &&
@@ -5566,7 +5296,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
@@ -5617,7 +5347,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -5670,7 +5400,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -5679,6 +5409,15 @@ export const test_createRandom_UltimateUnion = _test_random(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -5713,7 +5452,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -5753,7 +5492,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -5786,40 +5525,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -5852,7 +5558,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -5909,8 +5615,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (() => {
                         if ($io20(input)) return $io20(input);
                         if ($io19(input)) return $io19(input);
@@ -5918,7 +5623,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                         if ($io21(input)) return $io21(input);
                         if ($io23(input)) return $io23(input);
                         if ($io24(input)) return $io24(input);
-                        if ($io31(input)) return $io31(input);
+                        if ($io30(input)) return $io30(input);
                         return false;
                     })();
                 })();
@@ -5943,15 +5648,15 @@ export const test_createRandom_UltimateUnion = _test_random(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -5962,19 +5667,18 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (() => {
-                        if ($io38(input)) return $io38(input);
                         if ($io37(input)) return $io37(input);
                         if ($io36(input)) return $io36(input);
-                        if ($io39(input)) return $io39(input);
+                        if ($io35(input)) return $io35(input);
+                        if ($io38(input)) return $io38(input);
+                        if ($io40(input)) return $io40(input);
                         if ($io41(input)) return $io41(input);
-                        if ($io42(input)) return $io42(input);
-                        if ($io49(input)) return $io49(input);
+                        if ($io47(input)) return $io47(input);
                         return false;
                     })();
                 })();
@@ -6014,7 +5718,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path + ".schemas[" + _index2 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
@@ -6025,7 +5729,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 $guard(_exceptionable, {
                                     path: _path + ".schemas[" + _index2 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
@@ -6042,7 +5746,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: "IJsonComponents",
                             value: input.components,
                         })) &&
-                        $ao32(
+                        $ao31(
                             input.components,
                             _path + ".components",
                             true && _exceptionable,
@@ -7708,7 +7412,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                             value: input.items,
                         })) &&
                         $au0(
@@ -7719,7 +7423,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                             value: input.items,
                         })) &&
                     (undefined === input.minItems ||
@@ -7943,7 +7647,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path + ".items[" + _index23 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
@@ -7954,7 +7658,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 $guard(_exceptionable, {
                                     path: _path + ".items[" + _index23 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
@@ -7962,6 +7666,45 @@ export const test_createRandom_UltimateUnion = _test_random(
                             path: _path + ".items",
                             expected: "Array<IJsonSchema>",
                             value: input.items,
+                        })) &&
+                    (("number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        (parseInt(input.minItems) === input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            })) &&
+                        (0 <= input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minItems",
+                            expected: "number",
+                            value: input.minItems,
+                        })) &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            (parseInt(input.maxItems) === input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maxItems",
+                            expected: "(number | undefined)",
+                            value: input.maxItems,
                         })) &&
                     ("array" === input.type ||
                         $guard(_exceptionable, {
@@ -8126,7 +7869,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path + ".oneOf[" + _index26 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
@@ -8137,7 +7880,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 $guard(_exceptionable, {
                                     path: _path + ".oneOf[" + _index26 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
@@ -8422,11 +8165,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("string" === typeof input.$recursiveRef ||
+                    ("null" === input.type ||
                         $guard(_exceptionable, {
-                            path: _path + ".$recursiveRef",
-                            expected: "string",
-                            value: input.$recursiveRef,
+                            path: _path + ".type",
+                            expected: '"null"',
+                            value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -8563,10 +8306,16 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("null" === input.type ||
+                    (null !== input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"null"',
+                            expected: "undefined",
+                            value: input.type,
+                        })) &&
+                    (undefined === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: "undefined",
                             value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
@@ -8704,31 +8453,171 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (null !== input.type ||
+                    undefined === input.schemas ||
+                    ((("object" === typeof input.schemas &&
+                        null !== input.schemas &&
+                        false === Array.isArray(input.schemas)) ||
                         $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
+                            path: _path + ".schemas",
+                            expected:
+                                "(Record<string, IObject | IAlias> | undefined)",
+                            value: input.schemas,
                         })) &&
-                    (undefined === input.type ||
+                        $ao32(
+                            input.schemas,
+                            _path + ".schemas",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".schemas",
+                        expected:
+                            "(Record<string, IObject | IAlias> | undefined)",
+                        value: input.schemas,
+                    });
+                const $ao32 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    false === _exceptionable ||
+                    Object.keys(input).every((key: any) => {
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        if (RegExp(/(.*)/).test(key))
+                            return (
+                                ((("object" === typeof value &&
+                                    null !== value &&
+                                    false === Array.isArray(value)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected:
+                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                        value: value,
+                                    })) &&
+                                    $au2(
+                                        value,
+                                        _path + $join(key),
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + $join(key),
+                                    expected:
+                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                    value: value,
+                                })
+                            );
+                        return true;
+                    });
+                const $ao33 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.$id ||
+                        "string" === typeof input.$id ||
                         $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
-                        })) &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated ||
-                        $guard(_exceptionable, {
-                            path: _path + ".deprecated",
-                            expected: "(boolean | undefined)",
-                            value: input.deprecated,
-                        })) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title ||
-                        $guard(_exceptionable, {
-                            path: _path + ".title",
+                            path: _path + ".$id",
                             expected: "(string | undefined)",
-                            value: input.title,
+                            value: input.$id,
+                        })) &&
+                    ("object" === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: '"object"',
+                            value: input.type,
+                        })) &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
+                        $guard(_exceptionable, {
+                            path: _path + ".nullable",
+                            expected: "(boolean | undefined)",
+                            value: input.nullable,
+                        })) &&
+                    (((("object" === typeof input.properties &&
+                        null !== input.properties &&
+                        false === Array.isArray(input.properties)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".properties",
+                            expected: "Record<string, IJsonSchema>",
+                            value: input.properties,
+                        })) &&
+                        $ao34(
+                            input.properties,
+                            _path + ".properties",
+                            true && _exceptionable,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".properties",
+                            expected: "Record<string, IJsonSchema>",
+                            value: input.properties,
+                        })) &&
+                    (undefined === input.patternProperties ||
+                        ((("object" === typeof input.patternProperties &&
+                            null !== input.patternProperties &&
+                            false === Array.isArray(input.patternProperties)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".patternProperties",
+                                expected:
+                                    "(Record<string, IJsonSchema> | undefined)",
+                                value: input.patternProperties,
+                            })) &&
+                            $ao34(
+                                input.patternProperties,
+                                _path + ".patternProperties",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".patternProperties",
+                            expected:
+                                "(Record<string, IJsonSchema> | undefined)",
+                            value: input.patternProperties,
+                        })) &&
+                    (undefined === input.additionalProperties ||
+                        ((("object" === typeof input.additionalProperties &&
+                            null !== input.additionalProperties &&
+                            false ===
+                                Array.isArray(input.additionalProperties)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".additionalProperties",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                value: input.additionalProperties,
+                            })) &&
+                            $au0(
+                                input.additionalProperties,
+                                _path + ".additionalProperties",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".additionalProperties",
+                            expected:
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                            value: input.additionalProperties,
+                        })) &&
+                    (undefined === input.required ||
+                        ((Array.isArray(input.required) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".required",
+                                expected: "(Array<string> | undefined)",
+                                value: input.required,
+                            })) &&
+                            input.required.every(
+                                (elem: any, _index35: number) =>
+                                    "string" === typeof elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".required[" +
+                                            _index35 +
+                                            "]",
+                                        expected: "string",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".required",
+                            expected: "(Array<string> | undefined)",
+                            value: input.required,
                         })) &&
                     (undefined === input.description ||
                         "string" === typeof input.description ||
@@ -8736,51 +8625,6 @@ export const test_createRandom_UltimateUnion = _test_random(
                             path: _path + ".description",
                             expected: "(string | undefined)",
                             value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        ((Array.isArray(input["x-typia-metaTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any, _index35: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index35 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        })) &&
-                                        $au1(
-                                            elem,
-                                            _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index35 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-metaTags"][' +
-                                            _index35 +
-                                            "]",
-                                        expected:
-                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-metaTags"]',
-                            expected: "(Array<IMetadataTag> | undefined)",
-                            value: input["x-typia-metaTags"],
                         })) &&
                     (undefined === input["x-typia-jsDocTags"] ||
                         ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -8825,255 +8669,6 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: "(Array<IJsDocTagInfo> | undefined)",
                             value: input["x-typia-jsDocTags"],
                         })) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-required"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-required"],
-                        })) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-optional"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-optional"],
-                        })) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-rest"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-rest"],
-                        }));
-                const $ao32 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    undefined === input.schemas ||
-                    ((("object" === typeof input.schemas &&
-                        null !== input.schemas &&
-                        false === Array.isArray(input.schemas)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".schemas",
-                            expected:
-                                "(Record<string, IObject | IAlias> | undefined)",
-                            value: input.schemas,
-                        })) &&
-                        $ao33(
-                            input.schemas,
-                            _path + ".schemas",
-                            true && _exceptionable,
-                        )) ||
-                    $guard(_exceptionable, {
-                        path: _path + ".schemas",
-                        expected:
-                            "(Record<string, IObject | IAlias> | undefined)",
-                        value: input.schemas,
-                    });
-                const $ao33 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    false === _exceptionable ||
-                    Object.keys(input).every((key: any) => {
-                        const value = input[key];
-                        if (undefined === value) return true;
-                        if (RegExp(/(.*)/).test(key))
-                            return (
-                                ((("object" === typeof value &&
-                                    null !== value &&
-                                    false === Array.isArray(value)) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + $join(key),
-                                        expected:
-                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                        value: value,
-                                    })) &&
-                                    $au2(
-                                        value,
-                                        _path + $join(key),
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + $join(key),
-                                    expected:
-                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                    value: value,
-                                })
-                            );
-                        return true;
-                    });
-                const $ao34 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$id",
-                            expected: "(string | undefined)",
-                            value: input.$id,
-                        })) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$recursiveAnchor",
-                            expected: "(boolean | undefined)",
-                            value: input.$recursiveAnchor,
-                        })) &&
-                    ("object" === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: '"object"',
-                            value: input.type,
-                        })) &&
-                    (undefined === input.nullable ||
-                        "boolean" === typeof input.nullable ||
-                        $guard(_exceptionable, {
-                            path: _path + ".nullable",
-                            expected: "(boolean | undefined)",
-                            value: input.nullable,
-                        })) &&
-                    (((("object" === typeof input.properties &&
-                        null !== input.properties &&
-                        false === Array.isArray(input.properties)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".properties",
-                            expected: "Record<string, IJsonSchema>",
-                            value: input.properties,
-                        })) &&
-                        $ao35(
-                            input.properties,
-                            _path + ".properties",
-                            true && _exceptionable,
-                        )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".properties",
-                            expected: "Record<string, IJsonSchema>",
-                            value: input.properties,
-                        })) &&
-                    (undefined === input.patternProperties ||
-                        ((("object" === typeof input.patternProperties &&
-                            null !== input.patternProperties &&
-                            false === Array.isArray(input.patternProperties)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".patternProperties",
-                                expected:
-                                    "(Record<string, IJsonSchema> | undefined)",
-                                value: input.patternProperties,
-                            })) &&
-                            $ao35(
-                                input.patternProperties,
-                                _path + ".patternProperties",
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".patternProperties",
-                            expected:
-                                "(Record<string, IJsonSchema> | undefined)",
-                            value: input.patternProperties,
-                        })) &&
-                    (undefined === input.additionalProperties ||
-                        ((("object" === typeof input.additionalProperties &&
-                            null !== input.additionalProperties &&
-                            false ===
-                                Array.isArray(input.additionalProperties)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".additionalProperties",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                value: input.additionalProperties,
-                            })) &&
-                            $au0(
-                                input.additionalProperties,
-                                _path + ".additionalProperties",
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".additionalProperties",
-                            expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                            value: input.additionalProperties,
-                        })) &&
-                    (undefined === input.required ||
-                        ((Array.isArray(input.required) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".required",
-                                expected: "(Array<string> | undefined)",
-                                value: input.required,
-                            })) &&
-                            input.required.every(
-                                (elem: any, _index37: number) =>
-                                    "string" === typeof elem ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            ".required[" +
-                                            _index37 +
-                                            "]",
-                                        expected: "string",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".required",
-                            expected: "(Array<string> | undefined)",
-                            value: input.required,
-                        })) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description ||
-                        $guard(_exceptionable, {
-                            path: _path + ".description",
-                            expected: "(string | undefined)",
-                            value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any, _index38: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index38 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        })) &&
-                                        $ao17(
-                                            elem,
-                                            _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index38 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-jsDocTags"][' +
-                                            _index38 +
-                                            "]",
-                                        expected: "IJsDocTagInfo",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-jsDocTags"]',
-                            expected: "(Array<IJsDocTagInfo> | undefined)",
-                            value: input["x-typia-jsDocTags"],
-                        })) &&
                     (undefined === input["x-typia-patternProperties"] ||
                         ((("object" ===
                             typeof input["x-typia-patternProperties"] &&
@@ -9088,7 +8683,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     "(Record<string, IJsonSchema> | undefined)",
                                 value: input["x-typia-patternProperties"],
                             })) &&
-                            $ao35(
+                            $ao34(
                                 input["x-typia-patternProperties"],
                                 _path + '["x-typia-patternProperties"]',
                                 true && _exceptionable,
@@ -9111,7 +8706,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 path:
                                     _path + '["x-typia-additionalProperties"]',
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                 value: input["x-typia-additionalProperties"],
                             })) &&
                             $au0(
@@ -9122,10 +8717,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                         $guard(_exceptionable, {
                             path: _path + '["x-typia-additionalProperties"]',
                             expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                             value: input["x-typia-additionalProperties"],
                         }));
-                const $ao35 = (
+                const $ao34 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -9142,7 +8737,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     $guard(_exceptionable, {
                                         path: _path + $join(key),
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: value,
                                     })) &&
                                     $au0(
@@ -9153,13 +8748,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 $guard(_exceptionable, {
                                     path: _path + $join(key),
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: value,
                                 })
                             );
                         return true;
                     });
-                const $ao36 = (
+                const $ao35 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -9171,10 +8766,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                             value: input["enum"],
                         })) &&
                         input["enum"].every(
-                            (elem: any, _index39: number) =>
+                            (elem: any, _index37: number) =>
                                 "boolean" === typeof elem ||
                                 $guard(_exceptionable, {
-                                    path: _path + '["enum"][' + _index39 + "]",
+                                    path: _path + '["enum"][' + _index37 + "]",
                                     expected: "boolean",
                                     value: elem,
                                 }),
@@ -9233,14 +8828,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index40: number) =>
+                                (elem: any, _index38: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index40 +
+                                                _index38 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -9250,7 +8845,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index40 +
+                                                _index38 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -9258,7 +8853,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index40 +
+                                            _index38 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -9278,14 +8873,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index41: number) =>
+                                (elem: any, _index39: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index41 +
+                                                _index39 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -9294,7 +8889,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index41 +
+                                                _index39 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -9302,7 +8897,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
-                                            _index41 +
+                                            _index39 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -9348,7 +8943,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: "(boolean | undefined)",
                             value: input.$recursiveAnchor,
                         }));
-                const $ao37 = (
+                const $ao36 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -9360,11 +8955,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                             value: input["enum"],
                         })) &&
                         input["enum"].every(
-                            (elem: any, _index42: number) =>
+                            (elem: any, _index40: number) =>
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem)) ||
                                 $guard(_exceptionable, {
-                                    path: _path + '["enum"][' + _index42 + "]",
+                                    path: _path + '["enum"][' + _index40 + "]",
                                     expected: "number",
                                     value: elem,
                                 }),
@@ -9424,14 +9019,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index43: number) =>
+                                (elem: any, _index41: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index43 +
+                                                _index41 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -9441,7 +9036,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index43 +
+                                                _index41 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -9449,7 +9044,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index43 +
+                                            _index41 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -9469,14 +9064,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index44: number) =>
+                                (elem: any, _index42: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index44 +
+                                                _index42 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -9485,7 +9080,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index44 +
+                                                _index42 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -9493,7 +9088,196 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
+                                            _index42 +
+                                            "]",
+                                        expected: "IJsDocTagInfo",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-jsDocTags"]',
+                            expected: "(Array<IJsDocTagInfo> | undefined)",
+                            value: input["x-typia-jsDocTags"],
+                        })) &&
+                    (undefined === input["x-typia-required"] ||
+                        "boolean" === typeof input["x-typia-required"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-required"]',
+                            expected: "(boolean | undefined)",
+                            value: input["x-typia-required"],
+                        })) &&
+                    (undefined === input["x-typia-optional"] ||
+                        "boolean" === typeof input["x-typia-optional"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-optional"]',
+                            expected: "(boolean | undefined)",
+                            value: input["x-typia-optional"],
+                        })) &&
+                    (undefined === input["x-typia-rest"] ||
+                        "boolean" === typeof input["x-typia-rest"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-rest"]',
+                            expected: "(boolean | undefined)",
+                            value: input["x-typia-rest"],
+                        })) &&
+                    (undefined === input.$id ||
+                        "string" === typeof input.$id ||
+                        $guard(_exceptionable, {
+                            path: _path + ".$id",
+                            expected: "(string | undefined)",
+                            value: input.$id,
+                        })) &&
+                    (undefined === input.$recursiveAnchor ||
+                        "boolean" === typeof input.$recursiveAnchor ||
+                        $guard(_exceptionable, {
+                            path: _path + ".$recursiveAnchor",
+                            expected: "(boolean | undefined)",
+                            value: input.$recursiveAnchor,
+                        }));
+                const $ao37 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (((Array.isArray(input["enum"]) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["enum"]',
+                            expected: "Array<string>",
+                            value: input["enum"],
+                        })) &&
+                        input["enum"].every(
+                            (elem: any, _index43: number) =>
+                                "string" === typeof elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["enum"][' + _index43 + "]",
+                                    expected: "string",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["enum"]',
+                            expected: "Array<string>",
+                            value: input["enum"],
+                        })) &&
+                    (undefined === input["default"] ||
+                        "string" === typeof input["default"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["default"]',
+                            expected: "(string | undefined)",
+                            value: input["default"],
+                        })) &&
+                    ("string" === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: '"string"',
+                            value: input.type,
+                        })) &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
+                        $guard(_exceptionable, {
+                            path: _path + ".nullable",
+                            expected: "(boolean | undefined)",
+                            value: input.nullable,
+                        })) &&
+                    (undefined === input.deprecated ||
+                        "boolean" === typeof input.deprecated ||
+                        $guard(_exceptionable, {
+                            path: _path + ".deprecated",
+                            expected: "(boolean | undefined)",
+                            value: input.deprecated,
+                        })) &&
+                    (undefined === input.title ||
+                        "string" === typeof input.title ||
+                        $guard(_exceptionable, {
+                            path: _path + ".title",
+                            expected: "(string | undefined)",
+                            value: input.title,
+                        })) &&
+                    (undefined === input.description ||
+                        "string" === typeof input.description ||
+                        $guard(_exceptionable, {
+                            path: _path + ".description",
+                            expected: "(string | undefined)",
+                            value: input.description,
+                        })) &&
+                    (undefined === input["x-typia-metaTags"] ||
+                        ((Array.isArray(input["x-typia-metaTags"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-metaTags"]',
+                                expected: "(Array<IMetadataTag> | undefined)",
+                                value: input["x-typia-metaTags"],
+                            })) &&
+                            input["x-typia-metaTags"].every(
+                                (elem: any, _index44: number) =>
+                                    ((("object" === typeof elem &&
+                                        null !== elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-metaTags"][' +
+                                                _index44 +
+                                                "]",
+                                            expected:
+                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                            value: elem,
+                                        })) &&
+                                        $au1(
+                                            elem,
+                                            _path +
+                                                '["x-typia-metaTags"][' +
+                                                _index44 +
+                                                "]",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            '["x-typia-metaTags"][' +
                                             _index44 +
+                                            "]",
+                                        expected:
+                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-metaTags"]',
+                            expected: "(Array<IMetadataTag> | undefined)",
+                            value: input["x-typia-metaTags"],
+                        })) &&
+                    (undefined === input["x-typia-jsDocTags"] ||
+                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-jsDocTags"]',
+                                expected: "(Array<IJsDocTagInfo> | undefined)",
+                                value: input["x-typia-jsDocTags"],
+                            })) &&
+                            input["x-typia-jsDocTags"].every(
+                                (elem: any, _index45: number) =>
+                                    ((("object" === typeof elem &&
+                                        null !== elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-jsDocTags"][' +
+                                                _index45 +
+                                                "]",
+                                            expected: "IJsDocTagInfo",
+                                            value: elem,
+                                        })) &&
+                                        $ao17(
+                                            elem,
+                                            _path +
+                                                '["x-typia-jsDocTags"][' +
+                                                _index45 +
+                                                "]",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            '["x-typia-jsDocTags"][' +
+                                            _index45 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -9544,37 +9328,17 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((Array.isArray(input["enum"]) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["enum"]',
-                            expected: "Array<string>",
-                            value: input["enum"],
-                        })) &&
-                        input["enum"].every(
-                            (elem: any, _index45: number) =>
-                                "string" === typeof elem ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["enum"][' + _index45 + "]",
-                                    expected: "string",
-                                    value: elem,
-                                }),
-                        )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["enum"]',
-                            expected: "Array<string>",
-                            value: input["enum"],
-                        })) &&
                     (undefined === input["default"] ||
-                        "string" === typeof input["default"] ||
+                        "boolean" === typeof input["default"] ||
                         $guard(_exceptionable, {
                             path: _path + '["default"]',
-                            expected: "(string | undefined)",
+                            expected: "(boolean | undefined)",
                             value: input["default"],
                         })) &&
-                    ("string" === input.type ||
+                    ("boolean" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"string"',
+                            expected: '"boolean"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -9733,17 +9497,74 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
+                    (undefined === input.minimum ||
+                        ("number" === typeof input.minimum &&
+                            Number.isFinite(input.minimum) &&
+                            (parseInt(input.minimum) === input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "(number | undefined)",
+                            value: input.minimum,
+                        })) &&
+                    (undefined === input.maximum ||
+                        ("number" === typeof input.maximum &&
+                            Number.isFinite(input.maximum) &&
+                            (parseInt(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "(number | undefined)",
+                            value: input.maximum,
+                        })) &&
+                    (undefined === input.exclusiveMinimum ||
+                        "boolean" === typeof input.exclusiveMinimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "(boolean | undefined)",
+                            value: input.exclusiveMinimum,
+                        })) &&
+                    (undefined === input.exclusiveMaximum ||
+                        "boolean" === typeof input.exclusiveMaximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMaximum",
+                            expected: "(boolean | undefined)",
+                            value: input.exclusiveMaximum,
+                        })) &&
+                    (undefined === input.multipleOf ||
+                        ("number" === typeof input.multipleOf &&
+                            Number.isFinite(input.multipleOf) &&
+                            (parseInt(input.multipleOf) === input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "(number | undefined)",
+                            value: input.multipleOf,
+                        })) &&
                     (undefined === input["default"] ||
-                        "boolean" === typeof input["default"] ||
+                        ("number" === typeof input["default"] &&
+                            Number.isFinite(input["default"])) ||
                         $guard(_exceptionable, {
                             path: _path + '["default"]',
-                            expected: "(boolean | undefined)",
+                            expected: "(number | undefined)",
                             value: input["default"],
                         })) &&
-                    ("boolean" === input.type ||
+                    ("integer" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"boolean"',
+                            expected: '"integer"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -9904,13 +9725,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                 ): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Number.isFinite(input.minimum) &&
-                            (parseInt(input.minimum) === input.minimum ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".minimum",
-                                    expected: "number (@type int)",
-                                    value: input.minimum,
-                                }))) ||
+                            Number.isFinite(input.minimum)) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "(number | undefined)",
@@ -9918,13 +9733,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                         })) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Number.isFinite(input.maximum) &&
-                            (parseInt(input.maximum) === input.maximum ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".maximum",
-                                    expected: "number (@type int)",
-                                    value: input.maximum,
-                                }))) ||
+                            Number.isFinite(input.maximum)) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "(number | undefined)",
@@ -9946,13 +9755,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                         })) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Number.isFinite(input.multipleOf) &&
-                            (parseInt(input.multipleOf) === input.multipleOf ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".multipleOf",
-                                    expected: "number (@type int)",
-                                    value: input.multipleOf,
-                                }))) ||
+                            Number.isFinite(input.multipleOf)) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "(number | undefined)",
@@ -9966,10 +9769,10 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: "(number | undefined)",
                             value: input["default"],
                         })) &&
-                    ("integer" === input.type ||
+                    ("number" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"integer"',
+                            expected: '"number"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -10128,56 +9931,71 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (undefined === input.minimum ||
-                        ("number" === typeof input.minimum &&
-                            Number.isFinite(input.minimum)) ||
+                    (undefined === input.minLength ||
+                        ("number" === typeof input.minLength &&
+                            Number.isFinite(input.minLength) &&
+                            (parseInt(input.minLength) === input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                })) &&
+                            (0 <= input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".minimum",
+                            path: _path + ".minLength",
                             expected: "(number | undefined)",
-                            value: input.minimum,
+                            value: input.minLength,
                         })) &&
-                    (undefined === input.maximum ||
-                        ("number" === typeof input.maximum &&
-                            Number.isFinite(input.maximum)) ||
+                    (undefined === input.maxLength ||
+                        ("number" === typeof input.maxLength &&
+                            Number.isFinite(input.maxLength) &&
+                            (parseInt(input.maxLength) === input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".maximum",
+                            path: _path + ".maxLength",
                             expected: "(number | undefined)",
-                            value: input.maximum,
+                            value: input.maxLength,
                         })) &&
-                    (undefined === input.exclusiveMinimum ||
-                        "boolean" === typeof input.exclusiveMinimum ||
+                    (undefined === input.pattern ||
+                        "string" === typeof input.pattern ||
                         $guard(_exceptionable, {
-                            path: _path + ".exclusiveMinimum",
-                            expected: "(boolean | undefined)",
-                            value: input.exclusiveMinimum,
+                            path: _path + ".pattern",
+                            expected: "(string | undefined)",
+                            value: input.pattern,
                         })) &&
-                    (undefined === input.exclusiveMaximum ||
-                        "boolean" === typeof input.exclusiveMaximum ||
+                    (undefined === input.format ||
+                        "string" === typeof input.format ||
                         $guard(_exceptionable, {
-                            path: _path + ".exclusiveMaximum",
-                            expected: "(boolean | undefined)",
-                            value: input.exclusiveMaximum,
-                        })) &&
-                    (undefined === input.multipleOf ||
-                        ("number" === typeof input.multipleOf &&
-                            Number.isFinite(input.multipleOf)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".multipleOf",
-                            expected: "(number | undefined)",
-                            value: input.multipleOf,
+                            path: _path + ".format",
+                            expected: "(string | undefined)",
+                            value: input.format,
                         })) &&
                     (undefined === input["default"] ||
-                        ("number" === typeof input["default"] &&
-                            Number.isFinite(input["default"])) ||
+                        "string" === typeof input["default"] ||
                         $guard(_exceptionable, {
                             path: _path + '["default"]',
-                            expected: "(number | undefined)",
+                            expected: "(string | undefined)",
                             value: input["default"],
                         })) &&
-                    ("number" === input.type ||
+                    ("string" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"number"',
+                            expected: '"string"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -10336,71 +10154,88 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (undefined === input.minLength ||
-                        ("number" === typeof input.minLength &&
-                            Number.isFinite(input.minLength) &&
-                            (parseInt(input.minLength) === input.minLength ||
+                    (((("object" === typeof input.items &&
+                        null !== input.items &&
+                        false === Array.isArray(input.items)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".items",
+                            expected:
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            value: input.items,
+                        })) &&
+                        $au0(
+                            input.items,
+                            _path + ".items",
+                            true && _exceptionable,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".items",
+                            expected:
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            value: input.items,
+                        })) &&
+                    (undefined === input.minItems ||
+                        ("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "number (@type uint)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 })) &&
-                            (0 <= input.minLength ||
+                            (0 <= input.minItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "number (@type uint)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".minLength",
+                            path: _path + ".minItems",
                             expected: "(number | undefined)",
-                            value: input.minLength,
+                            value: input.minItems,
                         })) &&
-                    (undefined === input.maxLength ||
-                        ("number" === typeof input.maxLength &&
-                            Number.isFinite(input.maxLength) &&
-                            (parseInt(input.maxLength) === input.maxLength ||
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            (parseInt(input.maxItems) === input.maxItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "number (@type uint)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 })) &&
-                            (0 <= input.maxLength ||
+                            (0 <= input.maxItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "number (@type uint)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".maxLength",
+                            path: _path + ".maxItems",
                             expected: "(number | undefined)",
-                            value: input.maxLength,
+                            value: input.maxItems,
                         })) &&
-                    (undefined === input.pattern ||
-                        "string" === typeof input.pattern ||
+                    (undefined === input["x-typia-tuple"] ||
+                        ((("object" === typeof input["x-typia-tuple"] &&
+                            null !== input["x-typia-tuple"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-tuple"]',
+                                expected: "(IJsonSchema.ITuple | undefined)",
+                                value: input["x-typia-tuple"],
+                            })) &&
+                            $ao26(
+                                input["x-typia-tuple"],
+                                _path + '["x-typia-tuple"]',
+                                true && _exceptionable,
+                            )) ||
                         $guard(_exceptionable, {
-                            path: _path + ".pattern",
-                            expected: "(string | undefined)",
-                            value: input.pattern,
+                            path: _path + '["x-typia-tuple"]',
+                            expected: "(IJsonSchema.ITuple | undefined)",
+                            value: input["x-typia-tuple"],
                         })) &&
-                    (undefined === input.format ||
-                        "string" === typeof input.format ||
-                        $guard(_exceptionable, {
-                            path: _path + ".format",
-                            expected: "(string | undefined)",
-                            value: input.format,
-                        })) &&
-                    (undefined === input["default"] ||
-                        "string" === typeof input["default"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["default"]',
-                            expected: "(string | undefined)",
-                            value: input["default"],
-                        })) &&
-                    ("string" === input.type ||
+                    ("array" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"string"',
+                            expected: '"array"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -10559,44 +10394,58 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((("object" === typeof input.items &&
-                        null !== input.items &&
-                        false === Array.isArray(input.items)) ||
+                    (((Array.isArray(input.items) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
-                            expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            expected: "Array<IJsonSchema>",
                             value: input.items,
                         })) &&
-                        $au0(
-                            input.items,
-                            _path + ".items",
-                            true && _exceptionable,
+                        input.items.every(
+                            (elem: any, _index56: number) =>
+                                ((("object" === typeof elem &&
+                                    null !== elem &&
+                                    false === Array.isArray(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".items[" + _index56 + "]",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: elem,
+                                    })) &&
+                                    $au0(
+                                        elem,
+                                        _path + ".items[" + _index56 + "]",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items[" + _index56 + "]",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: elem,
+                                }),
                         )) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
-                            expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            expected: "Array<IJsonSchema>",
                             value: input.items,
                         })) &&
-                    (undefined === input.minItems ||
-                        ("number" === typeof input.minItems &&
-                            Number.isFinite(input.minItems) &&
-                            (parseInt(input.minItems) === input.minItems ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".minItems",
-                                    expected: "number (@type uint)",
-                                    value: input.minItems,
-                                })) &&
-                            (0 <= input.minItems ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".minItems",
-                                    expected: "number (@type uint)",
-                                    value: input.minItems,
-                                }))) ||
+                    (("number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        (parseInt(input.minItems) === input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            })) &&
+                        (0 <= input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
-                            expected: "(number | undefined)",
+                            expected: "number",
                             value: input.minItems,
                         })) &&
                     (undefined === input.maxItems ||
@@ -10618,24 +10467,6 @@ export const test_createRandom_UltimateUnion = _test_random(
                             path: _path + ".maxItems",
                             expected: "(number | undefined)",
                             value: input.maxItems,
-                        })) &&
-                    (undefined === input["x-typia-tuple"] ||
-                        ((("object" === typeof input["x-typia-tuple"] &&
-                            null !== input["x-typia-tuple"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-tuple"]',
-                                expected: "(IJsonSchema.ITuple | undefined)",
-                                value: input["x-typia-tuple"],
-                            })) &&
-                            $ao26(
-                                input["x-typia-tuple"],
-                                _path + '["x-typia-tuple"]',
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-tuple"]',
-                            expected: "(IJsonSchema.ITuple | undefined)",
-                            value: input["x-typia-tuple"],
                         })) &&
                     ("array" === input.type ||
                         $guard(_exceptionable, {
@@ -10679,14 +10510,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index56: number) =>
+                                (elem: any, _index57: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index56 +
+                                                _index57 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -10696,7 +10527,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index56 +
+                                                _index57 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -10704,7 +10535,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index56 +
+                                            _index57 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -10724,14 +10555,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index57: number) =>
+                                (elem: any, _index58: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index57 +
+                                                _index58 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -10740,7 +10571,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index57 +
+                                                _index58 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -10748,7 +10579,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
-                                            _index57 +
+                                            _index58 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -10799,53 +10630,40 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((Array.isArray(input.items) ||
+                    (((Array.isArray(input.oneOf) ||
                         $guard(_exceptionable, {
-                            path: _path + ".items",
+                            path: _path + ".oneOf",
                             expected: "Array<IJsonSchema>",
-                            value: input.items,
+                            value: input.oneOf,
                         })) &&
-                        input.items.every(
-                            (elem: any, _index58: number) =>
+                        input.oneOf.every(
+                            (elem: any, _index59: number) =>
                                 ((("object" === typeof elem &&
                                     null !== elem &&
                                     false === Array.isArray(elem)) ||
                                     $guard(_exceptionable, {
                                         path:
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
                                         elem,
-                                        _path + ".items[" + _index58 + "]",
+                                        _path + ".oneOf[" + _index59 + "]",
                                         true && _exceptionable,
                                     )) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".items[" + _index58 + "]",
+                                    path: _path + ".oneOf[" + _index59 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
                         $guard(_exceptionable, {
-                            path: _path + ".items",
+                            path: _path + ".oneOf",
                             expected: "Array<IJsonSchema>",
-                            value: input.items,
-                        })) &&
-                    ("array" === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: '"array"',
-                            value: input.type,
-                        })) &&
-                    (undefined === input.nullable ||
-                        "boolean" === typeof input.nullable ||
-                        $guard(_exceptionable, {
-                            path: _path + ".nullable",
-                            expected: "(boolean | undefined)",
-                            value: input.nullable,
+                            value: input.oneOf,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -10876,14 +10694,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index59: number) =>
+                                (elem: any, _index60: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index59 +
+                                                _index60 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -10893,7 +10711,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index59 +
+                                                _index60 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -10901,7 +10719,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index59 +
+                                            _index60 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -10921,14 +10739,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index60: number) =>
+                                (elem: any, _index61: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index60 +
+                                                _index61 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -10937,7 +10755,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index60 +
+                                                _index61 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -10945,7 +10763,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
-                                            _index60 +
+                                            _index61 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -10996,40 +10814,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((Array.isArray(input.oneOf) ||
+                    ("string" === typeof input.$ref ||
                         $guard(_exceptionable, {
-                            path: _path + ".oneOf",
-                            expected: "Array<IJsonSchema>",
-                            value: input.oneOf,
-                        })) &&
-                        input.oneOf.every(
-                            (elem: any, _index61: number) =>
-                                ((("object" === typeof elem &&
-                                    null !== elem &&
-                                    false === Array.isArray(elem)) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path + ".oneOf[" + _index61 + "]",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                        value: elem,
-                                    })) &&
-                                    $au0(
-                                        elem,
-                                        _path + ".oneOf[" + _index61 + "]",
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".oneOf[" + _index61 + "]",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                    value: elem,
-                                }),
-                        )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".oneOf",
-                            expected: "Array<IJsonSchema>",
-                            value: input.oneOf,
+                            path: _path + ".$ref",
+                            expected: "string",
+                            value: input.$ref,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -11180,11 +10969,11 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("string" === typeof input.$ref ||
+                    ("null" === input.type ||
                         $guard(_exceptionable, {
-                            path: _path + ".$ref",
-                            expected: "string",
-                            value: input.$ref,
+                            path: _path + ".type",
+                            expected: '"null"',
+                            value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -11335,11 +11124,17 @@ export const test_createRandom_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("string" === typeof input.$recursiveRef ||
+                    (null !== input.type ||
                         $guard(_exceptionable, {
-                            path: _path + ".$recursiveRef",
-                            expected: "string",
-                            value: input.$recursiveRef,
+                            path: _path + ".type",
+                            expected: "undefined",
+                            value: input.type,
+                        })) &&
+                    (undefined === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: "undefined",
+                            value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -11485,322 +11280,6 @@ export const test_createRandom_UltimateUnion = _test_random(
                             expected: "(boolean | undefined)",
                             value: input.$recursiveAnchor,
                         }));
-                const $ao48 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    ("null" === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: '"null"',
-                            value: input.type,
-                        })) &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated ||
-                        $guard(_exceptionable, {
-                            path: _path + ".deprecated",
-                            expected: "(boolean | undefined)",
-                            value: input.deprecated,
-                        })) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title ||
-                        $guard(_exceptionable, {
-                            path: _path + ".title",
-                            expected: "(string | undefined)",
-                            value: input.title,
-                        })) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description ||
-                        $guard(_exceptionable, {
-                            path: _path + ".description",
-                            expected: "(string | undefined)",
-                            value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        ((Array.isArray(input["x-typia-metaTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any, _index68: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index68 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        })) &&
-                                        $au1(
-                                            elem,
-                                            _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index68 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-metaTags"][' +
-                                            _index68 +
-                                            "]",
-                                        expected:
-                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-metaTags"]',
-                            expected: "(Array<IMetadataTag> | undefined)",
-                            value: input["x-typia-metaTags"],
-                        })) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any, _index69: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index69 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        })) &&
-                                        $ao17(
-                                            elem,
-                                            _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index69 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-jsDocTags"][' +
-                                            _index69 +
-                                            "]",
-                                        expected: "IJsDocTagInfo",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-jsDocTags"]',
-                            expected: "(Array<IJsDocTagInfo> | undefined)",
-                            value: input["x-typia-jsDocTags"],
-                        })) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-required"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-required"],
-                        })) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-optional"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-optional"],
-                        })) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-rest"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-rest"],
-                        })) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$id",
-                            expected: "(string | undefined)",
-                            value: input.$id,
-                        })) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$recursiveAnchor",
-                            expected: "(boolean | undefined)",
-                            value: input.$recursiveAnchor,
-                        }));
-                const $ao49 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    (null !== input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
-                        })) &&
-                    (undefined === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
-                        })) &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated ||
-                        $guard(_exceptionable, {
-                            path: _path + ".deprecated",
-                            expected: "(boolean | undefined)",
-                            value: input.deprecated,
-                        })) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title ||
-                        $guard(_exceptionable, {
-                            path: _path + ".title",
-                            expected: "(string | undefined)",
-                            value: input.title,
-                        })) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description ||
-                        $guard(_exceptionable, {
-                            path: _path + ".description",
-                            expected: "(string | undefined)",
-                            value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        ((Array.isArray(input["x-typia-metaTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any, _index70: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index70 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        })) &&
-                                        $au1(
-                                            elem,
-                                            _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index70 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-metaTags"][' +
-                                            _index70 +
-                                            "]",
-                                        expected:
-                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-metaTags"]',
-                            expected: "(Array<IMetadataTag> | undefined)",
-                            value: input["x-typia-metaTags"],
-                        })) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any, _index71: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index71 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        })) &&
-                                        $ao17(
-                                            elem,
-                                            _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index71 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-jsDocTags"][' +
-                                            _index71 +
-                                            "]",
-                                        expected: "IJsDocTagInfo",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-jsDocTags"]',
-                            expected: "(Array<IJsDocTagInfo> | undefined)",
-                            value: input["x-typia-jsDocTags"],
-                        })) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-required"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-required"],
-                        })) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-optional"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-optional"],
-                        })) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-rest"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-rest"],
-                        })) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$id",
-                            expected: "(string | undefined)",
-                            value: input.$id,
-                        })) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$recursiveAnchor",
-                            expected: "(boolean | undefined)",
-                            value: input.$recursiveAnchor,
-                        }));
                 const $au0 = (
                     input: any,
                     _path: string,
@@ -11823,13 +11302,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
-                                (elem: any, _index72: number) =>
+                                (elem: any, _index68: number) =>
                                     "object" === typeof elem &&
                                     null !== elem &&
                                     false === Array.isArray(elem) &&
                                     $au0(
                                         elem,
-                                        _path + ".items[" + _index72 + "]",
+                                        _path + ".items[" + _index68 + "]",
                                         false && _exceptionable,
                                     ),
                             )
@@ -11839,10 +11318,8 @@ export const test_createRandom_UltimateUnion = _test_random(
                             return $ao27(input, _path, true && _exceptionable);
                         if (undefined !== input.$ref)
                             return $ao28(input, _path, true && _exceptionable);
-                        if (undefined !== input.$recursiveRef)
-                            return $ao29(input, _path, true && _exceptionable);
                         if ("null" === input.type)
-                            return $ao30(input, _path, true && _exceptionable);
+                            return $ao29(input, _path, true && _exceptionable);
                         return (
                             $ao20(input, _path, false && _exceptionable) ||
                             $ao19(input, _path, false && _exceptionable) ||
@@ -11850,7 +11327,7 @@ export const test_createRandom_UltimateUnion = _test_random(
                             $ao21(input, _path, false && _exceptionable) ||
                             $ao23(input, _path, false && _exceptionable) ||
                             $ao24(input, _path, false && _exceptionable) ||
-                            $ao31(input, _path, false && _exceptionable) ||
+                            $ao30(input, _path, false && _exceptionable) ||
                             $guard(_exceptionable, {
                                 path: _path,
                                 expected:
@@ -11909,9 +11386,9 @@ export const test_createRandom_UltimateUnion = _test_random(
                 ): any =>
                     (() => {
                         if ("object" === input.type)
-                            return $ao34(input, _path, true && _exceptionable);
+                            return $ao33(input, _path, true && _exceptionable);
                         if ("integer" === input.type)
-                            return $ao40(input, _path, true && _exceptionable);
+                            return $ao39(input, _path, true && _exceptionable);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
@@ -11922,38 +11399,36 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 false && _exceptionable,
                             )
                         )
-                            return $ao43(input, _path, true && _exceptionable);
+                            return $ao42(input, _path, true && _exceptionable);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
-                                (elem: any, _index73: number) =>
+                                (elem: any, _index69: number) =>
                                     "object" === typeof elem &&
                                     null !== elem &&
                                     false === Array.isArray(elem) &&
                                     $au0(
                                         elem,
-                                        _path + ".items[" + _index73 + "]",
+                                        _path + ".items[" + _index69 + "]",
                                         false && _exceptionable,
                                     ),
                             )
                         )
-                            return $ao44(input, _path, true && _exceptionable);
+                            return $ao43(input, _path, true && _exceptionable);
                         if (undefined !== input.oneOf)
-                            return $ao45(input, _path, true && _exceptionable);
+                            return $ao44(input, _path, true && _exceptionable);
                         if (undefined !== input.$ref)
-                            return $ao46(input, _path, true && _exceptionable);
-                        if (undefined !== input.$recursiveRef)
-                            return $ao47(input, _path, true && _exceptionable);
+                            return $ao45(input, _path, true && _exceptionable);
                         if ("null" === input.type)
-                            return $ao48(input, _path, true && _exceptionable);
+                            return $ao46(input, _path, true && _exceptionable);
                         return (
-                            $ao38(input, _path, false && _exceptionable) ||
                             $ao37(input, _path, false && _exceptionable) ||
                             $ao36(input, _path, false && _exceptionable) ||
-                            $ao39(input, _path, false && _exceptionable) ||
+                            $ao35(input, _path, false && _exceptionable) ||
+                            $ao38(input, _path, false && _exceptionable) ||
+                            $ao40(input, _path, false && _exceptionable) ||
                             $ao41(input, _path, false && _exceptionable) ||
-                            $ao42(input, _path, false && _exceptionable) ||
-                            $ao49(input, _path, false && _exceptionable) ||
+                            $ao47(input, _path, false && _exceptionable) ||
                             $guard(_exceptionable, {
                                 path: _path,
                                 expected:

--- a/test/generated/output/createStringify/test_createStringify_UltimateUnion.ts
+++ b/test/generated/output/createStringify/test_createStringify_UltimateUnion.ts
@@ -385,6 +385,13 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     false === Array.isArray(elem) &&
                     $iu0(elem),
             ) &&
+            "number" === typeof input.minItems &&
+            parseInt(input.minItems) === input.minItems &&
+            0 <= input.minItems &&
+            (undefined === input.maxItems ||
+                ("number" === typeof input.maxItems &&
+                    parseInt(input.maxItems) === input.maxItems &&
+                    0 <= input.maxItems)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
@@ -481,35 +488,6 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input["x-typia-rest"] ||
                 "boolean" === typeof input["x-typia-rest"]);
         const $io29 = (input: any): boolean =>
-            "string" === typeof input.$recursiveRef &&
-            (undefined === input.deprecated ||
-                "boolean" === typeof input.deprecated) &&
-            (undefined === input.title || "string" === typeof input.title) &&
-            (undefined === input.description ||
-                "string" === typeof input.description) &&
-            (undefined === input["x-typia-metaTags"] ||
-                (Array.isArray(input["x-typia-metaTags"]) &&
-                    input["x-typia-metaTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $iu1(elem),
-                    ))) &&
-            (undefined === input["x-typia-jsDocTags"] ||
-                (Array.isArray(input["x-typia-jsDocTags"]) &&
-                    input["x-typia-jsDocTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $io17(elem),
-                    ))) &&
-            (undefined === input["x-typia-required"] ||
-                "boolean" === typeof input["x-typia-required"]) &&
-            (undefined === input["x-typia-optional"] ||
-                "boolean" === typeof input["x-typia-optional"]) &&
-            (undefined === input["x-typia-rest"] ||
-                "boolean" === typeof input["x-typia-rest"]);
-        const $io30 = (input: any): boolean =>
             "null" === input.type &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
@@ -538,7 +516,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                 "boolean" === typeof input["x-typia-optional"]) &&
             (undefined === input["x-typia-rest"] ||
                 "boolean" === typeof input["x-typia-rest"]);
-        const $io31 = (input: any): boolean =>
+        const $io30 = (input: any): boolean =>
             null !== input.type &&
             undefined === input.type &&
             (undefined === input.deprecated ||
@@ -568,13 +546,13 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                 "boolean" === typeof input["x-typia-optional"]) &&
             (undefined === input["x-typia-rest"] ||
                 "boolean" === typeof input["x-typia-rest"]);
-        const $io32 = (input: any): boolean =>
+        const $io31 = (input: any): boolean =>
             undefined === input.schemas ||
             ("object" === typeof input.schemas &&
                 null !== input.schemas &&
                 false === Array.isArray(input.schemas) &&
-                $io33(input.schemas));
-        const $io33 = (input: any): boolean =>
+                $io32(input.schemas));
+        const $io32 = (input: any): boolean =>
             Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
@@ -587,22 +565,20 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     );
                 return true;
             });
-        const $io34 = (input: any): boolean =>
+        const $io33 = (input: any): boolean =>
             (undefined === input.$id || "string" === typeof input.$id) &&
-            (undefined === input.$recursiveAnchor ||
-                "boolean" === typeof input.$recursiveAnchor) &&
             "object" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
             "object" === typeof input.properties &&
             null !== input.properties &&
             false === Array.isArray(input.properties) &&
-            $io35(input.properties) &&
+            $io34(input.properties) &&
             (undefined === input.patternProperties ||
                 ("object" === typeof input.patternProperties &&
                     null !== input.patternProperties &&
                     false === Array.isArray(input.patternProperties) &&
-                    $io35(input.patternProperties))) &&
+                    $io34(input.patternProperties))) &&
             (undefined === input.additionalProperties ||
                 ("object" === typeof input.additionalProperties &&
                     null !== input.additionalProperties &&
@@ -628,14 +604,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     null !== input["x-typia-patternProperties"] &&
                     false ===
                         Array.isArray(input["x-typia-patternProperties"]) &&
-                    $io35(input["x-typia-patternProperties"]))) &&
+                    $io34(input["x-typia-patternProperties"]))) &&
             (undefined === input["x-typia-additionalProperties"] ||
                 ("object" === typeof input["x-typia-additionalProperties"] &&
                     null !== input["x-typia-additionalProperties"] &&
                     false ===
                         Array.isArray(input["x-typia-additionalProperties"]) &&
                     $iu0(input["x-typia-additionalProperties"])));
-        const $io35 = (input: any): boolean =>
+        const $io34 = (input: any): boolean =>
             Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
@@ -648,7 +624,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     );
                 return true;
             });
-        const $io36 = (input: any): boolean =>
+        const $io35 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "boolean" === typeof elem) &&
             (undefined === input["default"] ||
@@ -686,7 +662,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io37 = (input: any): boolean =>
+        const $io36 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "number" === typeof elem) &&
             (undefined === input["default"] ||
@@ -724,7 +700,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io38 = (input: any): boolean =>
+        const $io37 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
             input["enum"].every((elem: any) => "string" === typeof elem) &&
             (undefined === input["default"] ||
@@ -762,7 +738,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io39 = (input: any): boolean =>
+        const $io38 = (input: any): boolean =>
             (undefined === input["default"] ||
                 "boolean" === typeof input["default"]) &&
             "boolean" === input.type &&
@@ -798,7 +774,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io40 = (input: any): boolean =>
+        const $io39 = (input: any): boolean =>
             (undefined === input.minimum ||
                 ("number" === typeof input.minimum &&
                     parseInt(input.minimum) === input.minimum)) &&
@@ -847,7 +823,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io41 = (input: any): boolean =>
+        const $io40 = (input: any): boolean =>
             (undefined === input.minimum ||
                 "number" === typeof input.minimum) &&
             (undefined === input.maximum ||
@@ -893,7 +869,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io42 = (input: any): boolean =>
+        const $io41 = (input: any): boolean =>
             (undefined === input.minLength ||
                 ("number" === typeof input.minLength &&
                     parseInt(input.minLength) === input.minLength &&
@@ -940,7 +916,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io43 = (input: any): boolean =>
+        const $io42 = (input: any): boolean =>
             "object" === typeof input.items &&
             null !== input.items &&
             false === Array.isArray(input.items) &&
@@ -990,7 +966,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io44 = (input: any): boolean =>
+        const $io43 = (input: any): boolean =>
             Array.isArray(input.items) &&
             input.items.every(
                 (elem: any) =>
@@ -999,6 +975,13 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     false === Array.isArray(elem) &&
                     $iu0(elem),
             ) &&
+            "number" === typeof input.minItems &&
+            parseInt(input.minItems) === input.minItems &&
+            0 <= input.minItems &&
+            (undefined === input.maxItems ||
+                ("number" === typeof input.maxItems &&
+                    parseInt(input.maxItems) === input.maxItems &&
+                    0 <= input.maxItems)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
@@ -1032,7 +1015,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io45 = (input: any): boolean =>
+        const $io44 = (input: any): boolean =>
             Array.isArray(input.oneOf) &&
             input.oneOf.every(
                 (elem: any) =>
@@ -1071,7 +1054,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io46 = (input: any): boolean =>
+        const $io45 = (input: any): boolean =>
             "string" === typeof input.$ref &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
@@ -1103,39 +1086,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io47 = (input: any): boolean =>
-            "string" === typeof input.$recursiveRef &&
-            (undefined === input.deprecated ||
-                "boolean" === typeof input.deprecated) &&
-            (undefined === input.title || "string" === typeof input.title) &&
-            (undefined === input.description ||
-                "string" === typeof input.description) &&
-            (undefined === input["x-typia-metaTags"] ||
-                (Array.isArray(input["x-typia-metaTags"]) &&
-                    input["x-typia-metaTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $iu1(elem),
-                    ))) &&
-            (undefined === input["x-typia-jsDocTags"] ||
-                (Array.isArray(input["x-typia-jsDocTags"]) &&
-                    input["x-typia-jsDocTags"].every(
-                        (elem: any) =>
-                            "object" === typeof elem &&
-                            null !== elem &&
-                            $io17(elem),
-                    ))) &&
-            (undefined === input["x-typia-required"] ||
-                "boolean" === typeof input["x-typia-required"]) &&
-            (undefined === input["x-typia-optional"] ||
-                "boolean" === typeof input["x-typia-optional"]) &&
-            (undefined === input["x-typia-rest"] ||
-                "boolean" === typeof input["x-typia-rest"]) &&
-            (undefined === input.$id || "string" === typeof input.$id) &&
-            (undefined === input.$recursiveAnchor ||
-                "boolean" === typeof input.$recursiveAnchor);
-        const $io48 = (input: any): boolean =>
+        const $io46 = (input: any): boolean =>
             "null" === input.type &&
             (undefined === input.deprecated ||
                 "boolean" === typeof input.deprecated) &&
@@ -1167,7 +1118,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.$id || "string" === typeof input.$id) &&
             (undefined === input.$recursiveAnchor ||
                 "boolean" === typeof input.$recursiveAnchor);
-        const $io49 = (input: any): boolean =>
+        const $io47 = (input: any): boolean =>
             null !== input.type &&
             undefined === input.type &&
             (undefined === input.deprecated ||
@@ -1223,8 +1174,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     return $io26(input);
                 if (undefined !== input.oneOf) return $io27(input);
                 if (undefined !== input.$ref) return $io28(input);
-                if (undefined !== input.$recursiveRef) return $io29(input);
-                if ("null" === input.type) return $io30(input);
+                if ("null" === input.type) return $io29(input);
                 return (
                     $io20(input) ||
                     $io19(input) ||
@@ -1232,7 +1182,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     $io21(input) ||
                     $io23(input) ||
                     $io24(input) ||
-                    $io31(input)
+                    $io30(input)
                 );
             })();
         const $iu1 = (input: any): any =>
@@ -1256,15 +1206,15 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             })();
         const $iu2 = (input: any): any =>
             (() => {
-                if ("object" === input.type) return $io34(input);
-                if ("integer" === input.type) return $io40(input);
+                if ("object" === input.type) return $io33(input);
+                if ("integer" === input.type) return $io39(input);
                 if (
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
                     $iu0(input.items)
                 )
-                    return $io43(input);
+                    return $io42(input);
                 if (
                     Array.isArray(input.items) &&
                     input.items.every(
@@ -1275,19 +1225,18 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                             $iu0(elem),
                     )
                 )
-                    return $io44(input);
-                if (undefined !== input.oneOf) return $io45(input);
-                if (undefined !== input.$ref) return $io46(input);
-                if (undefined !== input.$recursiveRef) return $io47(input);
-                if ("null" === input.type) return $io48(input);
+                    return $io43(input);
+                if (undefined !== input.oneOf) return $io44(input);
+                if (undefined !== input.$ref) return $io45(input);
+                if ("null" === input.type) return $io46(input);
                 return (
-                    $io38(input) ||
                     $io37(input) ||
                     $io36(input) ||
-                    $io39(input) ||
+                    $io35(input) ||
+                    $io38(input) ||
+                    $io40(input) ||
                     $io41(input) ||
-                    $io42(input) ||
-                    $io49(input)
+                    $io47(input)
                 );
             })();
         const $string = (typia.createStringify as any).string;
@@ -1298,7 +1247,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
         const $so0 = (input: any): any =>
             `{"schemas":${`[${input.schemas
                 .map((elem: any) => $su0(elem))
-                .join(",")}]`},"components":${$so32(
+                .join(",")}]`},"components":${$so31(
                 input.components,
             )},"purpose":${(() => {
                 if ("string" === typeof input.purpose)
@@ -2386,6 +2335,14 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             })()}}`;
         const $so26 = (input: any): any =>
             `{${
+                undefined === input.maxItems
+                    ? ""
+                    : `"maxItems":${
+                          undefined !== input.maxItems
+                              ? $number(input.maxItems)
+                              : undefined
+                      },`
+            }${
                 undefined === input.nullable
                     ? ""
                     : `"nullable":${
@@ -2463,7 +2420,9 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                       },`
             }"items":${`[${input.items
                 .map((elem: any) => $su0(elem))
-                .join(",")}]`},"type":${(() => {
+                .join(",")}]`},"minItems":${$number(
+                input.minItems,
+            )},"type":${(() => {
                 if ("string" === typeof input.type) return $string(input.type);
                 if ("string" === typeof input.type)
                     return '"' + input.type + '"';
@@ -2683,76 +2642,6 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                               ? input["x-typia-rest"]
                               : undefined
                       },`
-            }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-        const $so30 = (input: any): any =>
-            `{${
-                undefined === input.deprecated
-                    ? ""
-                    : `"deprecated":${
-                          undefined !== input.deprecated
-                              ? input.deprecated
-                              : undefined
-                      },`
-            }${
-                undefined === input.title
-                    ? ""
-                    : `"title":${
-                          undefined !== input.title
-                              ? $string(input.title)
-                              : undefined
-                      },`
-            }${
-                undefined === input.description
-                    ? ""
-                    : `"description":${
-                          undefined !== input.description
-                              ? $string(input.description)
-                              : undefined
-                      },`
-            }${
-                undefined === input["x-typia-metaTags"]
-                    ? ""
-                    : `"x-typia-metaTags":${
-                          undefined !== input["x-typia-metaTags"]
-                              ? `[${input["x-typia-metaTags"]
-                                    .map((elem: any) => $su1(elem))
-                                    .join(",")}]`
-                              : undefined
-                      },`
-            }${
-                undefined === input["x-typia-jsDocTags"]
-                    ? ""
-                    : `"x-typia-jsDocTags":${
-                          undefined !== input["x-typia-jsDocTags"]
-                              ? `[${input["x-typia-jsDocTags"]
-                                    .map((elem: any) => $so17(elem))
-                                    .join(",")}]`
-                              : undefined
-                      },`
-            }${
-                undefined === input["x-typia-required"]
-                    ? ""
-                    : `"x-typia-required":${
-                          undefined !== input["x-typia-required"]
-                              ? input["x-typia-required"]
-                              : undefined
-                      },`
-            }${
-                undefined === input["x-typia-optional"]
-                    ? ""
-                    : `"x-typia-optional":${
-                          undefined !== input["x-typia-optional"]
-                              ? input["x-typia-optional"]
-                              : undefined
-                      },`
-            }${
-                undefined === input["x-typia-rest"]
-                    ? ""
-                    : `"x-typia-rest":${
-                          undefined !== input["x-typia-rest"]
-                              ? input["x-typia-rest"]
-                              : undefined
-                      },`
             }"type":${(() => {
                 if ("string" === typeof input.type) return $string(input.type);
                 if ("string" === typeof input.type)
@@ -2762,7 +2651,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so31 = (input: any): any =>
+        const $so30 = (input: any): any =>
             `{${$tail(
                 `${
                     undefined === input.deprecated
@@ -2834,19 +2723,19 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                           }`
                 }`,
             )}}`;
-        const $so32 = (input: any): any =>
+        const $so31 = (input: any): any =>
             `{${$tail(
                 `${
                     undefined === input.schemas
                         ? ""
                         : `"schemas":${
                               undefined !== input.schemas
-                                  ? $so33(input.schemas)
+                                  ? $so32(input.schemas)
                                   : undefined
                           }`
                 }`,
             )}}`;
-        const $so33 = (input: any): any =>
+        const $so32 = (input: any): any =>
             `{${Object.entries(input)
                 .map(([key, value]: [string, any]) => {
                     if (undefined === value) return "";
@@ -2854,21 +2743,13 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                 })
                 .filter((str: any) => "" !== str)
                 .join(",")}}`;
-        const $so34 = (input: any): any =>
+        const $so33 = (input: any): any =>
             `{${
                 undefined === input.$id
                     ? ""
                     : `"$id":${
                           undefined !== input.$id
                               ? $string(input.$id)
-                              : undefined
-                      },`
-            }${
-                undefined === input.$recursiveAnchor
-                    ? ""
-                    : `"$recursiveAnchor":${
-                          undefined !== input.$recursiveAnchor
-                              ? input.$recursiveAnchor
                               : undefined
                       },`
             }${
@@ -2884,7 +2765,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     ? ""
                     : `"patternProperties":${
                           undefined !== input.patternProperties
-                              ? $so35(input.patternProperties)
+                              ? $so34(input.patternProperties)
                               : undefined
                       },`
             }${
@@ -2928,7 +2809,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     ? ""
                     : `"x-typia-patternProperties":${
                           undefined !== input["x-typia-patternProperties"]
-                              ? $so35(input["x-typia-patternProperties"])
+                              ? $so34(input["x-typia-patternProperties"])
                               : undefined
                       },`
             }${
@@ -2947,8 +2828,8 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     expected: '"object"',
                     value: input.type,
                 });
-            })()},"properties":${$so35(input.properties)}}`;
-        const $so35 = (input: any): any =>
+            })()},"properties":${$so34(input.properties)}}`;
+        const $so34 = (input: any): any =>
             `{${Object.entries(input)
                 .map(([key, value]: [string, any]) => {
                     if (undefined === value) return "";
@@ -2956,7 +2837,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                 })
                 .filter((str: any) => "" !== str)
                 .join(",")}}`;
-        const $so36 = (input: any): any =>
+        const $so35 = (input: any): any =>
             `{${
                 undefined === input["default"]
                     ? ""
@@ -3068,7 +2949,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so37 = (input: any): any =>
+        const $so36 = (input: any): any =>
             `{${
                 undefined === input["default"]
                     ? ""
@@ -3180,7 +3061,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so38 = (input: any): any =>
+        const $so37 = (input: any): any =>
             `{${
                 undefined === input["default"]
                     ? ""
@@ -3292,7 +3173,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so39 = (input: any): any =>
+        const $so38 = (input: any): any =>
             `{${
                 undefined === input["default"]
                     ? ""
@@ -3402,7 +3283,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so40 = (input: any): any =>
+        const $so39 = (input: any): any =>
             `{${
                 undefined === input.minimum
                     ? ""
@@ -3552,7 +3433,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so41 = (input: any): any =>
+        const $so40 = (input: any): any =>
             `{${
                 undefined === input.minimum
                     ? ""
@@ -3702,7 +3583,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so42 = (input: any): any =>
+        const $so41 = (input: any): any =>
             `{${
                 undefined === input.minLength
                     ? ""
@@ -3844,7 +3725,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so43 = (input: any): any =>
+        const $so42 = (input: any): any =>
             `{${
                 undefined === input.minItems
                     ? ""
@@ -3970,8 +3851,16 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so44 = (input: any): any =>
+        const $so43 = (input: any): any =>
             `{${
+                undefined === input.maxItems
+                    ? ""
+                    : `"maxItems":${
+                          undefined !== input.maxItems
+                              ? $number(input.maxItems)
+                              : undefined
+                      },`
+            }${
                 undefined === input.nullable
                     ? ""
                     : `"nullable":${
@@ -4065,7 +3954,9 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                       },`
             }"items":${`[${input.items
                 .map((elem: any) => $su0(elem))
-                .join(",")}]`},"type":${(() => {
+                .join(",")}]`},"minItems":${$number(
+                input.minItems,
+            )},"type":${(() => {
                 if ("string" === typeof input.type) return $string(input.type);
                 if ("string" === typeof input.type)
                     return '"' + input.type + '"';
@@ -4074,7 +3965,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so45 = (input: any): any =>
+        const $so44 = (input: any): any =>
             `{${
                 undefined === input.deprecated
                     ? ""
@@ -4162,7 +4053,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             }"oneOf":${`[${input.oneOf
                 .map((elem: any) => $su0(elem))
                 .join(",")}]`}}`;
-        const $so46 = (input: any): any =>
+        const $so45 = (input: any): any =>
             `{${
                 undefined === input.deprecated
                     ? ""
@@ -4248,93 +4139,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                               : undefined
                       },`
             }"$ref":${$string(input.$ref)}}`;
-        const $so47 = (input: any): any =>
-            `{${
-                undefined === input.deprecated
-                    ? ""
-                    : `"deprecated":${
-                          undefined !== input.deprecated
-                              ? input.deprecated
-                              : undefined
-                      },`
-            }${
-                undefined === input.title
-                    ? ""
-                    : `"title":${
-                          undefined !== input.title
-                              ? $string(input.title)
-                              : undefined
-                      },`
-            }${
-                undefined === input.description
-                    ? ""
-                    : `"description":${
-                          undefined !== input.description
-                              ? $string(input.description)
-                              : undefined
-                      },`
-            }${
-                undefined === input["x-typia-metaTags"]
-                    ? ""
-                    : `"x-typia-metaTags":${
-                          undefined !== input["x-typia-metaTags"]
-                              ? `[${input["x-typia-metaTags"]
-                                    .map((elem: any) => $su1(elem))
-                                    .join(",")}]`
-                              : undefined
-                      },`
-            }${
-                undefined === input["x-typia-jsDocTags"]
-                    ? ""
-                    : `"x-typia-jsDocTags":${
-                          undefined !== input["x-typia-jsDocTags"]
-                              ? `[${input["x-typia-jsDocTags"]
-                                    .map((elem: any) => $so17(elem))
-                                    .join(",")}]`
-                              : undefined
-                      },`
-            }${
-                undefined === input["x-typia-required"]
-                    ? ""
-                    : `"x-typia-required":${
-                          undefined !== input["x-typia-required"]
-                              ? input["x-typia-required"]
-                              : undefined
-                      },`
-            }${
-                undefined === input["x-typia-optional"]
-                    ? ""
-                    : `"x-typia-optional":${
-                          undefined !== input["x-typia-optional"]
-                              ? input["x-typia-optional"]
-                              : undefined
-                      },`
-            }${
-                undefined === input["x-typia-rest"]
-                    ? ""
-                    : `"x-typia-rest":${
-                          undefined !== input["x-typia-rest"]
-                              ? input["x-typia-rest"]
-                              : undefined
-                      },`
-            }${
-                undefined === input.$id
-                    ? ""
-                    : `"$id":${
-                          undefined !== input.$id
-                              ? $string(input.$id)
-                              : undefined
-                      },`
-            }${
-                undefined === input.$recursiveAnchor
-                    ? ""
-                    : `"$recursiveAnchor":${
-                          undefined !== input.$recursiveAnchor
-                              ? input.$recursiveAnchor
-                              : undefined
-                      },`
-            }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-        const $so48 = (input: any): any =>
+        const $so46 = (input: any): any =>
             `{${
                 undefined === input.deprecated
                     ? ""
@@ -4428,7 +4233,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     value: input.type,
                 });
             })()}}`;
-        const $so49 = (input: any): any =>
+        const $so47 = (input: any): any =>
             `{${$tail(
                 `${
                     undefined === input.deprecated
@@ -4539,8 +4344,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     return $so26(input);
                 if (undefined !== input.oneOf) return $so27(input);
                 if (undefined !== input.$ref) return $so28(input);
-                if (undefined !== input.$recursiveRef) return $so29(input);
-                if ("null" === input.type) return $so30(input);
+                if ("null" === input.type) return $so29(input);
                 return (() => {
                     if ($io20(input)) return $so20(input);
                     if ($io19(input)) return $so19(input);
@@ -4548,7 +4352,7 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                     if ($io21(input)) return $so21(input);
                     if ($io23(input)) return $so23(input);
                     if ($io24(input)) return $so24(input);
-                    if ($io31(input)) return $so31(input);
+                    if ($io30(input)) return $so30(input);
                     $throws({
                         expected:
                             '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -4581,15 +4385,15 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             })();
         const $su2 = (input: any): any =>
             (() => {
-                if ("object" === input.type) return $so34(input);
-                if ("integer" === input.type) return $so40(input);
+                if ("object" === input.type) return $so33(input);
+                if ("integer" === input.type) return $so39(input);
                 if (
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
                     $iu0(input.items)
                 )
-                    return $so43(input);
+                    return $so42(input);
                 if (
                     Array.isArray(input.items) &&
                     input.items.every(
@@ -4600,19 +4404,18 @@ export const test_createStringify_UltimateUnion = _test_stringify(
                             $iu0(elem),
                     )
                 )
-                    return $so44(input);
-                if (undefined !== input.oneOf) return $so45(input);
-                if (undefined !== input.$ref) return $so46(input);
-                if (undefined !== input.$recursiveRef) return $so47(input);
-                if ("null" === input.type) return $so48(input);
+                    return $so43(input);
+                if (undefined !== input.oneOf) return $so44(input);
+                if (undefined !== input.$ref) return $so45(input);
+                if ("null" === input.type) return $so46(input);
                 return (() => {
-                    if ($io38(input)) return $so38(input);
                     if ($io37(input)) return $so37(input);
                     if ($io36(input)) return $so36(input);
-                    if ($io39(input)) return $so39(input);
+                    if ($io35(input)) return $so35(input);
+                    if ($io38(input)) return $so38(input);
+                    if ($io40(input)) return $so40(input);
                     if ($io41(input)) return $so41(input);
-                    if ($io42(input)) return $so42(input);
-                    if ($io49(input)) return $so49(input);
+                    if ($io47(input)) return $so47(input);
                     $throws({
                         expected:
                             '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/createValidate/test_createValidate_UltimateUnion.ts
+++ b/test/generated/output/createValidate/test_createValidate_UltimateUnion.ts
@@ -21,7 +21,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 "object" === typeof input.components &&
                 null !== input.components &&
                 false === Array.isArray(input.components) &&
-                $io32(input.components) &&
+                $io31(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose);
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
@@ -450,6 +450,15 @@ export const test_createValidate_UltimateUnion = _test_validate(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -549,36 +558,6 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -608,7 +587,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -639,13 +618,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -658,22 +637,20 @@ export const test_createValidate_UltimateUnion = _test_validate(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -699,7 +676,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -709,7 +686,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -722,7 +699,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -761,7 +738,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every(
                     (elem: any) =>
@@ -804,7 +781,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -843,7 +820,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -880,7 +857,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
@@ -934,7 +911,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum))) &&
@@ -985,7 +962,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
@@ -1036,7 +1013,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -1089,7 +1066,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -1098,6 +1075,15 @@ export const test_createValidate_UltimateUnion = _test_validate(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1132,7 +1118,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -1172,7 +1158,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1205,40 +1191,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1271,7 +1224,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -1328,8 +1281,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (() => {
                         if ($io20(input)) return $io20(input);
                         if ($io19(input)) return $io19(input);
@@ -1337,7 +1289,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                         if ($io21(input)) return $io21(input);
                         if ($io23(input)) return $io23(input);
                         if ($io24(input)) return $io24(input);
-                        if ($io31(input)) return $io31(input);
+                        if ($io30(input)) return $io30(input);
                         return false;
                     })();
                 })();
@@ -1362,15 +1314,15 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -1381,19 +1333,18 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (() => {
-                        if ($io38(input)) return $io38(input);
                         if ($io37(input)) return $io37(input);
                         if ($io36(input)) return $io36(input);
-                        if ($io39(input)) return $io39(input);
+                        if ($io35(input)) return $io35(input);
+                        if ($io38(input)) return $io38(input);
+                        if ($io40(input)) return $io40(input);
                         if ($io41(input)) return $io41(input);
-                        if ($io42(input)) return $io42(input);
-                        if ($io49(input)) return $io49(input);
+                        if ($io47(input)) return $io47(input);
                         return false;
                     })();
                 })();
@@ -1438,7 +1389,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     _index2 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $vu0(
@@ -1456,7 +1407,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 _index2 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )
@@ -1474,7 +1425,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: "IJsonComponents",
                                 value: input.components,
                             })) &&
-                            $vo32(
+                            $vo31(
                                 input.components,
                                 _path + ".components",
                                 true && _exceptionable,
@@ -3263,7 +3214,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             $report(_exceptionable, {
                                 path: _path + ".items",
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                 value: input.items,
                             })) &&
                             $vu0(
@@ -3274,7 +3225,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             $report(_exceptionable, {
                                 path: _path + ".items",
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                 value: input.items,
                             }),
                         undefined === input.minItems ||
@@ -3511,7 +3462,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     _index23 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $vu0(
@@ -3529,7 +3480,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 _index23 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )
@@ -3538,6 +3489,45 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 path: _path + ".items",
                                 expected: "Array<IJsonSchema>",
                                 value: input.items,
+                            }),
+                        ("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number",
+                                value: input.minItems,
+                            }),
+                        undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                (parseInt(input.maxItems) === input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (0 <= input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".maxItems",
+                                expected: "(number | undefined)",
+                                value: input.maxItems,
                             }),
                         "array" === input.type ||
                             $report(_exceptionable, {
@@ -3714,7 +3704,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     _index26 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $vu0(
@@ -3732,7 +3722,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 _index26 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )
@@ -4034,11 +4024,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        "string" === typeof input.$recursiveRef ||
+                        "null" === input.type ||
                             $report(_exceptionable, {
-                                path: _path + ".$recursiveRef",
-                                expected: "string",
-                                value: input.$recursiveRef,
+                                path: _path + ".type",
+                                expected: '"null"',
+                                value: input.type,
                             }),
                         undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -4183,12 +4173,18 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        "null" === input.type ||
+                        (null !== input.type ||
                             $report(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"null"',
+                                expected: "undefined",
                                 value: input.type,
-                            }),
+                            })) &&
+                            (undefined === input.type ||
+                                $report(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
+                                })),
                         undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
                             $report(_exceptionable, {
@@ -4332,31 +4328,183 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        (null !== input.type ||
+                        undefined === input.schemas ||
+                            ((("object" === typeof input.schemas &&
+                                null !== input.schemas &&
+                                false === Array.isArray(input.schemas)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".schemas",
+                                    expected:
+                                        "(Record<string, IObject | IAlias> | undefined)",
+                                    value: input.schemas,
+                                })) &&
+                                $vo32(
+                                    input.schemas,
+                                    _path + ".schemas",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".schemas",
+                                expected:
+                                    "(Record<string, IObject | IAlias> | undefined)",
+                                value: input.schemas,
+                            }),
+                    ].every((flag: boolean) => flag);
+                const $vo32 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key: any) => {
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    if (RegExp(/(.*)/).test(key))
+                                        return (
+                                            ((("object" === typeof value &&
+                                                null !== value &&
+                                                false ===
+                                                    Array.isArray(value)) ||
+                                                $report(_exceptionable, {
+                                                    path: _path + $join(key),
+                                                    expected:
+                                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                    value: value,
+                                                })) &&
+                                                $vu2(
+                                                    value,
+                                                    _path + $join(key),
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $report(_exceptionable, {
+                                                path: _path + $join(key),
+                                                expected:
+                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                value: value,
+                                            })
+                                        );
+                                    return true;
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                const $vo33 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.$id ||
+                            "string" === typeof input.$id ||
+                            $report(_exceptionable, {
+                                path: _path + ".$id",
+                                expected: "(string | undefined)",
+                                value: input.$id,
+                            }),
+                        "object" === input.type ||
                             $report(_exceptionable, {
                                 path: _path + ".type",
-                                expected: "undefined",
+                                expected: '"object"',
                                 value: input.type,
-                            })) &&
-                            (undefined === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })),
-                        undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $report(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
                             }),
-                        undefined === input.title ||
-                            "string" === typeof input.title ||
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
                             $report(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
+                                path: _path + ".nullable",
+                                expected: "(boolean | undefined)",
+                                value: input.nullable,
+                            }),
+                        ((("object" === typeof input.properties &&
+                            null !== input.properties &&
+                            false === Array.isArray(input.properties)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".properties",
+                                expected: "Record<string, IJsonSchema>",
+                                value: input.properties,
+                            })) &&
+                            $vo34(
+                                input.properties,
+                                _path + ".properties",
+                                true && _exceptionable,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".properties",
+                                expected: "Record<string, IJsonSchema>",
+                                value: input.properties,
+                            }),
+                        undefined === input.patternProperties ||
+                            ((("object" === typeof input.patternProperties &&
+                                null !== input.patternProperties &&
+                                false ===
+                                    Array.isArray(input.patternProperties)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                })) &&
+                                $vo34(
+                                    input.patternProperties,
+                                    _path + ".patternProperties",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".patternProperties",
+                                expected:
+                                    "(Record<string, IJsonSchema> | undefined)",
+                                value: input.patternProperties,
+                            }),
+                        undefined === input.additionalProperties ||
+                            ((("object" === typeof input.additionalProperties &&
+                                null !== input.additionalProperties &&
+                                false ===
+                                    Array.isArray(
+                                        input.additionalProperties,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                })) &&
+                                $vu0(
+                                    input.additionalProperties,
+                                    _path + ".additionalProperties",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".additionalProperties",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                value: input.additionalProperties,
+                            }),
+                        undefined === input.required ||
+                            ((Array.isArray(input.required) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
+                                })) &&
+                                input.required
+                                    .map(
+                                        (elem: any, _index35: number) =>
+                                            "string" === typeof elem ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".required[" +
+                                                    _index35 +
+                                                    "]",
+                                                expected: "string",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".required",
+                                expected: "(Array<string> | undefined)",
+                                value: input.required,
                             }),
                         undefined === input.description ||
                             "string" === typeof input.description ||
@@ -4364,54 +4512,6 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 path: _path + ".description",
                                 expected: "(string | undefined)",
                                 value: input.description,
-                            }),
-                        undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"]
-                                    .map(
-                                        (elem: any, _index35: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $vu1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index35 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
                             }),
                         undefined === input["x-typia-jsDocTags"] ||
                             ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4459,272 +4559,6 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: "(Array<IJsDocTagInfo> | undefined)",
                                 value: input["x-typia-jsDocTags"],
                             }),
-                        undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            }),
-                        undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            }),
-                        undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            }),
-                    ].every((flag: boolean) => flag);
-                const $vo32 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    [
-                        undefined === input.schemas ||
-                            ((("object" === typeof input.schemas &&
-                                null !== input.schemas &&
-                                false === Array.isArray(input.schemas)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".schemas",
-                                    expected:
-                                        "(Record<string, IObject | IAlias> | undefined)",
-                                    value: input.schemas,
-                                })) &&
-                                $vo33(
-                                    input.schemas,
-                                    _path + ".schemas",
-                                    true && _exceptionable,
-                                )) ||
-                            $report(_exceptionable, {
-                                path: _path + ".schemas",
-                                expected:
-                                    "(Record<string, IObject | IAlias> | undefined)",
-                                value: input.schemas,
-                            }),
-                    ].every((flag: boolean) => flag);
-                const $vo33 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    [
-                        false === _exceptionable ||
-                            Object.keys(input)
-                                .map((key: any) => {
-                                    const value = input[key];
-                                    if (undefined === value) return true;
-                                    if (RegExp(/(.*)/).test(key))
-                                        return (
-                                            ((("object" === typeof value &&
-                                                null !== value &&
-                                                false ===
-                                                    Array.isArray(value)) ||
-                                                $report(_exceptionable, {
-                                                    path: _path + $join(key),
-                                                    expected:
-                                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                    value: value,
-                                                })) &&
-                                                $vu2(
-                                                    value,
-                                                    _path + $join(key),
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $report(_exceptionable, {
-                                                path: _path + $join(key),
-                                                expected:
-                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                value: value,
-                                            })
-                                        );
-                                    return true;
-                                })
-                                .every((flag: boolean) => flag),
-                    ].every((flag: boolean) => flag);
-                const $vo34 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    [
-                        undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $report(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            }),
-                        undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $report(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }),
-                        "object" === input.type ||
-                            $report(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"object"',
-                                value: input.type,
-                            }),
-                        undefined === input.nullable ||
-                            "boolean" === typeof input.nullable ||
-                            $report(_exceptionable, {
-                                path: _path + ".nullable",
-                                expected: "(boolean | undefined)",
-                                value: input.nullable,
-                            }),
-                        ((("object" === typeof input.properties &&
-                            null !== input.properties &&
-                            false === Array.isArray(input.properties)) ||
-                            $report(_exceptionable, {
-                                path: _path + ".properties",
-                                expected: "Record<string, IJsonSchema>",
-                                value: input.properties,
-                            })) &&
-                            $vo35(
-                                input.properties,
-                                _path + ".properties",
-                                true && _exceptionable,
-                            )) ||
-                            $report(_exceptionable, {
-                                path: _path + ".properties",
-                                expected: "Record<string, IJsonSchema>",
-                                value: input.properties,
-                            }),
-                        undefined === input.patternProperties ||
-                            ((("object" === typeof input.patternProperties &&
-                                null !== input.patternProperties &&
-                                false ===
-                                    Array.isArray(input.patternProperties)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                })) &&
-                                $vo35(
-                                    input.patternProperties,
-                                    _path + ".patternProperties",
-                                    true && _exceptionable,
-                                )) ||
-                            $report(_exceptionable, {
-                                path: _path + ".patternProperties",
-                                expected:
-                                    "(Record<string, IJsonSchema> | undefined)",
-                                value: input.patternProperties,
-                            }),
-                        undefined === input.additionalProperties ||
-                            ((("object" === typeof input.additionalProperties &&
-                                null !== input.additionalProperties &&
-                                false ===
-                                    Array.isArray(
-                                        input.additionalProperties,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                })) &&
-                                $vu0(
-                                    input.additionalProperties,
-                                    _path + ".additionalProperties",
-                                    true && _exceptionable,
-                                )) ||
-                            $report(_exceptionable, {
-                                path: _path + ".additionalProperties",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                value: input.additionalProperties,
-                            }),
-                        undefined === input.required ||
-                            ((Array.isArray(input.required) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                })) &&
-                                input.required
-                                    .map(
-                                        (elem: any, _index37: number) =>
-                                            "string" === typeof elem ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".required[" +
-                                                    _index37 +
-                                                    "]",
-                                                expected: "string",
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                            $report(_exceptionable, {
-                                path: _path + ".required",
-                                expected: "(Array<string> | undefined)",
-                                value: input.required,
-                            }),
-                        undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $report(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            }),
-                        undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"]
-                                    .map(
-                                        (elem: any, _index38: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $vo17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index38 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            }),
                         undefined === input["x-typia-patternProperties"] ||
                             ((("object" ===
                                 typeof input["x-typia-patternProperties"] &&
@@ -4740,7 +4574,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         "(Record<string, IJsonSchema> | undefined)",
                                     value: input["x-typia-patternProperties"],
                                 })) &&
-                                $vo35(
+                                $vo34(
                                     input["x-typia-patternProperties"],
                                     _path + '["x-typia-patternProperties"]',
                                     true && _exceptionable,
@@ -4765,7 +4599,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
@@ -4779,11 +4613,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 path:
                                     _path + '["x-typia-additionalProperties"]',
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                 value: input["x-typia-additionalProperties"],
                             }),
                     ].every((flag: boolean) => flag);
-                const $vo35 = (
+                const $vo34 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -4803,7 +4637,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 $report(_exceptionable, {
                                                     path: _path + $join(key),
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: value,
                                                 })) &&
                                                 $vu0(
@@ -4814,7 +4648,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                             $report(_exceptionable, {
                                                 path: _path + $join(key),
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: value,
                                             })
                                         );
@@ -4822,7 +4656,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 })
                                 .every((flag: boolean) => flag),
                     ].every((flag: boolean) => flag);
-                const $vo36 = (
+                const $vo35 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -4836,13 +4670,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             })) &&
                             input["enum"]
                                 .map(
-                                    (elem: any, _index39: number) =>
+                                    (elem: any, _index37: number) =>
                                         "boolean" === typeof elem ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["enum"][' +
-                                                _index39 +
+                                                _index37 +
                                                 "]",
                                             expected: "boolean",
                                             value: elem,
@@ -4905,14 +4739,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 })) &&
                                 input["x-typia-metaTags"]
                                     .map(
-                                        (elem: any, _index40: number) =>
+                                        (elem: any, _index38: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4922,7 +4756,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -4930,7 +4764,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index40 +
+                                                    _index38 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -4953,14 +4787,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 })) &&
                                 input["x-typia-jsDocTags"]
                                     .map(
-                                        (elem: any, _index41: number) =>
+                                        (elem: any, _index39: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -4969,7 +4803,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -4977,7 +4811,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index41 +
+                                                    _index39 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -5025,7 +4859,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 value: input.$recursiveAnchor,
                             }),
                     ].every((flag: boolean) => flag);
-                const $vo37 = (
+                const $vo36 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -5039,14 +4873,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             })) &&
                             input["enum"]
                                 .map(
-                                    (elem: any, _index42: number) =>
+                                    (elem: any, _index40: number) =>
                                         ("number" === typeof elem &&
                                             Number.isFinite(elem)) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["enum"][' +
-                                                _index42 +
+                                                _index40 +
                                                 "]",
                                             expected: "number",
                                             value: elem,
@@ -5110,14 +4944,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 })) &&
                                 input["x-typia-metaTags"]
                                     .map(
-                                        (elem: any, _index43: number) =>
+                                        (elem: any, _index41: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5127,7 +4961,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -5135,7 +4969,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index43 +
+                                                    _index41 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5158,14 +4992,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 })) &&
                                 input["x-typia-jsDocTags"]
                                     .map(
-                                        (elem: any, _index44: number) =>
+                                        (elem: any, _index42: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index44 +
+                                                        _index42 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -5174,7 +5008,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index44 +
+                                                        _index42 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -5182,7 +5016,210 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
+                                                    _index42 +
+                                                    "]",
+                                                expected: "IJsDocTagInfo",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + '["x-typia-jsDocTags"]',
+                                expected: "(Array<IJsDocTagInfo> | undefined)",
+                                value: input["x-typia-jsDocTags"],
+                            }),
+                        undefined === input["x-typia-required"] ||
+                            "boolean" === typeof input["x-typia-required"] ||
+                            $report(_exceptionable, {
+                                path: _path + '["x-typia-required"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-required"],
+                            }),
+                        undefined === input["x-typia-optional"] ||
+                            "boolean" === typeof input["x-typia-optional"] ||
+                            $report(_exceptionable, {
+                                path: _path + '["x-typia-optional"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-optional"],
+                            }),
+                        undefined === input["x-typia-rest"] ||
+                            "boolean" === typeof input["x-typia-rest"] ||
+                            $report(_exceptionable, {
+                                path: _path + '["x-typia-rest"]',
+                                expected: "(boolean | undefined)",
+                                value: input["x-typia-rest"],
+                            }),
+                        undefined === input.$id ||
+                            "string" === typeof input.$id ||
+                            $report(_exceptionable, {
+                                path: _path + ".$id",
+                                expected: "(string | undefined)",
+                                value: input.$id,
+                            }),
+                        undefined === input.$recursiveAnchor ||
+                            "boolean" === typeof input.$recursiveAnchor ||
+                            $report(_exceptionable, {
+                                path: _path + ".$recursiveAnchor",
+                                expected: "(boolean | undefined)",
+                                value: input.$recursiveAnchor,
+                            }),
+                    ].every((flag: boolean) => flag);
+                const $vo37 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        ((Array.isArray(input["enum"]) ||
+                            $report(_exceptionable, {
+                                path: _path + '["enum"]',
+                                expected: "Array<string>",
+                                value: input["enum"],
+                            })) &&
+                            input["enum"]
+                                .map(
+                                    (elem: any, _index43: number) =>
+                                        "string" === typeof elem ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["enum"][' +
+                                                _index43 +
+                                                "]",
+                                            expected: "string",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + '["enum"]',
+                                expected: "Array<string>",
+                                value: input["enum"],
+                            }),
+                        undefined === input["default"] ||
+                            "string" === typeof input["default"] ||
+                            $report(_exceptionable, {
+                                path: _path + '["default"]',
+                                expected: "(string | undefined)",
+                                value: input["default"],
+                            }),
+                        "string" === input.type ||
+                            $report(_exceptionable, {
+                                path: _path + ".type",
+                                expected: '"string"',
+                                value: input.type,
+                            }),
+                        undefined === input.nullable ||
+                            "boolean" === typeof input.nullable ||
+                            $report(_exceptionable, {
+                                path: _path + ".nullable",
+                                expected: "(boolean | undefined)",
+                                value: input.nullable,
+                            }),
+                        undefined === input.deprecated ||
+                            "boolean" === typeof input.deprecated ||
+                            $report(_exceptionable, {
+                                path: _path + ".deprecated",
+                                expected: "(boolean | undefined)",
+                                value: input.deprecated,
+                            }),
+                        undefined === input.title ||
+                            "string" === typeof input.title ||
+                            $report(_exceptionable, {
+                                path: _path + ".title",
+                                expected: "(string | undefined)",
+                                value: input.title,
+                            }),
+                        undefined === input.description ||
+                            "string" === typeof input.description ||
+                            $report(_exceptionable, {
+                                path: _path + ".description",
+                                expected: "(string | undefined)",
+                                value: input.description,
+                            }),
+                        undefined === input["x-typia-metaTags"] ||
+                            ((Array.isArray(input["x-typia-metaTags"]) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                })) &&
+                                input["x-typia-metaTags"]
+                                    .map(
+                                        (elem: any, _index44: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-metaTags"][' +
+                                                        _index44 +
+                                                        "]",
+                                                    expected:
+                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                    value: elem,
+                                                })) &&
+                                                $vu1(
+                                                    elem,
+                                                    _path +
+                                                        '["x-typia-metaTags"][' +
+                                                        _index44 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-metaTags"][' +
                                                     _index44 +
+                                                    "]",
+                                                expected:
+                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + '["x-typia-metaTags"]',
+                                expected: "(Array<IMetadataTag> | undefined)",
+                                value: input["x-typia-metaTags"],
+                            }),
+                        undefined === input["x-typia-jsDocTags"] ||
+                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                })) &&
+                                input["x-typia-jsDocTags"]
+                                    .map(
+                                        (elem: any, _index45: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
+                                                        "]",
+                                                    expected: "IJsDocTagInfo",
+                                                    value: elem,
+                                                })) &&
+                                                $vo17(
+                                                    elem,
+                                                    _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["x-typia-jsDocTags"][' +
+                                                    _index45 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -5236,43 +5273,17 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        ((Array.isArray(input["enum"]) ||
-                            $report(_exceptionable, {
-                                path: _path + '["enum"]',
-                                expected: "Array<string>",
-                                value: input["enum"],
-                            })) &&
-                            input["enum"]
-                                .map(
-                                    (elem: any, _index45: number) =>
-                                        "string" === typeof elem ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["enum"][' +
-                                                _index45 +
-                                                "]",
-                                            expected: "string",
-                                            value: elem,
-                                        }),
-                                )
-                                .every((flag: boolean) => flag)) ||
-                            $report(_exceptionable, {
-                                path: _path + '["enum"]',
-                                expected: "Array<string>",
-                                value: input["enum"],
-                            }),
                         undefined === input["default"] ||
-                            "string" === typeof input["default"] ||
+                            "boolean" === typeof input["default"] ||
                             $report(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(string | undefined)",
+                                expected: "(boolean | undefined)",
                                 value: input["default"],
                             }),
-                        "string" === input.type ||
+                        "boolean" === input.type ||
                             $report(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"string"',
+                                expected: '"boolean"',
                                 value: input.type,
                             }),
                         undefined === input.nullable ||
@@ -5439,17 +5450,75 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
+                        undefined === input.minimum ||
+                            ("number" === typeof input.minimum &&
+                                Number.isFinite(input.minimum) &&
+                                (parseInt(input.minimum) === input.minimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
+                                    }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".minimum",
+                                expected: "(number | undefined)",
+                                value: input.minimum,
+                            }),
+                        undefined === input.maximum ||
+                            ("number" === typeof input.maximum &&
+                                Number.isFinite(input.maximum) &&
+                                (parseInt(input.maximum) === input.maximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".maximum",
+                                expected: "(number | undefined)",
+                                value: input.maximum,
+                            }),
+                        undefined === input.exclusiveMinimum ||
+                            "boolean" === typeof input.exclusiveMinimum ||
+                            $report(_exceptionable, {
+                                path: _path + ".exclusiveMinimum",
+                                expected: "(boolean | undefined)",
+                                value: input.exclusiveMinimum,
+                            }),
+                        undefined === input.exclusiveMaximum ||
+                            "boolean" === typeof input.exclusiveMaximum ||
+                            $report(_exceptionable, {
+                                path: _path + ".exclusiveMaximum",
+                                expected: "(boolean | undefined)",
+                                value: input.exclusiveMaximum,
+                            }),
+                        undefined === input.multipleOf ||
+                            ("number" === typeof input.multipleOf &&
+                                Number.isFinite(input.multipleOf) &&
+                                (parseInt(input.multipleOf) ===
+                                    input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".multipleOf",
+                                expected: "(number | undefined)",
+                                value: input.multipleOf,
+                            }),
                         undefined === input["default"] ||
-                            "boolean" === typeof input["default"] ||
+                            ("number" === typeof input["default"] &&
+                                Number.isFinite(input["default"])) ||
                             $report(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(boolean | undefined)",
+                                expected: "(number | undefined)",
                                 value: input["default"],
                             }),
-                        "boolean" === input.type ||
+                        "integer" === input.type ||
                             $report(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"boolean"',
+                                expected: '"integer"',
                                 value: input.type,
                             }),
                         undefined === input.nullable ||
@@ -5618,13 +5687,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     [
                         undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
-                                Number.isFinite(input.minimum) &&
-                                (parseInt(input.minimum) === input.minimum ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".minimum",
-                                        expected: "number (@type int)",
-                                        value: input.minimum,
-                                    }))) ||
+                                Number.isFinite(input.minimum)) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
                                 expected: "(number | undefined)",
@@ -5632,13 +5695,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             }),
                         undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
-                                Number.isFinite(input.maximum) &&
-                                (parseInt(input.maximum) === input.maximum ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".maximum",
-                                        expected: "number (@type int)",
-                                        value: input.maximum,
-                                    }))) ||
+                                Number.isFinite(input.maximum)) ||
                             $report(_exceptionable, {
                                 path: _path + ".maximum",
                                 expected: "(number | undefined)",
@@ -5660,14 +5717,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             }),
                         undefined === input.multipleOf ||
                             ("number" === typeof input.multipleOf &&
-                                Number.isFinite(input.multipleOf) &&
-                                (parseInt(input.multipleOf) ===
-                                    input.multipleOf ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".multipleOf",
-                                        expected: "number (@type int)",
-                                        value: input.multipleOf,
-                                    }))) ||
+                                Number.isFinite(input.multipleOf)) ||
                             $report(_exceptionable, {
                                 path: _path + ".multipleOf",
                                 expected: "(number | undefined)",
@@ -5681,10 +5731,10 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 expected: "(number | undefined)",
                                 value: input["default"],
                             }),
-                        "integer" === input.type ||
+                        "number" === input.type ||
                             $report(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"integer"',
+                                expected: '"number"',
                                 value: input.type,
                             }),
                         undefined === input.nullable ||
@@ -5851,56 +5901,73 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        undefined === input.minimum ||
-                            ("number" === typeof input.minimum &&
-                                Number.isFinite(input.minimum)) ||
+                        undefined === input.minLength ||
+                            ("number" === typeof input.minLength &&
+                                Number.isFinite(input.minLength) &&
+                                (parseInt(input.minLength) ===
+                                    input.minLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    })) &&
+                                (0 <= input.minLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
+                                    }))) ||
                             $report(_exceptionable, {
-                                path: _path + ".minimum",
+                                path: _path + ".minLength",
                                 expected: "(number | undefined)",
-                                value: input.minimum,
+                                value: input.minLength,
                             }),
-                        undefined === input.maximum ||
-                            ("number" === typeof input.maximum &&
-                                Number.isFinite(input.maximum)) ||
+                        undefined === input.maxLength ||
+                            ("number" === typeof input.maxLength &&
+                                Number.isFinite(input.maxLength) &&
+                                (parseInt(input.maxLength) ===
+                                    input.maxLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (0 <= input.maxLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    }))) ||
                             $report(_exceptionable, {
-                                path: _path + ".maximum",
+                                path: _path + ".maxLength",
                                 expected: "(number | undefined)",
-                                value: input.maximum,
+                                value: input.maxLength,
                             }),
-                        undefined === input.exclusiveMinimum ||
-                            "boolean" === typeof input.exclusiveMinimum ||
+                        undefined === input.pattern ||
+                            "string" === typeof input.pattern ||
                             $report(_exceptionable, {
-                                path: _path + ".exclusiveMinimum",
-                                expected: "(boolean | undefined)",
-                                value: input.exclusiveMinimum,
+                                path: _path + ".pattern",
+                                expected: "(string | undefined)",
+                                value: input.pattern,
                             }),
-                        undefined === input.exclusiveMaximum ||
-                            "boolean" === typeof input.exclusiveMaximum ||
+                        undefined === input.format ||
+                            "string" === typeof input.format ||
                             $report(_exceptionable, {
-                                path: _path + ".exclusiveMaximum",
-                                expected: "(boolean | undefined)",
-                                value: input.exclusiveMaximum,
-                            }),
-                        undefined === input.multipleOf ||
-                            ("number" === typeof input.multipleOf &&
-                                Number.isFinite(input.multipleOf)) ||
-                            $report(_exceptionable, {
-                                path: _path + ".multipleOf",
-                                expected: "(number | undefined)",
-                                value: input.multipleOf,
+                                path: _path + ".format",
+                                expected: "(string | undefined)",
+                                value: input.format,
                             }),
                         undefined === input["default"] ||
-                            ("number" === typeof input["default"] &&
-                                Number.isFinite(input["default"])) ||
+                            "string" === typeof input["default"] ||
                             $report(_exceptionable, {
                                 path: _path + '["default"]',
-                                expected: "(number | undefined)",
+                                expected: "(string | undefined)",
                                 value: input["default"],
                             }),
-                        "number" === input.type ||
+                        "string" === input.type ||
                             $report(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"number"',
+                                expected: '"string"',
                                 value: input.type,
                             }),
                         undefined === input.nullable ||
@@ -6067,73 +6134,89 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        undefined === input.minLength ||
-                            ("number" === typeof input.minLength &&
-                                Number.isFinite(input.minLength) &&
-                                (parseInt(input.minLength) ===
-                                    input.minLength ||
+                        ((("object" === typeof input.items &&
+                            null !== input.items &&
+                            false === Array.isArray(input.items)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".items",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                value: input.items,
+                            })) &&
+                            $vu0(
+                                input.items,
+                                _path + ".items",
+                                true && _exceptionable,
+                            )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".items",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                value: input.items,
+                            }),
+                        undefined === input.minItems ||
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
                                     $report(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "number (@type uint)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     })) &&
-                                (0 <= input.minLength ||
+                                (0 <= input.minItems ||
                                     $report(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "number (@type uint)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     }))) ||
                             $report(_exceptionable, {
-                                path: _path + ".minLength",
+                                path: _path + ".minItems",
                                 expected: "(number | undefined)",
-                                value: input.minLength,
+                                value: input.minItems,
                             }),
-                        undefined === input.maxLength ||
-                            ("number" === typeof input.maxLength &&
-                                Number.isFinite(input.maxLength) &&
-                                (parseInt(input.maxLength) ===
-                                    input.maxLength ||
+                        undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                (parseInt(input.maxItems) === input.maxItems ||
                                     $report(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "number (@type uint)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     })) &&
-                                (0 <= input.maxLength ||
+                                (0 <= input.maxItems ||
                                     $report(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "number (@type uint)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     }))) ||
                             $report(_exceptionable, {
-                                path: _path + ".maxLength",
+                                path: _path + ".maxItems",
                                 expected: "(number | undefined)",
-                                value: input.maxLength,
+                                value: input.maxItems,
                             }),
-                        undefined === input.pattern ||
-                            "string" === typeof input.pattern ||
+                        undefined === input["x-typia-tuple"] ||
+                            ((("object" === typeof input["x-typia-tuple"] &&
+                                null !== input["x-typia-tuple"]) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
+                                })) &&
+                                $vo26(
+                                    input["x-typia-tuple"],
+                                    _path + '["x-typia-tuple"]',
+                                    true && _exceptionable,
+                                )) ||
                             $report(_exceptionable, {
-                                path: _path + ".pattern",
-                                expected: "(string | undefined)",
-                                value: input.pattern,
+                                path: _path + '["x-typia-tuple"]',
+                                expected: "(IJsonSchema.ITuple | undefined)",
+                                value: input["x-typia-tuple"],
                             }),
-                        undefined === input.format ||
-                            "string" === typeof input.format ||
-                            $report(_exceptionable, {
-                                path: _path + ".format",
-                                expected: "(string | undefined)",
-                                value: input.format,
-                            }),
-                        undefined === input["default"] ||
-                            "string" === typeof input["default"] ||
-                            $report(_exceptionable, {
-                                path: _path + '["default"]',
-                                expected: "(string | undefined)",
-                                value: input["default"],
-                            }),
-                        "string" === input.type ||
+                        "array" === input.type ||
                             $report(_exceptionable, {
                                 path: _path + ".type",
-                                expected: '"string"',
+                                expected: '"array"',
                                 value: input.type,
                             }),
                         undefined === input.nullable ||
@@ -6300,44 +6383,70 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        ((("object" === typeof input.items &&
-                            null !== input.items &&
-                            false === Array.isArray(input.items)) ||
+                        ((Array.isArray(input.items) ||
                             $report(_exceptionable, {
                                 path: _path + ".items",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                expected: "Array<IJsonSchema>",
                                 value: input.items,
                             })) &&
-                            $vu0(
-                                input.items,
-                                _path + ".items",
-                                true && _exceptionable,
-                            )) ||
+                            input.items
+                                .map(
+                                    (elem: any, _index56: number) =>
+                                        ((("object" === typeof elem &&
+                                            null !== elem &&
+                                            false === Array.isArray(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                expected:
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                value: elem,
+                                            })) &&
+                                            $vu0(
+                                                elem,
+                                                _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".items[" +
+                                                _index56 +
+                                                "]",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
                             $report(_exceptionable, {
                                 path: _path + ".items",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                expected: "Array<IJsonSchema>",
                                 value: input.items,
                             }),
-                        undefined === input.minItems ||
-                            ("number" === typeof input.minItems &&
-                                Number.isFinite(input.minItems) &&
-                                (parseInt(input.minItems) === input.minItems ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".minItems",
-                                        expected: "number (@type uint)",
-                                        value: input.minItems,
-                                    })) &&
-                                (0 <= input.minItems ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".minItems",
-                                        expected: "number (@type uint)",
-                                        value: input.minItems,
-                                    }))) ||
+                        ("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                })) &&
+                            (0 <= input.minItems ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
+                                }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
-                                expected: "(number | undefined)",
+                                expected: "number",
                                 value: input.minItems,
                             }),
                         undefined === input.maxItems ||
@@ -6359,25 +6468,6 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 path: _path + ".maxItems",
                                 expected: "(number | undefined)",
                                 value: input.maxItems,
-                            }),
-                        undefined === input["x-typia-tuple"] ||
-                            ((("object" === typeof input["x-typia-tuple"] &&
-                                null !== input["x-typia-tuple"]) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
-                                })) &&
-                                $vo26(
-                                    input["x-typia-tuple"],
-                                    _path + '["x-typia-tuple"]',
-                                    true && _exceptionable,
-                                )) ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-tuple"]',
-                                expected: "(IJsonSchema.ITuple | undefined)",
-                                value: input["x-typia-tuple"],
                             }),
                         "array" === input.type ||
                             $report(_exceptionable, {
@@ -6423,14 +6513,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 })) &&
                                 input["x-typia-metaTags"]
                                     .map(
-                                        (elem: any, _index56: number) =>
+                                        (elem: any, _index57: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6440,7 +6530,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6448,7 +6538,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index56 +
+                                                    _index57 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6471,14 +6561,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 })) &&
                                 input["x-typia-jsDocTags"]
                                     .map(
-                                        (elem: any, _index57: number) =>
+                                        (elem: any, _index58: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6487,7 +6577,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6495,7 +6585,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index57 +
+                                                    _index58 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6549,65 +6639,52 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        ((Array.isArray(input.items) ||
+                        ((Array.isArray(input.oneOf) ||
                             $report(_exceptionable, {
-                                path: _path + ".items",
+                                path: _path + ".oneOf",
                                 expected: "Array<IJsonSchema>",
-                                value: input.items,
+                                value: input.oneOf,
                             })) &&
-                            input.items
+                            input.oneOf
                                 .map(
-                                    (elem: any, _index58: number) =>
+                                    (elem: any, _index59: number) =>
                                         ((("object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem)) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             })) &&
                                             $vu0(
                                                 elem,
                                                 _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 true && _exceptionable,
                                             )) ||
                                         $report(_exceptionable, {
                                             path:
                                                 _path +
-                                                ".items[" +
-                                                _index58 +
+                                                ".oneOf[" +
+                                                _index59 +
                                                 "]",
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                             value: elem,
                                         }),
                                 )
                                 .every((flag: boolean) => flag)) ||
                             $report(_exceptionable, {
-                                path: _path + ".items",
+                                path: _path + ".oneOf",
                                 expected: "Array<IJsonSchema>",
-                                value: input.items,
-                            }),
-                        "array" === input.type ||
-                            $report(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"array"',
-                                value: input.type,
-                            }),
-                        undefined === input.nullable ||
-                            "boolean" === typeof input.nullable ||
-                            $report(_exceptionable, {
-                                path: _path + ".nullable",
-                                expected: "(boolean | undefined)",
-                                value: input.nullable,
+                                value: input.oneOf,
                             }),
                         undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6640,14 +6717,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 })) &&
                                 input["x-typia-metaTags"]
                                     .map(
-                                        (elem: any, _index59: number) =>
+                                        (elem: any, _index60: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6657,7 +6734,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     elem,
                                                     _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6665,7 +6742,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 path:
                                                     _path +
                                                     '["x-typia-metaTags"][' +
-                                                    _index59 +
+                                                    _index60 +
                                                     "]",
                                                 expected:
                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6688,14 +6765,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 })) &&
                                 input["x-typia-jsDocTags"]
                                     .map(
-                                        (elem: any, _index60: number) =>
+                                        (elem: any, _index61: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6704,7 +6781,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                     elem,
                                                     _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
@@ -6712,7 +6789,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                                 path:
                                                     _path +
                                                     '["x-typia-jsDocTags"][' +
-                                                    _index60 +
+                                                    _index61 +
                                                     "]",
                                                 expected: "IJsDocTagInfo",
                                                 value: elem,
@@ -6766,52 +6843,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        ((Array.isArray(input.oneOf) ||
+                        "string" === typeof input.$ref ||
                             $report(_exceptionable, {
-                                path: _path + ".oneOf",
-                                expected: "Array<IJsonSchema>",
-                                value: input.oneOf,
-                            })) &&
-                            input.oneOf
-                                .map(
-                                    (elem: any, _index61: number) =>
-                                        ((("object" === typeof elem &&
-                                            null !== elem &&
-                                            false === Array.isArray(elem)) ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                value: elem,
-                                            })) &&
-                                            $vu0(
-                                                elem,
-                                                _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                true && _exceptionable,
-                                            )) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path +
-                                                ".oneOf[" +
-                                                _index61 +
-                                                "]",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                            value: elem,
-                                        }),
-                                )
-                                .every((flag: boolean) => flag)) ||
-                            $report(_exceptionable, {
-                                path: _path + ".oneOf",
-                                expected: "Array<IJsonSchema>",
-                                value: input.oneOf,
+                                path: _path + ".$ref",
+                                expected: "string",
+                                value: input.$ref,
                             }),
                         undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -6970,11 +7006,11 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        "string" === typeof input.$ref ||
+                        "null" === input.type ||
                             $report(_exceptionable, {
-                                path: _path + ".$ref",
-                                expected: "string",
-                                value: input.$ref,
+                                path: _path + ".type",
+                                expected: '"null"',
+                                value: input.type,
                             }),
                         undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
@@ -7133,12 +7169,18 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
-                        "string" === typeof input.$recursiveRef ||
+                        (null !== input.type ||
                             $report(_exceptionable, {
-                                path: _path + ".$recursiveRef",
-                                expected: "string",
-                                value: input.$recursiveRef,
-                            }),
+                                path: _path + ".type",
+                                expected: "undefined",
+                                value: input.type,
+                            })) &&
+                            (undefined === input.type ||
+                                $report(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
+                                })),
                         undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated ||
                             $report(_exceptionable, {
@@ -7290,338 +7332,6 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 value: input.$recursiveAnchor,
                             }),
                     ].every((flag: boolean) => flag);
-                const $vo48 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    [
-                        "null" === input.type ||
-                            $report(_exceptionable, {
-                                path: _path + ".type",
-                                expected: '"null"',
-                                value: input.type,
-                            }),
-                        undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $report(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            }),
-                        undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $report(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
-                            }),
-                        undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $report(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            }),
-                        undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"]
-                                    .map(
-                                        (elem: any, _index68: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $vu1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index68 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            }),
-                        undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"]
-                                    .map(
-                                        (elem: any, _index69: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $vo17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index69 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            }),
-                        undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            }),
-                        undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            }),
-                        undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            }),
-                        undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $report(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            }),
-                        undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $report(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }),
-                    ].every((flag: boolean) => flag);
-                const $vo49 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    [
-                        (null !== input.type ||
-                            $report(_exceptionable, {
-                                path: _path + ".type",
-                                expected: "undefined",
-                                value: input.type,
-                            })) &&
-                            (undefined === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })),
-                        undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated ||
-                            $report(_exceptionable, {
-                                path: _path + ".deprecated",
-                                expected: "(boolean | undefined)",
-                                value: input.deprecated,
-                            }),
-                        undefined === input.title ||
-                            "string" === typeof input.title ||
-                            $report(_exceptionable, {
-                                path: _path + ".title",
-                                expected: "(string | undefined)",
-                                value: input.title,
-                            }),
-                        undefined === input.description ||
-                            "string" === typeof input.description ||
-                            $report(_exceptionable, {
-                                path: _path + ".description",
-                                expected: "(string | undefined)",
-                                value: input.description,
-                            }),
-                        undefined === input["x-typia-metaTags"] ||
-                            ((Array.isArray(input["x-typia-metaTags"]) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                })) &&
-                                input["x-typia-metaTags"]
-                                    .map(
-                                        (elem: any, _index70: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                })) &&
-                                                $vu1(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-metaTags"][' +
-                                                    _index70 +
-                                                    "]",
-                                                expected:
-                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            }),
-                        undefined === input["x-typia-jsDocTags"] ||
-                            ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                })) &&
-                                input["x-typia-jsDocTags"]
-                                    .map(
-                                        (elem: any, _index71: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                })) &&
-                                                $vo17(
-                                                    elem,
-                                                    _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["x-typia-jsDocTags"][' +
-                                                    _index71 +
-                                                    "]",
-                                                expected: "IJsDocTagInfo",
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            }),
-                        undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"] ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-required"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-required"],
-                            }),
-                        undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"] ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-optional"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-optional"],
-                            }),
-                        undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"] ||
-                            $report(_exceptionable, {
-                                path: _path + '["x-typia-rest"]',
-                                expected: "(boolean | undefined)",
-                                value: input["x-typia-rest"],
-                            }),
-                        undefined === input.$id ||
-                            "string" === typeof input.$id ||
-                            $report(_exceptionable, {
-                                path: _path + ".$id",
-                                expected: "(string | undefined)",
-                                value: input.$id,
-                            }),
-                        undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor ||
-                            $report(_exceptionable, {
-                                path: _path + ".$recursiveAnchor",
-                                expected: "(boolean | undefined)",
-                                value: input.$recursiveAnchor,
-                            }),
-                    ].every((flag: boolean) => flag);
                 const $vu0 = (
                     input: any,
                     _path: string,
@@ -7645,13 +7355,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             Array.isArray(input.items) &&
                             input.items
                                 .map(
-                                    (elem: any, _index72: number) =>
+                                    (elem: any, _index68: number) =>
                                         "object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem) &&
                                         $vu0(
                                             elem,
-                                            _path + ".items[" + _index72 + "]",
+                                            _path + ".items[" + _index68 + "]",
                                             false && _exceptionable,
                                         ),
                                 )
@@ -7662,10 +7372,8 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             return $vo27(input, _path, true && _exceptionable);
                         if (undefined !== input.$ref)
                             return $vo28(input, _path, true && _exceptionable);
-                        if (undefined !== input.$recursiveRef)
-                            return $vo29(input, _path, true && _exceptionable);
                         if ("null" === input.type)
-                            return $vo30(input, _path, true && _exceptionable);
+                            return $vo29(input, _path, true && _exceptionable);
                         return (
                             $vo20(input, _path, false && _exceptionable) ||
                             $vo19(input, _path, false && _exceptionable) ||
@@ -7673,7 +7381,7 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             $vo21(input, _path, false && _exceptionable) ||
                             $vo23(input, _path, false && _exceptionable) ||
                             $vo24(input, _path, false && _exceptionable) ||
-                            $vo31(input, _path, false && _exceptionable)
+                            $vo30(input, _path, false && _exceptionable)
                         );
                     })();
                 const $vu1 = (
@@ -7726,9 +7434,9 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 ): any =>
                     (() => {
                         if ("object" === input.type)
-                            return $vo34(input, _path, true && _exceptionable);
+                            return $vo33(input, _path, true && _exceptionable);
                         if ("integer" === input.type)
-                            return $vo40(input, _path, true && _exceptionable);
+                            return $vo39(input, _path, true && _exceptionable);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
@@ -7739,40 +7447,38 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 false && _exceptionable,
                             )
                         )
-                            return $vo43(input, _path, true && _exceptionable);
+                            return $vo42(input, _path, true && _exceptionable);
                         if (
                             Array.isArray(input.items) &&
                             input.items
                                 .map(
-                                    (elem: any, _index73: number) =>
+                                    (elem: any, _index69: number) =>
                                         "object" === typeof elem &&
                                         null !== elem &&
                                         false === Array.isArray(elem) &&
                                         $vu0(
                                             elem,
-                                            _path + ".items[" + _index73 + "]",
+                                            _path + ".items[" + _index69 + "]",
                                             false && _exceptionable,
                                         ),
                                 )
                                 .every((flag: boolean) => flag)
                         )
-                            return $vo44(input, _path, true && _exceptionable);
+                            return $vo43(input, _path, true && _exceptionable);
                         if (undefined !== input.oneOf)
-                            return $vo45(input, _path, true && _exceptionable);
+                            return $vo44(input, _path, true && _exceptionable);
                         if (undefined !== input.$ref)
-                            return $vo46(input, _path, true && _exceptionable);
-                        if (undefined !== input.$recursiveRef)
-                            return $vo47(input, _path, true && _exceptionable);
+                            return $vo45(input, _path, true && _exceptionable);
                         if ("null" === input.type)
-                            return $vo48(input, _path, true && _exceptionable);
+                            return $vo46(input, _path, true && _exceptionable);
                         return (
-                            $vo38(input, _path, false && _exceptionable) ||
                             $vo37(input, _path, false && _exceptionable) ||
                             $vo36(input, _path, false && _exceptionable) ||
-                            $vo39(input, _path, false && _exceptionable) ||
+                            $vo35(input, _path, false && _exceptionable) ||
+                            $vo38(input, _path, false && _exceptionable) ||
+                            $vo40(input, _path, false && _exceptionable) ||
                             $vo41(input, _path, false && _exceptionable) ||
-                            $vo42(input, _path, false && _exceptionable) ||
-                            $vo49(input, _path, false && _exceptionable)
+                            $vo47(input, _path, false && _exceptionable)
                         );
                     })();
                 return (

--- a/test/generated/output/createValidateClone/test_createValidateClone_UltimateUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_UltimateUnion.ts
@@ -22,7 +22,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     "object" === typeof input.components &&
                     null !== input.components &&
                     false === Array.isArray(input.components) &&
-                    $io32(input.components) &&
+                    $io31(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose);
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
@@ -455,6 +455,15 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -554,36 +563,6 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -613,7 +592,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -644,13 +623,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -663,23 +642,21 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -709,7 +686,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -719,7 +696,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -732,7 +709,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -774,7 +751,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) =>
@@ -818,7 +795,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -860,7 +837,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -898,7 +875,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
@@ -953,7 +930,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum))) &&
@@ -1005,7 +982,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
@@ -1057,7 +1034,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -1111,7 +1088,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -1120,6 +1097,15 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1155,7 +1141,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -1196,7 +1182,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1230,41 +1216,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1298,7 +1250,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -1356,9 +1308,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (() => {
                             if ($io20(input)) return $io20(input);
                             if ($io19(input)) return $io19(input);
@@ -1366,7 +1316,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                             if ($io21(input)) return $io21(input);
                             if ($io23(input)) return $io23(input);
                             if ($io24(input)) return $io24(input);
-                            if ($io31(input)) return $io31(input);
+                            if ($io30(input)) return $io30(input);
                             return false;
                         })();
                     })();
@@ -1393,15 +1343,15 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -1412,20 +1362,18 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (() => {
-                            if ($io38(input)) return $io38(input);
                             if ($io37(input)) return $io37(input);
                             if ($io36(input)) return $io36(input);
-                            if ($io39(input)) return $io39(input);
+                            if ($io35(input)) return $io35(input);
+                            if ($io38(input)) return $io38(input);
+                            if ($io40(input)) return $io40(input);
                             if ($io41(input)) return $io41(input);
-                            if ($io42(input)) return $io42(input);
-                            if ($io49(input)) return $io49(input);
+                            if ($io47(input)) return $io47(input);
                             return false;
                         })();
                     })();
@@ -1475,7 +1423,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         _index2 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
@@ -1493,7 +1441,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     _index2 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
@@ -1511,7 +1459,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: "IJsonComponents",
                                     value: input.components,
                                 })) &&
-                                $vo32(
+                                $vo31(
                                     input.components,
                                     _path + ".components",
                                     true && _exceptionable,
@@ -3338,7 +3286,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 $report(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 })) &&
                                 $vu0(
@@ -3349,7 +3297,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 $report(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 }),
                             undefined === input.minItems ||
@@ -3595,7 +3543,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         _index23 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
@@ -3613,7 +3561,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     _index23 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
@@ -3622,6 +3570,46 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     path: _path + ".items",
                                     expected: "Array<IJsonSchema>",
                                     value: input.items,
+                                }),
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number",
+                                    value: input.minItems,
+                                }),
+                            undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "(number | undefined)",
+                                    value: input.maxItems,
                                 }),
                             "array" === input.type ||
                                 $report(_exceptionable, {
@@ -3804,7 +3792,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         _index26 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
@@ -3822,7 +3810,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     _index26 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
@@ -4134,11 +4122,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "string" === typeof input.$recursiveRef ||
+                            "null" === input.type ||
                                 $report(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -4288,12 +4276,18 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "null" === input.type ||
+                            (null !== input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"null"',
+                                    expected: "undefined",
                                     value: input.type,
-                                }),
+                                })) &&
+                                (undefined === input.type ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".type",
+                                        expected: "undefined",
+                                        value: input.type,
+                                    })),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
                                 $report(_exceptionable, {
@@ -4442,31 +4436,188 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            (null !== input.type ||
+                            undefined === input.schemas ||
+                                ((("object" === typeof input.schemas &&
+                                    null !== input.schemas &&
+                                    false === Array.isArray(input.schemas)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".schemas",
+                                        expected:
+                                            "(Record<string, IObject | IAlias> | undefined)",
+                                        value: input.schemas,
+                                    })) &&
+                                    $vo32(
+                                        input.schemas,
+                                        _path + ".schemas",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".schemas",
+                                    expected:
+                                        "(Record<string, IObject | IAlias> | undefined)",
+                                    value: input.schemas,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo32 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            false === _exceptionable ||
+                                Object.keys(input)
+                                    .map((key: any) => {
+                                        const value = input[key];
+                                        if (undefined === value) return true;
+                                        if (RegExp(/(.*)/).test(key))
+                                            return (
+                                                ((("object" === typeof value &&
+                                                    null !== value &&
+                                                    false ===
+                                                        Array.isArray(value)) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path + $join(key),
+                                                        expected:
+                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                        value: value,
+                                                    })) &&
+                                                    $vu2(
+                                                        value,
+                                                        _path + $join(key),
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path: _path + $join(key),
+                                                    expected:
+                                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                    value: value,
+                                                })
+                                            );
+                                        return true;
+                                    })
+                                    .every((flag: boolean) => flag),
+                        ].every((flag: boolean) => flag);
+                    const $vo33 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.$id ||
+                                "string" === typeof input.$id ||
+                                $report(_exceptionable, {
+                                    path: _path + ".$id",
+                                    expected: "(string | undefined)",
+                                    value: input.$id,
+                                }),
+                            "object" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: "undefined",
+                                    expected: '"object"',
                                     value: input.type,
-                                })) &&
-                                (undefined === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: "undefined",
-                                        value: input.type,
-                                    })),
-                            undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $report(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
                                 }),
-                            undefined === input.title ||
-                                "string" === typeof input.title ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                }),
+                            ((("object" === typeof input.properties &&
+                                null !== input.properties &&
+                                false === Array.isArray(input.properties)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                })) &&
+                                $vo34(
+                                    input.properties,
+                                    _path + ".properties",
+                                    true && _exceptionable,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                }),
+                            undefined === input.patternProperties ||
+                                ((("object" ===
+                                    typeof input.patternProperties &&
+                                    null !== input.patternProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.patternProperties,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".patternProperties",
+                                        expected:
+                                            "(Record<string, IJsonSchema> | undefined)",
+                                        value: input.patternProperties,
+                                    })) &&
+                                    $vo34(
+                                        input.patternProperties,
+                                        _path + ".patternProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                }),
+                            undefined === input.additionalProperties ||
+                                ((("object" ===
+                                    typeof input.additionalProperties &&
+                                    null !== input.additionalProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.additionalProperties,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".additionalProperties",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        value: input.additionalProperties,
+                                    })) &&
+                                    $vu0(
+                                        input.additionalProperties,
+                                        _path + ".additionalProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                }),
+                            undefined === input.required ||
+                                ((Array.isArray(input.required) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".required",
+                                        expected: "(Array<string> | undefined)",
+                                        value: input.required,
+                                    })) &&
+                                    input.required
+                                        .map(
+                                            (elem: any, _index35: number) =>
+                                                "string" === typeof elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".required[" +
+                                                        _index35 +
+                                                        "]",
+                                                    expected: "string",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
                                 }),
                             undefined === input.description ||
                                 "string" === typeof input.description ||
@@ -4474,55 +4625,6 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     path: _path + ".description",
                                     expected: "(string | undefined)",
                                     value: input.description,
-                                }),
-                            undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"]
-                                        .map(
-                                            (elem: any, _index35: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index35 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu1(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index35 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
                                 }),
                             undefined === input["x-typia-jsDocTags"] ||
                                 ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4572,281 +4674,6 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                         "(Array<IJsDocTagInfo> | undefined)",
                                     value: input["x-typia-jsDocTags"],
                                 }),
-                            undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                }),
-                            undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                }),
-                            undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }),
-                        ].every((flag: boolean) => flag);
-                    const $vo32 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            undefined === input.schemas ||
-                                ((("object" === typeof input.schemas &&
-                                    null !== input.schemas &&
-                                    false === Array.isArray(input.schemas)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".schemas",
-                                        expected:
-                                            "(Record<string, IObject | IAlias> | undefined)",
-                                        value: input.schemas,
-                                    })) &&
-                                    $vo33(
-                                        input.schemas,
-                                        _path + ".schemas",
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".schemas",
-                                    expected:
-                                        "(Record<string, IObject | IAlias> | undefined)",
-                                    value: input.schemas,
-                                }),
-                        ].every((flag: boolean) => flag);
-                    const $vo33 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            false === _exceptionable ||
-                                Object.keys(input)
-                                    .map((key: any) => {
-                                        const value = input[key];
-                                        if (undefined === value) return true;
-                                        if (RegExp(/(.*)/).test(key))
-                                            return (
-                                                ((("object" === typeof value &&
-                                                    null !== value &&
-                                                    false ===
-                                                        Array.isArray(value)) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path + $join(key),
-                                                        expected:
-                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                        value: value,
-                                                    })) &&
-                                                    $vu2(
-                                                        value,
-                                                        _path + $join(key),
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path: _path + $join(key),
-                                                    expected:
-                                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                    value: value,
-                                                })
-                                            );
-                                        return true;
-                                    })
-                                    .every((flag: boolean) => flag),
-                        ].every((flag: boolean) => flag);
-                    const $vo34 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                }),
-                            undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }),
-                            "object" === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"object"',
-                                    value: input.type,
-                                }),
-                            undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $report(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
-                                }),
-                            ((("object" === typeof input.properties &&
-                                null !== input.properties &&
-                                false === Array.isArray(input.properties)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                })) &&
-                                $vo35(
-                                    input.properties,
-                                    _path + ".properties",
-                                    true && _exceptionable,
-                                )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                }),
-                            undefined === input.patternProperties ||
-                                ((("object" ===
-                                    typeof input.patternProperties &&
-                                    null !== input.patternProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.patternProperties,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".patternProperties",
-                                        expected:
-                                            "(Record<string, IJsonSchema> | undefined)",
-                                        value: input.patternProperties,
-                                    })) &&
-                                    $vo35(
-                                        input.patternProperties,
-                                        _path + ".patternProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                }),
-                            undefined === input.additionalProperties ||
-                                ((("object" ===
-                                    typeof input.additionalProperties &&
-                                    null !== input.additionalProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.additionalProperties,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".additionalProperties",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                        value: input.additionalProperties,
-                                    })) &&
-                                    $vu0(
-                                        input.additionalProperties,
-                                        _path + ".additionalProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                }),
-                            undefined === input.required ||
-                                ((Array.isArray(input.required) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".required",
-                                        expected: "(Array<string> | undefined)",
-                                        value: input.required,
-                                    })) &&
-                                    input.required
-                                        .map(
-                                            (elem: any, _index37: number) =>
-                                                "string" === typeof elem ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        ".required[" +
-                                                        _index37 +
-                                                        "]",
-                                                    expected: "string",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                }),
-                            undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $report(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                }),
-                            undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"]
-                                        .map(
-                                            (elem: any, _index38: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index38 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vo17(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index38 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                }),
                             undefined === input["x-typia-patternProperties"] ||
                                 ((("object" ===
                                     typeof input["x-typia-patternProperties"] &&
@@ -4866,7 +4693,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             "x-typia-patternProperties"
                                         ],
                                     })) &&
-                                    $vo35(
+                                    $vo34(
                                         input["x-typia-patternProperties"],
                                         _path + '["x-typia-patternProperties"]',
                                         true && _exceptionable,
@@ -4897,7 +4724,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             _path +
                                             '["x-typia-additionalProperties"]',
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                         value: input[
                                             "x-typia-additionalProperties"
                                         ],
@@ -4913,13 +4740,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
                                 }),
                         ].every((flag: boolean) => flag);
-                    const $vo35 = (
+                    const $vo34 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4940,7 +4767,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         path:
                                                             _path + $join(key),
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: value,
                                                     })) &&
                                                     $vu0(
@@ -4951,7 +4778,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                 $report(_exceptionable, {
                                                     path: _path + $join(key),
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: value,
                                                 })
                                             );
@@ -4959,7 +4786,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     })
                                     .every((flag: boolean) => flag),
                         ].every((flag: boolean) => flag);
-                    const $vo36 = (
+                    const $vo35 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4973,13 +4800,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 })) &&
                                 input["enum"]
                                     .map(
-                                        (elem: any, _index39: number) =>
+                                        (elem: any, _index37: number) =>
                                             "boolean" === typeof elem ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["enum"][' +
-                                                    _index39 +
+                                                    _index37 +
                                                     "]",
                                                 expected: "boolean",
                                                 value: elem,
@@ -5042,14 +4869,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index40: number) =>
+                                            (elem: any, _index38: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index40 +
+                                                            _index38 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5059,7 +4886,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index40 +
+                                                            _index38 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5067,7 +4894,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5091,14 +4918,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index41: number) =>
+                                            (elem: any, _index39: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index41 +
+                                                            _index39 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5108,7 +4935,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index41 +
+                                                            _index39 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5116,7 +4943,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -5167,7 +4994,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     value: input.$recursiveAnchor,
                                 }),
                         ].every((flag: boolean) => flag);
-                    const $vo37 = (
+                    const $vo36 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -5181,14 +5008,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 })) &&
                                 input["enum"]
                                     .map(
-                                        (elem: any, _index42: number) =>
+                                        (elem: any, _index40: number) =>
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem)) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["enum"][' +
-                                                    _index42 +
+                                                    _index40 +
                                                     "]",
                                                 expected: "number",
                                                 value: elem,
@@ -5252,14 +5079,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index43: number) =>
+                                            (elem: any, _index41: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index43 +
+                                                            _index41 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5269,7 +5096,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index43 +
+                                                            _index41 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5277,7 +5104,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5301,14 +5128,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index44: number) =>
+                                            (elem: any, _index42: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index44 +
+                                                            _index42 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5318,7 +5145,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index44 +
+                                                            _index42 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5326,7 +5153,215 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
+                                                        _index42 +
+                                                        "]",
+                                                    expected: "IJsDocTagInfo",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                }),
+                            undefined === input["x-typia-required"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-required"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-required"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-required"],
+                                }),
+                            undefined === input["x-typia-optional"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-optional"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-optional"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-optional"],
+                                }),
+                            undefined === input["x-typia-rest"] ||
+                                "boolean" === typeof input["x-typia-rest"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-rest"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-rest"],
+                                }),
+                            undefined === input.$id ||
+                                "string" === typeof input.$id ||
+                                $report(_exceptionable, {
+                                    path: _path + ".$id",
+                                    expected: "(string | undefined)",
+                                    value: input.$id,
+                                }),
+                            undefined === input.$recursiveAnchor ||
+                                "boolean" === typeof input.$recursiveAnchor ||
+                                $report(_exceptionable, {
+                                    path: _path + ".$recursiveAnchor",
+                                    expected: "(boolean | undefined)",
+                                    value: input.$recursiveAnchor,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo37 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            ((Array.isArray(input["enum"]) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                })) &&
+                                input["enum"]
+                                    .map(
+                                        (elem: any, _index43: number) =>
+                                            "string" === typeof elem ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["enum"][' +
+                                                    _index43 +
+                                                    "]",
+                                                expected: "string",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                }),
+                            undefined === input["default"] ||
+                                "string" === typeof input["default"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["default"]',
+                                    expected: "(string | undefined)",
+                                    value: input["default"],
+                                }),
+                            "string" === input.type ||
+                                $report(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: '"string"',
+                                    value: input.type,
+                                }),
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
+                                $report(_exceptionable, {
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                }),
+                            undefined === input.deprecated ||
+                                "boolean" === typeof input.deprecated ||
+                                $report(_exceptionable, {
+                                    path: _path + ".deprecated",
+                                    expected: "(boolean | undefined)",
+                                    value: input.deprecated,
+                                }),
+                            undefined === input.title ||
+                                "string" === typeof input.title ||
+                                $report(_exceptionable, {
+                                    path: _path + ".title",
+                                    expected: "(string | undefined)",
+                                    value: input.title,
+                                }),
+                            undefined === input.description ||
+                                "string" === typeof input.description ||
+                                $report(_exceptionable, {
+                                    path: _path + ".description",
+                                    expected: "(string | undefined)",
+                                    value: input.description,
+                                }),
+                            undefined === input["x-typia-metaTags"] ||
+                                ((Array.isArray(input["x-typia-metaTags"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-metaTags"]',
+                                        expected:
+                                            "(Array<IMetadataTag> | undefined)",
+                                        value: input["x-typia-metaTags"],
+                                    })) &&
+                                    input["x-typia-metaTags"]
+                                        .map(
+                                            (elem: any, _index44: number) =>
+                                                ((("object" === typeof elem &&
+                                                    null !== elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-metaTags"][' +
+                                                            _index44 +
+                                                            "]",
+                                                        expected:
+                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                        value: elem,
+                                                    })) &&
+                                                    $vu1(
+                                                        elem,
+                                                        _path +
+                                                            '["x-typia-metaTags"][' +
+                                                            _index44 +
+                                                            "]",
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-metaTags"][' +
                                                         _index44 +
+                                                        "]",
+                                                    expected:
+                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                }),
+                            undefined === input["x-typia-jsDocTags"] ||
+                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-jsDocTags"]',
+                                        expected:
+                                            "(Array<IJsDocTagInfo> | undefined)",
+                                        value: input["x-typia-jsDocTags"],
+                                    })) &&
+                                    input["x-typia-jsDocTags"]
+                                        .map(
+                                            (elem: any, _index45: number) =>
+                                                ((("object" === typeof elem &&
+                                                    null !== elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-jsDocTags"][' +
+                                                            _index45 +
+                                                            "]",
+                                                        expected:
+                                                            "IJsDocTagInfo",
+                                                        value: elem,
+                                                    })) &&
+                                                    $vo17(
+                                                        elem,
+                                                        _path +
+                                                            '["x-typia-jsDocTags"][' +
+                                                            _index45 +
+                                                            "]",
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -5383,43 +5418,17 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((Array.isArray(input["enum"]) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                })) &&
-                                input["enum"]
-                                    .map(
-                                        (elem: any, _index45: number) =>
-                                            "string" === typeof elem ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["enum"][' +
-                                                    _index45 +
-                                                    "]",
-                                                expected: "string",
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                }),
                             undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
+                                "boolean" === typeof input["default"] ||
                                 $report(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(string | undefined)",
+                                    expected: "(boolean | undefined)",
                                     value: input["default"],
                                 }),
-                            "string" === input.type ||
+                            "boolean" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"boolean"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -5591,17 +5600,77 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
+                            undefined === input.minimum ||
+                                ("number" === typeof input.minimum &&
+                                    Number.isFinite(input.minimum) &&
+                                    (parseInt(input.minimum) ===
+                                        input.minimum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "(number | undefined)",
+                                    value: input.minimum,
+                                }),
+                            undefined === input.maximum ||
+                                ("number" === typeof input.maximum &&
+                                    Number.isFinite(input.maximum) &&
+                                    (parseInt(input.maximum) ===
+                                        input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "(number | undefined)",
+                                    value: input.maximum,
+                                }),
+                            undefined === input.exclusiveMinimum ||
+                                "boolean" === typeof input.exclusiveMinimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMinimum,
+                                }),
+                            undefined === input.exclusiveMaximum ||
+                                "boolean" === typeof input.exclusiveMaximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMaximum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMaximum,
+                                }),
+                            undefined === input.multipleOf ||
+                                ("number" === typeof input.multipleOf &&
+                                    Number.isFinite(input.multipleOf) &&
+                                    (parseInt(input.multipleOf) ===
+                                        input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "(number | undefined)",
+                                    value: input.multipleOf,
+                                }),
                             undefined === input["default"] ||
-                                "boolean" === typeof input["default"] ||
+                                ("number" === typeof input["default"] &&
+                                    Number.isFinite(input["default"])) ||
                                 $report(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(boolean | undefined)",
+                                    expected: "(number | undefined)",
                                     value: input["default"],
                                 }),
-                            "boolean" === input.type ||
+                            "integer" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"boolean"',
+                                    expected: '"integer"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -5775,14 +5844,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         [
                             undefined === input.minimum ||
                                 ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum) &&
-                                    (parseInt(input.minimum) ===
-                                        input.minimum ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".minimum",
-                                            expected: "number (@type int)",
-                                            value: input.minimum,
-                                        }))) ||
+                                    Number.isFinite(input.minimum)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "(number | undefined)",
@@ -5790,14 +5852,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 }),
                             undefined === input.maximum ||
                                 ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum) &&
-                                    (parseInt(input.maximum) ===
-                                        input.maximum ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".maximum",
-                                            expected: "number (@type int)",
-                                            value: input.maximum,
-                                        }))) ||
+                                    Number.isFinite(input.maximum)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "(number | undefined)",
@@ -5819,14 +5874,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 }),
                             undefined === input.multipleOf ||
                                 ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf) &&
-                                    (parseInt(input.multipleOf) ===
-                                        input.multipleOf ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".multipleOf",
-                                            expected: "number (@type int)",
-                                            value: input.multipleOf,
-                                        }))) ||
+                                    Number.isFinite(input.multipleOf)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "(number | undefined)",
@@ -5840,10 +5888,10 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     expected: "(number | undefined)",
                                     value: input["default"],
                                 }),
-                            "integer" === input.type ||
+                            "number" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"integer"',
+                                    expected: '"number"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -6015,56 +6063,73 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            undefined === input.minimum ||
-                                ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum)) ||
+                            undefined === input.minLength ||
+                                ("number" === typeof input.minLength &&
+                                    Number.isFinite(input.minLength) &&
+                                    (parseInt(input.minLength) ===
+                                        input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        })) &&
+                                    (0 <= input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".minimum",
+                                    path: _path + ".minLength",
                                     expected: "(number | undefined)",
-                                    value: input.minimum,
+                                    value: input.minLength,
                                 }),
-                            undefined === input.maximum ||
-                                ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum)) ||
+                            undefined === input.maxLength ||
+                                ("number" === typeof input.maxLength &&
+                                    Number.isFinite(input.maxLength) &&
+                                    (parseInt(input.maxLength) ===
+                                        input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".maximum",
+                                    path: _path + ".maxLength",
                                     expected: "(number | undefined)",
-                                    value: input.maximum,
+                                    value: input.maxLength,
                                 }),
-                            undefined === input.exclusiveMinimum ||
-                                "boolean" === typeof input.exclusiveMinimum ||
+                            undefined === input.pattern ||
+                                "string" === typeof input.pattern ||
                                 $report(_exceptionable, {
-                                    path: _path + ".exclusiveMinimum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMinimum,
+                                    path: _path + ".pattern",
+                                    expected: "(string | undefined)",
+                                    value: input.pattern,
                                 }),
-                            undefined === input.exclusiveMaximum ||
-                                "boolean" === typeof input.exclusiveMaximum ||
+                            undefined === input.format ||
+                                "string" === typeof input.format ||
                                 $report(_exceptionable, {
-                                    path: _path + ".exclusiveMaximum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMaximum,
-                                }),
-                            undefined === input.multipleOf ||
-                                ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".multipleOf",
-                                    expected: "(number | undefined)",
-                                    value: input.multipleOf,
+                                    path: _path + ".format",
+                                    expected: "(string | undefined)",
+                                    value: input.format,
                                 }),
                             undefined === input["default"] ||
-                                ("number" === typeof input["default"] &&
-                                    Number.isFinite(input["default"])) ||
+                                "string" === typeof input["default"] ||
                                 $report(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(number | undefined)",
+                                    expected: "(string | undefined)",
                                     value: input["default"],
                                 }),
-                            "number" === input.type ||
+                            "string" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"number"',
+                                    expected: '"string"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -6236,73 +6301,92 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            undefined === input.minLength ||
-                                ("number" === typeof input.minLength &&
-                                    Number.isFinite(input.minLength) &&
-                                    (parseInt(input.minLength) ===
-                                        input.minLength ||
+                            ((("object" === typeof input.items &&
+                                null !== input.items &&
+                                false === Array.isArray(input.items)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                })) &&
+                                $vu0(
+                                    input.items,
+                                    _path + ".items",
+                                    true && _exceptionable,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                }),
+                            undefined === input.minItems ||
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         })) &&
-                                    (0 <= input.minLength ||
+                                    (0 <= input.minItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "(number | undefined)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 }),
-                            undefined === input.maxLength ||
-                                ("number" === typeof input.maxLength &&
-                                    Number.isFinite(input.maxLength) &&
-                                    (parseInt(input.maxLength) ===
-                                        input.maxLength ||
+                            undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         })) &&
-                                    (0 <= input.maxLength ||
+                                    (0 <= input.maxItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "(number | undefined)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 }),
-                            undefined === input.pattern ||
-                                "string" === typeof input.pattern ||
+                            undefined === input["x-typia-tuple"] ||
+                                ((("object" === typeof input["x-typia-tuple"] &&
+                                    null !== input["x-typia-tuple"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-tuple"]',
+                                        expected:
+                                            "(IJsonSchema.ITuple | undefined)",
+                                        value: input["x-typia-tuple"],
+                                    })) &&
+                                    $vo26(
+                                        input["x-typia-tuple"],
+                                        _path + '["x-typia-tuple"]',
+                                        true && _exceptionable,
+                                    )) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".pattern",
-                                    expected: "(string | undefined)",
-                                    value: input.pattern,
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
                                 }),
-                            undefined === input.format ||
-                                "string" === typeof input.format ||
-                                $report(_exceptionable, {
-                                    path: _path + ".format",
-                                    expected: "(string | undefined)",
-                                    value: input.format,
-                                }),
-                            undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["default"]',
-                                    expected: "(string | undefined)",
-                                    value: input["default"],
-                                }),
-                            "string" === input.type ||
+                            "array" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"array"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -6474,45 +6558,71 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((("object" === typeof input.items &&
-                                null !== input.items &&
-                                false === Array.isArray(input.items)) ||
+                            ((Array.isArray(input.items) ||
                                 $report(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 })) &&
-                                $vu0(
-                                    input.items,
-                                    _path + ".items",
-                                    true && _exceptionable,
-                                )) ||
+                                input.items
+                                    .map(
+                                        (elem: any, _index56: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem &&
+                                                false ===
+                                                    Array.isArray(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index56 +
+                                                        "]",
+                                                    expected:
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    value: elem,
+                                                })) &&
+                                                $vu0(
+                                                    elem,
+                                                    _path +
+                                                        ".items[" +
+                                                        _index56 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                expected:
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 }),
-                            undefined === input.minItems ||
-                                ("number" === typeof input.minItems &&
-                                    Number.isFinite(input.minItems) &&
-                                    (parseInt(input.minItems) ===
-                                        input.minItems ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        })) &&
-                                    (0 <= input.minItems ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        }))) ||
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
-                                    expected: "(number | undefined)",
+                                    expected: "number",
                                     value: input.minItems,
                                 }),
                             undefined === input.maxItems ||
@@ -6535,26 +6645,6 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     path: _path + ".maxItems",
                                     expected: "(number | undefined)",
                                     value: input.maxItems,
-                                }),
-                            undefined === input["x-typia-tuple"] ||
-                                ((("object" === typeof input["x-typia-tuple"] &&
-                                    null !== input["x-typia-tuple"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-tuple"]',
-                                        expected:
-                                            "(IJsonSchema.ITuple | undefined)",
-                                        value: input["x-typia-tuple"],
-                                    })) &&
-                                    $vo26(
-                                        input["x-typia-tuple"],
-                                        _path + '["x-typia-tuple"]',
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
                                 }),
                             "array" === input.type ||
                                 $report(_exceptionable, {
@@ -6600,14 +6690,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index56: number) =>
+                                            (elem: any, _index57: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index56 +
+                                                            _index57 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6617,7 +6707,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index56 +
+                                                            _index57 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6625,7 +6715,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6649,14 +6739,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index57: number) =>
+                                            (elem: any, _index58: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index57 +
+                                                            _index58 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -6666,7 +6756,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index57 +
+                                                            _index58 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6674,7 +6764,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6731,15 +6821,15 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((Array.isArray(input.items) ||
+                            ((Array.isArray(input.oneOf) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
+                                    value: input.oneOf,
                                 })) &&
-                                input.items
+                                input.oneOf
                                     .map(
-                                        (elem: any, _index58: number) =>
+                                        (elem: any, _index59: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem &&
                                                 false ===
@@ -6747,50 +6837,37 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
-                                                        ".items[" +
-                                                        _index58 +
+                                                        ".oneOf[" +
+                                                        _index59 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
                                                     elem,
                                                     _path +
-                                                        ".items[" +
-                                                        _index58 +
+                                                        ".oneOf[" +
+                                                        _index59 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
                                     .every((flag: boolean) => flag)) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
-                                }),
-                            "array" === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"array"',
-                                    value: input.type,
-                                }),
-                            undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $report(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
+                                    value: input.oneOf,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -6823,14 +6900,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index59: number) =>
+                                            (elem: any, _index60: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index59 +
+                                                            _index60 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6840,7 +6917,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index59 +
+                                                            _index60 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6848,7 +6925,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6872,14 +6949,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index60: number) =>
+                                            (elem: any, _index61: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index60 +
+                                                            _index61 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -6889,7 +6966,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index60 +
+                                                            _index61 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6897,7 +6974,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6954,53 +7031,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((Array.isArray(input.oneOf) ||
+                            "string" === typeof input.$ref ||
                                 $report(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
-                                })) &&
-                                input.oneOf
-                                    .map(
-                                        (elem: any, _index61: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem &&
-                                                false ===
-                                                    Array.isArray(elem)) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        ".oneOf[" +
-                                                        _index61 +
-                                                        "]",
-                                                    expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                    value: elem,
-                                                })) &&
-                                                $vu0(
-                                                    elem,
-                                                    _path +
-                                                        ".oneOf[" +
-                                                        _index61 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
+                                    path: _path + ".$ref",
+                                    expected: "string",
+                                    value: input.$ref,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7164,11 +7199,11 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "string" === typeof input.$ref ||
+                            "null" === input.type ||
                                 $report(_exceptionable, {
-                                    path: _path + ".$ref",
-                                    expected: "string",
-                                    value: input.$ref,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7332,12 +7367,18 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "string" === typeof input.$recursiveRef ||
+                            (null !== input.type ||
                                 $report(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
-                                }),
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
+                                })) &&
+                                (undefined === input.type ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".type",
+                                        expected: "undefined",
+                                        value: input.type,
+                                    })),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
                                 $report(_exceptionable, {
@@ -7494,348 +7535,6 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     value: input.$recursiveAnchor,
                                 }),
                         ].every((flag: boolean) => flag);
-                    const $vo48 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            "null" === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"null"',
-                                    value: input.type,
-                                }),
-                            undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $report(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                }),
-                            undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $report(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                }),
-                            undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $report(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                }),
-                            undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"]
-                                        .map(
-                                            (elem: any, _index68: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index68 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu1(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index68 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                }),
-                            undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"]
-                                        .map(
-                                            (elem: any, _index69: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index69 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vo17(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index69 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                }),
-                            undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                }),
-                            undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                }),
-                            undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }),
-                            undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                }),
-                            undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }),
-                        ].every((flag: boolean) => flag);
-                    const $vo49 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            (null !== input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                                (undefined === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: "undefined",
-                                        value: input.type,
-                                    })),
-                            undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $report(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                }),
-                            undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $report(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                }),
-                            undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $report(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                }),
-                            undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"]
-                                        .map(
-                                            (elem: any, _index70: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index70 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu1(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index70 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                }),
-                            undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"]
-                                        .map(
-                                            (elem: any, _index71: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index71 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vo17(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index71 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                }),
-                            undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                }),
-                            undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                }),
-                            undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }),
-                            undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                }),
-                            undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }),
-                        ].every((flag: boolean) => flag);
                     const $vu0 = (
                         input: any,
                         _path: string,
@@ -7867,7 +7566,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 Array.isArray(input.items) &&
                                 input.items
                                     .map(
-                                        (elem: any, _index72: number) =>
+                                        (elem: any, _index68: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -7875,7 +7574,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index72 +
+                                                    _index68 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
@@ -7899,14 +7598,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     _path,
                                     true && _exceptionable,
                                 );
-                            if (undefined !== input.$recursiveRef)
-                                return $vo29(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
                             if ("null" === input.type)
-                                return $vo30(
+                                return $vo29(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7918,7 +7611,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 $vo21(input, _path, false && _exceptionable) ||
                                 $vo23(input, _path, false && _exceptionable) ||
                                 $vo24(input, _path, false && _exceptionable) ||
-                                $vo31(input, _path, false && _exceptionable)
+                                $vo30(input, _path, false && _exceptionable)
                             );
                         })();
                     const $vu1 = (
@@ -8031,13 +7724,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     ): any =>
                         (() => {
                             if ("object" === input.type)
-                                return $vo34(
+                                return $vo33(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("integer" === input.type)
-                                return $vo40(
+                                return $vo39(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -8052,7 +7745,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     false && _exceptionable,
                                 )
                             )
-                                return $vo43(
+                                return $vo42(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -8061,7 +7754,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 Array.isArray(input.items) &&
                                 input.items
                                     .map(
-                                        (elem: any, _index73: number) =>
+                                        (elem: any, _index69: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -8069,50 +7762,44 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index73 +
+                                                    _index69 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
                                     )
                                     .every((flag: boolean) => flag)
                             )
-                                return $vo44(
+                                return $vo43(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.oneOf)
-                                return $vo45(
+                                return $vo44(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.$ref)
-                                return $vo46(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
-                            if (undefined !== input.$recursiveRef)
-                                return $vo47(
+                                return $vo45(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("null" === input.type)
-                                return $vo48(
+                                return $vo46(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             return (
-                                $vo38(input, _path, false && _exceptionable) ||
                                 $vo37(input, _path, false && _exceptionable) ||
                                 $vo36(input, _path, false && _exceptionable) ||
-                                $vo39(input, _path, false && _exceptionable) ||
+                                $vo35(input, _path, false && _exceptionable) ||
+                                $vo38(input, _path, false && _exceptionable) ||
+                                $vo40(input, _path, false && _exceptionable) ||
                                 $vo41(input, _path, false && _exceptionable) ||
-                                $vo42(input, _path, false && _exceptionable) ||
-                                $vo49(input, _path, false && _exceptionable)
+                                $vo47(input, _path, false && _exceptionable)
                             );
                         })();
                     return (
@@ -8552,6 +8239,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -8651,36 +8345,6 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -8710,7 +8374,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -8741,13 +8405,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -8760,22 +8424,20 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -8801,7 +8463,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -8811,7 +8473,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -8824,7 +8486,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -8863,7 +8525,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "number" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -8902,7 +8564,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -8941,7 +8603,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -8978,7 +8640,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         parseInt(input.minimum) === input.minimum)) &&
@@ -9028,7 +8690,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     "number" === typeof input.minimum) &&
                 (undefined === input.maximum ||
@@ -9075,7 +8737,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         parseInt(input.minLength) === input.minLength &&
@@ -9124,7 +8786,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -9175,7 +8837,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -9184,6 +8846,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -9218,7 +8887,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -9258,7 +8927,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -9291,40 +8960,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -9357,7 +8993,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -9414,8 +9050,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (
                         $io20(input) ||
                         $io19(input) ||
@@ -9423,7 +9058,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         $io21(input) ||
                         $io23(input) ||
                         $io24(input) ||
-                        $io31(input)
+                        $io30(input)
                     );
                 })();
             const $iu1 = (input: any): any =>
@@ -9447,15 +9082,15 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -9466,19 +9101,18 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (
-                        $io38(input) ||
                         $io37(input) ||
                         $io36(input) ||
-                        $io39(input) ||
+                        $io35(input) ||
+                        $io38(input) ||
+                        $io40(input) ||
                         $io41(input) ||
-                        $io42(input) ||
-                        $io49(input)
+                        $io47(input)
                     );
                 })();
             const $join = (typia.createValidateClone as any).join;
@@ -9523,7 +9157,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 components:
                     "object" === typeof input.components &&
                     null !== input.components
-                        ? $co32(input.components)
+                        ? $co31(input.components)
                         : (input.components as any),
                 purpose: input.purpose as any,
             });
@@ -9770,6 +9404,8 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 items: Array.isArray(input.items)
                     ? $cp1(input.items)
                     : (input.items as any),
+                minItems: input.minItems as any,
+                maxItems: input.maxItems as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 deprecated: input.deprecated as any,
@@ -9818,7 +9454,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 "x-typia-rest": input["x-typia-rest"] as any,
             });
             const $co29 = (input: any): any => ({
-                $recursiveRef: input.$recursiveRef as any,
+                type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
                 description: input.description as any,
@@ -9848,27 +9484,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 "x-typia-rest": input["x-typia-rest"] as any,
             });
             const $co31 = (input: any): any => ({
-                type: input.type as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-            });
-            const $co32 = (input: any): any => ({
                 schemas:
                     "object" === typeof input.schemas && null !== input.schemas
-                        ? $co33(input.schemas)
+                        ? $co32(input.schemas)
                         : (input.schemas as any),
             });
-            const $co33 = (input: any): any => {
+            const $co32 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
                     if (RegExp(/(.*)/).test(key)) {
@@ -9881,20 +9502,19 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 }
                 return output;
             };
-            const $co34 = (input: any): any => ({
+            const $co33 = (input: any): any => ({
                 $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 properties:
                     "object" === typeof input.properties &&
                     null !== input.properties
-                        ? $co35(input.properties)
+                        ? $co34(input.properties)
                         : (input.properties as any),
                 patternProperties:
                     "object" === typeof input.patternProperties &&
                     null !== input.patternProperties
-                        ? $co35(input.patternProperties)
+                        ? $co34(input.patternProperties)
                         : (input.patternProperties as any),
                 additionalProperties:
                     "object" === typeof input.additionalProperties &&
@@ -9911,7 +9531,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 "x-typia-patternProperties":
                     "object" === typeof input["x-typia-patternProperties"] &&
                     null !== input["x-typia-patternProperties"]
-                        ? $co35(input["x-typia-patternProperties"])
+                        ? $co34(input["x-typia-patternProperties"])
                         : (input["x-typia-patternProperties"] as any),
                 "x-typia-additionalProperties":
                     "object" === typeof input["x-typia-additionalProperties"] &&
@@ -9919,7 +9539,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         ? $cu0(input["x-typia-additionalProperties"])
                         : (input["x-typia-additionalProperties"] as any),
             });
-            const $co35 = (input: any): any => {
+            const $co34 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
                     if (RegExp(/(.*)/).test(key)) {
@@ -9932,7 +9552,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 }
                 return output;
             };
-            const $co36 = (input: any): any => ({
+            const $co35 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp2(input["enum"])
                     : (input["enum"] as any),
@@ -9954,7 +9574,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co37 = (input: any): any => ({
+            const $co36 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp6(input["enum"])
                     : (input["enum"] as any),
@@ -9976,7 +9596,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co38 = (input: any): any => ({
+            const $co37 = (input: any): any => ({
                 enum: Array.isArray(input["enum"])
                     ? $cp7(input["enum"])
                     : (input["enum"] as any),
@@ -9998,7 +9618,31 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
+            const $co38 = (input: any): any => ({
+                default: input["default"] as any,
+                type: input.type as any,
+                nullable: input.nullable as any,
+                deprecated: input.deprecated as any,
+                title: input.title as any,
+                description: input.description as any,
+                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
+                    ? $cp3(input["x-typia-metaTags"])
+                    : (input["x-typia-metaTags"] as any),
+                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
+                    ? $cp4(input["x-typia-jsDocTags"])
+                    : (input["x-typia-jsDocTags"] as any),
+                "x-typia-required": input["x-typia-required"] as any,
+                "x-typia-optional": input["x-typia-optional"] as any,
+                "x-typia-rest": input["x-typia-rest"] as any,
+                $id: input.$id as any,
+                $recursiveAnchor: input.$recursiveAnchor as any,
+            });
             const $co39 = (input: any): any => ({
+                minimum: input.minimum as any,
+                maximum: input.maximum as any,
+                exclusiveMinimum: input.exclusiveMinimum as any,
+                exclusiveMaximum: input.exclusiveMaximum as any,
+                multipleOf: input.multipleOf as any,
                 default: input["default"] as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
@@ -10042,30 +9686,6 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
             const $co41 = (input: any): any => ({
-                minimum: input.minimum as any,
-                maximum: input.maximum as any,
-                exclusiveMinimum: input.exclusiveMinimum as any,
-                exclusiveMaximum: input.exclusiveMaximum as any,
-                multipleOf: input.multipleOf as any,
-                default: input["default"] as any,
-                type: input.type as any,
-                nullable: input.nullable as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-                $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
-            });
-            const $co42 = (input: any): any => ({
                 minLength: input.minLength as any,
                 maxLength: input.maxLength as any,
                 pattern: input.pattern as any,
@@ -10088,7 +9708,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co43 = (input: any): any => ({
+            const $co42 = (input: any): any => ({
                 items:
                     "object" === typeof input.items && null !== input.items
                         ? $cu0(input.items)
@@ -10117,10 +9737,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co44 = (input: any): any => ({
+            const $co43 = (input: any): any => ({
                 items: Array.isArray(input.items)
                     ? $cp1(input.items)
                     : (input.items as any),
+                minItems: input.minItems as any,
+                maxItems: input.maxItems as any,
                 type: input.type as any,
                 nullable: input.nullable as any,
                 deprecated: input.deprecated as any,
@@ -10138,7 +9760,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co45 = (input: any): any => ({
+            const $co44 = (input: any): any => ({
                 oneOf: Array.isArray(input.oneOf)
                     ? $cp1(input.oneOf)
                     : (input.oneOf as any),
@@ -10157,7 +9779,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co46 = (input: any): any => ({
+            const $co45 = (input: any): any => ({
                 $ref: input.$ref as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -10174,24 +9796,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co47 = (input: any): any => ({
-                $recursiveRef: input.$recursiveRef as any,
-                deprecated: input.deprecated as any,
-                title: input.title as any,
-                description: input.description as any,
-                "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                    ? $cp3(input["x-typia-metaTags"])
-                    : (input["x-typia-metaTags"] as any),
-                "x-typia-jsDocTags": Array.isArray(input["x-typia-jsDocTags"])
-                    ? $cp4(input["x-typia-jsDocTags"])
-                    : (input["x-typia-jsDocTags"] as any),
-                "x-typia-required": input["x-typia-required"] as any,
-                "x-typia-optional": input["x-typia-optional"] as any,
-                "x-typia-rest": input["x-typia-rest"] as any,
-                $id: input.$id as any,
-                $recursiveAnchor: input.$recursiveAnchor as any,
-            });
-            const $co48 = (input: any): any => ({
+            const $co46 = (input: any): any => ({
                 type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -10208,7 +9813,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 $id: input.$id as any,
                 $recursiveAnchor: input.$recursiveAnchor as any,
             });
-            const $co49 = (input: any): any => ({
+            const $co47 = (input: any): any => ({
                 type: input.type as any,
                 deprecated: input.deprecated as any,
                 title: input.title as any,
@@ -10248,8 +9853,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         return $co26(input);
                     if (undefined !== input.oneOf) return $co27(input);
                     if (undefined !== input.$ref) return $co28(input);
-                    if (undefined !== input.$recursiveRef) return $co29(input);
-                    if ("null" === input.type) return $co30(input);
+                    if ("null" === input.type) return $co29(input);
                     return (() => {
                         if ($io20(input)) return $co20(input);
                         if ($io19(input)) return $co19(input);
@@ -10257,7 +9861,7 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         if ($io21(input)) return $co21(input);
                         if ($io23(input)) return $co23(input);
                         if ($io24(input)) return $co24(input);
-                        if ($io31(input)) return $co31(input);
+                        if ($io30(input)) return $co30(input);
                         $throws({
                             expected:
                                 '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -10290,15 +9894,15 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 })();
             const $cu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $co34(input);
-                    if ("integer" === input.type) return $co40(input);
+                    if ("object" === input.type) return $co33(input);
+                    if ("integer" === input.type) return $co39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $co43(input);
+                        return $co42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -10309,19 +9913,18 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                 $iu0(elem),
                         )
                     )
-                        return $co44(input);
-                    if (undefined !== input.oneOf) return $co45(input);
-                    if (undefined !== input.$ref) return $co46(input);
-                    if (undefined !== input.$recursiveRef) return $co47(input);
-                    if ("null" === input.type) return $co48(input);
+                        return $co43(input);
+                    if (undefined !== input.oneOf) return $co44(input);
+                    if (undefined !== input.$ref) return $co45(input);
+                    if ("null" === input.type) return $co46(input);
                     return (() => {
-                        if ($io38(input)) return $co38(input);
                         if ($io37(input)) return $co37(input);
                         if ($io36(input)) return $co36(input);
-                        if ($io39(input)) return $co39(input);
+                        if ($io35(input)) return $co35(input);
+                        if ($io38(input)) return $co38(input);
+                        if ($io40(input)) return $co40(input);
                         if ($io41(input)) return $co41(input);
-                        if ($io42(input)) return $co42(input);
-                        if ($io49(input)) return $co49(input);
+                        if ($io47(input)) return $co47(input);
                         $throws({
                             expected:
                                 '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/createValidateParse/test_createValidateParse_UltimateUnion.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_UltimateUnion.ts
@@ -22,7 +22,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     "object" === typeof input.components &&
                     null !== input.components &&
                     false === Array.isArray(input.components) &&
-                    $io32(input.components) &&
+                    $io31(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose);
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
@@ -455,6 +455,15 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -554,36 +563,6 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -613,7 +592,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -644,13 +623,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -663,23 +642,21 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -709,7 +686,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -719,7 +696,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -732,7 +709,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -774,7 +751,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) =>
@@ -818,7 +795,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -860,7 +837,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -898,7 +875,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
@@ -953,7 +930,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum))) &&
@@ -1005,7 +982,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
@@ -1057,7 +1034,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -1111,7 +1088,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -1120,6 +1097,15 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1155,7 +1141,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -1196,7 +1182,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1230,41 +1216,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1298,7 +1250,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -1356,9 +1308,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (() => {
                             if ($io20(input)) return $io20(input);
                             if ($io19(input)) return $io19(input);
@@ -1366,7 +1316,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                             if ($io21(input)) return $io21(input);
                             if ($io23(input)) return $io23(input);
                             if ($io24(input)) return $io24(input);
-                            if ($io31(input)) return $io31(input);
+                            if ($io30(input)) return $io30(input);
                             return false;
                         })();
                     })();
@@ -1393,15 +1343,15 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -1412,20 +1362,18 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (() => {
-                            if ($io38(input)) return $io38(input);
                             if ($io37(input)) return $io37(input);
                             if ($io36(input)) return $io36(input);
-                            if ($io39(input)) return $io39(input);
+                            if ($io35(input)) return $io35(input);
+                            if ($io38(input)) return $io38(input);
+                            if ($io40(input)) return $io40(input);
                             if ($io41(input)) return $io41(input);
-                            if ($io42(input)) return $io42(input);
-                            if ($io49(input)) return $io49(input);
+                            if ($io47(input)) return $io47(input);
                             return false;
                         })();
                     })();
@@ -1475,7 +1423,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         _index2 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
@@ -1493,7 +1441,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     _index2 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
@@ -1511,7 +1459,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: "IJsonComponents",
                                     value: input.components,
                                 })) &&
-                                $vo32(
+                                $vo31(
                                     input.components,
                                     _path + ".components",
                                     true && _exceptionable,
@@ -3338,7 +3286,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                 $report(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 })) &&
                                 $vu0(
@@ -3349,7 +3297,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                 $report(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 }),
                             undefined === input.minItems ||
@@ -3595,7 +3543,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         _index23 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
@@ -3613,7 +3561,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     _index23 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
@@ -3622,6 +3570,46 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     path: _path + ".items",
                                     expected: "Array<IJsonSchema>",
                                     value: input.items,
+                                }),
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number",
+                                    value: input.minItems,
+                                }),
+                            undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "(number | undefined)",
+                                    value: input.maxItems,
                                 }),
                             "array" === input.type ||
                                 $report(_exceptionable, {
@@ -3804,7 +3792,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         _index26 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
@@ -3822,7 +3810,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     _index26 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
@@ -4134,11 +4122,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "string" === typeof input.$recursiveRef ||
+                            "null" === input.type ||
                                 $report(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -4288,12 +4276,18 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "null" === input.type ||
+                            (null !== input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"null"',
+                                    expected: "undefined",
                                     value: input.type,
-                                }),
+                                })) &&
+                                (undefined === input.type ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".type",
+                                        expected: "undefined",
+                                        value: input.type,
+                                    })),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
                                 $report(_exceptionable, {
@@ -4442,31 +4436,188 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            (null !== input.type ||
+                            undefined === input.schemas ||
+                                ((("object" === typeof input.schemas &&
+                                    null !== input.schemas &&
+                                    false === Array.isArray(input.schemas)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".schemas",
+                                        expected:
+                                            "(Record<string, IObject | IAlias> | undefined)",
+                                        value: input.schemas,
+                                    })) &&
+                                    $vo32(
+                                        input.schemas,
+                                        _path + ".schemas",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".schemas",
+                                    expected:
+                                        "(Record<string, IObject | IAlias> | undefined)",
+                                    value: input.schemas,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo32 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            false === _exceptionable ||
+                                Object.keys(input)
+                                    .map((key: any) => {
+                                        const value = input[key];
+                                        if (undefined === value) return true;
+                                        if (RegExp(/(.*)/).test(key))
+                                            return (
+                                                ((("object" === typeof value &&
+                                                    null !== value &&
+                                                    false ===
+                                                        Array.isArray(value)) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path + $join(key),
+                                                        expected:
+                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                        value: value,
+                                                    })) &&
+                                                    $vu2(
+                                                        value,
+                                                        _path + $join(key),
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path: _path + $join(key),
+                                                    expected:
+                                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                    value: value,
+                                                })
+                                            );
+                                        return true;
+                                    })
+                                    .every((flag: boolean) => flag),
+                        ].every((flag: boolean) => flag);
+                    const $vo33 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.$id ||
+                                "string" === typeof input.$id ||
+                                $report(_exceptionable, {
+                                    path: _path + ".$id",
+                                    expected: "(string | undefined)",
+                                    value: input.$id,
+                                }),
+                            "object" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: "undefined",
+                                    expected: '"object"',
                                     value: input.type,
-                                })) &&
-                                (undefined === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: "undefined",
-                                        value: input.type,
-                                    })),
-                            undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $report(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
                                 }),
-                            undefined === input.title ||
-                                "string" === typeof input.title ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                }),
+                            ((("object" === typeof input.properties &&
+                                null !== input.properties &&
+                                false === Array.isArray(input.properties)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                })) &&
+                                $vo34(
+                                    input.properties,
+                                    _path + ".properties",
+                                    true && _exceptionable,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                }),
+                            undefined === input.patternProperties ||
+                                ((("object" ===
+                                    typeof input.patternProperties &&
+                                    null !== input.patternProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.patternProperties,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".patternProperties",
+                                        expected:
+                                            "(Record<string, IJsonSchema> | undefined)",
+                                        value: input.patternProperties,
+                                    })) &&
+                                    $vo34(
+                                        input.patternProperties,
+                                        _path + ".patternProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                }),
+                            undefined === input.additionalProperties ||
+                                ((("object" ===
+                                    typeof input.additionalProperties &&
+                                    null !== input.additionalProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.additionalProperties,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".additionalProperties",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        value: input.additionalProperties,
+                                    })) &&
+                                    $vu0(
+                                        input.additionalProperties,
+                                        _path + ".additionalProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                }),
+                            undefined === input.required ||
+                                ((Array.isArray(input.required) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".required",
+                                        expected: "(Array<string> | undefined)",
+                                        value: input.required,
+                                    })) &&
+                                    input.required
+                                        .map(
+                                            (elem: any, _index35: number) =>
+                                                "string" === typeof elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".required[" +
+                                                        _index35 +
+                                                        "]",
+                                                    expected: "string",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
                                 }),
                             undefined === input.description ||
                                 "string" === typeof input.description ||
@@ -4474,55 +4625,6 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     path: _path + ".description",
                                     expected: "(string | undefined)",
                                     value: input.description,
-                                }),
-                            undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"]
-                                        .map(
-                                            (elem: any, _index35: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index35 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu1(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index35 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
                                 }),
                             undefined === input["x-typia-jsDocTags"] ||
                                 ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4572,281 +4674,6 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                         "(Array<IJsDocTagInfo> | undefined)",
                                     value: input["x-typia-jsDocTags"],
                                 }),
-                            undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                }),
-                            undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                }),
-                            undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }),
-                        ].every((flag: boolean) => flag);
-                    const $vo32 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            undefined === input.schemas ||
-                                ((("object" === typeof input.schemas &&
-                                    null !== input.schemas &&
-                                    false === Array.isArray(input.schemas)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".schemas",
-                                        expected:
-                                            "(Record<string, IObject | IAlias> | undefined)",
-                                        value: input.schemas,
-                                    })) &&
-                                    $vo33(
-                                        input.schemas,
-                                        _path + ".schemas",
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".schemas",
-                                    expected:
-                                        "(Record<string, IObject | IAlias> | undefined)",
-                                    value: input.schemas,
-                                }),
-                        ].every((flag: boolean) => flag);
-                    const $vo33 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            false === _exceptionable ||
-                                Object.keys(input)
-                                    .map((key: any) => {
-                                        const value = input[key];
-                                        if (undefined === value) return true;
-                                        if (RegExp(/(.*)/).test(key))
-                                            return (
-                                                ((("object" === typeof value &&
-                                                    null !== value &&
-                                                    false ===
-                                                        Array.isArray(value)) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path + $join(key),
-                                                        expected:
-                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                        value: value,
-                                                    })) &&
-                                                    $vu2(
-                                                        value,
-                                                        _path + $join(key),
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path: _path + $join(key),
-                                                    expected:
-                                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                    value: value,
-                                                })
-                                            );
-                                        return true;
-                                    })
-                                    .every((flag: boolean) => flag),
-                        ].every((flag: boolean) => flag);
-                    const $vo34 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                }),
-                            undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }),
-                            "object" === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"object"',
-                                    value: input.type,
-                                }),
-                            undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $report(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
-                                }),
-                            ((("object" === typeof input.properties &&
-                                null !== input.properties &&
-                                false === Array.isArray(input.properties)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                })) &&
-                                $vo35(
-                                    input.properties,
-                                    _path + ".properties",
-                                    true && _exceptionable,
-                                )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                }),
-                            undefined === input.patternProperties ||
-                                ((("object" ===
-                                    typeof input.patternProperties &&
-                                    null !== input.patternProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.patternProperties,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".patternProperties",
-                                        expected:
-                                            "(Record<string, IJsonSchema> | undefined)",
-                                        value: input.patternProperties,
-                                    })) &&
-                                    $vo35(
-                                        input.patternProperties,
-                                        _path + ".patternProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                }),
-                            undefined === input.additionalProperties ||
-                                ((("object" ===
-                                    typeof input.additionalProperties &&
-                                    null !== input.additionalProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.additionalProperties,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".additionalProperties",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                        value: input.additionalProperties,
-                                    })) &&
-                                    $vu0(
-                                        input.additionalProperties,
-                                        _path + ".additionalProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                }),
-                            undefined === input.required ||
-                                ((Array.isArray(input.required) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".required",
-                                        expected: "(Array<string> | undefined)",
-                                        value: input.required,
-                                    })) &&
-                                    input.required
-                                        .map(
-                                            (elem: any, _index37: number) =>
-                                                "string" === typeof elem ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        ".required[" +
-                                                        _index37 +
-                                                        "]",
-                                                    expected: "string",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                }),
-                            undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $report(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                }),
-                            undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"]
-                                        .map(
-                                            (elem: any, _index38: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index38 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vo17(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index38 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                }),
                             undefined === input["x-typia-patternProperties"] ||
                                 ((("object" ===
                                     typeof input["x-typia-patternProperties"] &&
@@ -4866,7 +4693,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             "x-typia-patternProperties"
                                         ],
                                     })) &&
-                                    $vo35(
+                                    $vo34(
                                         input["x-typia-patternProperties"],
                                         _path + '["x-typia-patternProperties"]',
                                         true && _exceptionable,
@@ -4897,7 +4724,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             _path +
                                             '["x-typia-additionalProperties"]',
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                         value: input[
                                             "x-typia-additionalProperties"
                                         ],
@@ -4913,13 +4740,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
                                 }),
                         ].every((flag: boolean) => flag);
-                    const $vo35 = (
+                    const $vo34 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4940,7 +4767,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         path:
                                                             _path + $join(key),
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: value,
                                                     })) &&
                                                     $vu0(
@@ -4951,7 +4778,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                 $report(_exceptionable, {
                                                     path: _path + $join(key),
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: value,
                                                 })
                                             );
@@ -4959,7 +4786,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     })
                                     .every((flag: boolean) => flag),
                         ].every((flag: boolean) => flag);
-                    const $vo36 = (
+                    const $vo35 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4973,13 +4800,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                 })) &&
                                 input["enum"]
                                     .map(
-                                        (elem: any, _index39: number) =>
+                                        (elem: any, _index37: number) =>
                                             "boolean" === typeof elem ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["enum"][' +
-                                                    _index39 +
+                                                    _index37 +
                                                     "]",
                                                 expected: "boolean",
                                                 value: elem,
@@ -5042,14 +4869,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index40: number) =>
+                                            (elem: any, _index38: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index40 +
+                                                            _index38 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5059,7 +4886,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index40 +
+                                                            _index38 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5067,7 +4894,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5091,14 +4918,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index41: number) =>
+                                            (elem: any, _index39: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index41 +
+                                                            _index39 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5108,7 +4935,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index41 +
+                                                            _index39 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5116,7 +4943,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -5167,7 +4994,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     value: input.$recursiveAnchor,
                                 }),
                         ].every((flag: boolean) => flag);
-                    const $vo37 = (
+                    const $vo36 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -5181,14 +5008,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                 })) &&
                                 input["enum"]
                                     .map(
-                                        (elem: any, _index42: number) =>
+                                        (elem: any, _index40: number) =>
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem)) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["enum"][' +
-                                                    _index42 +
+                                                    _index40 +
                                                     "]",
                                                 expected: "number",
                                                 value: elem,
@@ -5252,14 +5079,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index43: number) =>
+                                            (elem: any, _index41: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index43 +
+                                                            _index41 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5269,7 +5096,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index43 +
+                                                            _index41 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5277,7 +5104,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5301,14 +5128,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index44: number) =>
+                                            (elem: any, _index42: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index44 +
+                                                            _index42 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5318,7 +5145,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index44 +
+                                                            _index42 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5326,7 +5153,215 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
+                                                        _index42 +
+                                                        "]",
+                                                    expected: "IJsDocTagInfo",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                }),
+                            undefined === input["x-typia-required"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-required"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-required"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-required"],
+                                }),
+                            undefined === input["x-typia-optional"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-optional"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-optional"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-optional"],
+                                }),
+                            undefined === input["x-typia-rest"] ||
+                                "boolean" === typeof input["x-typia-rest"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-rest"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-rest"],
+                                }),
+                            undefined === input.$id ||
+                                "string" === typeof input.$id ||
+                                $report(_exceptionable, {
+                                    path: _path + ".$id",
+                                    expected: "(string | undefined)",
+                                    value: input.$id,
+                                }),
+                            undefined === input.$recursiveAnchor ||
+                                "boolean" === typeof input.$recursiveAnchor ||
+                                $report(_exceptionable, {
+                                    path: _path + ".$recursiveAnchor",
+                                    expected: "(boolean | undefined)",
+                                    value: input.$recursiveAnchor,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo37 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            ((Array.isArray(input["enum"]) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                })) &&
+                                input["enum"]
+                                    .map(
+                                        (elem: any, _index43: number) =>
+                                            "string" === typeof elem ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["enum"][' +
+                                                    _index43 +
+                                                    "]",
+                                                expected: "string",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                }),
+                            undefined === input["default"] ||
+                                "string" === typeof input["default"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["default"]',
+                                    expected: "(string | undefined)",
+                                    value: input["default"],
+                                }),
+                            "string" === input.type ||
+                                $report(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: '"string"',
+                                    value: input.type,
+                                }),
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
+                                $report(_exceptionable, {
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                }),
+                            undefined === input.deprecated ||
+                                "boolean" === typeof input.deprecated ||
+                                $report(_exceptionable, {
+                                    path: _path + ".deprecated",
+                                    expected: "(boolean | undefined)",
+                                    value: input.deprecated,
+                                }),
+                            undefined === input.title ||
+                                "string" === typeof input.title ||
+                                $report(_exceptionable, {
+                                    path: _path + ".title",
+                                    expected: "(string | undefined)",
+                                    value: input.title,
+                                }),
+                            undefined === input.description ||
+                                "string" === typeof input.description ||
+                                $report(_exceptionable, {
+                                    path: _path + ".description",
+                                    expected: "(string | undefined)",
+                                    value: input.description,
+                                }),
+                            undefined === input["x-typia-metaTags"] ||
+                                ((Array.isArray(input["x-typia-metaTags"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-metaTags"]',
+                                        expected:
+                                            "(Array<IMetadataTag> | undefined)",
+                                        value: input["x-typia-metaTags"],
+                                    })) &&
+                                    input["x-typia-metaTags"]
+                                        .map(
+                                            (elem: any, _index44: number) =>
+                                                ((("object" === typeof elem &&
+                                                    null !== elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-metaTags"][' +
+                                                            _index44 +
+                                                            "]",
+                                                        expected:
+                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                        value: elem,
+                                                    })) &&
+                                                    $vu1(
+                                                        elem,
+                                                        _path +
+                                                            '["x-typia-metaTags"][' +
+                                                            _index44 +
+                                                            "]",
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-metaTags"][' +
                                                         _index44 +
+                                                        "]",
+                                                    expected:
+                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                }),
+                            undefined === input["x-typia-jsDocTags"] ||
+                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-jsDocTags"]',
+                                        expected:
+                                            "(Array<IJsDocTagInfo> | undefined)",
+                                        value: input["x-typia-jsDocTags"],
+                                    })) &&
+                                    input["x-typia-jsDocTags"]
+                                        .map(
+                                            (elem: any, _index45: number) =>
+                                                ((("object" === typeof elem &&
+                                                    null !== elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-jsDocTags"][' +
+                                                            _index45 +
+                                                            "]",
+                                                        expected:
+                                                            "IJsDocTagInfo",
+                                                        value: elem,
+                                                    })) &&
+                                                    $vo17(
+                                                        elem,
+                                                        _path +
+                                                            '["x-typia-jsDocTags"][' +
+                                                            _index45 +
+                                                            "]",
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -5383,43 +5418,17 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((Array.isArray(input["enum"]) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                })) &&
-                                input["enum"]
-                                    .map(
-                                        (elem: any, _index45: number) =>
-                                            "string" === typeof elem ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["enum"][' +
-                                                    _index45 +
-                                                    "]",
-                                                expected: "string",
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                }),
                             undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
+                                "boolean" === typeof input["default"] ||
                                 $report(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(string | undefined)",
+                                    expected: "(boolean | undefined)",
                                     value: input["default"],
                                 }),
-                            "string" === input.type ||
+                            "boolean" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"boolean"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -5591,17 +5600,77 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
+                            undefined === input.minimum ||
+                                ("number" === typeof input.minimum &&
+                                    Number.isFinite(input.minimum) &&
+                                    (parseInt(input.minimum) ===
+                                        input.minimum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "(number | undefined)",
+                                    value: input.minimum,
+                                }),
+                            undefined === input.maximum ||
+                                ("number" === typeof input.maximum &&
+                                    Number.isFinite(input.maximum) &&
+                                    (parseInt(input.maximum) ===
+                                        input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "(number | undefined)",
+                                    value: input.maximum,
+                                }),
+                            undefined === input.exclusiveMinimum ||
+                                "boolean" === typeof input.exclusiveMinimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMinimum,
+                                }),
+                            undefined === input.exclusiveMaximum ||
+                                "boolean" === typeof input.exclusiveMaximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMaximum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMaximum,
+                                }),
+                            undefined === input.multipleOf ||
+                                ("number" === typeof input.multipleOf &&
+                                    Number.isFinite(input.multipleOf) &&
+                                    (parseInt(input.multipleOf) ===
+                                        input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "(number | undefined)",
+                                    value: input.multipleOf,
+                                }),
                             undefined === input["default"] ||
-                                "boolean" === typeof input["default"] ||
+                                ("number" === typeof input["default"] &&
+                                    Number.isFinite(input["default"])) ||
                                 $report(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(boolean | undefined)",
+                                    expected: "(number | undefined)",
                                     value: input["default"],
                                 }),
-                            "boolean" === input.type ||
+                            "integer" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"boolean"',
+                                    expected: '"integer"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -5775,14 +5844,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         [
                             undefined === input.minimum ||
                                 ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum) &&
-                                    (parseInt(input.minimum) ===
-                                        input.minimum ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".minimum",
-                                            expected: "number (@type int)",
-                                            value: input.minimum,
-                                        }))) ||
+                                    Number.isFinite(input.minimum)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "(number | undefined)",
@@ -5790,14 +5852,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                 }),
                             undefined === input.maximum ||
                                 ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum) &&
-                                    (parseInt(input.maximum) ===
-                                        input.maximum ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".maximum",
-                                            expected: "number (@type int)",
-                                            value: input.maximum,
-                                        }))) ||
+                                    Number.isFinite(input.maximum)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "(number | undefined)",
@@ -5819,14 +5874,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                 }),
                             undefined === input.multipleOf ||
                                 ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf) &&
-                                    (parseInt(input.multipleOf) ===
-                                        input.multipleOf ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".multipleOf",
-                                            expected: "number (@type int)",
-                                            value: input.multipleOf,
-                                        }))) ||
+                                    Number.isFinite(input.multipleOf)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "(number | undefined)",
@@ -5840,10 +5888,10 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     expected: "(number | undefined)",
                                     value: input["default"],
                                 }),
-                            "integer" === input.type ||
+                            "number" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"integer"',
+                                    expected: '"number"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -6015,56 +6063,73 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            undefined === input.minimum ||
-                                ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum)) ||
+                            undefined === input.minLength ||
+                                ("number" === typeof input.minLength &&
+                                    Number.isFinite(input.minLength) &&
+                                    (parseInt(input.minLength) ===
+                                        input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        })) &&
+                                    (0 <= input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".minimum",
+                                    path: _path + ".minLength",
                                     expected: "(number | undefined)",
-                                    value: input.minimum,
+                                    value: input.minLength,
                                 }),
-                            undefined === input.maximum ||
-                                ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum)) ||
+                            undefined === input.maxLength ||
+                                ("number" === typeof input.maxLength &&
+                                    Number.isFinite(input.maxLength) &&
+                                    (parseInt(input.maxLength) ===
+                                        input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".maximum",
+                                    path: _path + ".maxLength",
                                     expected: "(number | undefined)",
-                                    value: input.maximum,
+                                    value: input.maxLength,
                                 }),
-                            undefined === input.exclusiveMinimum ||
-                                "boolean" === typeof input.exclusiveMinimum ||
+                            undefined === input.pattern ||
+                                "string" === typeof input.pattern ||
                                 $report(_exceptionable, {
-                                    path: _path + ".exclusiveMinimum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMinimum,
+                                    path: _path + ".pattern",
+                                    expected: "(string | undefined)",
+                                    value: input.pattern,
                                 }),
-                            undefined === input.exclusiveMaximum ||
-                                "boolean" === typeof input.exclusiveMaximum ||
+                            undefined === input.format ||
+                                "string" === typeof input.format ||
                                 $report(_exceptionable, {
-                                    path: _path + ".exclusiveMaximum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMaximum,
-                                }),
-                            undefined === input.multipleOf ||
-                                ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".multipleOf",
-                                    expected: "(number | undefined)",
-                                    value: input.multipleOf,
+                                    path: _path + ".format",
+                                    expected: "(string | undefined)",
+                                    value: input.format,
                                 }),
                             undefined === input["default"] ||
-                                ("number" === typeof input["default"] &&
-                                    Number.isFinite(input["default"])) ||
+                                "string" === typeof input["default"] ||
                                 $report(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(number | undefined)",
+                                    expected: "(string | undefined)",
                                     value: input["default"],
                                 }),
-                            "number" === input.type ||
+                            "string" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"number"',
+                                    expected: '"string"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -6236,73 +6301,92 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            undefined === input.minLength ||
-                                ("number" === typeof input.minLength &&
-                                    Number.isFinite(input.minLength) &&
-                                    (parseInt(input.minLength) ===
-                                        input.minLength ||
+                            ((("object" === typeof input.items &&
+                                null !== input.items &&
+                                false === Array.isArray(input.items)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                })) &&
+                                $vu0(
+                                    input.items,
+                                    _path + ".items",
+                                    true && _exceptionable,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                }),
+                            undefined === input.minItems ||
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         })) &&
-                                    (0 <= input.minLength ||
+                                    (0 <= input.minItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "(number | undefined)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 }),
-                            undefined === input.maxLength ||
-                                ("number" === typeof input.maxLength &&
-                                    Number.isFinite(input.maxLength) &&
-                                    (parseInt(input.maxLength) ===
-                                        input.maxLength ||
+                            undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         })) &&
-                                    (0 <= input.maxLength ||
+                                    (0 <= input.maxItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "(number | undefined)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 }),
-                            undefined === input.pattern ||
-                                "string" === typeof input.pattern ||
+                            undefined === input["x-typia-tuple"] ||
+                                ((("object" === typeof input["x-typia-tuple"] &&
+                                    null !== input["x-typia-tuple"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-tuple"]',
+                                        expected:
+                                            "(IJsonSchema.ITuple | undefined)",
+                                        value: input["x-typia-tuple"],
+                                    })) &&
+                                    $vo26(
+                                        input["x-typia-tuple"],
+                                        _path + '["x-typia-tuple"]',
+                                        true && _exceptionable,
+                                    )) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".pattern",
-                                    expected: "(string | undefined)",
-                                    value: input.pattern,
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
                                 }),
-                            undefined === input.format ||
-                                "string" === typeof input.format ||
-                                $report(_exceptionable, {
-                                    path: _path + ".format",
-                                    expected: "(string | undefined)",
-                                    value: input.format,
-                                }),
-                            undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["default"]',
-                                    expected: "(string | undefined)",
-                                    value: input["default"],
-                                }),
-                            "string" === input.type ||
+                            "array" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"array"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -6474,45 +6558,71 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((("object" === typeof input.items &&
-                                null !== input.items &&
-                                false === Array.isArray(input.items)) ||
+                            ((Array.isArray(input.items) ||
                                 $report(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 })) &&
-                                $vu0(
-                                    input.items,
-                                    _path + ".items",
-                                    true && _exceptionable,
-                                )) ||
+                                input.items
+                                    .map(
+                                        (elem: any, _index56: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem &&
+                                                false ===
+                                                    Array.isArray(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index56 +
+                                                        "]",
+                                                    expected:
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    value: elem,
+                                                })) &&
+                                                $vu0(
+                                                    elem,
+                                                    _path +
+                                                        ".items[" +
+                                                        _index56 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                expected:
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 }),
-                            undefined === input.minItems ||
-                                ("number" === typeof input.minItems &&
-                                    Number.isFinite(input.minItems) &&
-                                    (parseInt(input.minItems) ===
-                                        input.minItems ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        })) &&
-                                    (0 <= input.minItems ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        }))) ||
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
-                                    expected: "(number | undefined)",
+                                    expected: "number",
                                     value: input.minItems,
                                 }),
                             undefined === input.maxItems ||
@@ -6535,26 +6645,6 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     path: _path + ".maxItems",
                                     expected: "(number | undefined)",
                                     value: input.maxItems,
-                                }),
-                            undefined === input["x-typia-tuple"] ||
-                                ((("object" === typeof input["x-typia-tuple"] &&
-                                    null !== input["x-typia-tuple"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-tuple"]',
-                                        expected:
-                                            "(IJsonSchema.ITuple | undefined)",
-                                        value: input["x-typia-tuple"],
-                                    })) &&
-                                    $vo26(
-                                        input["x-typia-tuple"],
-                                        _path + '["x-typia-tuple"]',
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
                                 }),
                             "array" === input.type ||
                                 $report(_exceptionable, {
@@ -6600,14 +6690,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index56: number) =>
+                                            (elem: any, _index57: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index56 +
+                                                            _index57 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6617,7 +6707,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index56 +
+                                                            _index57 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6625,7 +6715,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6649,14 +6739,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index57: number) =>
+                                            (elem: any, _index58: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index57 +
+                                                            _index58 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -6666,7 +6756,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index57 +
+                                                            _index58 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6674,7 +6764,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6731,15 +6821,15 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((Array.isArray(input.items) ||
+                            ((Array.isArray(input.oneOf) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
+                                    value: input.oneOf,
                                 })) &&
-                                input.items
+                                input.oneOf
                                     .map(
-                                        (elem: any, _index58: number) =>
+                                        (elem: any, _index59: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem &&
                                                 false ===
@@ -6747,50 +6837,37 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
-                                                        ".items[" +
-                                                        _index58 +
+                                                        ".oneOf[" +
+                                                        _index59 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
                                                     elem,
                                                     _path +
-                                                        ".items[" +
-                                                        _index58 +
+                                                        ".oneOf[" +
+                                                        _index59 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
                                     .every((flag: boolean) => flag)) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
-                                }),
-                            "array" === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"array"',
-                                    value: input.type,
-                                }),
-                            undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $report(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
+                                    value: input.oneOf,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -6823,14 +6900,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index59: number) =>
+                                            (elem: any, _index60: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index59 +
+                                                            _index60 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6840,7 +6917,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index59 +
+                                                            _index60 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6848,7 +6925,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6872,14 +6949,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index60: number) =>
+                                            (elem: any, _index61: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index60 +
+                                                            _index61 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -6889,7 +6966,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index60 +
+                                                            _index61 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6897,7 +6974,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6954,53 +7031,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((Array.isArray(input.oneOf) ||
+                            "string" === typeof input.$ref ||
                                 $report(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
-                                })) &&
-                                input.oneOf
-                                    .map(
-                                        (elem: any, _index61: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem &&
-                                                false ===
-                                                    Array.isArray(elem)) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        ".oneOf[" +
-                                                        _index61 +
-                                                        "]",
-                                                    expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                    value: elem,
-                                                })) &&
-                                                $vu0(
-                                                    elem,
-                                                    _path +
-                                                        ".oneOf[" +
-                                                        _index61 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
+                                    path: _path + ".$ref",
+                                    expected: "string",
+                                    value: input.$ref,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7164,11 +7199,11 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "string" === typeof input.$ref ||
+                            "null" === input.type ||
                                 $report(_exceptionable, {
-                                    path: _path + ".$ref",
-                                    expected: "string",
-                                    value: input.$ref,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7332,12 +7367,18 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "string" === typeof input.$recursiveRef ||
+                            (null !== input.type ||
                                 $report(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
-                                }),
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
+                                })) &&
+                                (undefined === input.type ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".type",
+                                        expected: "undefined",
+                                        value: input.type,
+                                    })),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
                                 $report(_exceptionable, {
@@ -7494,348 +7535,6 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     value: input.$recursiveAnchor,
                                 }),
                         ].every((flag: boolean) => flag);
-                    const $vo48 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            "null" === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"null"',
-                                    value: input.type,
-                                }),
-                            undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $report(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                }),
-                            undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $report(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                }),
-                            undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $report(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                }),
-                            undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"]
-                                        .map(
-                                            (elem: any, _index68: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index68 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu1(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index68 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                }),
-                            undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"]
-                                        .map(
-                                            (elem: any, _index69: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index69 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vo17(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index69 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                }),
-                            undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                }),
-                            undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                }),
-                            undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }),
-                            undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                }),
-                            undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }),
-                        ].every((flag: boolean) => flag);
-                    const $vo49 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            (null !== input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                                (undefined === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: "undefined",
-                                        value: input.type,
-                                    })),
-                            undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $report(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                }),
-                            undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $report(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                }),
-                            undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $report(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                }),
-                            undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"]
-                                        .map(
-                                            (elem: any, _index70: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index70 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu1(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index70 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                }),
-                            undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"]
-                                        .map(
-                                            (elem: any, _index71: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index71 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vo17(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index71 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                }),
-                            undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                }),
-                            undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                }),
-                            undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }),
-                            undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                }),
-                            undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }),
-                        ].every((flag: boolean) => flag);
                     const $vu0 = (
                         input: any,
                         _path: string,
@@ -7867,7 +7566,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                 Array.isArray(input.items) &&
                                 input.items
                                     .map(
-                                        (elem: any, _index72: number) =>
+                                        (elem: any, _index68: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -7875,7 +7574,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index72 +
+                                                    _index68 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
@@ -7899,14 +7598,8 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     _path,
                                     true && _exceptionable,
                                 );
-                            if (undefined !== input.$recursiveRef)
-                                return $vo29(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
                             if ("null" === input.type)
-                                return $vo30(
+                                return $vo29(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7918,7 +7611,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                 $vo21(input, _path, false && _exceptionable) ||
                                 $vo23(input, _path, false && _exceptionable) ||
                                 $vo24(input, _path, false && _exceptionable) ||
-                                $vo31(input, _path, false && _exceptionable)
+                                $vo30(input, _path, false && _exceptionable)
                             );
                         })();
                     const $vu1 = (
@@ -8031,13 +7724,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     ): any =>
                         (() => {
                             if ("object" === input.type)
-                                return $vo34(
+                                return $vo33(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("integer" === input.type)
-                                return $vo40(
+                                return $vo39(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -8052,7 +7745,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     false && _exceptionable,
                                 )
                             )
-                                return $vo43(
+                                return $vo42(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -8061,7 +7754,7 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                 Array.isArray(input.items) &&
                                 input.items
                                     .map(
-                                        (elem: any, _index73: number) =>
+                                        (elem: any, _index69: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -8069,50 +7762,44 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index73 +
+                                                    _index69 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
                                     )
                                     .every((flag: boolean) => flag)
                             )
-                                return $vo44(
+                                return $vo43(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.oneOf)
-                                return $vo45(
+                                return $vo44(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.$ref)
-                                return $vo46(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
-                            if (undefined !== input.$recursiveRef)
-                                return $vo47(
+                                return $vo45(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("null" === input.type)
-                                return $vo48(
+                                return $vo46(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             return (
-                                $vo38(input, _path, false && _exceptionable) ||
                                 $vo37(input, _path, false && _exceptionable) ||
                                 $vo36(input, _path, false && _exceptionable) ||
-                                $vo39(input, _path, false && _exceptionable) ||
+                                $vo35(input, _path, false && _exceptionable) ||
+                                $vo38(input, _path, false && _exceptionable) ||
+                                $vo40(input, _path, false && _exceptionable) ||
                                 $vo41(input, _path, false && _exceptionable) ||
-                                $vo42(input, _path, false && _exceptionable) ||
-                                $vo49(input, _path, false && _exceptionable)
+                                $vo47(input, _path, false && _exceptionable)
                             );
                         })();
                     return (

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_UltimateUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_UltimateUnion.ts
@@ -23,7 +23,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "object" === typeof input.components &&
                         null !== input.components &&
                         false === Array.isArray(input.components) &&
-                        $io32(input.components) &&
+                        $io31(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose);
                     const $io1 = (input: any): boolean =>
@@ -460,6 +460,15 @@ export const test_createValidateStringify_UltimateUnion =
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -559,36 +568,6 @@ export const test_createValidateStringify_UltimateUnion =
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
                     const $io29 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]);
-                    const $io30 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -618,7 +597,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io31 = (input: any): boolean =>
+                    const $io30 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -649,13 +628,13 @@ export const test_createValidateStringify_UltimateUnion =
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io32 = (input: any): boolean =>
+                    const $io31 = (input: any): boolean =>
                         undefined === input.schemas ||
                         ("object" === typeof input.schemas &&
                             null !== input.schemas &&
                             false === Array.isArray(input.schemas) &&
-                            $io33(input.schemas));
-                    const $io33 = (input: any): boolean =>
+                            $io32(input.schemas));
+                    const $io32 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -668,24 +647,22 @@ export const test_createValidateStringify_UltimateUnion =
                                 );
                             return true;
                         });
-                    const $io34 = (input: any): boolean =>
+                    const $io33 = (input: any): boolean =>
                         (undefined === input.$id ||
                             "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
-                        $io35(input.properties) &&
+                        $io34(input.properties) &&
                         (undefined === input.patternProperties ||
                             ("object" === typeof input.patternProperties &&
                                 null !== input.patternProperties &&
                                 false ===
                                     Array.isArray(input.patternProperties) &&
-                                $io35(input.patternProperties))) &&
+                                $io34(input.patternProperties))) &&
                         (undefined === input.additionalProperties ||
                             ("object" === typeof input.additionalProperties &&
                                 null !== input.additionalProperties &&
@@ -715,7 +692,7 @@ export const test_createValidateStringify_UltimateUnion =
                                     Array.isArray(
                                         input["x-typia-patternProperties"],
                                     ) &&
-                                $io35(input["x-typia-patternProperties"]))) &&
+                                $io34(input["x-typia-patternProperties"]))) &&
                         (undefined === input["x-typia-additionalProperties"] ||
                             ("object" ===
                                 typeof input["x-typia-additionalProperties"] &&
@@ -726,7 +703,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         input["x-typia-additionalProperties"],
                                     ) &&
                                 $iu0(input["x-typia-additionalProperties"])));
-                    const $io35 = (input: any): boolean =>
+                    const $io34 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -739,7 +716,7 @@ export const test_createValidateStringify_UltimateUnion =
                                 );
                             return true;
                         });
-                    const $io36 = (input: any): boolean =>
+                    const $io35 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "boolean" === typeof elem,
@@ -781,7 +758,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io37 = (input: any): boolean =>
+                    const $io36 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) =>
@@ -826,7 +803,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io38 = (input: any): boolean =>
+                    const $io37 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "string" === typeof elem,
@@ -868,7 +845,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io39 = (input: any): boolean =>
+                    const $io38 = (input: any): boolean =>
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
@@ -906,7 +883,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io40 = (input: any): boolean =>
+                    const $io39 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
@@ -962,7 +939,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io41 = (input: any): boolean =>
+                    const $io40 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum))) &&
@@ -1014,7 +991,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io42 = (input: any): boolean =>
+                    const $io41 = (input: any): boolean =>
                         (undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
@@ -1066,7 +1043,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io43 = (input: any): boolean =>
+                    const $io42 = (input: any): boolean =>
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
@@ -1120,7 +1097,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io44 = (input: any): boolean =>
+                    const $io43 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         input.items.every(
                             (elem: any) =>
@@ -1129,6 +1106,15 @@ export const test_createValidateStringify_UltimateUnion =
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -1164,7 +1150,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io45 = (input: any): boolean =>
+                    const $io44 = (input: any): boolean =>
                         Array.isArray(input.oneOf) &&
                         input.oneOf.every(
                             (elem: any) =>
@@ -1205,7 +1191,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io46 = (input: any): boolean =>
+                    const $io45 = (input: any): boolean =>
                         "string" === typeof input.$ref &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1239,41 +1225,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io47 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor);
-                    const $io48 = (input: any): boolean =>
+                    const $io46 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1307,7 +1259,7 @@ export const test_createValidateStringify_UltimateUnion =
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io49 = (input: any): boolean =>
+                    const $io47 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -1365,9 +1317,7 @@ export const test_createValidateStringify_UltimateUnion =
                                 return $io26(input);
                             if (undefined !== input.oneOf) return $io27(input);
                             if (undefined !== input.$ref) return $io28(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io29(input);
-                            if ("null" === input.type) return $io30(input);
+                            if ("null" === input.type) return $io29(input);
                             return (() => {
                                 if ($io20(input)) return $io20(input);
                                 if ($io19(input)) return $io19(input);
@@ -1375,7 +1325,7 @@ export const test_createValidateStringify_UltimateUnion =
                                 if ($io21(input)) return $io21(input);
                                 if ($io23(input)) return $io23(input);
                                 if ($io24(input)) return $io24(input);
-                                if ($io31(input)) return $io31(input);
+                                if ($io30(input)) return $io30(input);
                                 return false;
                             })();
                         })();
@@ -1402,15 +1352,15 @@ export const test_createValidateStringify_UltimateUnion =
                         })();
                     const $iu2 = (input: any): any =>
                         (() => {
-                            if ("object" === input.type) return $io34(input);
-                            if ("integer" === input.type) return $io40(input);
+                            if ("object" === input.type) return $io33(input);
+                            if ("integer" === input.type) return $io39(input);
                             if (
                                 "object" === typeof input.items &&
                                 null !== input.items &&
                                 false === Array.isArray(input.items) &&
                                 $iu0(input.items)
                             )
-                                return $io43(input);
+                                return $io42(input);
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
@@ -1421,20 +1371,18 @@ export const test_createValidateStringify_UltimateUnion =
                                         $iu0(elem),
                                 )
                             )
-                                return $io44(input);
-                            if (undefined !== input.oneOf) return $io45(input);
-                            if (undefined !== input.$ref) return $io46(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io47(input);
-                            if ("null" === input.type) return $io48(input);
+                                return $io43(input);
+                            if (undefined !== input.oneOf) return $io44(input);
+                            if (undefined !== input.$ref) return $io45(input);
+                            if ("null" === input.type) return $io46(input);
                             return (() => {
-                                if ($io38(input)) return $io38(input);
                                 if ($io37(input)) return $io37(input);
                                 if ($io36(input)) return $io36(input);
-                                if ($io39(input)) return $io39(input);
+                                if ($io35(input)) return $io35(input);
+                                if ($io38(input)) return $io38(input);
+                                if ($io40(input)) return $io40(input);
                                 if ($io41(input)) return $io41(input);
-                                if ($io42(input)) return $io42(input);
-                                if ($io49(input)) return $io49(input);
+                                if ($io47(input)) return $io47(input);
                                 return false;
                             })();
                         })();
@@ -1485,7 +1433,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             _index2 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -1503,7 +1451,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         _index2 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -1522,7 +1470,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: "IJsonComponents",
                                         value: input.components,
                                     })) &&
-                                    $vo32(
+                                    $vo31(
                                         input.components,
                                         _path + ".components",
                                         true && _exceptionable,
@@ -3484,7 +3432,7 @@ export const test_createValidateStringify_UltimateUnion =
                                     $report(_exceptionable, {
                                         path: _path + ".items",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: input.items,
                                     })) &&
                                     $vu0(
@@ -3495,7 +3443,7 @@ export const test_createValidateStringify_UltimateUnion =
                                     $report(_exceptionable, {
                                         path: _path + ".items",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: input.items,
                                     }),
                                 undefined === input.minItems ||
@@ -3760,7 +3708,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             _index23 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -3778,7 +3726,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         _index23 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -3787,6 +3735,47 @@ export const test_createValidateStringify_UltimateUnion =
                                         path: _path + ".items",
                                         expected: "Array<IJsonSchema>",
                                         value: input.items,
+                                    }),
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number",
+                                        value: input.minItems,
+                                    }),
+                                undefined === input.maxItems ||
+                                    ("number" === typeof input.maxItems &&
+                                        Number.isFinite(input.maxItems) &&
+                                        (parseInt(input.maxItems) ===
+                                            input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "(number | undefined)",
+                                        value: input.maxItems,
                                     }),
                                 "array" === input.type ||
                                     $report(_exceptionable, {
@@ -3987,7 +3976,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             _index26 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -4005,7 +3994,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         _index26 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -4353,11 +4342,11 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$recursiveRef ||
+                                "null" === input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$recursiveRef",
-                                        expected: "string",
-                                        value: input.$recursiveRef,
+                                        path: _path + ".type",
+                                        expected: '"null"',
+                                        value: input.type,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -4525,12 +4514,18 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "null" === input.type ||
+                                (null !== input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"null"',
+                                        expected: "undefined",
                                         value: input.type,
-                                    }),
+                                    })) &&
+                                    (undefined === input.type ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".type",
+                                            expected: "undefined",
+                                            value: input.type,
+                                        })),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
                                     $report(_exceptionable, {
@@ -4697,31 +4692,202 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                (null !== input.type ||
+                                undefined === input.schemas ||
+                                    ((("object" === typeof input.schemas &&
+                                        null !== input.schemas &&
+                                        false ===
+                                            Array.isArray(input.schemas)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".schemas",
+                                            expected:
+                                                "(Record<string, IObject | IAlias> | undefined)",
+                                            value: input.schemas,
+                                        })) &&
+                                        $vo32(
+                                            input.schemas,
+                                            _path + ".schemas",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".schemas",
+                                        expected:
+                                            "(Record<string, IObject | IAlias> | undefined)",
+                                        value: input.schemas,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo32 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                false === _exceptionable ||
+                                    Object.keys(input)
+                                        .map((key: any) => {
+                                            const value = input[key];
+                                            if (undefined === value)
+                                                return true;
+                                            if (RegExp(/(.*)/).test(key))
+                                                return (
+                                                    ((("object" ===
+                                                        typeof value &&
+                                                        null !== value &&
+                                                        false ===
+                                                            Array.isArray(
+                                                                value,
+                                                            )) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    $join(key),
+                                                                expected:
+                                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                                value: value,
+                                                            },
+                                                        )) &&
+                                                        $vu2(
+                                                            value,
+                                                            _path + $join(key),
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path + $join(key),
+                                                        expected:
+                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                        value: value,
+                                                    })
+                                                );
+                                            return true;
+                                        })
+                                        .every((flag: boolean) => flag),
+                            ].every((flag: boolean) => flag);
+                        const $vo33 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.$id ||
+                                    "string" === typeof input.$id ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$id",
+                                        expected: "(string | undefined)",
+                                        value: input.$id,
+                                    }),
+                                "object" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: "undefined",
+                                        expected: '"object"',
                                         value: input.type,
-                                    })) &&
-                                    (undefined === input.type ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".type",
-                                            expected: "undefined",
-                                            value: input.type,
-                                        })),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
                                     }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
+                                        path: _path + ".nullable",
+                                        expected: "(boolean | undefined)",
+                                        value: input.nullable,
+                                    }),
+                                ((("object" === typeof input.properties &&
+                                    null !== input.properties &&
+                                    false ===
+                                        Array.isArray(input.properties)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".properties",
+                                        expected: "Record<string, IJsonSchema>",
+                                        value: input.properties,
+                                    })) &&
+                                    $vo34(
+                                        input.properties,
+                                        _path + ".properties",
+                                        true && _exceptionable,
+                                    )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".properties",
+                                        expected: "Record<string, IJsonSchema>",
+                                        value: input.properties,
+                                    }),
+                                undefined === input.patternProperties ||
+                                    ((("object" ===
+                                        typeof input.patternProperties &&
+                                        null !== input.patternProperties &&
+                                        false ===
+                                            Array.isArray(
+                                                input.patternProperties,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".patternProperties",
+                                            expected:
+                                                "(Record<string, IJsonSchema> | undefined)",
+                                            value: input.patternProperties,
+                                        })) &&
+                                        $vo34(
+                                            input.patternProperties,
+                                            _path + ".patternProperties",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".patternProperties",
+                                        expected:
+                                            "(Record<string, IJsonSchema> | undefined)",
+                                        value: input.patternProperties,
+                                    }),
+                                undefined === input.additionalProperties ||
+                                    ((("object" ===
+                                        typeof input.additionalProperties &&
+                                        null !== input.additionalProperties &&
+                                        false ===
+                                            Array.isArray(
+                                                input.additionalProperties,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + ".additionalProperties",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            value: input.additionalProperties,
+                                        })) &&
+                                        $vu0(
+                                            input.additionalProperties,
+                                            _path + ".additionalProperties",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".additionalProperties",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        value: input.additionalProperties,
+                                    }),
+                                undefined === input.required ||
+                                    ((Array.isArray(input.required) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".required",
+                                            expected:
+                                                "(Array<string> | undefined)",
+                                            value: input.required,
+                                        })) &&
+                                        input.required
+                                            .map(
+                                                (elem: any, _index35: number) =>
+                                                    "string" === typeof elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".required[" +
+                                                            _index35 +
+                                                            "]",
+                                                        expected: "string",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".required",
+                                        expected: "(Array<string> | undefined)",
+                                        value: input.required,
                                     }),
                                 undefined === input.description ||
                                     "string" === typeof input.description ||
@@ -4729,63 +4895,6 @@ export const test_createValidateStringify_UltimateUnion =
                                         path: _path + ".description",
                                         expected: "(string | undefined)",
                                         value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index35: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index35 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index35 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index35 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
                                     }),
                                 undefined === input["x-typia-jsDocTags"] ||
                                     ((Array.isArray(
@@ -4844,306 +4953,6 @@ export const test_createValidateStringify_UltimateUnion =
                                             "(Array<IJsDocTagInfo> | undefined)",
                                         value: input["x-typia-jsDocTags"],
                                     }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo32 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                undefined === input.schemas ||
-                                    ((("object" === typeof input.schemas &&
-                                        null !== input.schemas &&
-                                        false ===
-                                            Array.isArray(input.schemas)) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".schemas",
-                                            expected:
-                                                "(Record<string, IObject | IAlias> | undefined)",
-                                            value: input.schemas,
-                                        })) &&
-                                        $vo33(
-                                            input.schemas,
-                                            _path + ".schemas",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".schemas",
-                                        expected:
-                                            "(Record<string, IObject | IAlias> | undefined)",
-                                        value: input.schemas,
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo33 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                false === _exceptionable ||
-                                    Object.keys(input)
-                                        .map((key: any) => {
-                                            const value = input[key];
-                                            if (undefined === value)
-                                                return true;
-                                            if (RegExp(/(.*)/).test(key))
-                                                return (
-                                                    ((("object" ===
-                                                        typeof value &&
-                                                        null !== value &&
-                                                        false ===
-                                                            Array.isArray(
-                                                                value,
-                                                            )) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    $join(key),
-                                                                expected:
-                                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                                value: value,
-                                                            },
-                                                        )) &&
-                                                        $vu2(
-                                                            value,
-                                                            _path + $join(key),
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path + $join(key),
-                                                        expected:
-                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                        value: value,
-                                                    })
-                                                );
-                                            return true;
-                                        })
-                                        .every((flag: boolean) => flag),
-                            ].every((flag: boolean) => flag);
-                        const $vo34 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                                "object" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"object"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.nullable ||
-                                    "boolean" === typeof input.nullable ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".nullable",
-                                        expected: "(boolean | undefined)",
-                                        value: input.nullable,
-                                    }),
-                                ((("object" === typeof input.properties &&
-                                    null !== input.properties &&
-                                    false ===
-                                        Array.isArray(input.properties)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".properties",
-                                        expected: "Record<string, IJsonSchema>",
-                                        value: input.properties,
-                                    })) &&
-                                    $vo35(
-                                        input.properties,
-                                        _path + ".properties",
-                                        true && _exceptionable,
-                                    )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".properties",
-                                        expected: "Record<string, IJsonSchema>",
-                                        value: input.properties,
-                                    }),
-                                undefined === input.patternProperties ||
-                                    ((("object" ===
-                                        typeof input.patternProperties &&
-                                        null !== input.patternProperties &&
-                                        false ===
-                                            Array.isArray(
-                                                input.patternProperties,
-                                            )) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".patternProperties",
-                                            expected:
-                                                "(Record<string, IJsonSchema> | undefined)",
-                                            value: input.patternProperties,
-                                        })) &&
-                                        $vo35(
-                                            input.patternProperties,
-                                            _path + ".patternProperties",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".patternProperties",
-                                        expected:
-                                            "(Record<string, IJsonSchema> | undefined)",
-                                        value: input.patternProperties,
-                                    }),
-                                undefined === input.additionalProperties ||
-                                    ((("object" ===
-                                        typeof input.additionalProperties &&
-                                        null !== input.additionalProperties &&
-                                        false ===
-                                            Array.isArray(
-                                                input.additionalProperties,
-                                            )) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + ".additionalProperties",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                            value: input.additionalProperties,
-                                        })) &&
-                                        $vu0(
-                                            input.additionalProperties,
-                                            _path + ".additionalProperties",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".additionalProperties",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                        value: input.additionalProperties,
-                                    }),
-                                undefined === input.required ||
-                                    ((Array.isArray(input.required) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".required",
-                                            expected:
-                                                "(Array<string> | undefined)",
-                                            value: input.required,
-                                        })) &&
-                                        input.required
-                                            .map(
-                                                (elem: any, _index37: number) =>
-                                                    "string" === typeof elem ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            ".required[" +
-                                                            _index37 +
-                                                            "]",
-                                                        expected: "string",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".required",
-                                        expected: "(Array<string> | undefined)",
-                                        value: input.required,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index38: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index38 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index38 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index38 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
                                 undefined ===
                                     input["x-typia-patternProperties"] ||
                                     ((("object" ===
@@ -5170,7 +4979,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                 "x-typia-patternProperties"
                                             ],
                                         })) &&
-                                        $vo35(
+                                        $vo34(
                                             input["x-typia-patternProperties"],
                                             _path +
                                                 '["x-typia-patternProperties"]',
@@ -5207,7 +5016,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                 _path +
                                                 '["x-typia-additionalProperties"]',
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                             value: input[
                                                 "x-typia-additionalProperties"
                                             ],
@@ -5225,13 +5034,13 @@ export const test_createValidateStringify_UltimateUnion =
                                             _path +
                                             '["x-typia-additionalProperties"]',
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                         value: input[
                                             "x-typia-additionalProperties"
                                         ],
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo35 = (
+                        const $vo34 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5259,7 +5068,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                                     _path +
                                                                     $join(key),
                                                                 expected:
-                                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                                 value: value,
                                                             },
                                                         )) &&
@@ -5273,7 +5082,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         path:
                                                             _path + $join(key),
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: value,
                                                     })
                                                 );
@@ -5281,7 +5090,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         })
                                         .every((flag: boolean) => flag),
                             ].every((flag: boolean) => flag);
-                        const $vo36 = (
+                        const $vo35 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5295,13 +5104,13 @@ export const test_createValidateStringify_UltimateUnion =
                                     })) &&
                                     input["enum"]
                                         .map(
-                                            (elem: any, _index39: number) =>
+                                            (elem: any, _index37: number) =>
                                                 "boolean" === typeof elem ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["enum"][' +
-                                                        _index39 +
+                                                        _index37 +
                                                         "]",
                                                     expected: "boolean",
                                                     value: elem,
@@ -5367,7 +5176,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index40: number) =>
+                                                (elem: any, _index38: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5377,7 +5186,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index40 +
+                                                                    _index38 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5388,7 +5197,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index40 +
+                                                                _index38 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5397,7 +5206,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index40 +
+                                                            _index38 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5424,7 +5233,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index41: number) =>
+                                                (elem: any, _index39: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5434,7 +5243,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index41 +
+                                                                    _index39 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -5445,7 +5254,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index41 +
+                                                                _index39 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5454,7 +5263,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index41 +
+                                                            _index39 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5508,7 +5317,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         value: input.$recursiveAnchor,
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo37 = (
+                        const $vo36 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5522,14 +5331,14 @@ export const test_createValidateStringify_UltimateUnion =
                                     })) &&
                                     input["enum"]
                                         .map(
-                                            (elem: any, _index42: number) =>
+                                            (elem: any, _index40: number) =>
                                                 ("number" === typeof elem &&
                                                     Number.isFinite(elem)) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["enum"][' +
-                                                        _index42 +
+                                                        _index40 +
                                                         "]",
                                                     expected: "number",
                                                     value: elem,
@@ -5596,7 +5405,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index43: number) =>
+                                                (elem: any, _index41: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5606,7 +5415,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index43 +
+                                                                    _index41 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5617,7 +5426,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index43 +
+                                                                _index41 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5626,7 +5435,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index43 +
+                                                            _index41 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5653,7 +5462,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index44: number) =>
+                                                (elem: any, _index42: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5663,7 +5472,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index44 +
+                                                                    _index42 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -5674,7 +5483,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index44 +
+                                                                _index42 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5683,7 +5492,234 @@ export const test_createValidateStringify_UltimateUnion =
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
+                                                            _index42 +
+                                                            "]",
+                                                        expected:
+                                                            "IJsDocTagInfo",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-jsDocTags"]',
+                                        expected:
+                                            "(Array<IJsDocTagInfo> | undefined)",
+                                        value: input["x-typia-jsDocTags"],
+                                    }),
+                                undefined === input["x-typia-required"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-required"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-required"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-required"],
+                                    }),
+                                undefined === input["x-typia-optional"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-optional"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-optional"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-optional"],
+                                    }),
+                                undefined === input["x-typia-rest"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-rest"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-rest"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-rest"],
+                                    }),
+                                undefined === input.$id ||
+                                    "string" === typeof input.$id ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$id",
+                                        expected: "(string | undefined)",
+                                        value: input.$id,
+                                    }),
+                                undefined === input.$recursiveAnchor ||
+                                    "boolean" ===
+                                        typeof input.$recursiveAnchor ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$recursiveAnchor",
+                                        expected: "(boolean | undefined)",
+                                        value: input.$recursiveAnchor,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo37 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                ((Array.isArray(input["enum"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["enum"]',
+                                        expected: "Array<string>",
+                                        value: input["enum"],
+                                    })) &&
+                                    input["enum"]
+                                        .map(
+                                            (elem: any, _index43: number) =>
+                                                "string" === typeof elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["enum"][' +
+                                                        _index43 +
+                                                        "]",
+                                                    expected: "string",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["enum"]',
+                                        expected: "Array<string>",
+                                        value: input["enum"],
+                                    }),
+                                undefined === input["default"] ||
+                                    "string" === typeof input["default"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["default"]',
+                                        expected: "(string | undefined)",
+                                        value: input["default"],
+                                    }),
+                                "string" === input.type ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".type",
+                                        expected: '"string"',
+                                        value: input.type,
+                                    }),
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".nullable",
+                                        expected: "(boolean | undefined)",
+                                        value: input.nullable,
+                                    }),
+                                undefined === input.deprecated ||
+                                    "boolean" === typeof input.deprecated ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".deprecated",
+                                        expected: "(boolean | undefined)",
+                                        value: input.deprecated,
+                                    }),
+                                undefined === input.title ||
+                                    "string" === typeof input.title ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".title",
+                                        expected: "(string | undefined)",
+                                        value: input.title,
+                                    }),
+                                undefined === input.description ||
+                                    "string" === typeof input.description ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".description",
+                                        expected: "(string | undefined)",
+                                        value: input.description,
+                                    }),
+                                undefined === input["x-typia-metaTags"] ||
+                                    ((Array.isArray(
+                                        input["x-typia-metaTags"],
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + '["x-typia-metaTags"]',
+                                            expected:
+                                                "(Array<IMetadataTag> | undefined)",
+                                            value: input["x-typia-metaTags"],
+                                        })) &&
+                                        input["x-typia-metaTags"]
+                                            .map(
+                                                (elem: any, _index44: number) =>
+                                                    ((("object" ===
+                                                        typeof elem &&
+                                                        null !== elem) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    '["x-typia-metaTags"][' +
+                                                                    _index44 +
+                                                                    "]",
+                                                                expected:
+                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                        $vu1(
+                                                            elem,
+                                                            _path +
+                                                                '["x-typia-metaTags"][' +
+                                                                _index44 +
+                                                                "]",
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-metaTags"][' +
                                                             _index44 +
+                                                            "]",
+                                                        expected:
+                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-metaTags"]',
+                                        expected:
+                                            "(Array<IMetadataTag> | undefined)",
+                                        value: input["x-typia-metaTags"],
+                                    }),
+                                undefined === input["x-typia-jsDocTags"] ||
+                                    ((Array.isArray(
+                                        input["x-typia-jsDocTags"],
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + '["x-typia-jsDocTags"]',
+                                            expected:
+                                                "(Array<IJsDocTagInfo> | undefined)",
+                                            value: input["x-typia-jsDocTags"],
+                                        })) &&
+                                        input["x-typia-jsDocTags"]
+                                            .map(
+                                                (elem: any, _index45: number) =>
+                                                    ((("object" ===
+                                                        typeof elem &&
+                                                        null !== elem) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    '["x-typia-jsDocTags"][' +
+                                                                    _index45 +
+                                                                    "]",
+                                                                expected:
+                                                                    "IJsDocTagInfo",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                        $vo17(
+                                                            elem,
+                                                            _path +
+                                                                '["x-typia-jsDocTags"][' +
+                                                                _index45 +
+                                                                "]",
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-jsDocTags"][' +
+                                                            _index45 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5743,43 +5779,17 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input["enum"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["enum"]',
-                                        expected: "Array<string>",
-                                        value: input["enum"],
-                                    })) &&
-                                    input["enum"]
-                                        .map(
-                                            (elem: any, _index45: number) =>
-                                                "string" === typeof elem ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["enum"][' +
-                                                        _index45 +
-                                                        "]",
-                                                    expected: "string",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["enum"]',
-                                        expected: "Array<string>",
-                                        value: input["enum"],
-                                    }),
                                 undefined === input["default"] ||
-                                    "string" === typeof input["default"] ||
+                                    "boolean" === typeof input["default"] ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(string | undefined)",
+                                        expected: "(boolean | undefined)",
                                         value: input["default"],
                                     }),
-                                "string" === input.type ||
+                                "boolean" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"string"',
+                                        expected: '"boolean"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -5970,17 +5980,79 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
+                                undefined === input.minimum ||
+                                    ("number" === typeof input.minimum &&
+                                        Number.isFinite(input.minimum) &&
+                                        (parseInt(input.minimum) ===
+                                            input.minimum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "(number | undefined)",
+                                        value: input.minimum,
+                                    }),
+                                undefined === input.maximum ||
+                                    ("number" === typeof input.maximum &&
+                                        Number.isFinite(input.maximum) &&
+                                        (parseInt(input.maximum) ===
+                                            input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "(number | undefined)",
+                                        value: input.maximum,
+                                    }),
+                                undefined === input.exclusiveMinimum ||
+                                    "boolean" ===
+                                        typeof input.exclusiveMinimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected: "(boolean | undefined)",
+                                        value: input.exclusiveMinimum,
+                                    }),
+                                undefined === input.exclusiveMaximum ||
+                                    "boolean" ===
+                                        typeof input.exclusiveMaximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMaximum",
+                                        expected: "(boolean | undefined)",
+                                        value: input.exclusiveMaximum,
+                                    }),
+                                undefined === input.multipleOf ||
+                                    ("number" === typeof input.multipleOf &&
+                                        Number.isFinite(input.multipleOf) &&
+                                        (parseInt(input.multipleOf) ===
+                                            input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "(number | undefined)",
+                                        value: input.multipleOf,
+                                    }),
                                 undefined === input["default"] ||
-                                    "boolean" === typeof input["default"] ||
+                                    ("number" === typeof input["default"] &&
+                                        Number.isFinite(input["default"])) ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(boolean | undefined)",
+                                        expected: "(number | undefined)",
                                         value: input["default"],
                                     }),
-                                "boolean" === input.type ||
+                                "integer" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"boolean"',
+                                        expected: '"integer"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6173,14 +6245,7 @@ export const test_createValidateStringify_UltimateUnion =
                             [
                                 undefined === input.minimum ||
                                     ("number" === typeof input.minimum &&
-                                        Number.isFinite(input.minimum) &&
-                                        (parseInt(input.minimum) ===
-                                            input.minimum ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minimum",
-                                                expected: "number (@type int)",
-                                                value: input.minimum,
-                                            }))) ||
+                                        Number.isFinite(input.minimum)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
                                         expected: "(number | undefined)",
@@ -6188,14 +6253,7 @@ export const test_createValidateStringify_UltimateUnion =
                                     }),
                                 undefined === input.maximum ||
                                     ("number" === typeof input.maximum &&
-                                        Number.isFinite(input.maximum) &&
-                                        (parseInt(input.maximum) ===
-                                            input.maximum ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".maximum",
-                                                expected: "number (@type int)",
-                                                value: input.maximum,
-                                            }))) ||
+                                        Number.isFinite(input.maximum)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "(number | undefined)",
@@ -6219,14 +6277,7 @@ export const test_createValidateStringify_UltimateUnion =
                                     }),
                                 undefined === input.multipleOf ||
                                     ("number" === typeof input.multipleOf &&
-                                        Number.isFinite(input.multipleOf) &&
-                                        (parseInt(input.multipleOf) ===
-                                            input.multipleOf ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".multipleOf",
-                                                expected: "number (@type int)",
-                                                value: input.multipleOf,
-                                            }))) ||
+                                        Number.isFinite(input.multipleOf)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "(number | undefined)",
@@ -6240,10 +6291,10 @@ export const test_createValidateStringify_UltimateUnion =
                                         expected: "(number | undefined)",
                                         value: input["default"],
                                     }),
-                                "integer" === input.type ||
+                                "number" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"integer"',
+                                        expected: '"number"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6434,58 +6485,73 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                undefined === input.minimum ||
-                                    ("number" === typeof input.minimum &&
-                                        Number.isFinite(input.minimum)) ||
+                                undefined === input.minLength ||
+                                    ("number" === typeof input.minLength &&
+                                        Number.isFinite(input.minLength) &&
+                                        (parseInt(input.minLength) ===
+                                            input.minLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
+                                            })) &&
+                                        (0 <= input.minLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
+                                            }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".minimum",
+                                        path: _path + ".minLength",
                                         expected: "(number | undefined)",
-                                        value: input.minimum,
+                                        value: input.minLength,
                                     }),
-                                undefined === input.maximum ||
-                                    ("number" === typeof input.maximum &&
-                                        Number.isFinite(input.maximum)) ||
+                                undefined === input.maxLength ||
+                                    ("number" === typeof input.maxLength &&
+                                        Number.isFinite(input.maxLength) &&
+                                        (parseInt(input.maxLength) ===
+                                            input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".maximum",
+                                        path: _path + ".maxLength",
                                         expected: "(number | undefined)",
-                                        value: input.maximum,
+                                        value: input.maxLength,
                                     }),
-                                undefined === input.exclusiveMinimum ||
-                                    "boolean" ===
-                                        typeof input.exclusiveMinimum ||
+                                undefined === input.pattern ||
+                                    "string" === typeof input.pattern ||
                                     $report(_exceptionable, {
-                                        path: _path + ".exclusiveMinimum",
-                                        expected: "(boolean | undefined)",
-                                        value: input.exclusiveMinimum,
+                                        path: _path + ".pattern",
+                                        expected: "(string | undefined)",
+                                        value: input.pattern,
                                     }),
-                                undefined === input.exclusiveMaximum ||
-                                    "boolean" ===
-                                        typeof input.exclusiveMaximum ||
+                                undefined === input.format ||
+                                    "string" === typeof input.format ||
                                     $report(_exceptionable, {
-                                        path: _path + ".exclusiveMaximum",
-                                        expected: "(boolean | undefined)",
-                                        value: input.exclusiveMaximum,
-                                    }),
-                                undefined === input.multipleOf ||
-                                    ("number" === typeof input.multipleOf &&
-                                        Number.isFinite(input.multipleOf)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".multipleOf",
-                                        expected: "(number | undefined)",
-                                        value: input.multipleOf,
+                                        path: _path + ".format",
+                                        expected: "(string | undefined)",
+                                        value: input.format,
                                     }),
                                 undefined === input["default"] ||
-                                    ("number" === typeof input["default"] &&
-                                        Number.isFinite(input["default"])) ||
+                                    "string" === typeof input["default"] ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(number | undefined)",
+                                        expected: "(string | undefined)",
                                         value: input["default"],
                                     }),
-                                "number" === input.type ||
+                                "string" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"number"',
+                                        expected: '"string"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6676,73 +6742,93 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                undefined === input.minLength ||
-                                    ("number" === typeof input.minLength &&
-                                        Number.isFinite(input.minLength) &&
-                                        (parseInt(input.minLength) ===
-                                            input.minLength ||
+                                ((("object" === typeof input.items &&
+                                    null !== input.items &&
+                                    false === Array.isArray(input.items)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: input.items,
+                                    })) &&
+                                    $vu0(
+                                        input.items,
+                                        _path + ".items",
+                                        true && _exceptionable,
+                                    )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: input.items,
+                                    }),
+                                undefined === input.minItems ||
+                                    ("number" === typeof input.minItems &&
+                                        Number.isFinite(input.minItems) &&
+                                        (parseInt(input.minItems) ===
+                                            input.minItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".minLength",
+                                                path: _path + ".minItems",
                                                 expected: "number (@type uint)",
-                                                value: input.minLength,
+                                                value: input.minItems,
                                             })) &&
-                                        (0 <= input.minLength ||
+                                        (0 <= input.minItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".minLength",
+                                                path: _path + ".minItems",
                                                 expected: "number (@type uint)",
-                                                value: input.minLength,
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "(number | undefined)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     }),
-                                undefined === input.maxLength ||
-                                    ("number" === typeof input.maxLength &&
-                                        Number.isFinite(input.maxLength) &&
-                                        (parseInt(input.maxLength) ===
-                                            input.maxLength ||
+                                undefined === input.maxItems ||
+                                    ("number" === typeof input.maxItems &&
+                                        Number.isFinite(input.maxItems) &&
+                                        (parseInt(input.maxItems) ===
+                                            input.maxItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".maxLength",
+                                                path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
-                                                value: input.maxLength,
+                                                value: input.maxItems,
                                             })) &&
-                                        (0 <= input.maxLength ||
+                                        (0 <= input.maxItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".maxLength",
+                                                path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
-                                                value: input.maxLength,
+                                                value: input.maxItems,
                                             }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "(number | undefined)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     }),
-                                undefined === input.pattern ||
-                                    "string" === typeof input.pattern ||
+                                undefined === input["x-typia-tuple"] ||
+                                    ((("object" ===
+                                        typeof input["x-typia-tuple"] &&
+                                        null !== input["x-typia-tuple"]) ||
+                                        $report(_exceptionable, {
+                                            path: _path + '["x-typia-tuple"]',
+                                            expected:
+                                                "(IJsonSchema.ITuple | undefined)",
+                                            value: input["x-typia-tuple"],
+                                        })) &&
+                                        $vo26(
+                                            input["x-typia-tuple"],
+                                            _path + '["x-typia-tuple"]',
+                                            true && _exceptionable,
+                                        )) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".pattern",
-                                        expected: "(string | undefined)",
-                                        value: input.pattern,
+                                        path: _path + '["x-typia-tuple"]',
+                                        expected:
+                                            "(IJsonSchema.ITuple | undefined)",
+                                        value: input["x-typia-tuple"],
                                     }),
-                                undefined === input.format ||
-                                    "string" === typeof input.format ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".format",
-                                        expected: "(string | undefined)",
-                                        value: input.format,
-                                    }),
-                                undefined === input["default"] ||
-                                    "string" === typeof input["default"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["default"]',
-                                        expected: "(string | undefined)",
-                                        value: input["default"],
-                                    }),
-                                "string" === input.type ||
+                                "array" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"string"',
+                                        expected: '"array"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6933,45 +7019,72 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((("object" === typeof input.items &&
-                                    null !== input.items &&
-                                    false === Array.isArray(input.items)) ||
+                                ((Array.isArray(input.items) ||
                                     $report(_exceptionable, {
                                         path: _path + ".items",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        expected: "Array<IJsonSchema>",
                                         value: input.items,
                                     })) &&
-                                    $vu0(
-                                        input.items,
-                                        _path + ".items",
-                                        true && _exceptionable,
-                                    )) ||
+                                    input.items
+                                        .map(
+                                            (elem: any, _index56: number) =>
+                                                ((("object" === typeof elem &&
+                                                    null !== elem &&
+                                                    false ===
+                                                        Array.isArray(elem)) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".items[" +
+                                                            _index56 +
+                                                            "]",
+                                                        expected:
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        value: elem,
+                                                    })) &&
+                                                    $vu0(
+                                                        elem,
+                                                        _path +
+                                                            ".items[" +
+                                                            _index56 +
+                                                            "]",
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index56 +
+                                                        "]",
+                                                    expected:
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".items",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        expected: "Array<IJsonSchema>",
                                         value: input.items,
                                     }),
-                                undefined === input.minItems ||
-                                    ("number" === typeof input.minItems &&
-                                        Number.isFinite(input.minItems) &&
-                                        (parseInt(input.minItems) ===
-                                            input.minItems ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minItems",
-                                                expected: "number (@type uint)",
-                                                value: input.minItems,
-                                            })) &&
-                                        (0 <= input.minItems ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minItems",
-                                                expected: "number (@type uint)",
-                                                value: input.minItems,
-                                            }))) ||
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
-                                        expected: "(number | undefined)",
+                                        expected: "number",
                                         value: input.minItems,
                                     }),
                                 undefined === input.maxItems ||
@@ -6994,27 +7107,6 @@ export const test_createValidateStringify_UltimateUnion =
                                         path: _path + ".maxItems",
                                         expected: "(number | undefined)",
                                         value: input.maxItems,
-                                    }),
-                                undefined === input["x-typia-tuple"] ||
-                                    ((("object" ===
-                                        typeof input["x-typia-tuple"] &&
-                                        null !== input["x-typia-tuple"]) ||
-                                        $report(_exceptionable, {
-                                            path: _path + '["x-typia-tuple"]',
-                                            expected:
-                                                "(IJsonSchema.ITuple | undefined)",
-                                            value: input["x-typia-tuple"],
-                                        })) &&
-                                        $vo26(
-                                            input["x-typia-tuple"],
-                                            _path + '["x-typia-tuple"]',
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-tuple"]',
-                                        expected:
-                                            "(IJsonSchema.ITuple | undefined)",
-                                        value: input["x-typia-tuple"],
                                     }),
                                 "array" === input.type ||
                                     $report(_exceptionable, {
@@ -7063,7 +7155,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index56: number) =>
+                                                (elem: any, _index57: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7073,7 +7165,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index56 +
+                                                                    _index57 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7084,7 +7176,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index56 +
+                                                                _index57 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7093,7 +7185,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index56 +
+                                                            _index57 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7120,7 +7212,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index57: number) =>
+                                                (elem: any, _index58: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7130,7 +7222,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index57 +
+                                                                    _index58 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -7141,7 +7233,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index57 +
+                                                                _index58 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7150,7 +7242,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index57 +
+                                                            _index58 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -7210,15 +7302,15 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input.items) ||
+                                ((Array.isArray(input.oneOf) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".items",
+                                        path: _path + ".oneOf",
                                         expected: "Array<IJsonSchema>",
-                                        value: input.items,
+                                        value: input.oneOf,
                                     })) &&
-                                    input.items
+                                    input.oneOf
                                         .map(
-                                            (elem: any, _index58: number) =>
+                                            (elem: any, _index59: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem &&
                                                     false ===
@@ -7226,50 +7318,37 @@ export const test_createValidateStringify_UltimateUnion =
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
-                                                            ".items[" +
-                                                            _index58 +
+                                                            ".oneOf[" +
+                                                            _index59 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
                                                         elem,
                                                         _path +
-                                                            ".items[" +
-                                                            _index58 +
+                                                            ".oneOf[" +
+                                                            _index59 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
-                                                        ".items[" +
-                                                        _index58 +
+                                                        ".oneOf[" +
+                                                        _index59 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
                                         .every((flag: boolean) => flag)) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".items",
+                                        path: _path + ".oneOf",
                                         expected: "Array<IJsonSchema>",
-                                        value: input.items,
-                                    }),
-                                "array" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"array"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.nullable ||
-                                    "boolean" === typeof input.nullable ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".nullable",
-                                        expected: "(boolean | undefined)",
-                                        value: input.nullable,
+                                        value: input.oneOf,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7305,7 +7384,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index59: number) =>
+                                                (elem: any, _index60: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7315,7 +7394,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index59 +
+                                                                    _index60 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7326,7 +7405,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index59 +
+                                                                _index60 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7335,7 +7414,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index59 +
+                                                            _index60 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7362,7 +7441,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index60: number) =>
+                                                (elem: any, _index61: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7372,7 +7451,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index60 +
+                                                                    _index61 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -7383,7 +7462,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index60 +
+                                                                _index61 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7392,7 +7471,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index60 +
+                                                            _index61 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -7452,53 +7531,11 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input.oneOf) ||
+                                "string" === typeof input.$ref ||
                                     $report(_exceptionable, {
-                                        path: _path + ".oneOf",
-                                        expected: "Array<IJsonSchema>",
-                                        value: input.oneOf,
-                                    })) &&
-                                    input.oneOf
-                                        .map(
-                                            (elem: any, _index61: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem &&
-                                                    false ===
-                                                        Array.isArray(elem)) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            ".oneOf[" +
-                                                            _index61 +
-                                                            "]",
-                                                        expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu0(
-                                                        elem,
-                                                        _path +
-                                                            ".oneOf[" +
-                                                            _index61 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        ".oneOf[" +
-                                                        _index61 +
-                                                        "]",
-                                                    expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".oneOf",
-                                        expected: "Array<IJsonSchema>",
-                                        value: input.oneOf,
+                                        path: _path + ".$ref",
+                                        expected: "string",
+                                        value: input.$ref,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7681,11 +7718,11 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$ref ||
+                                "null" === input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$ref",
-                                        expected: "string",
-                                        value: input.$ref,
+                                        path: _path + ".type",
+                                        expected: '"null"',
+                                        value: input.type,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7868,12 +7905,18 @@ export const test_createValidateStringify_UltimateUnion =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$recursiveRef ||
+                                (null !== input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$recursiveRef",
-                                        expected: "string",
-                                        value: input.$recursiveRef,
-                                    }),
+                                        path: _path + ".type",
+                                        expected: "undefined",
+                                        value: input.type,
+                                    })) &&
+                                    (undefined === input.type ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".type",
+                                            expected: "undefined",
+                                            value: input.type,
+                                        })),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
                                     $report(_exceptionable, {
@@ -8049,386 +8092,6 @@ export const test_createValidateStringify_UltimateUnion =
                                         value: input.$recursiveAnchor,
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo48 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                "null" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"null"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
-                                    }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index68: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index68 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index68 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index68 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index69: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index69 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index69 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index69 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo49 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                (null !== input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: "undefined",
-                                        value: input.type,
-                                    })) &&
-                                    (undefined === input.type ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".type",
-                                            expected: "undefined",
-                                            value: input.type,
-                                        })),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
-                                    }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index70: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index70 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index70 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index70 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index71: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index71 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index71 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index71 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                            ].every((flag: boolean) => flag);
                         const $vu0 = (
                             input: any,
                             _path: string,
@@ -8460,7 +8123,7 @@ export const test_createValidateStringify_UltimateUnion =
                                     Array.isArray(input.items) &&
                                     input.items
                                         .map(
-                                            (elem: any, _index72: number) =>
+                                            (elem: any, _index68: number) =>
                                                 "object" === typeof elem &&
                                                 null !== elem &&
                                                 false === Array.isArray(elem) &&
@@ -8468,7 +8131,7 @@ export const test_createValidateStringify_UltimateUnion =
                                                     elem,
                                                     _path +
                                                         ".items[" +
-                                                        _index72 +
+                                                        _index68 +
                                                         "]",
                                                     false && _exceptionable,
                                                 ),
@@ -8492,14 +8155,8 @@ export const test_createValidateStringify_UltimateUnion =
                                         _path,
                                         true && _exceptionable,
                                     );
-                                if (undefined !== input.$recursiveRef)
-                                    return $vo29(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
                                 if ("null" === input.type)
-                                    return $vo30(
+                                    return $vo29(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8535,7 +8192,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo31(input, _path, false && _exceptionable)
+                                    $vo30(input, _path, false && _exceptionable)
                                 );
                             })();
                         const $vu1 = (
@@ -8648,13 +8305,13 @@ export const test_createValidateStringify_UltimateUnion =
                         ): any =>
                             (() => {
                                 if ("object" === input.type)
-                                    return $vo34(
+                                    return $vo33(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("integer" === input.type)
-                                    return $vo40(
+                                    return $vo39(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8669,7 +8326,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         false && _exceptionable,
                                     )
                                 )
-                                    return $vo43(
+                                    return $vo42(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8678,7 +8335,7 @@ export const test_createValidateStringify_UltimateUnion =
                                     Array.isArray(input.items) &&
                                     input.items
                                         .map(
-                                            (elem: any, _index73: number) =>
+                                            (elem: any, _index69: number) =>
                                                 "object" === typeof elem &&
                                                 null !== elem &&
                                                 false === Array.isArray(elem) &&
@@ -8686,48 +8343,37 @@ export const test_createValidateStringify_UltimateUnion =
                                                     elem,
                                                     _path +
                                                         ".items[" +
-                                                        _index73 +
+                                                        _index69 +
                                                         "]",
                                                     false && _exceptionable,
                                                 ),
                                         )
                                         .every((flag: boolean) => flag)
                                 )
-                                    return $vo44(
+                                    return $vo43(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.oneOf)
-                                    return $vo45(
+                                    return $vo44(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.$ref)
-                                    return $vo46(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
-                                if (undefined !== input.$recursiveRef)
-                                    return $vo47(
+                                    return $vo45(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("null" === input.type)
-                                    return $vo48(
+                                    return $vo46(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 return (
-                                    $vo38(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
                                     $vo37(
                                         input,
                                         _path,
@@ -8738,7 +8384,17 @@ export const test_createValidateStringify_UltimateUnion =
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo39(
+                                    $vo35(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $vo38(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $vo40(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -8748,12 +8404,7 @@ export const test_createValidateStringify_UltimateUnion =
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo42(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
-                                    $vo49(input, _path, false && _exceptionable)
+                                    $vo47(input, _path, false && _exceptionable)
                                 );
                             })();
                         return (
@@ -9207,6 +8858,13 @@ export const test_createValidateStringify_UltimateUnion =
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9306,36 +8964,6 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -9365,7 +8993,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -9396,13 +9024,13 @@ export const test_createValidateStringify_UltimateUnion =
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -9415,23 +9043,21 @@ export const test_createValidateStringify_UltimateUnion =
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -9461,7 +9087,7 @@ export const test_createValidateStringify_UltimateUnion =
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -9471,7 +9097,7 @@ export const test_createValidateStringify_UltimateUnion =
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -9484,7 +9110,7 @@ export const test_createValidateStringify_UltimateUnion =
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -9526,7 +9152,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "number" === typeof elem,
@@ -9568,7 +9194,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -9610,7 +9236,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -9648,7 +9274,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             parseInt(input.minimum) === input.minimum)) &&
@@ -9699,7 +9325,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         "number" === typeof input.minimum) &&
                     (undefined === input.maximum ||
@@ -9747,7 +9373,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             parseInt(input.minLength) === input.minLength &&
@@ -9797,7 +9423,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -9849,7 +9475,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -9858,6 +9484,13 @@ export const test_createValidateStringify_UltimateUnion =
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9893,7 +9526,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -9934,7 +9567,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -9968,41 +9601,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -10036,7 +9635,7 @@ export const test_createValidateStringify_UltimateUnion =
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -10094,9 +9693,7 @@ export const test_createValidateStringify_UltimateUnion =
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (
                             $io20(input) ||
                             $io19(input) ||
@@ -10104,7 +9701,7 @@ export const test_createValidateStringify_UltimateUnion =
                             $io21(input) ||
                             $io23(input) ||
                             $io24(input) ||
-                            $io31(input)
+                            $io30(input)
                         );
                     })();
                 const $iu1 = (input: any): any =>
@@ -10130,15 +9727,15 @@ export const test_createValidateStringify_UltimateUnion =
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -10149,20 +9746,18 @@ export const test_createValidateStringify_UltimateUnion =
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (
-                            $io38(input) ||
                             $io37(input) ||
                             $io36(input) ||
-                            $io39(input) ||
+                            $io35(input) ||
+                            $io38(input) ||
+                            $io40(input) ||
                             $io41(input) ||
-                            $io42(input) ||
-                            $io49(input)
+                            $io47(input)
                         );
                     })();
                 const $string = (typia.createValidateStringify as any).string;
@@ -10173,7 +9768,7 @@ export const test_createValidateStringify_UltimateUnion =
                 const $so0 = (input: any): any =>
                     `{"schemas":${`[${input.schemas
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"components":${$so32(
+                        .join(",")}]`},"components":${$so31(
                         input.components,
                     )},"purpose":${(() => {
                         if ("string" === typeof input.purpose)
@@ -11284,6 +10879,14 @@ export const test_createValidateStringify_UltimateUnion =
                     })()}}`;
                 const $so26 = (input: any): any =>
                     `{${
+                        undefined === input.maxItems
+                            ? ""
+                            : `"maxItems":${
+                                  undefined !== input.maxItems
+                                      ? $number(input.maxItems)
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.nullable
                             ? ""
                             : `"nullable":${
@@ -11361,7 +10964,9 @@ export const test_createValidateStringify_UltimateUnion =
                               },`
                     }"items":${`[${input.items
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"type":${(() => {
+                        .join(",")}]`},"minItems":${$number(
+                        input.minItems,
+                    )},"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
                         if ("string" === typeof input.type)
@@ -11582,76 +11187,6 @@ export const test_createValidateStringify_UltimateUnion =
                                       ? input["x-typia-rest"]
                                       : undefined
                               },`
-                    }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-                const $so30 = (input: any): any =>
-                    `{${
-                        undefined === input.deprecated
-                            ? ""
-                            : `"deprecated":${
-                                  undefined !== input.deprecated
-                                      ? input.deprecated
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.title
-                            ? ""
-                            : `"title":${
-                                  undefined !== input.title
-                                      ? $string(input.title)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.description
-                            ? ""
-                            : `"description":${
-                                  undefined !== input.description
-                                      ? $string(input.description)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-metaTags"]
-                            ? ""
-                            : `"x-typia-metaTags":${
-                                  undefined !== input["x-typia-metaTags"]
-                                      ? `[${input["x-typia-metaTags"]
-                                            .map((elem: any) => $su1(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-jsDocTags"]
-                            ? ""
-                            : `"x-typia-jsDocTags":${
-                                  undefined !== input["x-typia-jsDocTags"]
-                                      ? `[${input["x-typia-jsDocTags"]
-                                            .map((elem: any) => $so17(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-required"]
-                            ? ""
-                            : `"x-typia-required":${
-                                  undefined !== input["x-typia-required"]
-                                      ? input["x-typia-required"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-optional"]
-                            ? ""
-                            : `"x-typia-optional":${
-                                  undefined !== input["x-typia-optional"]
-                                      ? input["x-typia-optional"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-rest"]
-                            ? ""
-                            : `"x-typia-rest":${
-                                  undefined !== input["x-typia-rest"]
-                                      ? input["x-typia-rest"]
-                                      : undefined
-                              },`
                     }"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
@@ -11662,7 +11197,7 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so31 = (input: any): any =>
+                const $so30 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.deprecated
@@ -11734,19 +11269,19 @@ export const test_createValidateStringify_UltimateUnion =
                                   }`
                         }`,
                     )}}`;
-                const $so32 = (input: any): any =>
+                const $so31 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.schemas
                                 ? ""
                                 : `"schemas":${
                                       undefined !== input.schemas
-                                          ? $so33(input.schemas)
+                                          ? $so32(input.schemas)
                                           : undefined
                                   }`
                         }`,
                     )}}`;
-                const $so33 = (input: any): any =>
+                const $so32 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
@@ -11754,21 +11289,13 @@ export const test_createValidateStringify_UltimateUnion =
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;
-                const $so34 = (input: any): any =>
+                const $so33 = (input: any): any =>
                     `{${
                         undefined === input.$id
                             ? ""
                             : `"$id":${
                                   undefined !== input.$id
                                       ? $string(input.$id)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$recursiveAnchor
-                            ? ""
-                            : `"$recursiveAnchor":${
-                                  undefined !== input.$recursiveAnchor
-                                      ? input.$recursiveAnchor
                                       : undefined
                               },`
                     }${
@@ -11784,7 +11311,7 @@ export const test_createValidateStringify_UltimateUnion =
                             ? ""
                             : `"patternProperties":${
                                   undefined !== input.patternProperties
-                                      ? $so35(input.patternProperties)
+                                      ? $so34(input.patternProperties)
                                       : undefined
                               },`
                     }${
@@ -11829,7 +11356,7 @@ export const test_createValidateStringify_UltimateUnion =
                             : `"x-typia-patternProperties":${
                                   undefined !==
                                   input["x-typia-patternProperties"]
-                                      ? $so35(
+                                      ? $so34(
                                             input["x-typia-patternProperties"],
                                         )
                                       : undefined
@@ -11856,8 +11383,8 @@ export const test_createValidateStringify_UltimateUnion =
                             expected: '"object"',
                             value: input.type,
                         });
-                    })()},"properties":${$so35(input.properties)}}`;
-                const $so35 = (input: any): any =>
+                    })()},"properties":${$so34(input.properties)}}`;
+                const $so34 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
@@ -11865,7 +11392,7 @@ export const test_createValidateStringify_UltimateUnion =
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;
-                const $so36 = (input: any): any =>
+                const $so35 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -11978,7 +11505,7 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so37 = (input: any): any =>
+                const $so36 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -12091,7 +11618,7 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so38 = (input: any): any =>
+                const $so37 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -12204,7 +11731,7 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so39 = (input: any): any =>
+                const $so38 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -12315,7 +11842,7 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so40 = (input: any): any =>
+                const $so39 = (input: any): any =>
                     `{${
                         undefined === input.minimum
                             ? ""
@@ -12466,7 +11993,7 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so41 = (input: any): any =>
+                const $so40 = (input: any): any =>
                     `{${
                         undefined === input.minimum
                             ? ""
@@ -12617,7 +12144,7 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so42 = (input: any): any =>
+                const $so41 = (input: any): any =>
                     `{${
                         undefined === input.minLength
                             ? ""
@@ -12760,7 +12287,7 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so43 = (input: any): any =>
+                const $so42 = (input: any): any =>
                     `{${
                         undefined === input.minItems
                             ? ""
@@ -12887,8 +12414,16 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so44 = (input: any): any =>
+                const $so43 = (input: any): any =>
                     `{${
+                        undefined === input.maxItems
+                            ? ""
+                            : `"maxItems":${
+                                  undefined !== input.maxItems
+                                      ? $number(input.maxItems)
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.nullable
                             ? ""
                             : `"nullable":${
@@ -12982,7 +12517,9 @@ export const test_createValidateStringify_UltimateUnion =
                               },`
                     }"items":${`[${input.items
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"type":${(() => {
+                        .join(",")}]`},"minItems":${$number(
+                        input.minItems,
+                    )},"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
                         if ("string" === typeof input.type)
@@ -12992,7 +12529,7 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so45 = (input: any): any =>
+                const $so44 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -13080,7 +12617,7 @@ export const test_createValidateStringify_UltimateUnion =
                     }"oneOf":${`[${input.oneOf
                         .map((elem: any) => $su0(elem))
                         .join(",")}]`}}`;
-                const $so46 = (input: any): any =>
+                const $so45 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -13166,93 +12703,7 @@ export const test_createValidateStringify_UltimateUnion =
                                       : undefined
                               },`
                     }"$ref":${$string(input.$ref)}}`;
-                const $so47 = (input: any): any =>
-                    `{${
-                        undefined === input.deprecated
-                            ? ""
-                            : `"deprecated":${
-                                  undefined !== input.deprecated
-                                      ? input.deprecated
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.title
-                            ? ""
-                            : `"title":${
-                                  undefined !== input.title
-                                      ? $string(input.title)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.description
-                            ? ""
-                            : `"description":${
-                                  undefined !== input.description
-                                      ? $string(input.description)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-metaTags"]
-                            ? ""
-                            : `"x-typia-metaTags":${
-                                  undefined !== input["x-typia-metaTags"]
-                                      ? `[${input["x-typia-metaTags"]
-                                            .map((elem: any) => $su1(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-jsDocTags"]
-                            ? ""
-                            : `"x-typia-jsDocTags":${
-                                  undefined !== input["x-typia-jsDocTags"]
-                                      ? `[${input["x-typia-jsDocTags"]
-                                            .map((elem: any) => $so17(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-required"]
-                            ? ""
-                            : `"x-typia-required":${
-                                  undefined !== input["x-typia-required"]
-                                      ? input["x-typia-required"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-optional"]
-                            ? ""
-                            : `"x-typia-optional":${
-                                  undefined !== input["x-typia-optional"]
-                                      ? input["x-typia-optional"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-rest"]
-                            ? ""
-                            : `"x-typia-rest":${
-                                  undefined !== input["x-typia-rest"]
-                                      ? input["x-typia-rest"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$id
-                            ? ""
-                            : `"$id":${
-                                  undefined !== input.$id
-                                      ? $string(input.$id)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$recursiveAnchor
-                            ? ""
-                            : `"$recursiveAnchor":${
-                                  undefined !== input.$recursiveAnchor
-                                      ? input.$recursiveAnchor
-                                      : undefined
-                              },`
-                    }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-                const $so48 = (input: any): any =>
+                const $so46 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -13347,7 +12798,7 @@ export const test_createValidateStringify_UltimateUnion =
                             value: input.type,
                         });
                     })()}}`;
-                const $so49 = (input: any): any =>
+                const $so47 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.deprecated
@@ -13458,9 +12909,7 @@ export const test_createValidateStringify_UltimateUnion =
                             return $so26(input);
                         if (undefined !== input.oneOf) return $so27(input);
                         if (undefined !== input.$ref) return $so28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $so29(input);
-                        if ("null" === input.type) return $so30(input);
+                        if ("null" === input.type) return $so29(input);
                         return (() => {
                             if ($io20(input)) return $so20(input);
                             if ($io19(input)) return $so19(input);
@@ -13468,7 +12917,7 @@ export const test_createValidateStringify_UltimateUnion =
                             if ($io21(input)) return $so21(input);
                             if ($io23(input)) return $so23(input);
                             if ($io24(input)) return $so24(input);
-                            if ($io31(input)) return $so31(input);
+                            if ($io30(input)) return $so30(input);
                             $throws({
                                 expected:
                                     '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -13503,15 +12952,15 @@ export const test_createValidateStringify_UltimateUnion =
                     })();
                 const $su2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $so34(input);
-                        if ("integer" === input.type) return $so40(input);
+                        if ("object" === input.type) return $so33(input);
+                        if ("integer" === input.type) return $so39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $so43(input);
+                            return $so42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -13522,20 +12971,18 @@ export const test_createValidateStringify_UltimateUnion =
                                     $iu0(elem),
                             )
                         )
-                            return $so44(input);
-                        if (undefined !== input.oneOf) return $so45(input);
-                        if (undefined !== input.$ref) return $so46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $so47(input);
-                        if ("null" === input.type) return $so48(input);
+                            return $so43(input);
+                        if (undefined !== input.oneOf) return $so44(input);
+                        if (undefined !== input.$ref) return $so45(input);
+                        if ("null" === input.type) return $so46(input);
                         return (() => {
-                            if ($io38(input)) return $so38(input);
                             if ($io37(input)) return $so37(input);
                             if ($io36(input)) return $so36(input);
-                            if ($io39(input)) return $so39(input);
+                            if ($io35(input)) return $so35(input);
+                            if ($io38(input)) return $so38(input);
+                            if ($io40(input)) return $so40(input);
                             if ($io41(input)) return $so41(input);
-                            if ($io42(input)) return $so42(input);
-                            if ($io49(input)) return $so49(input);
+                            if ($io47(input)) return $so47(input);
                             $throws({
                                 expected:
                                     '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/is/test_is_UltimateUnion.ts
+++ b/test/generated/output/is/test_is_UltimateUnion.ts
@@ -20,7 +20,7 @@ export const test_is_UltimateUnion = _test_is(
                 "object" === typeof input.components &&
                 null !== input.components &&
                 false === Array.isArray(input.components) &&
-                $io32(input.components) &&
+                $io31(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose);
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
@@ -449,6 +449,15 @@ export const test_is_UltimateUnion = _test_is(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -548,36 +557,6 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -607,7 +586,7 @@ export const test_is_UltimateUnion = _test_is(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -638,13 +617,13 @@ export const test_is_UltimateUnion = _test_is(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -657,22 +636,20 @@ export const test_is_UltimateUnion = _test_is(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -698,7 +675,7 @@ export const test_is_UltimateUnion = _test_is(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -708,7 +685,7 @@ export const test_is_UltimateUnion = _test_is(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -721,7 +698,7 @@ export const test_is_UltimateUnion = _test_is(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -760,7 +737,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every(
                     (elem: any) =>
@@ -803,7 +780,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -842,7 +819,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -879,7 +856,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
@@ -933,7 +910,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum))) &&
@@ -984,7 +961,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
@@ -1035,7 +1012,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -1088,7 +1065,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -1097,6 +1074,15 @@ export const test_is_UltimateUnion = _test_is(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1131,7 +1117,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -1171,7 +1157,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1204,40 +1190,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1270,7 +1223,7 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -1327,8 +1280,7 @@ export const test_is_UltimateUnion = _test_is(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (() => {
                         if ($io20(input)) return $io20(input);
                         if ($io19(input)) return $io19(input);
@@ -1336,7 +1288,7 @@ export const test_is_UltimateUnion = _test_is(
                         if ($io21(input)) return $io21(input);
                         if ($io23(input)) return $io23(input);
                         if ($io24(input)) return $io24(input);
-                        if ($io31(input)) return $io31(input);
+                        if ($io30(input)) return $io30(input);
                         return false;
                     })();
                 })();
@@ -1361,15 +1313,15 @@ export const test_is_UltimateUnion = _test_is(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -1380,19 +1332,18 @@ export const test_is_UltimateUnion = _test_is(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (() => {
-                        if ($io38(input)) return $io38(input);
                         if ($io37(input)) return $io37(input);
                         if ($io36(input)) return $io36(input);
-                        if ($io39(input)) return $io39(input);
+                        if ($io35(input)) return $io35(input);
+                        if ($io38(input)) return $io38(input);
+                        if ($io40(input)) return $io40(input);
                         if ($io41(input)) return $io41(input);
-                        if ($io42(input)) return $io42(input);
-                        if ($io49(input)) return $io49(input);
+                        if ($io47(input)) return $io47(input);
                         return false;
                     })();
                 })();

--- a/test/generated/output/isClone/test_isClone_UltimateUnion.ts
+++ b/test/generated/output/isClone/test_isClone_UltimateUnion.ts
@@ -23,7 +23,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     "object" === typeof input.components &&
                     null !== input.components &&
                     false === Array.isArray(input.components) &&
-                    $io32(input.components) &&
+                    $io31(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose);
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
@@ -456,6 +456,15 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -555,36 +564,6 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -614,7 +593,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -645,13 +624,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -664,23 +643,21 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -710,7 +687,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -720,7 +697,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -733,7 +710,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -775,7 +752,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) =>
@@ -819,7 +796,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -861,7 +838,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -899,7 +876,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
@@ -954,7 +931,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum))) &&
@@ -1006,7 +983,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
@@ -1058,7 +1035,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -1112,7 +1089,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -1121,6 +1098,15 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1156,7 +1142,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -1197,7 +1183,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1231,41 +1217,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1299,7 +1251,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -1357,9 +1309,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (() => {
                             if ($io20(input)) return $io20(input);
                             if ($io19(input)) return $io19(input);
@@ -1367,7 +1317,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             if ($io21(input)) return $io21(input);
                             if ($io23(input)) return $io23(input);
                             if ($io24(input)) return $io24(input);
-                            if ($io31(input)) return $io31(input);
+                            if ($io30(input)) return $io30(input);
                             return false;
                         })();
                     })();
@@ -1394,15 +1344,15 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -1413,20 +1363,18 @@ export const test_isClone_UltimateUnion = _test_isClone(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (() => {
-                            if ($io38(input)) return $io38(input);
                             if ($io37(input)) return $io37(input);
                             if ($io36(input)) return $io36(input);
-                            if ($io39(input)) return $io39(input);
+                            if ($io35(input)) return $io35(input);
+                            if ($io38(input)) return $io38(input);
+                            if ($io40(input)) return $io40(input);
                             if ($io41(input)) return $io41(input);
-                            if ($io42(input)) return $io42(input);
-                            if ($io49(input)) return $io49(input);
+                            if ($io47(input)) return $io47(input);
                             return false;
                         })();
                     })();
@@ -1843,6 +1791,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1942,36 +1897,6 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -2001,7 +1926,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -2032,13 +1957,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -2051,23 +1976,21 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -2097,7 +2020,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -2107,7 +2030,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -2120,7 +2043,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -2162,7 +2085,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "number" === typeof elem,
@@ -2204,7 +2127,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -2246,7 +2169,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -2284,7 +2207,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             parseInt(input.minimum) === input.minimum)) &&
@@ -2335,7 +2258,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         "number" === typeof input.minimum) &&
                     (undefined === input.maximum ||
@@ -2383,7 +2306,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             parseInt(input.minLength) === input.minLength &&
@@ -2433,7 +2356,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -2485,7 +2408,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -2494,6 +2417,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2529,7 +2459,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -2570,7 +2500,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -2604,41 +2534,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -2672,7 +2568,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -2730,9 +2626,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (
                             $io20(input) ||
                             $io19(input) ||
@@ -2740,7 +2634,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             $io21(input) ||
                             $io23(input) ||
                             $io24(input) ||
-                            $io31(input)
+                            $io30(input)
                         );
                     })();
                 const $iu1 = (input: any): any =>
@@ -2766,15 +2660,15 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -2785,20 +2679,18 @@ export const test_isClone_UltimateUnion = _test_isClone(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (
-                            $io38(input) ||
                             $io37(input) ||
                             $io36(input) ||
-                            $io39(input) ||
+                            $io35(input) ||
+                            $io38(input) ||
+                            $io40(input) ||
                             $io41(input) ||
-                            $io42(input) ||
-                            $io49(input)
+                            $io47(input)
                         );
                     })();
                 const $join = (typia.isClone as any).join;
@@ -2846,7 +2738,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     components:
                         "object" === typeof input.components &&
                         null !== input.components
-                            ? $co32(input.components)
+                            ? $co31(input.components)
                             : (input.components as any),
                     purpose: input.purpose as any,
                 });
@@ -3109,6 +3001,8 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     items: Array.isArray(input.items)
                         ? $cp1(input.items)
                         : (input.items as any),
+                    minItems: input.minItems as any,
+                    maxItems: input.maxItems as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
                     deprecated: input.deprecated as any,
@@ -3163,7 +3057,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     "x-typia-rest": input["x-typia-rest"] as any,
                 });
                 const $co29 = (input: any): any => ({
-                    $recursiveRef: input.$recursiveRef as any,
+                    type: input.type as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
                     description: input.description as any,
@@ -3197,30 +3091,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     "x-typia-rest": input["x-typia-rest"] as any,
                 });
                 const $co31 = (input: any): any => ({
-                    type: input.type as any,
-                    deprecated: input.deprecated as any,
-                    title: input.title as any,
-                    description: input.description as any,
-                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                        ? $cp3(input["x-typia-metaTags"])
-                        : (input["x-typia-metaTags"] as any),
-                    "x-typia-jsDocTags": Array.isArray(
-                        input["x-typia-jsDocTags"],
-                    )
-                        ? $cp4(input["x-typia-jsDocTags"])
-                        : (input["x-typia-jsDocTags"] as any),
-                    "x-typia-required": input["x-typia-required"] as any,
-                    "x-typia-optional": input["x-typia-optional"] as any,
-                    "x-typia-rest": input["x-typia-rest"] as any,
-                });
-                const $co32 = (input: any): any => ({
                     schemas:
                         "object" === typeof input.schemas &&
                         null !== input.schemas
-                            ? $co33(input.schemas)
+                            ? $co32(input.schemas)
                             : (input.schemas as any),
                 });
-                const $co33 = (input: any): any => {
+                const $co32 = (input: any): any => {
                     const output = {} as any;
                     for (const [key, value] of Object.entries(input)) {
                         if (RegExp(/(.*)/).test(key)) {
@@ -3233,20 +3110,19 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     }
                     return output;
                 };
-                const $co34 = (input: any): any => ({
+                const $co33 = (input: any): any => ({
                     $id: input.$id as any,
-                    $recursiveAnchor: input.$recursiveAnchor as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
                     properties:
                         "object" === typeof input.properties &&
                         null !== input.properties
-                            ? $co35(input.properties)
+                            ? $co34(input.properties)
                             : (input.properties as any),
                     patternProperties:
                         "object" === typeof input.patternProperties &&
                         null !== input.patternProperties
-                            ? $co35(input.patternProperties)
+                            ? $co34(input.patternProperties)
                             : (input.patternProperties as any),
                     additionalProperties:
                         "object" === typeof input.additionalProperties &&
@@ -3266,7 +3142,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         "object" ===
                             typeof input["x-typia-patternProperties"] &&
                         null !== input["x-typia-patternProperties"]
-                            ? $co35(input["x-typia-patternProperties"])
+                            ? $co34(input["x-typia-patternProperties"])
                             : (input["x-typia-patternProperties"] as any),
                     "x-typia-additionalProperties":
                         "object" ===
@@ -3275,7 +3151,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             ? $cu0(input["x-typia-additionalProperties"])
                             : (input["x-typia-additionalProperties"] as any),
                 });
-                const $co35 = (input: any): any => {
+                const $co34 = (input: any): any => {
                     const output = {} as any;
                     for (const [key, value] of Object.entries(input)) {
                         if (RegExp(/(.*)/).test(key)) {
@@ -3288,7 +3164,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     }
                     return output;
                 };
-                const $co36 = (input: any): any => ({
+                const $co35 = (input: any): any => ({
                     enum: Array.isArray(input["enum"])
                         ? $cp2(input["enum"])
                         : (input["enum"] as any),
@@ -3312,7 +3188,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co37 = (input: any): any => ({
+                const $co36 = (input: any): any => ({
                     enum: Array.isArray(input["enum"])
                         ? $cp6(input["enum"])
                         : (input["enum"] as any),
@@ -3336,7 +3212,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co38 = (input: any): any => ({
+                const $co37 = (input: any): any => ({
                     enum: Array.isArray(input["enum"])
                         ? $cp7(input["enum"])
                         : (input["enum"] as any),
@@ -3360,7 +3236,33 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
+                const $co38 = (input: any): any => ({
+                    default: input["default"] as any,
+                    type: input.type as any,
+                    nullable: input.nullable as any,
+                    deprecated: input.deprecated as any,
+                    title: input.title as any,
+                    description: input.description as any,
+                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
+                        ? $cp3(input["x-typia-metaTags"])
+                        : (input["x-typia-metaTags"] as any),
+                    "x-typia-jsDocTags": Array.isArray(
+                        input["x-typia-jsDocTags"],
+                    )
+                        ? $cp4(input["x-typia-jsDocTags"])
+                        : (input["x-typia-jsDocTags"] as any),
+                    "x-typia-required": input["x-typia-required"] as any,
+                    "x-typia-optional": input["x-typia-optional"] as any,
+                    "x-typia-rest": input["x-typia-rest"] as any,
+                    $id: input.$id as any,
+                    $recursiveAnchor: input.$recursiveAnchor as any,
+                });
                 const $co39 = (input: any): any => ({
+                    minimum: input.minimum as any,
+                    maximum: input.maximum as any,
+                    exclusiveMinimum: input.exclusiveMinimum as any,
+                    exclusiveMaximum: input.exclusiveMaximum as any,
+                    multipleOf: input.multipleOf as any,
                     default: input["default"] as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
@@ -3408,32 +3310,6 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
                 const $co41 = (input: any): any => ({
-                    minimum: input.minimum as any,
-                    maximum: input.maximum as any,
-                    exclusiveMinimum: input.exclusiveMinimum as any,
-                    exclusiveMaximum: input.exclusiveMaximum as any,
-                    multipleOf: input.multipleOf as any,
-                    default: input["default"] as any,
-                    type: input.type as any,
-                    nullable: input.nullable as any,
-                    deprecated: input.deprecated as any,
-                    title: input.title as any,
-                    description: input.description as any,
-                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                        ? $cp3(input["x-typia-metaTags"])
-                        : (input["x-typia-metaTags"] as any),
-                    "x-typia-jsDocTags": Array.isArray(
-                        input["x-typia-jsDocTags"],
-                    )
-                        ? $cp4(input["x-typia-jsDocTags"])
-                        : (input["x-typia-jsDocTags"] as any),
-                    "x-typia-required": input["x-typia-required"] as any,
-                    "x-typia-optional": input["x-typia-optional"] as any,
-                    "x-typia-rest": input["x-typia-rest"] as any,
-                    $id: input.$id as any,
-                    $recursiveAnchor: input.$recursiveAnchor as any,
-                });
-                const $co42 = (input: any): any => ({
                     minLength: input.minLength as any,
                     maxLength: input.maxLength as any,
                     pattern: input.pattern as any,
@@ -3458,7 +3334,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co43 = (input: any): any => ({
+                const $co42 = (input: any): any => ({
                     items:
                         "object" === typeof input.items && null !== input.items
                             ? $cu0(input.items)
@@ -3489,10 +3365,12 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co44 = (input: any): any => ({
+                const $co43 = (input: any): any => ({
                     items: Array.isArray(input.items)
                         ? $cp1(input.items)
                         : (input.items as any),
+                    minItems: input.minItems as any,
+                    maxItems: input.maxItems as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
                     deprecated: input.deprecated as any,
@@ -3512,7 +3390,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co45 = (input: any): any => ({
+                const $co44 = (input: any): any => ({
                     oneOf: Array.isArray(input.oneOf)
                         ? $cp1(input.oneOf)
                         : (input.oneOf as any),
@@ -3533,7 +3411,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co46 = (input: any): any => ({
+                const $co45 = (input: any): any => ({
                     $ref: input.$ref as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
@@ -3552,26 +3430,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co47 = (input: any): any => ({
-                    $recursiveRef: input.$recursiveRef as any,
-                    deprecated: input.deprecated as any,
-                    title: input.title as any,
-                    description: input.description as any,
-                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                        ? $cp3(input["x-typia-metaTags"])
-                        : (input["x-typia-metaTags"] as any),
-                    "x-typia-jsDocTags": Array.isArray(
-                        input["x-typia-jsDocTags"],
-                    )
-                        ? $cp4(input["x-typia-jsDocTags"])
-                        : (input["x-typia-jsDocTags"] as any),
-                    "x-typia-required": input["x-typia-required"] as any,
-                    "x-typia-optional": input["x-typia-optional"] as any,
-                    "x-typia-rest": input["x-typia-rest"] as any,
-                    $id: input.$id as any,
-                    $recursiveAnchor: input.$recursiveAnchor as any,
-                });
-                const $co48 = (input: any): any => ({
+                const $co46 = (input: any): any => ({
                     type: input.type as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
@@ -3590,7 +3449,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co49 = (input: any): any => ({
+                const $co47 = (input: any): any => ({
                     type: input.type as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
@@ -3632,9 +3491,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             return $co26(input);
                         if (undefined !== input.oneOf) return $co27(input);
                         if (undefined !== input.$ref) return $co28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $co29(input);
-                        if ("null" === input.type) return $co30(input);
+                        if ("null" === input.type) return $co29(input);
                         return (() => {
                             if ($io20(input)) return $co20(input);
                             if ($io19(input)) return $co19(input);
@@ -3642,7 +3499,7 @@ export const test_isClone_UltimateUnion = _test_isClone(
                             if ($io21(input)) return $co21(input);
                             if ($io23(input)) return $co23(input);
                             if ($io24(input)) return $co24(input);
-                            if ($io31(input)) return $co31(input);
+                            if ($io30(input)) return $co30(input);
                             $throws({
                                 expected:
                                     '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -3677,15 +3534,15 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     })();
                 const $cu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $co34(input);
-                        if ("integer" === input.type) return $co40(input);
+                        if ("object" === input.type) return $co33(input);
+                        if ("integer" === input.type) return $co39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $co43(input);
+                            return $co42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -3696,20 +3553,18 @@ export const test_isClone_UltimateUnion = _test_isClone(
                                     $iu0(elem),
                             )
                         )
-                            return $co44(input);
-                        if (undefined !== input.oneOf) return $co45(input);
-                        if (undefined !== input.$ref) return $co46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $co47(input);
-                        if ("null" === input.type) return $co48(input);
+                            return $co43(input);
+                        if (undefined !== input.oneOf) return $co44(input);
+                        if (undefined !== input.$ref) return $co45(input);
+                        if ("null" === input.type) return $co46(input);
                         return (() => {
-                            if ($io38(input)) return $co38(input);
                             if ($io37(input)) return $co37(input);
                             if ($io36(input)) return $co36(input);
-                            if ($io39(input)) return $co39(input);
+                            if ($io35(input)) return $co35(input);
+                            if ($io38(input)) return $co38(input);
+                            if ($io40(input)) return $co40(input);
                             if ($io41(input)) return $co41(input);
-                            if ($io42(input)) return $co42(input);
-                            if ($io49(input)) return $co49(input);
+                            if ($io47(input)) return $co47(input);
                             $throws({
                                 expected:
                                     '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/isParse/test_isParse_UltimateUnion.ts
+++ b/test/generated/output/isParse/test_isParse_UltimateUnion.ts
@@ -21,7 +21,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     "object" === typeof input.components &&
                     null !== input.components &&
                     false === Array.isArray(input.components) &&
-                    $io32(input.components) &&
+                    $io31(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose);
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
@@ -454,6 +454,15 @@ export const test_isParse_UltimateUnion = _test_isParse(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -553,36 +562,6 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -612,7 +591,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -643,13 +622,13 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -662,23 +641,21 @@ export const test_isParse_UltimateUnion = _test_isParse(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -708,7 +685,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -718,7 +695,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -731,7 +708,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -773,7 +750,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) =>
@@ -817,7 +794,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -859,7 +836,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -897,7 +874,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
@@ -952,7 +929,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum))) &&
@@ -1004,7 +981,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
@@ -1056,7 +1033,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -1110,7 +1087,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -1119,6 +1096,15 @@ export const test_isParse_UltimateUnion = _test_isParse(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1154,7 +1140,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -1195,7 +1181,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1229,41 +1215,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1297,7 +1249,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -1355,9 +1307,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (() => {
                             if ($io20(input)) return $io20(input);
                             if ($io19(input)) return $io19(input);
@@ -1365,7 +1315,7 @@ export const test_isParse_UltimateUnion = _test_isParse(
                             if ($io21(input)) return $io21(input);
                             if ($io23(input)) return $io23(input);
                             if ($io24(input)) return $io24(input);
-                            if ($io31(input)) return $io31(input);
+                            if ($io30(input)) return $io30(input);
                             return false;
                         })();
                     })();
@@ -1392,15 +1342,15 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -1411,20 +1361,18 @@ export const test_isParse_UltimateUnion = _test_isParse(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (() => {
-                            if ($io38(input)) return $io38(input);
                             if ($io37(input)) return $io37(input);
                             if ($io36(input)) return $io36(input);
-                            if ($io39(input)) return $io39(input);
+                            if ($io35(input)) return $io35(input);
+                            if ($io38(input)) return $io38(input);
+                            if ($io40(input)) return $io40(input);
                             if ($io41(input)) return $io41(input);
-                            if ($io42(input)) return $io42(input);
-                            if ($io49(input)) return $io49(input);
+                            if ($io47(input)) return $io47(input);
                             return false;
                         })();
                     })();

--- a/test/generated/output/isStringify/test_isStringify_UltimateUnion.ts
+++ b/test/generated/output/isStringify/test_isStringify_UltimateUnion.ts
@@ -21,7 +21,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     "object" === typeof input.components &&
                     null !== input.components &&
                     false === Array.isArray(input.components) &&
-                    $io32(input.components) &&
+                    $io31(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose);
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
@@ -454,6 +454,15 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -553,36 +562,6 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -612,7 +591,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -643,13 +622,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -662,23 +641,21 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -708,7 +685,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -718,7 +695,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -731,7 +708,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -773,7 +750,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) =>
@@ -817,7 +794,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -859,7 +836,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -897,7 +874,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
@@ -952,7 +929,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum))) &&
@@ -1004,7 +981,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
@@ -1056,7 +1033,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -1110,7 +1087,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -1119,6 +1096,15 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1154,7 +1140,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -1195,7 +1181,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1229,41 +1215,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1297,7 +1249,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -1355,9 +1307,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (() => {
                             if ($io20(input)) return $io20(input);
                             if ($io19(input)) return $io19(input);
@@ -1365,7 +1315,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             if ($io21(input)) return $io21(input);
                             if ($io23(input)) return $io23(input);
                             if ($io24(input)) return $io24(input);
-                            if ($io31(input)) return $io31(input);
+                            if ($io30(input)) return $io30(input);
                             return false;
                         })();
                     })();
@@ -1392,15 +1342,15 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -1411,20 +1361,18 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (() => {
-                            if ($io38(input)) return $io38(input);
                             if ($io37(input)) return $io37(input);
                             if ($io36(input)) return $io36(input);
-                            if ($io39(input)) return $io39(input);
+                            if ($io35(input)) return $io35(input);
+                            if ($io38(input)) return $io38(input);
+                            if ($io40(input)) return $io40(input);
                             if ($io41(input)) return $io41(input);
-                            if ($io42(input)) return $io42(input);
-                            if ($io49(input)) return $io49(input);
+                            if ($io47(input)) return $io47(input);
                             return false;
                         })();
                     })();
@@ -1841,6 +1789,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1940,36 +1895,6 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1999,7 +1924,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -2030,13 +1955,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -2049,23 +1974,21 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -2095,7 +2018,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -2105,7 +2028,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -2118,7 +2041,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -2160,7 +2083,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "number" === typeof elem,
@@ -2202,7 +2125,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -2244,7 +2167,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -2282,7 +2205,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             parseInt(input.minimum) === input.minimum)) &&
@@ -2333,7 +2256,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         "number" === typeof input.minimum) &&
                     (undefined === input.maximum ||
@@ -2381,7 +2304,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             parseInt(input.minLength) === input.minLength &&
@@ -2431,7 +2354,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -2483,7 +2406,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -2492,6 +2415,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2527,7 +2457,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -2568,7 +2498,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -2602,41 +2532,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -2670,7 +2566,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -2728,9 +2624,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (
                             $io20(input) ||
                             $io19(input) ||
@@ -2738,7 +2632,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             $io21(input) ||
                             $io23(input) ||
                             $io24(input) ||
-                            $io31(input)
+                            $io30(input)
                         );
                     })();
                 const $iu1 = (input: any): any =>
@@ -2764,15 +2658,15 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -2783,20 +2677,18 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (
-                            $io38(input) ||
                             $io37(input) ||
                             $io36(input) ||
-                            $io39(input) ||
+                            $io35(input) ||
+                            $io38(input) ||
+                            $io40(input) ||
                             $io41(input) ||
-                            $io42(input) ||
-                            $io49(input)
+                            $io47(input)
                         );
                     })();
                 const $string = (typia.isStringify as any).string;
@@ -2807,7 +2699,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                 const $so0 = (input: any): any =>
                     `{"schemas":${`[${input.schemas
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"components":${$so32(
+                        .join(",")}]`},"components":${$so31(
                         input.components,
                     )},"purpose":${(() => {
                         if ("string" === typeof input.purpose)
@@ -3918,6 +3810,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     })()}}`;
                 const $so26 = (input: any): any =>
                     `{${
+                        undefined === input.maxItems
+                            ? ""
+                            : `"maxItems":${
+                                  undefined !== input.maxItems
+                                      ? $number(input.maxItems)
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.nullable
                             ? ""
                             : `"nullable":${
@@ -3995,7 +3895,9 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                               },`
                     }"items":${`[${input.items
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"type":${(() => {
+                        .join(",")}]`},"minItems":${$number(
+                        input.minItems,
+                    )},"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
                         if ("string" === typeof input.type)
@@ -4216,76 +4118,6 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                       ? input["x-typia-rest"]
                                       : undefined
                               },`
-                    }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-                const $so30 = (input: any): any =>
-                    `{${
-                        undefined === input.deprecated
-                            ? ""
-                            : `"deprecated":${
-                                  undefined !== input.deprecated
-                                      ? input.deprecated
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.title
-                            ? ""
-                            : `"title":${
-                                  undefined !== input.title
-                                      ? $string(input.title)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.description
-                            ? ""
-                            : `"description":${
-                                  undefined !== input.description
-                                      ? $string(input.description)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-metaTags"]
-                            ? ""
-                            : `"x-typia-metaTags":${
-                                  undefined !== input["x-typia-metaTags"]
-                                      ? `[${input["x-typia-metaTags"]
-                                            .map((elem: any) => $su1(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-jsDocTags"]
-                            ? ""
-                            : `"x-typia-jsDocTags":${
-                                  undefined !== input["x-typia-jsDocTags"]
-                                      ? `[${input["x-typia-jsDocTags"]
-                                            .map((elem: any) => $so17(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-required"]
-                            ? ""
-                            : `"x-typia-required":${
-                                  undefined !== input["x-typia-required"]
-                                      ? input["x-typia-required"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-optional"]
-                            ? ""
-                            : `"x-typia-optional":${
-                                  undefined !== input["x-typia-optional"]
-                                      ? input["x-typia-optional"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-rest"]
-                            ? ""
-                            : `"x-typia-rest":${
-                                  undefined !== input["x-typia-rest"]
-                                      ? input["x-typia-rest"]
-                                      : undefined
-                              },`
                     }"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
@@ -4296,7 +4128,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so31 = (input: any): any =>
+                const $so30 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.deprecated
@@ -4368,19 +4200,19 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                   }`
                         }`,
                     )}}`;
-                const $so32 = (input: any): any =>
+                const $so31 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.schemas
                                 ? ""
                                 : `"schemas":${
                                       undefined !== input.schemas
-                                          ? $so33(input.schemas)
+                                          ? $so32(input.schemas)
                                           : undefined
                                   }`
                         }`,
                     )}}`;
-                const $so33 = (input: any): any =>
+                const $so32 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
@@ -4388,21 +4220,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;
-                const $so34 = (input: any): any =>
+                const $so33 = (input: any): any =>
                     `{${
                         undefined === input.$id
                             ? ""
                             : `"$id":${
                                   undefined !== input.$id
                                       ? $string(input.$id)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$recursiveAnchor
-                            ? ""
-                            : `"$recursiveAnchor":${
-                                  undefined !== input.$recursiveAnchor
-                                      ? input.$recursiveAnchor
                                       : undefined
                               },`
                     }${
@@ -4418,7 +4242,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             ? ""
                             : `"patternProperties":${
                                   undefined !== input.patternProperties
-                                      ? $so35(input.patternProperties)
+                                      ? $so34(input.patternProperties)
                                       : undefined
                               },`
                     }${
@@ -4463,7 +4287,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             : `"x-typia-patternProperties":${
                                   undefined !==
                                   input["x-typia-patternProperties"]
-                                      ? $so35(
+                                      ? $so34(
                                             input["x-typia-patternProperties"],
                                         )
                                       : undefined
@@ -4490,8 +4314,8 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             expected: '"object"',
                             value: input.type,
                         });
-                    })()},"properties":${$so35(input.properties)}}`;
-                const $so35 = (input: any): any =>
+                    })()},"properties":${$so34(input.properties)}}`;
+                const $so34 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
@@ -4499,7 +4323,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;
-                const $so36 = (input: any): any =>
+                const $so35 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -4612,7 +4436,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so37 = (input: any): any =>
+                const $so36 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -4725,7 +4549,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so38 = (input: any): any =>
+                const $so37 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -4838,7 +4662,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so39 = (input: any): any =>
+                const $so38 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -4949,7 +4773,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so40 = (input: any): any =>
+                const $so39 = (input: any): any =>
                     `{${
                         undefined === input.minimum
                             ? ""
@@ -5100,7 +4924,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so41 = (input: any): any =>
+                const $so40 = (input: any): any =>
                     `{${
                         undefined === input.minimum
                             ? ""
@@ -5251,7 +5075,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so42 = (input: any): any =>
+                const $so41 = (input: any): any =>
                     `{${
                         undefined === input.minLength
                             ? ""
@@ -5394,7 +5218,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so43 = (input: any): any =>
+                const $so42 = (input: any): any =>
                     `{${
                         undefined === input.minItems
                             ? ""
@@ -5521,8 +5345,16 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so44 = (input: any): any =>
+                const $so43 = (input: any): any =>
                     `{${
+                        undefined === input.maxItems
+                            ? ""
+                            : `"maxItems":${
+                                  undefined !== input.maxItems
+                                      ? $number(input.maxItems)
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.nullable
                             ? ""
                             : `"nullable":${
@@ -5616,7 +5448,9 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                               },`
                     }"items":${`[${input.items
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"type":${(() => {
+                        .join(",")}]`},"minItems":${$number(
+                        input.minItems,
+                    )},"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
                         if ("string" === typeof input.type)
@@ -5626,7 +5460,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so45 = (input: any): any =>
+                const $so44 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -5714,7 +5548,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     }"oneOf":${`[${input.oneOf
                         .map((elem: any) => $su0(elem))
                         .join(",")}]`}}`;
-                const $so46 = (input: any): any =>
+                const $so45 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -5800,93 +5634,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                       : undefined
                               },`
                     }"$ref":${$string(input.$ref)}}`;
-                const $so47 = (input: any): any =>
-                    `{${
-                        undefined === input.deprecated
-                            ? ""
-                            : `"deprecated":${
-                                  undefined !== input.deprecated
-                                      ? input.deprecated
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.title
-                            ? ""
-                            : `"title":${
-                                  undefined !== input.title
-                                      ? $string(input.title)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.description
-                            ? ""
-                            : `"description":${
-                                  undefined !== input.description
-                                      ? $string(input.description)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-metaTags"]
-                            ? ""
-                            : `"x-typia-metaTags":${
-                                  undefined !== input["x-typia-metaTags"]
-                                      ? `[${input["x-typia-metaTags"]
-                                            .map((elem: any) => $su1(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-jsDocTags"]
-                            ? ""
-                            : `"x-typia-jsDocTags":${
-                                  undefined !== input["x-typia-jsDocTags"]
-                                      ? `[${input["x-typia-jsDocTags"]
-                                            .map((elem: any) => $so17(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-required"]
-                            ? ""
-                            : `"x-typia-required":${
-                                  undefined !== input["x-typia-required"]
-                                      ? input["x-typia-required"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-optional"]
-                            ? ""
-                            : `"x-typia-optional":${
-                                  undefined !== input["x-typia-optional"]
-                                      ? input["x-typia-optional"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-rest"]
-                            ? ""
-                            : `"x-typia-rest":${
-                                  undefined !== input["x-typia-rest"]
-                                      ? input["x-typia-rest"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$id
-                            ? ""
-                            : `"$id":${
-                                  undefined !== input.$id
-                                      ? $string(input.$id)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$recursiveAnchor
-                            ? ""
-                            : `"$recursiveAnchor":${
-                                  undefined !== input.$recursiveAnchor
-                                      ? input.$recursiveAnchor
-                                      : undefined
-                              },`
-                    }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-                const $so48 = (input: any): any =>
+                const $so46 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -5981,7 +5729,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so49 = (input: any): any =>
+                const $so47 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.deprecated
@@ -6092,9 +5840,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             return $so26(input);
                         if (undefined !== input.oneOf) return $so27(input);
                         if (undefined !== input.$ref) return $so28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $so29(input);
-                        if ("null" === input.type) return $so30(input);
+                        if ("null" === input.type) return $so29(input);
                         return (() => {
                             if ($io20(input)) return $so20(input);
                             if ($io19(input)) return $so19(input);
@@ -6102,7 +5848,7 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                             if ($io21(input)) return $so21(input);
                             if ($io23(input)) return $so23(input);
                             if ($io24(input)) return $so24(input);
-                            if ($io31(input)) return $so31(input);
+                            if ($io30(input)) return $so30(input);
                             $throws({
                                 expected:
                                     '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -6137,15 +5883,15 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     })();
                 const $su2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $so34(input);
-                        if ("integer" === input.type) return $so40(input);
+                        if ("object" === input.type) return $so33(input);
+                        if ("integer" === input.type) return $so39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $so43(input);
+                            return $so42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -6156,20 +5902,18 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                                     $iu0(elem),
                             )
                         )
-                            return $so44(input);
-                        if (undefined !== input.oneOf) return $so45(input);
-                        if (undefined !== input.$ref) return $so46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $so47(input);
-                        if ("null" === input.type) return $so48(input);
+                            return $so43(input);
+                        if (undefined !== input.oneOf) return $so44(input);
+                        if (undefined !== input.$ref) return $so45(input);
+                        if ("null" === input.type) return $so46(input);
                         return (() => {
-                            if ($io38(input)) return $so38(input);
                             if ($io37(input)) return $so37(input);
                             if ($io36(input)) return $so36(input);
-                            if ($io39(input)) return $so39(input);
+                            if ($io35(input)) return $so35(input);
+                            if ($io38(input)) return $so38(input);
+                            if ($io40(input)) return $so40(input);
                             if ($io41(input)) return $so41(input);
-                            if ($io42(input)) return $so42(input);
-                            if ($io49(input)) return $so49(input);
+                            if ($io47(input)) return $so47(input);
                             $throws({
                                 expected:
                                     '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/random/test_random_UltimateUnion.ts
+++ b/test/generated/output/random/test_random_UltimateUnion.ts
@@ -39,14 +39,12 @@ export const test_random_UltimateUnion = _test_random(
                         () =>
                             $ro28(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
-                            $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
-                            $ro31(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
                             $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                        () =>
+                            $ro29(_recursive, _recursive ? 1 + _depth : _depth),
                     ])(),
                 ),
-                components: $ro32(_recursive, _recursive ? 1 + _depth : _depth),
+                components: $ro31(_recursive, _recursive ? 1 + _depth : _depth),
                 purpose: $pick([() => "ajv", () => "swagger"])(),
             });
             const $ro1 = (
@@ -1302,9 +1300,8 @@ export const test_random_UltimateUnion = _test_random(
                     () => $ro26(true, _recursive ? 1 + _depth : _depth),
                     () => $ro27(true, _recursive ? 1 + _depth : _depth),
                     () => $ro28(true, _recursive ? 1 + _depth : _depth),
-                    () => $ro29(true, _recursive ? 1 + _depth : _depth),
-                    () => $ro31(true, _recursive ? 1 + _depth : _depth),
                     () => $ro30(true, _recursive ? 1 + _depth : _depth),
+                    () => $ro29(true, _recursive ? 1 + _depth : _depth),
                 ])(),
                 minItems: $pick([
                     () => undefined,
@@ -1530,23 +1527,35 @@ export const test_random_UltimateUnion = _test_random(
                                           _recursive ? 1 + _depth : _depth,
                                       ),
                                   () =>
-                                      $ro29(
-                                          true,
-                                          _recursive ? 1 + _depth : _depth,
-                                      ),
-                                  () =>
-                                      $ro31(
-                                          true,
-                                          _recursive ? 1 + _depth : _depth,
-                                      ),
-                                  () =>
                                       $ro30(
+                                          true,
+                                          _recursive ? 1 + _depth : _depth,
+                                      ),
+                                  () =>
+                                      $ro29(
                                           true,
                                           _recursive ? 1 + _depth : _depth,
                                       ),
                               ])(),
                           )
                         : [],
+                minItems:
+                    (generator?.customs ?? $generator.customs)?.number?.([
+                        {
+                            name: "type",
+                            value: "uint",
+                        },
+                    ]) ?? (generator?.integer ?? $generator.integer)(0, 10),
+                maxItems: $pick([
+                    () => undefined,
+                    () =>
+                        (generator?.customs ?? $generator.customs)?.number?.([
+                            {
+                                name: "type",
+                                value: "uint",
+                            },
+                        ]) ?? (generator?.integer ?? $generator.integer)(0, 10),
+                ])(),
                 type: "array",
                 nullable: $pick([
                     () => undefined,
@@ -1747,17 +1756,12 @@ export const test_random_UltimateUnion = _test_random(
                                           _recursive ? 1 + _depth : _depth,
                                       ),
                                   () =>
-                                      $ro29(
-                                          true,
-                                          _recursive ? 1 + _depth : _depth,
-                                      ),
-                                  () =>
-                                      $ro31(
-                                          true,
-                                          _recursive ? 1 + _depth : _depth,
-                                      ),
-                                  () =>
                                       $ro30(
+                                          true,
+                                          _recursive ? 1 + _depth : _depth,
+                                      ),
+                                  () =>
+                                      $ro29(
                                           true,
                                           _recursive ? 1 + _depth : _depth,
                                       ),
@@ -2025,9 +2029,7 @@ export const test_random_UltimateUnion = _test_random(
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
-                $recursiveRef:
-                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                    (generator?.string ?? $generator.string)(),
+                type: "null",
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -2153,7 +2155,7 @@ export const test_random_UltimateUnion = _test_random(
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
-                type: "null",
+                type: undefined,
                 deprecated: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
@@ -2279,138 +2281,12 @@ export const test_random_UltimateUnion = _test_random(
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
-                type: undefined,
-                deprecated: $pick([
+                schemas: $pick([
                     () => undefined,
-                    () => (generator?.boolean ?? $generator.boolean)(),
-                ])(),
-                title: $pick([
-                    () => undefined,
-                    () =>
-                        (generator?.customs ?? $generator.customs)?.string?.(
-                            [],
-                        ) ?? (generator?.string ?? $generator.string)(),
-                ])(),
-                description: $pick([
-                    () => undefined,
-                    () =>
-                        (generator?.customs ?? $generator.customs)?.string?.(
-                            [],
-                        ) ?? (generator?.string ?? $generator.string)(),
-                ])(),
-                "x-typia-metaTags": $pick([
-                    () => undefined,
-                    () =>
-                        (generator?.array ?? $generator.array)(() =>
-                            $pick([
-                                () =>
-                                    $ro16(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro15(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro14(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro13(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro12(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro11(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro10(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro9(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro8(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro7(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro6(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro5(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro4(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro3(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro2(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                            ])(),
-                        ),
-                ])(),
-                "x-typia-jsDocTags": $pick([
-                    () => undefined,
-                    () =>
-                        (generator?.array ?? $generator.array)(() =>
-                            $ro17(_recursive, _recursive ? 1 + _depth : _depth),
-                        ),
-                ])(),
-                "x-typia-required": $pick([
-                    () => undefined,
-                    () => (generator?.boolean ?? $generator.boolean)(),
-                ])(),
-                "x-typia-optional": $pick([
-                    () => undefined,
-                    () => (generator?.boolean ?? $generator.boolean)(),
-                ])(),
-                "x-typia-rest": $pick([
-                    () => undefined,
-                    () => (generator?.boolean ?? $generator.boolean)(),
+                    () => $ro32(_recursive, _recursive ? 1 + _depth : _depth),
                 ])(),
             });
             const $ro32 = (
-                _recursive: boolean = false,
-                _depth: number = 0,
-            ): any => ({
-                schemas: $pick([
-                    () => undefined,
-                    () => $ro33(_recursive, _recursive ? 1 + _depth : _depth),
-                ])(),
-            });
-            const $ro33 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => {
@@ -2424,12 +2300,7 @@ export const test_random_UltimateUnion = _test_random(
                                 (generator?.string ?? $generator.string)()
                         ] = $pick([
                             () =>
-                                $ro34(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro38(
+                                $ro33(
                                     _recursive,
                                     _recursive ? 1 + _depth : _depth,
                                 ),
@@ -2444,17 +2315,27 @@ export const test_random_UltimateUnion = _test_random(
                                     _recursive ? 1 + _depth : _depth,
                                 ),
                             () =>
+                                $ro35(
+                                    _recursive,
+                                    _recursive ? 1 + _depth : _depth,
+                                ),
+                            () =>
+                                $ro38(
+                                    _recursive,
+                                    _recursive ? 1 + _depth : _depth,
+                                ),
+                            () =>
+                                $ro40(
+                                    _recursive,
+                                    _recursive ? 1 + _depth : _depth,
+                                ),
+                            () =>
                                 $ro39(
                                     _recursive,
                                     _recursive ? 1 + _depth : _depth,
                                 ),
                             () =>
                                 $ro41(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro40(
                                     _recursive,
                                     _recursive ? 1 + _depth : _depth,
                                 ),
@@ -2479,22 +2360,12 @@ export const test_random_UltimateUnion = _test_random(
                                     _recursive ? 1 + _depth : _depth,
                                 ),
                             () =>
-                                $ro46(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
                                 $ro47(
                                     _recursive,
                                     _recursive ? 1 + _depth : _depth,
                                 ),
                             () =>
-                                $ro49(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro48(
+                                $ro46(
                                     _recursive,
                                     _recursive ? 1 + _depth : _depth,
                                 ),
@@ -2503,7 +2374,7 @@ export const test_random_UltimateUnion = _test_random(
                 );
                 return output;
             };
-            const $ro34 = (
+            const $ro33 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -2514,19 +2385,15 @@ export const test_random_UltimateUnion = _test_random(
                             [],
                         ) ?? (generator?.string ?? $generator.string)(),
                 ])(),
-                $recursiveAnchor: $pick([
-                    () => undefined,
-                    () => (generator?.boolean ?? $generator.boolean)(),
-                ])(),
                 type: "object",
                 nullable: $pick([
                     () => undefined,
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
-                properties: $ro35(_recursive, _recursive ? 1 + _depth : _depth),
+                properties: $ro34(_recursive, _recursive ? 1 + _depth : _depth),
                 patternProperties: $pick([
                     () => undefined,
-                    () => $ro35(_recursive, _recursive ? 1 + _depth : _depth),
+                    () => $ro34(_recursive, _recursive ? 1 + _depth : _depth),
                 ])(),
                 additionalProperties: $pick([
                     () => undefined,
@@ -2541,9 +2408,8 @@ export const test_random_UltimateUnion = _test_random(
                     () => $ro26(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro27(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro28(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro31(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
                 ])(),
                 required: $pick([
                     () => undefined,
@@ -2572,7 +2438,7 @@ export const test_random_UltimateUnion = _test_random(
                 ])(),
                 "x-typia-patternProperties": $pick([
                     () => undefined,
-                    () => $ro35(_recursive, _recursive ? 1 + _depth : _depth),
+                    () => $ro34(_recursive, _recursive ? 1 + _depth : _depth),
                 ])(),
                 "x-typia-additionalProperties": $pick([
                     () => undefined,
@@ -2587,12 +2453,11 @@ export const test_random_UltimateUnion = _test_random(
                     () => $ro26(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro27(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro28(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro31(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
                 ])(),
             });
-            const $ro35 = (
+            const $ro34 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => {
@@ -2661,17 +2526,12 @@ export const test_random_UltimateUnion = _test_random(
                                     _recursive ? 1 + _depth : _depth,
                                 ),
                             () =>
-                                $ro29(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
-                                $ro31(
-                                    _recursive,
-                                    _recursive ? 1 + _depth : _depth,
-                                ),
-                            () =>
                                 $ro30(
+                                    _recursive,
+                                    _recursive ? 1 + _depth : _depth,
+                                ),
+                            () =>
+                                $ro29(
                                     _recursive,
                                     _recursive ? 1 + _depth : _depth,
                                 ),
@@ -2680,7 +2540,7 @@ export const test_random_UltimateUnion = _test_random(
                 );
                 return output;
             };
-            const $ro36 = (
+            const $ro35 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -2828,7 +2688,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro37 = (
+            const $ro36 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -2982,7 +2842,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro38 = (
+            const $ro37 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -3136,7 +2996,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro39 = (
+            const $ro38 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -3281,7 +3141,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro40 = (
+            const $ro39 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -3470,7 +3330,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro41 = (
+            const $ro40 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -3647,7 +3507,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro42 = (
+            const $ro41 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -3829,7 +3689,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro43 = (
+            const $ro42 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -3845,9 +3705,8 @@ export const test_random_UltimateUnion = _test_random(
                     () => $ro26(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro27(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro28(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                    () => $ro31(_recursive, _recursive ? 1 + _depth : _depth),
                     () => $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                    () => $ro29(_recursive, _recursive ? 1 + _depth : _depth),
                 ])(),
                 minItems: $pick([
                     () => undefined,
@@ -4010,7 +3869,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro44 = (
+            const $ro43 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -4039,13 +3898,28 @@ export const test_random_UltimateUnion = _test_random(
                         () =>
                             $ro28(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
-                            $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
-                            $ro31(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
                             $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                        () =>
+                            $ro29(_recursive, _recursive ? 1 + _depth : _depth),
                     ])(),
                 ),
+                minItems:
+                    (generator?.customs ?? $generator.customs)?.number?.([
+                        {
+                            name: "type",
+                            value: "uint",
+                        },
+                    ]) ?? (generator?.integer ?? $generator.integer)(0, 10),
+                maxItems: $pick([
+                    () => undefined,
+                    () =>
+                        (generator?.customs ?? $generator.customs)?.number?.([
+                            {
+                                name: "type",
+                                value: "uint",
+                            },
+                        ]) ?? (generator?.integer ?? $generator.integer)(0, 10),
+                ])(),
                 type: "array",
                 nullable: $pick([
                     () => undefined,
@@ -4183,7 +4057,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro45 = (
+            const $ro44 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -4212,11 +4086,9 @@ export const test_random_UltimateUnion = _test_random(
                         () =>
                             $ro28(_recursive, _recursive ? 1 + _depth : _depth),
                         () =>
-                            $ro29(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
-                            $ro31(_recursive, _recursive ? 1 + _depth : _depth),
-                        () =>
                             $ro30(_recursive, _recursive ? 1 + _depth : _depth),
+                        () =>
+                            $ro29(_recursive, _recursive ? 1 + _depth : _depth),
                     ])(),
                 ),
                 deprecated: $pick([
@@ -4351,7 +4223,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro46 = (
+            const $ro45 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -4490,146 +4362,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro47 = (
-                _recursive: boolean = false,
-                _depth: number = 0,
-            ): any => ({
-                $recursiveRef:
-                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
-                    (generator?.string ?? $generator.string)(),
-                deprecated: $pick([
-                    () => undefined,
-                    () => (generator?.boolean ?? $generator.boolean)(),
-                ])(),
-                title: $pick([
-                    () => undefined,
-                    () =>
-                        (generator?.customs ?? $generator.customs)?.string?.(
-                            [],
-                        ) ?? (generator?.string ?? $generator.string)(),
-                ])(),
-                description: $pick([
-                    () => undefined,
-                    () =>
-                        (generator?.customs ?? $generator.customs)?.string?.(
-                            [],
-                        ) ?? (generator?.string ?? $generator.string)(),
-                ])(),
-                "x-typia-metaTags": $pick([
-                    () => undefined,
-                    () =>
-                        (generator?.array ?? $generator.array)(() =>
-                            $pick([
-                                () =>
-                                    $ro16(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro15(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro14(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro13(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro12(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro11(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro10(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro9(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro8(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro7(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro6(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro5(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro4(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro3(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                                () =>
-                                    $ro2(
-                                        _recursive,
-                                        _recursive ? 1 + _depth : _depth,
-                                    ),
-                            ])(),
-                        ),
-                ])(),
-                "x-typia-jsDocTags": $pick([
-                    () => undefined,
-                    () =>
-                        (generator?.array ?? $generator.array)(() =>
-                            $ro17(_recursive, _recursive ? 1 + _depth : _depth),
-                        ),
-                ])(),
-                "x-typia-required": $pick([
-                    () => undefined,
-                    () => (generator?.boolean ?? $generator.boolean)(),
-                ])(),
-                "x-typia-optional": $pick([
-                    () => undefined,
-                    () => (generator?.boolean ?? $generator.boolean)(),
-                ])(),
-                "x-typia-rest": $pick([
-                    () => undefined,
-                    () => (generator?.boolean ?? $generator.boolean)(),
-                ])(),
-                $id: $pick([
-                    () => undefined,
-                    () =>
-                        (generator?.customs ?? $generator.customs)?.string?.(
-                            [],
-                        ) ?? (generator?.string ?? $generator.string)(),
-                ])(),
-                $recursiveAnchor: $pick([
-                    () => undefined,
-                    () => (generator?.boolean ?? $generator.boolean)(),
-                ])(),
-            });
-            const $ro48 = (
+            const $ro46 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -4766,7 +4499,7 @@ export const test_random_UltimateUnion = _test_random(
                     () => (generator?.boolean ?? $generator.boolean)(),
                 ])(),
             });
-            const $ro49 = (
+            const $ro47 = (
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
@@ -4920,7 +4653,7 @@ export const test_random_UltimateUnion = _test_random(
                 "object" === typeof input.components &&
                 null !== input.components &&
                 false === Array.isArray(input.components) &&
-                $io32(input.components) &&
+                $io31(input.components) &&
                 ("ajv" === input.purpose || "swagger" === input.purpose);
             const $io1 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
@@ -5349,6 +5082,15 @@ export const test_random_UltimateUnion = _test_random(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -5448,36 +5190,6 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -5507,7 +5219,7 @@ export const test_random_UltimateUnion = _test_random(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -5538,13 +5250,13 @@ export const test_random_UltimateUnion = _test_random(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -5557,22 +5269,20 @@ export const test_random_UltimateUnion = _test_random(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -5598,7 +5308,7 @@ export const test_random_UltimateUnion = _test_random(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -5608,7 +5318,7 @@ export const test_random_UltimateUnion = _test_random(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -5621,7 +5331,7 @@ export const test_random_UltimateUnion = _test_random(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -5660,7 +5370,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every(
                     (elem: any) =>
@@ -5703,7 +5413,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -5742,7 +5452,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -5779,7 +5489,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
@@ -5833,7 +5543,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum))) &&
@@ -5884,7 +5594,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
@@ -5935,7 +5645,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -5988,7 +5698,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -5997,6 +5707,15 @@ export const test_random_UltimateUnion = _test_random(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                Number.isFinite(input.minItems) &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        Number.isFinite(input.maxItems) &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -6031,7 +5750,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -6071,7 +5790,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -6104,40 +5823,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -6170,7 +5856,7 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -6227,8 +5913,7 @@ export const test_random_UltimateUnion = _test_random(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (() => {
                         if ($io20(input)) return $io20(input);
                         if ($io19(input)) return $io19(input);
@@ -6236,7 +5921,7 @@ export const test_random_UltimateUnion = _test_random(
                         if ($io21(input)) return $io21(input);
                         if ($io23(input)) return $io23(input);
                         if ($io24(input)) return $io24(input);
-                        if ($io31(input)) return $io31(input);
+                        if ($io30(input)) return $io30(input);
                         return false;
                     })();
                 })();
@@ -6261,15 +5946,15 @@ export const test_random_UltimateUnion = _test_random(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -6280,19 +5965,18 @@ export const test_random_UltimateUnion = _test_random(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (() => {
-                        if ($io38(input)) return $io38(input);
                         if ($io37(input)) return $io37(input);
                         if ($io36(input)) return $io36(input);
-                        if ($io39(input)) return $io39(input);
+                        if ($io35(input)) return $io35(input);
+                        if ($io38(input)) return $io38(input);
+                        if ($io40(input)) return $io40(input);
                         if ($io41(input)) return $io41(input);
-                        if ($io42(input)) return $io42(input);
-                        if ($io49(input)) return $io49(input);
+                        if ($io47(input)) return $io47(input);
                         return false;
                     })();
                 })();
@@ -6332,7 +6016,7 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path + ".schemas[" + _index2 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
@@ -6343,7 +6027,7 @@ export const test_random_UltimateUnion = _test_random(
                                 $guard(_exceptionable, {
                                     path: _path + ".schemas[" + _index2 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
@@ -6360,7 +6044,7 @@ export const test_random_UltimateUnion = _test_random(
                             expected: "IJsonComponents",
                             value: input.components,
                         })) &&
-                        $ao32(
+                        $ao31(
                             input.components,
                             _path + ".components",
                             true && _exceptionable,
@@ -8026,7 +7710,7 @@ export const test_random_UltimateUnion = _test_random(
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                             value: input.items,
                         })) &&
                         $au0(
@@ -8037,7 +7721,7 @@ export const test_random_UltimateUnion = _test_random(
                         $guard(_exceptionable, {
                             path: _path + ".items",
                             expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                             value: input.items,
                         })) &&
                     (undefined === input.minItems ||
@@ -8261,7 +7945,7 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path + ".items[" + _index23 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
@@ -8272,7 +7956,7 @@ export const test_random_UltimateUnion = _test_random(
                                 $guard(_exceptionable, {
                                     path: _path + ".items[" + _index23 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
@@ -8280,6 +7964,45 @@ export const test_random_UltimateUnion = _test_random(
                             path: _path + ".items",
                             expected: "Array<IJsonSchema>",
                             value: input.items,
+                        })) &&
+                    (("number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        (parseInt(input.minItems) === input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            })) &&
+                        (0 <= input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minItems",
+                            expected: "number",
+                            value: input.minItems,
+                        })) &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            (parseInt(input.maxItems) === input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maxItems",
+                            expected: "(number | undefined)",
+                            value: input.maxItems,
                         })) &&
                     ("array" === input.type ||
                         $guard(_exceptionable, {
@@ -8444,7 +8167,7 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path + ".oneOf[" + _index26 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
@@ -8455,7 +8178,7 @@ export const test_random_UltimateUnion = _test_random(
                                 $guard(_exceptionable, {
                                     path: _path + ".oneOf[" + _index26 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
@@ -8740,11 +8463,11 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("string" === typeof input.$recursiveRef ||
+                    ("null" === input.type ||
                         $guard(_exceptionable, {
-                            path: _path + ".$recursiveRef",
-                            expected: "string",
-                            value: input.$recursiveRef,
+                            path: _path + ".type",
+                            expected: '"null"',
+                            value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -8881,10 +8604,16 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("null" === input.type ||
+                    (null !== input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"null"',
+                            expected: "undefined",
+                            value: input.type,
+                        })) &&
+                    (undefined === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: "undefined",
                             value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
@@ -9022,31 +8751,171 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (null !== input.type ||
+                    undefined === input.schemas ||
+                    ((("object" === typeof input.schemas &&
+                        null !== input.schemas &&
+                        false === Array.isArray(input.schemas)) ||
                         $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
+                            path: _path + ".schemas",
+                            expected:
+                                "(Record<string, IObject | IAlias> | undefined)",
+                            value: input.schemas,
                         })) &&
-                    (undefined === input.type ||
+                        $ao32(
+                            input.schemas,
+                            _path + ".schemas",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".schemas",
+                        expected:
+                            "(Record<string, IObject | IAlias> | undefined)",
+                        value: input.schemas,
+                    });
+                const $ao32 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    false === _exceptionable ||
+                    Object.keys(input).every((key: any) => {
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        if (RegExp(/(.*)/).test(key))
+                            return (
+                                ((("object" === typeof value &&
+                                    null !== value &&
+                                    false === Array.isArray(value)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected:
+                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                        value: value,
+                                    })) &&
+                                    $au2(
+                                        value,
+                                        _path + $join(key),
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + $join(key),
+                                    expected:
+                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                    value: value,
+                                })
+                            );
+                        return true;
+                    });
+                const $ao33 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.$id ||
+                        "string" === typeof input.$id ||
                         $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
-                        })) &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated ||
-                        $guard(_exceptionable, {
-                            path: _path + ".deprecated",
-                            expected: "(boolean | undefined)",
-                            value: input.deprecated,
-                        })) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title ||
-                        $guard(_exceptionable, {
-                            path: _path + ".title",
+                            path: _path + ".$id",
                             expected: "(string | undefined)",
-                            value: input.title,
+                            value: input.$id,
+                        })) &&
+                    ("object" === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: '"object"',
+                            value: input.type,
+                        })) &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
+                        $guard(_exceptionable, {
+                            path: _path + ".nullable",
+                            expected: "(boolean | undefined)",
+                            value: input.nullable,
+                        })) &&
+                    (((("object" === typeof input.properties &&
+                        null !== input.properties &&
+                        false === Array.isArray(input.properties)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".properties",
+                            expected: "Record<string, IJsonSchema>",
+                            value: input.properties,
+                        })) &&
+                        $ao34(
+                            input.properties,
+                            _path + ".properties",
+                            true && _exceptionable,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".properties",
+                            expected: "Record<string, IJsonSchema>",
+                            value: input.properties,
+                        })) &&
+                    (undefined === input.patternProperties ||
+                        ((("object" === typeof input.patternProperties &&
+                            null !== input.patternProperties &&
+                            false === Array.isArray(input.patternProperties)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".patternProperties",
+                                expected:
+                                    "(Record<string, IJsonSchema> | undefined)",
+                                value: input.patternProperties,
+                            })) &&
+                            $ao34(
+                                input.patternProperties,
+                                _path + ".patternProperties",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".patternProperties",
+                            expected:
+                                "(Record<string, IJsonSchema> | undefined)",
+                            value: input.patternProperties,
+                        })) &&
+                    (undefined === input.additionalProperties ||
+                        ((("object" === typeof input.additionalProperties &&
+                            null !== input.additionalProperties &&
+                            false ===
+                                Array.isArray(input.additionalProperties)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".additionalProperties",
+                                expected:
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                value: input.additionalProperties,
+                            })) &&
+                            $au0(
+                                input.additionalProperties,
+                                _path + ".additionalProperties",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".additionalProperties",
+                            expected:
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                            value: input.additionalProperties,
+                        })) &&
+                    (undefined === input.required ||
+                        ((Array.isArray(input.required) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".required",
+                                expected: "(Array<string> | undefined)",
+                                value: input.required,
+                            })) &&
+                            input.required.every(
+                                (elem: any, _index35: number) =>
+                                    "string" === typeof elem ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            ".required[" +
+                                            _index35 +
+                                            "]",
+                                        expected: "string",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".required",
+                            expected: "(Array<string> | undefined)",
+                            value: input.required,
                         })) &&
                     (undefined === input.description ||
                         "string" === typeof input.description ||
@@ -9054,51 +8923,6 @@ export const test_random_UltimateUnion = _test_random(
                             path: _path + ".description",
                             expected: "(string | undefined)",
                             value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        ((Array.isArray(input["x-typia-metaTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any, _index35: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index35 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        })) &&
-                                        $au1(
-                                            elem,
-                                            _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index35 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-metaTags"][' +
-                                            _index35 +
-                                            "]",
-                                        expected:
-                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-metaTags"]',
-                            expected: "(Array<IMetadataTag> | undefined)",
-                            value: input["x-typia-metaTags"],
                         })) &&
                     (undefined === input["x-typia-jsDocTags"] ||
                         ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -9143,255 +8967,6 @@ export const test_random_UltimateUnion = _test_random(
                             expected: "(Array<IJsDocTagInfo> | undefined)",
                             value: input["x-typia-jsDocTags"],
                         })) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-required"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-required"],
-                        })) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-optional"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-optional"],
-                        })) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-rest"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-rest"],
-                        }));
-                const $ao32 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    undefined === input.schemas ||
-                    ((("object" === typeof input.schemas &&
-                        null !== input.schemas &&
-                        false === Array.isArray(input.schemas)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".schemas",
-                            expected:
-                                "(Record<string, IObject | IAlias> | undefined)",
-                            value: input.schemas,
-                        })) &&
-                        $ao33(
-                            input.schemas,
-                            _path + ".schemas",
-                            true && _exceptionable,
-                        )) ||
-                    $guard(_exceptionable, {
-                        path: _path + ".schemas",
-                        expected:
-                            "(Record<string, IObject | IAlias> | undefined)",
-                        value: input.schemas,
-                    });
-                const $ao33 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    false === _exceptionable ||
-                    Object.keys(input).every((key: any) => {
-                        const value = input[key];
-                        if (undefined === value) return true;
-                        if (RegExp(/(.*)/).test(key))
-                            return (
-                                ((("object" === typeof value &&
-                                    null !== value &&
-                                    false === Array.isArray(value)) ||
-                                    $guard(_exceptionable, {
-                                        path: _path + $join(key),
-                                        expected:
-                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                        value: value,
-                                    })) &&
-                                    $au2(
-                                        value,
-                                        _path + $join(key),
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + $join(key),
-                                    expected:
-                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                    value: value,
-                                })
-                            );
-                        return true;
-                    });
-                const $ao34 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$id",
-                            expected: "(string | undefined)",
-                            value: input.$id,
-                        })) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$recursiveAnchor",
-                            expected: "(boolean | undefined)",
-                            value: input.$recursiveAnchor,
-                        })) &&
-                    ("object" === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: '"object"',
-                            value: input.type,
-                        })) &&
-                    (undefined === input.nullable ||
-                        "boolean" === typeof input.nullable ||
-                        $guard(_exceptionable, {
-                            path: _path + ".nullable",
-                            expected: "(boolean | undefined)",
-                            value: input.nullable,
-                        })) &&
-                    (((("object" === typeof input.properties &&
-                        null !== input.properties &&
-                        false === Array.isArray(input.properties)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".properties",
-                            expected: "Record<string, IJsonSchema>",
-                            value: input.properties,
-                        })) &&
-                        $ao35(
-                            input.properties,
-                            _path + ".properties",
-                            true && _exceptionable,
-                        )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".properties",
-                            expected: "Record<string, IJsonSchema>",
-                            value: input.properties,
-                        })) &&
-                    (undefined === input.patternProperties ||
-                        ((("object" === typeof input.patternProperties &&
-                            null !== input.patternProperties &&
-                            false === Array.isArray(input.patternProperties)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".patternProperties",
-                                expected:
-                                    "(Record<string, IJsonSchema> | undefined)",
-                                value: input.patternProperties,
-                            })) &&
-                            $ao35(
-                                input.patternProperties,
-                                _path + ".patternProperties",
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".patternProperties",
-                            expected:
-                                "(Record<string, IJsonSchema> | undefined)",
-                            value: input.patternProperties,
-                        })) &&
-                    (undefined === input.additionalProperties ||
-                        ((("object" === typeof input.additionalProperties &&
-                            null !== input.additionalProperties &&
-                            false ===
-                                Array.isArray(input.additionalProperties)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".additionalProperties",
-                                expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                value: input.additionalProperties,
-                            })) &&
-                            $au0(
-                                input.additionalProperties,
-                                _path + ".additionalProperties",
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".additionalProperties",
-                            expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                            value: input.additionalProperties,
-                        })) &&
-                    (undefined === input.required ||
-                        ((Array.isArray(input.required) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".required",
-                                expected: "(Array<string> | undefined)",
-                                value: input.required,
-                            })) &&
-                            input.required.every(
-                                (elem: any, _index37: number) =>
-                                    "string" === typeof elem ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            ".required[" +
-                                            _index37 +
-                                            "]",
-                                        expected: "string",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".required",
-                            expected: "(Array<string> | undefined)",
-                            value: input.required,
-                        })) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description ||
-                        $guard(_exceptionable, {
-                            path: _path + ".description",
-                            expected: "(string | undefined)",
-                            value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any, _index38: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index38 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        })) &&
-                                        $ao17(
-                                            elem,
-                                            _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index38 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-jsDocTags"][' +
-                                            _index38 +
-                                            "]",
-                                        expected: "IJsDocTagInfo",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-jsDocTags"]',
-                            expected: "(Array<IJsDocTagInfo> | undefined)",
-                            value: input["x-typia-jsDocTags"],
-                        })) &&
                     (undefined === input["x-typia-patternProperties"] ||
                         ((("object" ===
                             typeof input["x-typia-patternProperties"] &&
@@ -9406,7 +8981,7 @@ export const test_random_UltimateUnion = _test_random(
                                     "(Record<string, IJsonSchema> | undefined)",
                                 value: input["x-typia-patternProperties"],
                             })) &&
-                            $ao35(
+                            $ao34(
                                 input["x-typia-patternProperties"],
                                 _path + '["x-typia-patternProperties"]',
                                 true && _exceptionable,
@@ -9429,7 +9004,7 @@ export const test_random_UltimateUnion = _test_random(
                                 path:
                                     _path + '["x-typia-additionalProperties"]',
                                 expected:
-                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                 value: input["x-typia-additionalProperties"],
                             })) &&
                             $au0(
@@ -9440,10 +9015,10 @@ export const test_random_UltimateUnion = _test_random(
                         $guard(_exceptionable, {
                             path: _path + '["x-typia-additionalProperties"]',
                             expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                             value: input["x-typia-additionalProperties"],
                         }));
-                const $ao35 = (
+                const $ao34 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -9460,7 +9035,7 @@ export const test_random_UltimateUnion = _test_random(
                                     $guard(_exceptionable, {
                                         path: _path + $join(key),
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: value,
                                     })) &&
                                     $au0(
@@ -9471,13 +9046,13 @@ export const test_random_UltimateUnion = _test_random(
                                 $guard(_exceptionable, {
                                     path: _path + $join(key),
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: value,
                                 })
                             );
                         return true;
                     });
-                const $ao36 = (
+                const $ao35 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -9489,10 +9064,10 @@ export const test_random_UltimateUnion = _test_random(
                             value: input["enum"],
                         })) &&
                         input["enum"].every(
-                            (elem: any, _index39: number) =>
+                            (elem: any, _index37: number) =>
                                 "boolean" === typeof elem ||
                                 $guard(_exceptionable, {
-                                    path: _path + '["enum"][' + _index39 + "]",
+                                    path: _path + '["enum"][' + _index37 + "]",
                                     expected: "boolean",
                                     value: elem,
                                 }),
@@ -9551,14 +9126,14 @@ export const test_random_UltimateUnion = _test_random(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index40: number) =>
+                                (elem: any, _index38: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index40 +
+                                                _index38 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -9568,7 +9143,7 @@ export const test_random_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index40 +
+                                                _index38 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -9576,7 +9151,7 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index40 +
+                                            _index38 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -9596,14 +9171,14 @@ export const test_random_UltimateUnion = _test_random(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index41: number) =>
+                                (elem: any, _index39: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index41 +
+                                                _index39 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -9612,7 +9187,7 @@ export const test_random_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index41 +
+                                                _index39 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -9620,7 +9195,7 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
-                                            _index41 +
+                                            _index39 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -9666,7 +9241,7 @@ export const test_random_UltimateUnion = _test_random(
                             expected: "(boolean | undefined)",
                             value: input.$recursiveAnchor,
                         }));
-                const $ao37 = (
+                const $ao36 = (
                     input: any,
                     _path: string,
                     _exceptionable: boolean = true,
@@ -9678,11 +9253,11 @@ export const test_random_UltimateUnion = _test_random(
                             value: input["enum"],
                         })) &&
                         input["enum"].every(
-                            (elem: any, _index42: number) =>
+                            (elem: any, _index40: number) =>
                                 ("number" === typeof elem &&
                                     Number.isFinite(elem)) ||
                                 $guard(_exceptionable, {
-                                    path: _path + '["enum"][' + _index42 + "]",
+                                    path: _path + '["enum"][' + _index40 + "]",
                                     expected: "number",
                                     value: elem,
                                 }),
@@ -9742,14 +9317,14 @@ export const test_random_UltimateUnion = _test_random(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index43: number) =>
+                                (elem: any, _index41: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index43 +
+                                                _index41 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -9759,7 +9334,7 @@ export const test_random_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index43 +
+                                                _index41 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -9767,7 +9342,7 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index43 +
+                                            _index41 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -9787,14 +9362,14 @@ export const test_random_UltimateUnion = _test_random(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index44: number) =>
+                                (elem: any, _index42: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index44 +
+                                                _index42 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -9803,7 +9378,7 @@ export const test_random_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index44 +
+                                                _index42 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -9811,7 +9386,196 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
+                                            _index42 +
+                                            "]",
+                                        expected: "IJsDocTagInfo",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-jsDocTags"]',
+                            expected: "(Array<IJsDocTagInfo> | undefined)",
+                            value: input["x-typia-jsDocTags"],
+                        })) &&
+                    (undefined === input["x-typia-required"] ||
+                        "boolean" === typeof input["x-typia-required"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-required"]',
+                            expected: "(boolean | undefined)",
+                            value: input["x-typia-required"],
+                        })) &&
+                    (undefined === input["x-typia-optional"] ||
+                        "boolean" === typeof input["x-typia-optional"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-optional"]',
+                            expected: "(boolean | undefined)",
+                            value: input["x-typia-optional"],
+                        })) &&
+                    (undefined === input["x-typia-rest"] ||
+                        "boolean" === typeof input["x-typia-rest"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-rest"]',
+                            expected: "(boolean | undefined)",
+                            value: input["x-typia-rest"],
+                        })) &&
+                    (undefined === input.$id ||
+                        "string" === typeof input.$id ||
+                        $guard(_exceptionable, {
+                            path: _path + ".$id",
+                            expected: "(string | undefined)",
+                            value: input.$id,
+                        })) &&
+                    (undefined === input.$recursiveAnchor ||
+                        "boolean" === typeof input.$recursiveAnchor ||
+                        $guard(_exceptionable, {
+                            path: _path + ".$recursiveAnchor",
+                            expected: "(boolean | undefined)",
+                            value: input.$recursiveAnchor,
+                        }));
+                const $ao37 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (((Array.isArray(input["enum"]) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["enum"]',
+                            expected: "Array<string>",
+                            value: input["enum"],
+                        })) &&
+                        input["enum"].every(
+                            (elem: any, _index43: number) =>
+                                "string" === typeof elem ||
+                                $guard(_exceptionable, {
+                                    path: _path + '["enum"][' + _index43 + "]",
+                                    expected: "string",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["enum"]',
+                            expected: "Array<string>",
+                            value: input["enum"],
+                        })) &&
+                    (undefined === input["default"] ||
+                        "string" === typeof input["default"] ||
+                        $guard(_exceptionable, {
+                            path: _path + '["default"]',
+                            expected: "(string | undefined)",
+                            value: input["default"],
+                        })) &&
+                    ("string" === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: '"string"',
+                            value: input.type,
+                        })) &&
+                    (undefined === input.nullable ||
+                        "boolean" === typeof input.nullable ||
+                        $guard(_exceptionable, {
+                            path: _path + ".nullable",
+                            expected: "(boolean | undefined)",
+                            value: input.nullable,
+                        })) &&
+                    (undefined === input.deprecated ||
+                        "boolean" === typeof input.deprecated ||
+                        $guard(_exceptionable, {
+                            path: _path + ".deprecated",
+                            expected: "(boolean | undefined)",
+                            value: input.deprecated,
+                        })) &&
+                    (undefined === input.title ||
+                        "string" === typeof input.title ||
+                        $guard(_exceptionable, {
+                            path: _path + ".title",
+                            expected: "(string | undefined)",
+                            value: input.title,
+                        })) &&
+                    (undefined === input.description ||
+                        "string" === typeof input.description ||
+                        $guard(_exceptionable, {
+                            path: _path + ".description",
+                            expected: "(string | undefined)",
+                            value: input.description,
+                        })) &&
+                    (undefined === input["x-typia-metaTags"] ||
+                        ((Array.isArray(input["x-typia-metaTags"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-metaTags"]',
+                                expected: "(Array<IMetadataTag> | undefined)",
+                                value: input["x-typia-metaTags"],
+                            })) &&
+                            input["x-typia-metaTags"].every(
+                                (elem: any, _index44: number) =>
+                                    ((("object" === typeof elem &&
+                                        null !== elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-metaTags"][' +
+                                                _index44 +
+                                                "]",
+                                            expected:
+                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                            value: elem,
+                                        })) &&
+                                        $au1(
+                                            elem,
+                                            _path +
+                                                '["x-typia-metaTags"][' +
+                                                _index44 +
+                                                "]",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            '["x-typia-metaTags"][' +
                                             _index44 +
+                                            "]",
+                                        expected:
+                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + '["x-typia-metaTags"]',
+                            expected: "(Array<IMetadataTag> | undefined)",
+                            value: input["x-typia-metaTags"],
+                        })) &&
+                    (undefined === input["x-typia-jsDocTags"] ||
+                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-jsDocTags"]',
+                                expected: "(Array<IJsDocTagInfo> | undefined)",
+                                value: input["x-typia-jsDocTags"],
+                            })) &&
+                            input["x-typia-jsDocTags"].every(
+                                (elem: any, _index45: number) =>
+                                    ((("object" === typeof elem &&
+                                        null !== elem) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                '["x-typia-jsDocTags"][' +
+                                                _index45 +
+                                                "]",
+                                            expected: "IJsDocTagInfo",
+                                            value: elem,
+                                        })) &&
+                                        $ao17(
+                                            elem,
+                                            _path +
+                                                '["x-typia-jsDocTags"][' +
+                                                _index45 +
+                                                "]",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path +
+                                            '["x-typia-jsDocTags"][' +
+                                            _index45 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -9862,37 +9626,17 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((Array.isArray(input["enum"]) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["enum"]',
-                            expected: "Array<string>",
-                            value: input["enum"],
-                        })) &&
-                        input["enum"].every(
-                            (elem: any, _index45: number) =>
-                                "string" === typeof elem ||
-                                $guard(_exceptionable, {
-                                    path: _path + '["enum"][' + _index45 + "]",
-                                    expected: "string",
-                                    value: elem,
-                                }),
-                        )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["enum"]',
-                            expected: "Array<string>",
-                            value: input["enum"],
-                        })) &&
                     (undefined === input["default"] ||
-                        "string" === typeof input["default"] ||
+                        "boolean" === typeof input["default"] ||
                         $guard(_exceptionable, {
                             path: _path + '["default"]',
-                            expected: "(string | undefined)",
+                            expected: "(boolean | undefined)",
                             value: input["default"],
                         })) &&
-                    ("string" === input.type ||
+                    ("boolean" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"string"',
+                            expected: '"boolean"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -10051,17 +9795,74 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
+                    (undefined === input.minimum ||
+                        ("number" === typeof input.minimum &&
+                            Number.isFinite(input.minimum) &&
+                            (parseInt(input.minimum) === input.minimum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".minimum",
+                            expected: "(number | undefined)",
+                            value: input.minimum,
+                        })) &&
+                    (undefined === input.maximum ||
+                        ("number" === typeof input.maximum &&
+                            Number.isFinite(input.maximum) &&
+                            (parseInt(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".maximum",
+                            expected: "(number | undefined)",
+                            value: input.maximum,
+                        })) &&
+                    (undefined === input.exclusiveMinimum ||
+                        "boolean" === typeof input.exclusiveMinimum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMinimum",
+                            expected: "(boolean | undefined)",
+                            value: input.exclusiveMinimum,
+                        })) &&
+                    (undefined === input.exclusiveMaximum ||
+                        "boolean" === typeof input.exclusiveMaximum ||
+                        $guard(_exceptionable, {
+                            path: _path + ".exclusiveMaximum",
+                            expected: "(boolean | undefined)",
+                            value: input.exclusiveMaximum,
+                        })) &&
+                    (undefined === input.multipleOf ||
+                        ("number" === typeof input.multipleOf &&
+                            Number.isFinite(input.multipleOf) &&
+                            (parseInt(input.multipleOf) === input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".multipleOf",
+                            expected: "(number | undefined)",
+                            value: input.multipleOf,
+                        })) &&
                     (undefined === input["default"] ||
-                        "boolean" === typeof input["default"] ||
+                        ("number" === typeof input["default"] &&
+                            Number.isFinite(input["default"])) ||
                         $guard(_exceptionable, {
                             path: _path + '["default"]',
-                            expected: "(boolean | undefined)",
+                            expected: "(number | undefined)",
                             value: input["default"],
                         })) &&
-                    ("boolean" === input.type ||
+                    ("integer" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"boolean"',
+                            expected: '"integer"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -10222,13 +10023,7 @@ export const test_random_UltimateUnion = _test_random(
                 ): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Number.isFinite(input.minimum) &&
-                            (parseInt(input.minimum) === input.minimum ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".minimum",
-                                    expected: "number (@type int)",
-                                    value: input.minimum,
-                                }))) ||
+                            Number.isFinite(input.minimum)) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
                             expected: "(number | undefined)",
@@ -10236,13 +10031,7 @@ export const test_random_UltimateUnion = _test_random(
                         })) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Number.isFinite(input.maximum) &&
-                            (parseInt(input.maximum) === input.maximum ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".maximum",
-                                    expected: "number (@type int)",
-                                    value: input.maximum,
-                                }))) ||
+                            Number.isFinite(input.maximum)) ||
                         $guard(_exceptionable, {
                             path: _path + ".maximum",
                             expected: "(number | undefined)",
@@ -10264,13 +10053,7 @@ export const test_random_UltimateUnion = _test_random(
                         })) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Number.isFinite(input.multipleOf) &&
-                            (parseInt(input.multipleOf) === input.multipleOf ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".multipleOf",
-                                    expected: "number (@type int)",
-                                    value: input.multipleOf,
-                                }))) ||
+                            Number.isFinite(input.multipleOf)) ||
                         $guard(_exceptionable, {
                             path: _path + ".multipleOf",
                             expected: "(number | undefined)",
@@ -10284,10 +10067,10 @@ export const test_random_UltimateUnion = _test_random(
                             expected: "(number | undefined)",
                             value: input["default"],
                         })) &&
-                    ("integer" === input.type ||
+                    ("number" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"integer"',
+                            expected: '"number"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -10446,56 +10229,71 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (undefined === input.minimum ||
-                        ("number" === typeof input.minimum &&
-                            Number.isFinite(input.minimum)) ||
+                    (undefined === input.minLength ||
+                        ("number" === typeof input.minLength &&
+                            Number.isFinite(input.minLength) &&
+                            (parseInt(input.minLength) === input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                })) &&
+                            (0 <= input.minLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
+                                }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".minimum",
+                            path: _path + ".minLength",
                             expected: "(number | undefined)",
-                            value: input.minimum,
+                            value: input.minLength,
                         })) &&
-                    (undefined === input.maximum ||
-                        ("number" === typeof input.maximum &&
-                            Number.isFinite(input.maximum)) ||
+                    (undefined === input.maxLength ||
+                        ("number" === typeof input.maxLength &&
+                            Number.isFinite(input.maxLength) &&
+                            (parseInt(input.maxLength) === input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".maximum",
+                            path: _path + ".maxLength",
                             expected: "(number | undefined)",
-                            value: input.maximum,
+                            value: input.maxLength,
                         })) &&
-                    (undefined === input.exclusiveMinimum ||
-                        "boolean" === typeof input.exclusiveMinimum ||
+                    (undefined === input.pattern ||
+                        "string" === typeof input.pattern ||
                         $guard(_exceptionable, {
-                            path: _path + ".exclusiveMinimum",
-                            expected: "(boolean | undefined)",
-                            value: input.exclusiveMinimum,
+                            path: _path + ".pattern",
+                            expected: "(string | undefined)",
+                            value: input.pattern,
                         })) &&
-                    (undefined === input.exclusiveMaximum ||
-                        "boolean" === typeof input.exclusiveMaximum ||
+                    (undefined === input.format ||
+                        "string" === typeof input.format ||
                         $guard(_exceptionable, {
-                            path: _path + ".exclusiveMaximum",
-                            expected: "(boolean | undefined)",
-                            value: input.exclusiveMaximum,
-                        })) &&
-                    (undefined === input.multipleOf ||
-                        ("number" === typeof input.multipleOf &&
-                            Number.isFinite(input.multipleOf)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".multipleOf",
-                            expected: "(number | undefined)",
-                            value: input.multipleOf,
+                            path: _path + ".format",
+                            expected: "(string | undefined)",
+                            value: input.format,
                         })) &&
                     (undefined === input["default"] ||
-                        ("number" === typeof input["default"] &&
-                            Number.isFinite(input["default"])) ||
+                        "string" === typeof input["default"] ||
                         $guard(_exceptionable, {
                             path: _path + '["default"]',
-                            expected: "(number | undefined)",
+                            expected: "(string | undefined)",
                             value: input["default"],
                         })) &&
-                    ("number" === input.type ||
+                    ("string" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"number"',
+                            expected: '"string"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -10654,71 +10452,88 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (undefined === input.minLength ||
-                        ("number" === typeof input.minLength &&
-                            Number.isFinite(input.minLength) &&
-                            (parseInt(input.minLength) === input.minLength ||
+                    (((("object" === typeof input.items &&
+                        null !== input.items &&
+                        false === Array.isArray(input.items)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".items",
+                            expected:
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            value: input.items,
+                        })) &&
+                        $au0(
+                            input.items,
+                            _path + ".items",
+                            true && _exceptionable,
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".items",
+                            expected:
+                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            value: input.items,
+                        })) &&
+                    (undefined === input.minItems ||
+                        ("number" === typeof input.minItems &&
+                            Number.isFinite(input.minItems) &&
+                            (parseInt(input.minItems) === input.minItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "number (@type uint)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 })) &&
-                            (0 <= input.minLength ||
+                            (0 <= input.minItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "number (@type uint)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".minLength",
+                            path: _path + ".minItems",
                             expected: "(number | undefined)",
-                            value: input.minLength,
+                            value: input.minItems,
                         })) &&
-                    (undefined === input.maxLength ||
-                        ("number" === typeof input.maxLength &&
-                            Number.isFinite(input.maxLength) &&
-                            (parseInt(input.maxLength) === input.maxLength ||
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            (parseInt(input.maxItems) === input.maxItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "number (@type uint)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 })) &&
-                            (0 <= input.maxLength ||
+                            (0 <= input.maxItems ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "number (@type uint)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 }))) ||
                         $guard(_exceptionable, {
-                            path: _path + ".maxLength",
+                            path: _path + ".maxItems",
                             expected: "(number | undefined)",
-                            value: input.maxLength,
+                            value: input.maxItems,
                         })) &&
-                    (undefined === input.pattern ||
-                        "string" === typeof input.pattern ||
+                    (undefined === input["x-typia-tuple"] ||
+                        ((("object" === typeof input["x-typia-tuple"] &&
+                            null !== input["x-typia-tuple"]) ||
+                            $guard(_exceptionable, {
+                                path: _path + '["x-typia-tuple"]',
+                                expected: "(IJsonSchema.ITuple | undefined)",
+                                value: input["x-typia-tuple"],
+                            })) &&
+                            $ao26(
+                                input["x-typia-tuple"],
+                                _path + '["x-typia-tuple"]',
+                                true && _exceptionable,
+                            )) ||
                         $guard(_exceptionable, {
-                            path: _path + ".pattern",
-                            expected: "(string | undefined)",
-                            value: input.pattern,
+                            path: _path + '["x-typia-tuple"]',
+                            expected: "(IJsonSchema.ITuple | undefined)",
+                            value: input["x-typia-tuple"],
                         })) &&
-                    (undefined === input.format ||
-                        "string" === typeof input.format ||
-                        $guard(_exceptionable, {
-                            path: _path + ".format",
-                            expected: "(string | undefined)",
-                            value: input.format,
-                        })) &&
-                    (undefined === input["default"] ||
-                        "string" === typeof input["default"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["default"]',
-                            expected: "(string | undefined)",
-                            value: input["default"],
-                        })) &&
-                    ("string" === input.type ||
+                    ("array" === input.type ||
                         $guard(_exceptionable, {
                             path: _path + ".type",
-                            expected: '"string"',
+                            expected: '"array"',
                             value: input.type,
                         })) &&
                     (undefined === input.nullable ||
@@ -10877,44 +10692,58 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((("object" === typeof input.items &&
-                        null !== input.items &&
-                        false === Array.isArray(input.items)) ||
+                    (((Array.isArray(input.items) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
-                            expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            expected: "Array<IJsonSchema>",
                             value: input.items,
                         })) &&
-                        $au0(
-                            input.items,
-                            _path + ".items",
-                            true && _exceptionable,
+                        input.items.every(
+                            (elem: any, _index56: number) =>
+                                ((("object" === typeof elem &&
+                                    null !== elem &&
+                                    false === Array.isArray(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".items[" + _index56 + "]",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: elem,
+                                    })) &&
+                                    $au0(
+                                        elem,
+                                        _path + ".items[" + _index56 + "]",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".items[" + _index56 + "]",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: elem,
+                                }),
                         )) ||
                         $guard(_exceptionable, {
                             path: _path + ".items",
-                            expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            expected: "Array<IJsonSchema>",
                             value: input.items,
                         })) &&
-                    (undefined === input.minItems ||
-                        ("number" === typeof input.minItems &&
-                            Number.isFinite(input.minItems) &&
-                            (parseInt(input.minItems) === input.minItems ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".minItems",
-                                    expected: "number (@type uint)",
-                                    value: input.minItems,
-                                })) &&
-                            (0 <= input.minItems ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".minItems",
-                                    expected: "number (@type uint)",
-                                    value: input.minItems,
-                                }))) ||
+                    (("number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        (parseInt(input.minItems) === input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            })) &&
+                        (0 <= input.minItems ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
+                            }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
-                            expected: "(number | undefined)",
+                            expected: "number",
                             value: input.minItems,
                         })) &&
                     (undefined === input.maxItems ||
@@ -10936,24 +10765,6 @@ export const test_random_UltimateUnion = _test_random(
                             path: _path + ".maxItems",
                             expected: "(number | undefined)",
                             value: input.maxItems,
-                        })) &&
-                    (undefined === input["x-typia-tuple"] ||
-                        ((("object" === typeof input["x-typia-tuple"] &&
-                            null !== input["x-typia-tuple"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-tuple"]',
-                                expected: "(IJsonSchema.ITuple | undefined)",
-                                value: input["x-typia-tuple"],
-                            })) &&
-                            $ao26(
-                                input["x-typia-tuple"],
-                                _path + '["x-typia-tuple"]',
-                                true && _exceptionable,
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-tuple"]',
-                            expected: "(IJsonSchema.ITuple | undefined)",
-                            value: input["x-typia-tuple"],
                         })) &&
                     ("array" === input.type ||
                         $guard(_exceptionable, {
@@ -10997,14 +10808,14 @@ export const test_random_UltimateUnion = _test_random(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index56: number) =>
+                                (elem: any, _index57: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index56 +
+                                                _index57 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -11014,7 +10825,7 @@ export const test_random_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index56 +
+                                                _index57 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -11022,7 +10833,7 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index56 +
+                                            _index57 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -11042,14 +10853,14 @@ export const test_random_UltimateUnion = _test_random(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index57: number) =>
+                                (elem: any, _index58: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index57 +
+                                                _index58 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -11058,7 +10869,7 @@ export const test_random_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index57 +
+                                                _index58 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -11066,7 +10877,7 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
-                                            _index57 +
+                                            _index58 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -11117,53 +10928,40 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((Array.isArray(input.items) ||
+                    (((Array.isArray(input.oneOf) ||
                         $guard(_exceptionable, {
-                            path: _path + ".items",
+                            path: _path + ".oneOf",
                             expected: "Array<IJsonSchema>",
-                            value: input.items,
+                            value: input.oneOf,
                         })) &&
-                        input.items.every(
-                            (elem: any, _index58: number) =>
+                        input.oneOf.every(
+                            (elem: any, _index59: number) =>
                                 ((("object" === typeof elem &&
                                     null !== elem &&
                                     false === Array.isArray(elem)) ||
                                     $guard(_exceptionable, {
                                         path:
-                                            _path + ".items[" + _index58 + "]",
+                                            _path + ".oneOf[" + _index59 + "]",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: elem,
                                     })) &&
                                     $au0(
                                         elem,
-                                        _path + ".items[" + _index58 + "]",
+                                        _path + ".oneOf[" + _index59 + "]",
                                         true && _exceptionable,
                                     )) ||
                                 $guard(_exceptionable, {
-                                    path: _path + ".items[" + _index58 + "]",
+                                    path: _path + ".oneOf[" + _index59 + "]",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: elem,
                                 }),
                         )) ||
                         $guard(_exceptionable, {
-                            path: _path + ".items",
+                            path: _path + ".oneOf",
                             expected: "Array<IJsonSchema>",
-                            value: input.items,
-                        })) &&
-                    ("array" === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: '"array"',
-                            value: input.type,
-                        })) &&
-                    (undefined === input.nullable ||
-                        "boolean" === typeof input.nullable ||
-                        $guard(_exceptionable, {
-                            path: _path + ".nullable",
-                            expected: "(boolean | undefined)",
-                            value: input.nullable,
+                            value: input.oneOf,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -11194,14 +10992,14 @@ export const test_random_UltimateUnion = _test_random(
                                 value: input["x-typia-metaTags"],
                             })) &&
                             input["x-typia-metaTags"].every(
-                                (elem: any, _index59: number) =>
+                                (elem: any, _index60: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index59 +
+                                                _index60 +
                                                 "]",
                                             expected:
                                                 "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -11211,7 +11009,7 @@ export const test_random_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-metaTags"][' +
-                                                _index59 +
+                                                _index60 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -11219,7 +11017,7 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-metaTags"][' +
-                                            _index59 +
+                                            _index60 +
                                             "]",
                                         expected:
                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -11239,14 +11037,14 @@ export const test_random_UltimateUnion = _test_random(
                                 value: input["x-typia-jsDocTags"],
                             })) &&
                             input["x-typia-jsDocTags"].every(
-                                (elem: any, _index60: number) =>
+                                (elem: any, _index61: number) =>
                                     ((("object" === typeof elem &&
                                         null !== elem) ||
                                         $guard(_exceptionable, {
                                             path:
                                                 _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index60 +
+                                                _index61 +
                                                 "]",
                                             expected: "IJsDocTagInfo",
                                             value: elem,
@@ -11255,7 +11053,7 @@ export const test_random_UltimateUnion = _test_random(
                                             elem,
                                             _path +
                                                 '["x-typia-jsDocTags"][' +
-                                                _index60 +
+                                                _index61 +
                                                 "]",
                                             true && _exceptionable,
                                         )) ||
@@ -11263,7 +11061,7 @@ export const test_random_UltimateUnion = _test_random(
                                         path:
                                             _path +
                                             '["x-typia-jsDocTags"][' +
-                                            _index60 +
+                                            _index61 +
                                             "]",
                                         expected: "IJsDocTagInfo",
                                         value: elem,
@@ -11314,40 +11112,11 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    (((Array.isArray(input.oneOf) ||
+                    ("string" === typeof input.$ref ||
                         $guard(_exceptionable, {
-                            path: _path + ".oneOf",
-                            expected: "Array<IJsonSchema>",
-                            value: input.oneOf,
-                        })) &&
-                        input.oneOf.every(
-                            (elem: any, _index61: number) =>
-                                ((("object" === typeof elem &&
-                                    null !== elem &&
-                                    false === Array.isArray(elem)) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path + ".oneOf[" + _index61 + "]",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                        value: elem,
-                                    })) &&
-                                    $au0(
-                                        elem,
-                                        _path + ".oneOf[" + _index61 + "]",
-                                        true && _exceptionable,
-                                    )) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".oneOf[" + _index61 + "]",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                    value: elem,
-                                }),
-                        )) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".oneOf",
-                            expected: "Array<IJsonSchema>",
-                            value: input.oneOf,
+                            path: _path + ".$ref",
+                            expected: "string",
+                            value: input.$ref,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -11498,11 +11267,11 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("string" === typeof input.$ref ||
+                    ("null" === input.type ||
                         $guard(_exceptionable, {
-                            path: _path + ".$ref",
-                            expected: "string",
-                            value: input.$ref,
+                            path: _path + ".type",
+                            expected: '"null"',
+                            value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -11653,11 +11422,17 @@ export const test_random_UltimateUnion = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
-                    ("string" === typeof input.$recursiveRef ||
+                    (null !== input.type ||
                         $guard(_exceptionable, {
-                            path: _path + ".$recursiveRef",
-                            expected: "string",
-                            value: input.$recursiveRef,
+                            path: _path + ".type",
+                            expected: "undefined",
+                            value: input.type,
+                        })) &&
+                    (undefined === input.type ||
+                        $guard(_exceptionable, {
+                            path: _path + ".type",
+                            expected: "undefined",
+                            value: input.type,
                         })) &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated ||
@@ -11803,322 +11578,6 @@ export const test_random_UltimateUnion = _test_random(
                             expected: "(boolean | undefined)",
                             value: input.$recursiveAnchor,
                         }));
-                const $ao48 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    ("null" === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: '"null"',
-                            value: input.type,
-                        })) &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated ||
-                        $guard(_exceptionable, {
-                            path: _path + ".deprecated",
-                            expected: "(boolean | undefined)",
-                            value: input.deprecated,
-                        })) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title ||
-                        $guard(_exceptionable, {
-                            path: _path + ".title",
-                            expected: "(string | undefined)",
-                            value: input.title,
-                        })) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description ||
-                        $guard(_exceptionable, {
-                            path: _path + ".description",
-                            expected: "(string | undefined)",
-                            value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        ((Array.isArray(input["x-typia-metaTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any, _index68: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index68 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        })) &&
-                                        $au1(
-                                            elem,
-                                            _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index68 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-metaTags"][' +
-                                            _index68 +
-                                            "]",
-                                        expected:
-                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-metaTags"]',
-                            expected: "(Array<IMetadataTag> | undefined)",
-                            value: input["x-typia-metaTags"],
-                        })) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any, _index69: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index69 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        })) &&
-                                        $ao17(
-                                            elem,
-                                            _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index69 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-jsDocTags"][' +
-                                            _index69 +
-                                            "]",
-                                        expected: "IJsDocTagInfo",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-jsDocTags"]',
-                            expected: "(Array<IJsDocTagInfo> | undefined)",
-                            value: input["x-typia-jsDocTags"],
-                        })) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-required"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-required"],
-                        })) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-optional"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-optional"],
-                        })) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-rest"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-rest"],
-                        })) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$id",
-                            expected: "(string | undefined)",
-                            value: input.$id,
-                        })) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$recursiveAnchor",
-                            expected: "(boolean | undefined)",
-                            value: input.$recursiveAnchor,
-                        }));
-                const $ao49 = (
-                    input: any,
-                    _path: string,
-                    _exceptionable: boolean = true,
-                ): boolean =>
-                    (null !== input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
-                        })) &&
-                    (undefined === input.type ||
-                        $guard(_exceptionable, {
-                            path: _path + ".type",
-                            expected: "undefined",
-                            value: input.type,
-                        })) &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated ||
-                        $guard(_exceptionable, {
-                            path: _path + ".deprecated",
-                            expected: "(boolean | undefined)",
-                            value: input.deprecated,
-                        })) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title ||
-                        $guard(_exceptionable, {
-                            path: _path + ".title",
-                            expected: "(string | undefined)",
-                            value: input.title,
-                        })) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description ||
-                        $guard(_exceptionable, {
-                            path: _path + ".description",
-                            expected: "(string | undefined)",
-                            value: input.description,
-                        })) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        ((Array.isArray(input["x-typia-metaTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-metaTags"]',
-                                expected: "(Array<IMetadataTag> | undefined)",
-                                value: input["x-typia-metaTags"],
-                            })) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any, _index70: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index70 +
-                                                "]",
-                                            expected:
-                                                "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                            value: elem,
-                                        })) &&
-                                        $au1(
-                                            elem,
-                                            _path +
-                                                '["x-typia-metaTags"][' +
-                                                _index70 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-metaTags"][' +
-                                            _index70 +
-                                            "]",
-                                        expected:
-                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-metaTags"]',
-                            expected: "(Array<IMetadataTag> | undefined)",
-                            value: input["x-typia-metaTags"],
-                        })) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                            $guard(_exceptionable, {
-                                path: _path + '["x-typia-jsDocTags"]',
-                                expected: "(Array<IJsDocTagInfo> | undefined)",
-                                value: input["x-typia-jsDocTags"],
-                            })) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any, _index71: number) =>
-                                    ((("object" === typeof elem &&
-                                        null !== elem) ||
-                                        $guard(_exceptionable, {
-                                            path:
-                                                _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index71 +
-                                                "]",
-                                            expected: "IJsDocTagInfo",
-                                            value: elem,
-                                        })) &&
-                                        $ao17(
-                                            elem,
-                                            _path +
-                                                '["x-typia-jsDocTags"][' +
-                                                _index71 +
-                                                "]",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $guard(_exceptionable, {
-                                        path:
-                                            _path +
-                                            '["x-typia-jsDocTags"][' +
-                                            _index71 +
-                                            "]",
-                                        expected: "IJsDocTagInfo",
-                                        value: elem,
-                                    }),
-                            )) ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-jsDocTags"]',
-                            expected: "(Array<IJsDocTagInfo> | undefined)",
-                            value: input["x-typia-jsDocTags"],
-                        })) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-required"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-required"],
-                        })) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-optional"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-optional"],
-                        })) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"] ||
-                        $guard(_exceptionable, {
-                            path: _path + '["x-typia-rest"]',
-                            expected: "(boolean | undefined)",
-                            value: input["x-typia-rest"],
-                        })) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$id",
-                            expected: "(string | undefined)",
-                            value: input.$id,
-                        })) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor ||
-                        $guard(_exceptionable, {
-                            path: _path + ".$recursiveAnchor",
-                            expected: "(boolean | undefined)",
-                            value: input.$recursiveAnchor,
-                        }));
                 const $au0 = (
                     input: any,
                     _path: string,
@@ -12141,13 +11600,13 @@ export const test_random_UltimateUnion = _test_random(
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
-                                (elem: any, _index72: number) =>
+                                (elem: any, _index68: number) =>
                                     "object" === typeof elem &&
                                     null !== elem &&
                                     false === Array.isArray(elem) &&
                                     $au0(
                                         elem,
-                                        _path + ".items[" + _index72 + "]",
+                                        _path + ".items[" + _index68 + "]",
                                         false && _exceptionable,
                                     ),
                             )
@@ -12157,10 +11616,8 @@ export const test_random_UltimateUnion = _test_random(
                             return $ao27(input, _path, true && _exceptionable);
                         if (undefined !== input.$ref)
                             return $ao28(input, _path, true && _exceptionable);
-                        if (undefined !== input.$recursiveRef)
-                            return $ao29(input, _path, true && _exceptionable);
                         if ("null" === input.type)
-                            return $ao30(input, _path, true && _exceptionable);
+                            return $ao29(input, _path, true && _exceptionable);
                         return (
                             $ao20(input, _path, false && _exceptionable) ||
                             $ao19(input, _path, false && _exceptionable) ||
@@ -12168,7 +11625,7 @@ export const test_random_UltimateUnion = _test_random(
                             $ao21(input, _path, false && _exceptionable) ||
                             $ao23(input, _path, false && _exceptionable) ||
                             $ao24(input, _path, false && _exceptionable) ||
-                            $ao31(input, _path, false && _exceptionable) ||
+                            $ao30(input, _path, false && _exceptionable) ||
                             $guard(_exceptionable, {
                                 path: _path,
                                 expected:
@@ -12227,9 +11684,9 @@ export const test_random_UltimateUnion = _test_random(
                 ): any =>
                     (() => {
                         if ("object" === input.type)
-                            return $ao34(input, _path, true && _exceptionable);
+                            return $ao33(input, _path, true && _exceptionable);
                         if ("integer" === input.type)
-                            return $ao40(input, _path, true && _exceptionable);
+                            return $ao39(input, _path, true && _exceptionable);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
@@ -12240,38 +11697,36 @@ export const test_random_UltimateUnion = _test_random(
                                 false && _exceptionable,
                             )
                         )
-                            return $ao43(input, _path, true && _exceptionable);
+                            return $ao42(input, _path, true && _exceptionable);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
-                                (elem: any, _index73: number) =>
+                                (elem: any, _index69: number) =>
                                     "object" === typeof elem &&
                                     null !== elem &&
                                     false === Array.isArray(elem) &&
                                     $au0(
                                         elem,
-                                        _path + ".items[" + _index73 + "]",
+                                        _path + ".items[" + _index69 + "]",
                                         false && _exceptionable,
                                     ),
                             )
                         )
-                            return $ao44(input, _path, true && _exceptionable);
+                            return $ao43(input, _path, true && _exceptionable);
                         if (undefined !== input.oneOf)
-                            return $ao45(input, _path, true && _exceptionable);
+                            return $ao44(input, _path, true && _exceptionable);
                         if (undefined !== input.$ref)
-                            return $ao46(input, _path, true && _exceptionable);
-                        if (undefined !== input.$recursiveRef)
-                            return $ao47(input, _path, true && _exceptionable);
+                            return $ao45(input, _path, true && _exceptionable);
                         if ("null" === input.type)
-                            return $ao48(input, _path, true && _exceptionable);
+                            return $ao46(input, _path, true && _exceptionable);
                         return (
-                            $ao38(input, _path, false && _exceptionable) ||
                             $ao37(input, _path, false && _exceptionable) ||
                             $ao36(input, _path, false && _exceptionable) ||
-                            $ao39(input, _path, false && _exceptionable) ||
+                            $ao35(input, _path, false && _exceptionable) ||
+                            $ao38(input, _path, false && _exceptionable) ||
+                            $ao40(input, _path, false && _exceptionable) ||
                             $ao41(input, _path, false && _exceptionable) ||
-                            $ao42(input, _path, false && _exceptionable) ||
-                            $ao49(input, _path, false && _exceptionable) ||
+                            $ao47(input, _path, false && _exceptionable) ||
                             $guard(_exceptionable, {
                                 path: _path,
                                 expected:

--- a/test/generated/output/stringify/test_stringify_UltimateUnion.ts
+++ b/test/generated/output/stringify/test_stringify_UltimateUnion.ts
@@ -396,6 +396,13 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -495,36 +502,6 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
             const $io29 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]);
-            const $io30 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -554,7 +531,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io31 = (input: any): boolean =>
+            const $io30 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -585,13 +562,13 @@ export const test_stringify_UltimateUnion = _test_stringify(
                     "boolean" === typeof input["x-typia-optional"]) &&
                 (undefined === input["x-typia-rest"] ||
                     "boolean" === typeof input["x-typia-rest"]);
-            const $io32 = (input: any): boolean =>
+            const $io31 = (input: any): boolean =>
                 undefined === input.schemas ||
                 ("object" === typeof input.schemas &&
                     null !== input.schemas &&
                     false === Array.isArray(input.schemas) &&
-                    $io33(input.schemas));
-            const $io33 = (input: any): boolean =>
+                    $io32(input.schemas));
+            const $io32 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -604,22 +581,20 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         );
                     return true;
                 });
-            const $io34 = (input: any): boolean =>
+            const $io33 = (input: any): boolean =>
                 (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor) &&
                 "object" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
                 "object" === typeof input.properties &&
                 null !== input.properties &&
                 false === Array.isArray(input.properties) &&
-                $io35(input.properties) &&
+                $io34(input.properties) &&
                 (undefined === input.patternProperties ||
                     ("object" === typeof input.patternProperties &&
                         null !== input.patternProperties &&
                         false === Array.isArray(input.patternProperties) &&
-                        $io35(input.patternProperties))) &&
+                        $io34(input.patternProperties))) &&
                 (undefined === input.additionalProperties ||
                     ("object" === typeof input.additionalProperties &&
                         null !== input.additionalProperties &&
@@ -645,7 +620,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         null !== input["x-typia-patternProperties"] &&
                         false ===
                             Array.isArray(input["x-typia-patternProperties"]) &&
-                        $io35(input["x-typia-patternProperties"]))) &&
+                        $io34(input["x-typia-patternProperties"]))) &&
                 (undefined === input["x-typia-additionalProperties"] ||
                     ("object" ===
                         typeof input["x-typia-additionalProperties"] &&
@@ -655,7 +630,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                                 input["x-typia-additionalProperties"],
                             ) &&
                         $iu0(input["x-typia-additionalProperties"])));
-            const $io35 = (input: any): boolean =>
+            const $io34 = (input: any): boolean =>
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
@@ -668,7 +643,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         );
                     return true;
                 });
-            const $io36 = (input: any): boolean =>
+            const $io35 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "boolean" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -707,7 +682,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io37 = (input: any): boolean =>
+            const $io36 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "number" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -746,7 +721,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io38 = (input: any): boolean =>
+            const $io37 = (input: any): boolean =>
                 Array.isArray(input["enum"]) &&
                 input["enum"].every((elem: any) => "string" === typeof elem) &&
                 (undefined === input["default"] ||
@@ -785,7 +760,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io39 = (input: any): boolean =>
+            const $io38 = (input: any): boolean =>
                 (undefined === input["default"] ||
                     "boolean" === typeof input["default"]) &&
                 "boolean" === input.type &&
@@ -822,7 +797,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io40 = (input: any): boolean =>
+            const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         parseInt(input.minimum) === input.minimum)) &&
@@ -872,7 +847,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io41 = (input: any): boolean =>
+            const $io40 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     "number" === typeof input.minimum) &&
                 (undefined === input.maximum ||
@@ -919,7 +894,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io42 = (input: any): boolean =>
+            const $io41 = (input: any): boolean =>
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         parseInt(input.minLength) === input.minLength &&
@@ -968,7 +943,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io43 = (input: any): boolean =>
+            const $io42 = (input: any): boolean =>
                 "object" === typeof input.items &&
                 null !== input.items &&
                 false === Array.isArray(input.items) &&
@@ -1019,7 +994,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io44 = (input: any): boolean =>
+            const $io43 = (input: any): boolean =>
                 Array.isArray(input.items) &&
                 input.items.every(
                     (elem: any) =>
@@ -1028,6 +1003,13 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         false === Array.isArray(elem) &&
                         $iu0(elem),
                 ) &&
+                "number" === typeof input.minItems &&
+                parseInt(input.minItems) === input.minItems &&
+                0 <= input.minItems &&
+                (undefined === input.maxItems ||
+                    ("number" === typeof input.maxItems &&
+                        parseInt(input.maxItems) === input.maxItems &&
+                        0 <= input.maxItems)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1062,7 +1044,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io45 = (input: any): boolean =>
+            const $io44 = (input: any): boolean =>
                 Array.isArray(input.oneOf) &&
                 input.oneOf.every(
                     (elem: any) =>
@@ -1102,7 +1084,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io46 = (input: any): boolean =>
+            const $io45 = (input: any): boolean =>
                 "string" === typeof input.$ref &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1135,40 +1117,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io47 = (input: any): boolean =>
-                "string" === typeof input.$recursiveRef &&
-                (undefined === input.deprecated ||
-                    "boolean" === typeof input.deprecated) &&
-                (undefined === input.title ||
-                    "string" === typeof input.title) &&
-                (undefined === input.description ||
-                    "string" === typeof input.description) &&
-                (undefined === input["x-typia-metaTags"] ||
-                    (Array.isArray(input["x-typia-metaTags"]) &&
-                        input["x-typia-metaTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $iu1(elem),
-                        ))) &&
-                (undefined === input["x-typia-jsDocTags"] ||
-                    (Array.isArray(input["x-typia-jsDocTags"]) &&
-                        input["x-typia-jsDocTags"].every(
-                            (elem: any) =>
-                                "object" === typeof elem &&
-                                null !== elem &&
-                                $io17(elem),
-                        ))) &&
-                (undefined === input["x-typia-required"] ||
-                    "boolean" === typeof input["x-typia-required"]) &&
-                (undefined === input["x-typia-optional"] ||
-                    "boolean" === typeof input["x-typia-optional"]) &&
-                (undefined === input["x-typia-rest"] ||
-                    "boolean" === typeof input["x-typia-rest"]) &&
-                (undefined === input.$id || "string" === typeof input.$id) &&
-                (undefined === input.$recursiveAnchor ||
-                    "boolean" === typeof input.$recursiveAnchor);
-            const $io48 = (input: any): boolean =>
+            const $io46 = (input: any): boolean =>
                 "null" === input.type &&
                 (undefined === input.deprecated ||
                     "boolean" === typeof input.deprecated) &&
@@ -1201,7 +1150,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.$id || "string" === typeof input.$id) &&
                 (undefined === input.$recursiveAnchor ||
                     "boolean" === typeof input.$recursiveAnchor);
-            const $io49 = (input: any): boolean =>
+            const $io47 = (input: any): boolean =>
                 null !== input.type &&
                 undefined === input.type &&
                 (undefined === input.deprecated ||
@@ -1258,8 +1207,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         return $io26(input);
                     if (undefined !== input.oneOf) return $io27(input);
                     if (undefined !== input.$ref) return $io28(input);
-                    if (undefined !== input.$recursiveRef) return $io29(input);
-                    if ("null" === input.type) return $io30(input);
+                    if ("null" === input.type) return $io29(input);
                     return (
                         $io20(input) ||
                         $io19(input) ||
@@ -1267,7 +1215,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         $io21(input) ||
                         $io23(input) ||
                         $io24(input) ||
-                        $io31(input)
+                        $io30(input)
                     );
                 })();
             const $iu1 = (input: any): any =>
@@ -1291,15 +1239,15 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 })();
             const $iu2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $io34(input);
-                    if ("integer" === input.type) return $io40(input);
+                    if ("object" === input.type) return $io33(input);
+                    if ("integer" === input.type) return $io39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $io43(input);
+                        return $io42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -1310,19 +1258,18 @@ export const test_stringify_UltimateUnion = _test_stringify(
                                 $iu0(elem),
                         )
                     )
-                        return $io44(input);
-                    if (undefined !== input.oneOf) return $io45(input);
-                    if (undefined !== input.$ref) return $io46(input);
-                    if (undefined !== input.$recursiveRef) return $io47(input);
-                    if ("null" === input.type) return $io48(input);
+                        return $io43(input);
+                    if (undefined !== input.oneOf) return $io44(input);
+                    if (undefined !== input.$ref) return $io45(input);
+                    if ("null" === input.type) return $io46(input);
                     return (
-                        $io38(input) ||
                         $io37(input) ||
                         $io36(input) ||
-                        $io39(input) ||
+                        $io35(input) ||
+                        $io38(input) ||
+                        $io40(input) ||
                         $io41(input) ||
-                        $io42(input) ||
-                        $io49(input)
+                        $io47(input)
                     );
                 })();
             const $string = (typia.stringify as any).string;
@@ -1333,7 +1280,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
             const $so0 = (input: any): any =>
                 `{"schemas":${`[${input.schemas
                     .map((elem: any) => $su0(elem))
-                    .join(",")}]`},"components":${$so32(
+                    .join(",")}]`},"components":${$so31(
                     input.components,
                 )},"purpose":${(() => {
                     if ("string" === typeof input.purpose)
@@ -2444,6 +2391,14 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 })()}}`;
             const $so26 = (input: any): any =>
                 `{${
+                    undefined === input.maxItems
+                        ? ""
+                        : `"maxItems":${
+                              undefined !== input.maxItems
+                                  ? $number(input.maxItems)
+                                  : undefined
+                          },`
+                }${
                     undefined === input.nullable
                         ? ""
                         : `"nullable":${
@@ -2521,7 +2476,9 @@ export const test_stringify_UltimateUnion = _test_stringify(
                           },`
                 }"items":${`[${input.items
                     .map((elem: any) => $su0(elem))
-                    .join(",")}]`},"type":${(() => {
+                    .join(",")}]`},"minItems":${$number(
+                    input.minItems,
+                )},"type":${(() => {
                     if ("string" === typeof input.type)
                         return $string(input.type);
                     if ("string" === typeof input.type)
@@ -2742,76 +2699,6 @@ export const test_stringify_UltimateUnion = _test_stringify(
                                   ? input["x-typia-rest"]
                                   : undefined
                           },`
-                }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-            const $so30 = (input: any): any =>
-                `{${
-                    undefined === input.deprecated
-                        ? ""
-                        : `"deprecated":${
-                              undefined !== input.deprecated
-                                  ? input.deprecated
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.title
-                        ? ""
-                        : `"title":${
-                              undefined !== input.title
-                                  ? $string(input.title)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.description
-                        ? ""
-                        : `"description":${
-                              undefined !== input.description
-                                  ? $string(input.description)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-metaTags"]
-                        ? ""
-                        : `"x-typia-metaTags":${
-                              undefined !== input["x-typia-metaTags"]
-                                  ? `[${input["x-typia-metaTags"]
-                                        .map((elem: any) => $su1(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-jsDocTags"]
-                        ? ""
-                        : `"x-typia-jsDocTags":${
-                              undefined !== input["x-typia-jsDocTags"]
-                                  ? `[${input["x-typia-jsDocTags"]
-                                        .map((elem: any) => $so17(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-required"]
-                        ? ""
-                        : `"x-typia-required":${
-                              undefined !== input["x-typia-required"]
-                                  ? input["x-typia-required"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-optional"]
-                        ? ""
-                        : `"x-typia-optional":${
-                              undefined !== input["x-typia-optional"]
-                                  ? input["x-typia-optional"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-rest"]
-                        ? ""
-                        : `"x-typia-rest":${
-                              undefined !== input["x-typia-rest"]
-                                  ? input["x-typia-rest"]
-                                  : undefined
-                          },`
                 }"type":${(() => {
                     if ("string" === typeof input.type)
                         return $string(input.type);
@@ -2822,7 +2709,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so31 = (input: any): any =>
+            const $so30 = (input: any): any =>
                 `{${$tail(
                     `${
                         undefined === input.deprecated
@@ -2894,19 +2781,19 @@ export const test_stringify_UltimateUnion = _test_stringify(
                               }`
                     }`,
                 )}}`;
-            const $so32 = (input: any): any =>
+            const $so31 = (input: any): any =>
                 `{${$tail(
                     `${
                         undefined === input.schemas
                             ? ""
                             : `"schemas":${
                                   undefined !== input.schemas
-                                      ? $so33(input.schemas)
+                                      ? $so32(input.schemas)
                                       : undefined
                               }`
                     }`,
                 )}}`;
-            const $so33 = (input: any): any =>
+            const $so32 = (input: any): any =>
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {
                         if (undefined === value) return "";
@@ -2914,21 +2801,13 @@ export const test_stringify_UltimateUnion = _test_stringify(
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;
-            const $so34 = (input: any): any =>
+            const $so33 = (input: any): any =>
                 `{${
                     undefined === input.$id
                         ? ""
                         : `"$id":${
                               undefined !== input.$id
                                   ? $string(input.$id)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.$recursiveAnchor
-                        ? ""
-                        : `"$recursiveAnchor":${
-                              undefined !== input.$recursiveAnchor
-                                  ? input.$recursiveAnchor
                                   : undefined
                           },`
                 }${
@@ -2944,7 +2823,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         ? ""
                         : `"patternProperties":${
                               undefined !== input.patternProperties
-                                  ? $so35(input.patternProperties)
+                                  ? $so34(input.patternProperties)
                                   : undefined
                           },`
                 }${
@@ -2988,7 +2867,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         ? ""
                         : `"x-typia-patternProperties":${
                               undefined !== input["x-typia-patternProperties"]
-                                  ? $so35(input["x-typia-patternProperties"])
+                                  ? $so34(input["x-typia-patternProperties"])
                                   : undefined
                           },`
                 }${
@@ -3009,8 +2888,8 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         expected: '"object"',
                         value: input.type,
                     });
-                })()},"properties":${$so35(input.properties)}}`;
-            const $so35 = (input: any): any =>
+                })()},"properties":${$so34(input.properties)}}`;
+            const $so34 = (input: any): any =>
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {
                         if (undefined === value) return "";
@@ -3018,7 +2897,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;
-            const $so36 = (input: any): any =>
+            const $so35 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -3131,7 +3010,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so37 = (input: any): any =>
+            const $so36 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -3244,7 +3123,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so38 = (input: any): any =>
+            const $so37 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -3357,7 +3236,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so39 = (input: any): any =>
+            const $so38 = (input: any): any =>
                 `{${
                     undefined === input["default"]
                         ? ""
@@ -3468,7 +3347,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so40 = (input: any): any =>
+            const $so39 = (input: any): any =>
                 `{${
                     undefined === input.minimum
                         ? ""
@@ -3619,7 +3498,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so41 = (input: any): any =>
+            const $so40 = (input: any): any =>
                 `{${
                     undefined === input.minimum
                         ? ""
@@ -3770,7 +3649,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so42 = (input: any): any =>
+            const $so41 = (input: any): any =>
                 `{${
                     undefined === input.minLength
                         ? ""
@@ -3913,7 +3792,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so43 = (input: any): any =>
+            const $so42 = (input: any): any =>
                 `{${
                     undefined === input.minItems
                         ? ""
@@ -4040,8 +3919,16 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so44 = (input: any): any =>
+            const $so43 = (input: any): any =>
                 `{${
+                    undefined === input.maxItems
+                        ? ""
+                        : `"maxItems":${
+                              undefined !== input.maxItems
+                                  ? $number(input.maxItems)
+                                  : undefined
+                          },`
+                }${
                     undefined === input.nullable
                         ? ""
                         : `"nullable":${
@@ -4135,7 +4022,9 @@ export const test_stringify_UltimateUnion = _test_stringify(
                           },`
                 }"items":${`[${input.items
                     .map((elem: any) => $su0(elem))
-                    .join(",")}]`},"type":${(() => {
+                    .join(",")}]`},"minItems":${$number(
+                    input.minItems,
+                )},"type":${(() => {
                     if ("string" === typeof input.type)
                         return $string(input.type);
                     if ("string" === typeof input.type)
@@ -4145,7 +4034,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so45 = (input: any): any =>
+            const $so44 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
                         ? ""
@@ -4233,7 +4122,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 }"oneOf":${`[${input.oneOf
                     .map((elem: any) => $su0(elem))
                     .join(",")}]`}}`;
-            const $so46 = (input: any): any =>
+            const $so45 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
                         ? ""
@@ -4319,93 +4208,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                                   : undefined
                           },`
                 }"$ref":${$string(input.$ref)}}`;
-            const $so47 = (input: any): any =>
-                `{${
-                    undefined === input.deprecated
-                        ? ""
-                        : `"deprecated":${
-                              undefined !== input.deprecated
-                                  ? input.deprecated
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.title
-                        ? ""
-                        : `"title":${
-                              undefined !== input.title
-                                  ? $string(input.title)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.description
-                        ? ""
-                        : `"description":${
-                              undefined !== input.description
-                                  ? $string(input.description)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-metaTags"]
-                        ? ""
-                        : `"x-typia-metaTags":${
-                              undefined !== input["x-typia-metaTags"]
-                                  ? `[${input["x-typia-metaTags"]
-                                        .map((elem: any) => $su1(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-jsDocTags"]
-                        ? ""
-                        : `"x-typia-jsDocTags":${
-                              undefined !== input["x-typia-jsDocTags"]
-                                  ? `[${input["x-typia-jsDocTags"]
-                                        .map((elem: any) => $so17(elem))
-                                        .join(",")}]`
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-required"]
-                        ? ""
-                        : `"x-typia-required":${
-                              undefined !== input["x-typia-required"]
-                                  ? input["x-typia-required"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-optional"]
-                        ? ""
-                        : `"x-typia-optional":${
-                              undefined !== input["x-typia-optional"]
-                                  ? input["x-typia-optional"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input["x-typia-rest"]
-                        ? ""
-                        : `"x-typia-rest":${
-                              undefined !== input["x-typia-rest"]
-                                  ? input["x-typia-rest"]
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.$id
-                        ? ""
-                        : `"$id":${
-                              undefined !== input.$id
-                                  ? $string(input.$id)
-                                  : undefined
-                          },`
-                }${
-                    undefined === input.$recursiveAnchor
-                        ? ""
-                        : `"$recursiveAnchor":${
-                              undefined !== input.$recursiveAnchor
-                                  ? input.$recursiveAnchor
-                                  : undefined
-                          },`
-                }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-            const $so48 = (input: any): any =>
+            const $so46 = (input: any): any =>
                 `{${
                     undefined === input.deprecated
                         ? ""
@@ -4500,7 +4303,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         value: input.type,
                     });
                 })()}}`;
-            const $so49 = (input: any): any =>
+            const $so47 = (input: any): any =>
                 `{${$tail(
                     `${
                         undefined === input.deprecated
@@ -4611,8 +4414,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         return $so26(input);
                     if (undefined !== input.oneOf) return $so27(input);
                     if (undefined !== input.$ref) return $so28(input);
-                    if (undefined !== input.$recursiveRef) return $so29(input);
-                    if ("null" === input.type) return $so30(input);
+                    if ("null" === input.type) return $so29(input);
                     return (() => {
                         if ($io20(input)) return $so20(input);
                         if ($io19(input)) return $so19(input);
@@ -4620,7 +4422,7 @@ export const test_stringify_UltimateUnion = _test_stringify(
                         if ($io21(input)) return $so21(input);
                         if ($io23(input)) return $so23(input);
                         if ($io24(input)) return $so24(input);
-                        if ($io31(input)) return $so31(input);
+                        if ($io30(input)) return $so30(input);
                         $throws({
                             expected:
                                 '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -4653,15 +4455,15 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 })();
             const $su2 = (input: any): any =>
                 (() => {
-                    if ("object" === input.type) return $so34(input);
-                    if ("integer" === input.type) return $so40(input);
+                    if ("object" === input.type) return $so33(input);
+                    if ("integer" === input.type) return $so39(input);
                     if (
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
                         $iu0(input.items)
                     )
-                        return $so43(input);
+                        return $so42(input);
                     if (
                         Array.isArray(input.items) &&
                         input.items.every(
@@ -4672,19 +4474,18 @@ export const test_stringify_UltimateUnion = _test_stringify(
                                 $iu0(elem),
                         )
                     )
-                        return $so44(input);
-                    if (undefined !== input.oneOf) return $so45(input);
-                    if (undefined !== input.$ref) return $so46(input);
-                    if (undefined !== input.$recursiveRef) return $so47(input);
-                    if ("null" === input.type) return $so48(input);
+                        return $so43(input);
+                    if (undefined !== input.oneOf) return $so44(input);
+                    if (undefined !== input.$ref) return $so45(input);
+                    if ("null" === input.type) return $so46(input);
                     return (() => {
-                        if ($io38(input)) return $so38(input);
                         if ($io37(input)) return $so37(input);
                         if ($io36(input)) return $so36(input);
-                        if ($io39(input)) return $so39(input);
+                        if ($io35(input)) return $so35(input);
+                        if ($io38(input)) return $so38(input);
+                        if ($io40(input)) return $so40(input);
                         if ($io41(input)) return $so41(input);
-                        if ($io42(input)) return $so42(input);
-                        if ($io49(input)) return $so49(input);
+                        if ($io47(input)) return $so47(input);
                         $throws({
                             expected:
                                 '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/validate/test_validate_UltimateUnion.ts
+++ b/test/generated/output/validate/test_validate_UltimateUnion.ts
@@ -24,7 +24,7 @@ export const test_validate_UltimateUnion = _test_validate(
                     "object" === typeof input.components &&
                     null !== input.components &&
                     false === Array.isArray(input.components) &&
-                    $io32(input.components) &&
+                    $io31(input.components) &&
                     ("ajv" === input.purpose || "swagger" === input.purpose);
                 const $io1 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
@@ -457,6 +457,15 @@ export const test_validate_UltimateUnion = _test_validate(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -556,36 +565,6 @@ export const test_validate_UltimateUnion = _test_validate(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -615,7 +594,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -646,13 +625,13 @@ export const test_validate_UltimateUnion = _test_validate(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -665,23 +644,21 @@ export const test_validate_UltimateUnion = _test_validate(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -711,7 +688,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -721,7 +698,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -734,7 +711,7 @@ export const test_validate_UltimateUnion = _test_validate(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -776,7 +753,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) =>
@@ -820,7 +797,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -862,7 +839,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -900,7 +877,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
@@ -955,7 +932,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum))) &&
@@ -1007,7 +984,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
@@ -1059,7 +1036,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -1113,7 +1090,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -1122,6 +1099,15 @@ export const test_validate_UltimateUnion = _test_validate(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    Number.isFinite(input.minItems) &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            Number.isFinite(input.maxItems) &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1157,7 +1143,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -1198,7 +1184,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1232,41 +1218,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -1300,7 +1252,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -1358,9 +1310,7 @@ export const test_validate_UltimateUnion = _test_validate(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (() => {
                             if ($io20(input)) return $io20(input);
                             if ($io19(input)) return $io19(input);
@@ -1368,7 +1318,7 @@ export const test_validate_UltimateUnion = _test_validate(
                             if ($io21(input)) return $io21(input);
                             if ($io23(input)) return $io23(input);
                             if ($io24(input)) return $io24(input);
-                            if ($io31(input)) return $io31(input);
+                            if ($io30(input)) return $io30(input);
                             return false;
                         })();
                     })();
@@ -1395,15 +1345,15 @@ export const test_validate_UltimateUnion = _test_validate(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -1414,20 +1364,18 @@ export const test_validate_UltimateUnion = _test_validate(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (() => {
-                            if ($io38(input)) return $io38(input);
                             if ($io37(input)) return $io37(input);
                             if ($io36(input)) return $io36(input);
-                            if ($io39(input)) return $io39(input);
+                            if ($io35(input)) return $io35(input);
+                            if ($io38(input)) return $io38(input);
+                            if ($io40(input)) return $io40(input);
                             if ($io41(input)) return $io41(input);
-                            if ($io42(input)) return $io42(input);
-                            if ($io49(input)) return $io49(input);
+                            if ($io47(input)) return $io47(input);
                             return false;
                         })();
                     })();
@@ -1475,7 +1423,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         _index2 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
@@ -1493,7 +1441,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     _index2 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
@@ -1511,7 +1459,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: "IJsonComponents",
                                     value: input.components,
                                 })) &&
-                                $vo32(
+                                $vo31(
                                     input.components,
                                     _path + ".components",
                                     true && _exceptionable,
@@ -3338,7 +3286,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                 $report(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 })) &&
                                 $vu0(
@@ -3349,7 +3297,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                 $report(_exceptionable, {
                                     path: _path + ".items",
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                     value: input.items,
                                 }),
                             undefined === input.minItems ||
@@ -3595,7 +3543,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         _index23 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
@@ -3613,7 +3561,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     _index23 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
@@ -3622,6 +3570,46 @@ export const test_validate_UltimateUnion = _test_validate(
                                     path: _path + ".items",
                                     expected: "Array<IJsonSchema>",
                                     value: input.items,
+                                }),
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number",
+                                    value: input.minItems,
+                                }),
+                            undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "(number | undefined)",
+                                    value: input.maxItems,
                                 }),
                             "array" === input.type ||
                                 $report(_exceptionable, {
@@ -3804,7 +3792,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         _index26 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
@@ -3822,7 +3810,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     _index26 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
@@ -4134,11 +4122,11 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "string" === typeof input.$recursiveRef ||
+                            "null" === input.type ||
                                 $report(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -4288,12 +4276,18 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "null" === input.type ||
+                            (null !== input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"null"',
+                                    expected: "undefined",
                                     value: input.type,
-                                }),
+                                })) &&
+                                (undefined === input.type ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".type",
+                                        expected: "undefined",
+                                        value: input.type,
+                                    })),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
                                 $report(_exceptionable, {
@@ -4442,31 +4436,188 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            (null !== input.type ||
+                            undefined === input.schemas ||
+                                ((("object" === typeof input.schemas &&
+                                    null !== input.schemas &&
+                                    false === Array.isArray(input.schemas)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".schemas",
+                                        expected:
+                                            "(Record<string, IObject | IAlias> | undefined)",
+                                        value: input.schemas,
+                                    })) &&
+                                    $vo32(
+                                        input.schemas,
+                                        _path + ".schemas",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".schemas",
+                                    expected:
+                                        "(Record<string, IObject | IAlias> | undefined)",
+                                    value: input.schemas,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo32 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            false === _exceptionable ||
+                                Object.keys(input)
+                                    .map((key: any) => {
+                                        const value = input[key];
+                                        if (undefined === value) return true;
+                                        if (RegExp(/(.*)/).test(key))
+                                            return (
+                                                ((("object" === typeof value &&
+                                                    null !== value &&
+                                                    false ===
+                                                        Array.isArray(value)) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path + $join(key),
+                                                        expected:
+                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                        value: value,
+                                                    })) &&
+                                                    $vu2(
+                                                        value,
+                                                        _path + $join(key),
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path: _path + $join(key),
+                                                    expected:
+                                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                    value: value,
+                                                })
+                                            );
+                                        return true;
+                                    })
+                                    .every((flag: boolean) => flag),
+                        ].every((flag: boolean) => flag);
+                    const $vo33 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.$id ||
+                                "string" === typeof input.$id ||
+                                $report(_exceptionable, {
+                                    path: _path + ".$id",
+                                    expected: "(string | undefined)",
+                                    value: input.$id,
+                                }),
+                            "object" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: "undefined",
+                                    expected: '"object"',
                                     value: input.type,
-                                })) &&
-                                (undefined === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: "undefined",
-                                        value: input.type,
-                                    })),
-                            undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $report(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
                                 }),
-                            undefined === input.title ||
-                                "string" === typeof input.title ||
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
                                 $report(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                }),
+                            ((("object" === typeof input.properties &&
+                                null !== input.properties &&
+                                false === Array.isArray(input.properties)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                })) &&
+                                $vo34(
+                                    input.properties,
+                                    _path + ".properties",
+                                    true && _exceptionable,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".properties",
+                                    expected: "Record<string, IJsonSchema>",
+                                    value: input.properties,
+                                }),
+                            undefined === input.patternProperties ||
+                                ((("object" ===
+                                    typeof input.patternProperties &&
+                                    null !== input.patternProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.patternProperties,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".patternProperties",
+                                        expected:
+                                            "(Record<string, IJsonSchema> | undefined)",
+                                        value: input.patternProperties,
+                                    })) &&
+                                    $vo34(
+                                        input.patternProperties,
+                                        _path + ".patternProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".patternProperties",
+                                    expected:
+                                        "(Record<string, IJsonSchema> | undefined)",
+                                    value: input.patternProperties,
+                                }),
+                            undefined === input.additionalProperties ||
+                                ((("object" ===
+                                    typeof input.additionalProperties &&
+                                    null !== input.additionalProperties &&
+                                    false ===
+                                        Array.isArray(
+                                            input.additionalProperties,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".additionalProperties",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        value: input.additionalProperties,
+                                    })) &&
+                                    $vu0(
+                                        input.additionalProperties,
+                                        _path + ".additionalProperties",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".additionalProperties",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                    value: input.additionalProperties,
+                                }),
+                            undefined === input.required ||
+                                ((Array.isArray(input.required) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".required",
+                                        expected: "(Array<string> | undefined)",
+                                        value: input.required,
+                                    })) &&
+                                    input.required
+                                        .map(
+                                            (elem: any, _index35: number) =>
+                                                "string" === typeof elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".required[" +
+                                                        _index35 +
+                                                        "]",
+                                                    expected: "string",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".required",
+                                    expected: "(Array<string> | undefined)",
+                                    value: input.required,
                                 }),
                             undefined === input.description ||
                                 "string" === typeof input.description ||
@@ -4474,55 +4625,6 @@ export const test_validate_UltimateUnion = _test_validate(
                                     path: _path + ".description",
                                     expected: "(string | undefined)",
                                     value: input.description,
-                                }),
-                            undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"]
-                                        .map(
-                                            (elem: any, _index35: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index35 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu1(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index35 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index35 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
                                 }),
                             undefined === input["x-typia-jsDocTags"] ||
                                 ((Array.isArray(input["x-typia-jsDocTags"]) ||
@@ -4572,281 +4674,6 @@ export const test_validate_UltimateUnion = _test_validate(
                                         "(Array<IJsDocTagInfo> | undefined)",
                                     value: input["x-typia-jsDocTags"],
                                 }),
-                            undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                }),
-                            undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                }),
-                            undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }),
-                        ].every((flag: boolean) => flag);
-                    const $vo32 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            undefined === input.schemas ||
-                                ((("object" === typeof input.schemas &&
-                                    null !== input.schemas &&
-                                    false === Array.isArray(input.schemas)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".schemas",
-                                        expected:
-                                            "(Record<string, IObject | IAlias> | undefined)",
-                                        value: input.schemas,
-                                    })) &&
-                                    $vo33(
-                                        input.schemas,
-                                        _path + ".schemas",
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".schemas",
-                                    expected:
-                                        "(Record<string, IObject | IAlias> | undefined)",
-                                    value: input.schemas,
-                                }),
-                        ].every((flag: boolean) => flag);
-                    const $vo33 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            false === _exceptionable ||
-                                Object.keys(input)
-                                    .map((key: any) => {
-                                        const value = input[key];
-                                        if (undefined === value) return true;
-                                        if (RegExp(/(.*)/).test(key))
-                                            return (
-                                                ((("object" === typeof value &&
-                                                    null !== value &&
-                                                    false ===
-                                                        Array.isArray(value)) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path + $join(key),
-                                                        expected:
-                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                        value: value,
-                                                    })) &&
-                                                    $vu2(
-                                                        value,
-                                                        _path + $join(key),
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path: _path + $join(key),
-                                                    expected:
-                                                        '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                    value: value,
-                                                })
-                                            );
-                                        return true;
-                                    })
-                                    .every((flag: boolean) => flag),
-                        ].every((flag: boolean) => flag);
-                    const $vo34 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                }),
-                            undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }),
-                            "object" === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"object"',
-                                    value: input.type,
-                                }),
-                            undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $report(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
-                                }),
-                            ((("object" === typeof input.properties &&
-                                null !== input.properties &&
-                                false === Array.isArray(input.properties)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                })) &&
-                                $vo35(
-                                    input.properties,
-                                    _path + ".properties",
-                                    true && _exceptionable,
-                                )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".properties",
-                                    expected: "Record<string, IJsonSchema>",
-                                    value: input.properties,
-                                }),
-                            undefined === input.patternProperties ||
-                                ((("object" ===
-                                    typeof input.patternProperties &&
-                                    null !== input.patternProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.patternProperties,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".patternProperties",
-                                        expected:
-                                            "(Record<string, IJsonSchema> | undefined)",
-                                        value: input.patternProperties,
-                                    })) &&
-                                    $vo35(
-                                        input.patternProperties,
-                                        _path + ".patternProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".patternProperties",
-                                    expected:
-                                        "(Record<string, IJsonSchema> | undefined)",
-                                    value: input.patternProperties,
-                                }),
-                            undefined === input.additionalProperties ||
-                                ((("object" ===
-                                    typeof input.additionalProperties &&
-                                    null !== input.additionalProperties &&
-                                    false ===
-                                        Array.isArray(
-                                            input.additionalProperties,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".additionalProperties",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                        value: input.additionalProperties,
-                                    })) &&
-                                    $vu0(
-                                        input.additionalProperties,
-                                        _path + ".additionalProperties",
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".additionalProperties",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                    value: input.additionalProperties,
-                                }),
-                            undefined === input.required ||
-                                ((Array.isArray(input.required) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".required",
-                                        expected: "(Array<string> | undefined)",
-                                        value: input.required,
-                                    })) &&
-                                    input.required
-                                        .map(
-                                            (elem: any, _index37: number) =>
-                                                "string" === typeof elem ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        ".required[" +
-                                                        _index37 +
-                                                        "]",
-                                                    expected: "string",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".required",
-                                    expected: "(Array<string> | undefined)",
-                                    value: input.required,
-                                }),
-                            undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $report(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                }),
-                            undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"]
-                                        .map(
-                                            (elem: any, _index38: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index38 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vo17(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index38 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index38 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                }),
                             undefined === input["x-typia-patternProperties"] ||
                                 ((("object" ===
                                     typeof input["x-typia-patternProperties"] &&
@@ -4866,7 +4693,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                             "x-typia-patternProperties"
                                         ],
                                     })) &&
-                                    $vo35(
+                                    $vo34(
                                         input["x-typia-patternProperties"],
                                         _path + '["x-typia-patternProperties"]',
                                         true && _exceptionable,
@@ -4897,7 +4724,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                             _path +
                                             '["x-typia-additionalProperties"]',
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                         value: input[
                                             "x-typia-additionalProperties"
                                         ],
@@ -4913,13 +4740,13 @@ export const test_validate_UltimateUnion = _test_validate(
                                         _path +
                                         '["x-typia-additionalProperties"]',
                                     expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                     value: input[
                                         "x-typia-additionalProperties"
                                     ],
                                 }),
                         ].every((flag: boolean) => flag);
-                    const $vo35 = (
+                    const $vo34 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4940,7 +4767,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         path:
                                                             _path + $join(key),
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: value,
                                                     })) &&
                                                     $vu0(
@@ -4951,7 +4778,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                 $report(_exceptionable, {
                                                     path: _path + $join(key),
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: value,
                                                 })
                                             );
@@ -4959,7 +4786,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                     })
                                     .every((flag: boolean) => flag),
                         ].every((flag: boolean) => flag);
-                    const $vo36 = (
+                    const $vo35 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -4973,13 +4800,13 @@ export const test_validate_UltimateUnion = _test_validate(
                                 })) &&
                                 input["enum"]
                                     .map(
-                                        (elem: any, _index39: number) =>
+                                        (elem: any, _index37: number) =>
                                             "boolean" === typeof elem ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["enum"][' +
-                                                    _index39 +
+                                                    _index37 +
                                                     "]",
                                                 expected: "boolean",
                                                 value: elem,
@@ -5042,14 +4869,14 @@ export const test_validate_UltimateUnion = _test_validate(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index40: number) =>
+                                            (elem: any, _index38: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index40 +
+                                                            _index38 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5059,7 +4886,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index40 +
+                                                            _index38 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5067,7 +4894,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index40 +
+                                                        _index38 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5091,14 +4918,14 @@ export const test_validate_UltimateUnion = _test_validate(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index41: number) =>
+                                            (elem: any, _index39: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index41 +
+                                                            _index39 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5108,7 +4935,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index41 +
+                                                            _index39 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5116,7 +4943,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index41 +
+                                                        _index39 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -5167,7 +4994,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                     value: input.$recursiveAnchor,
                                 }),
                         ].every((flag: boolean) => flag);
-                    const $vo37 = (
+                    const $vo36 = (
                         input: any,
                         _path: string,
                         _exceptionable: boolean = true,
@@ -5181,14 +5008,14 @@ export const test_validate_UltimateUnion = _test_validate(
                                 })) &&
                                 input["enum"]
                                     .map(
-                                        (elem: any, _index42: number) =>
+                                        (elem: any, _index40: number) =>
                                             ("number" === typeof elem &&
                                                 Number.isFinite(elem)) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
                                                     '["enum"][' +
-                                                    _index42 +
+                                                    _index40 +
                                                     "]",
                                                 expected: "number",
                                                 value: elem,
@@ -5252,14 +5079,14 @@ export const test_validate_UltimateUnion = _test_validate(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index43: number) =>
+                                            (elem: any, _index41: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index43 +
+                                                            _index41 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5269,7 +5096,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index43 +
+                                                            _index41 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5277,7 +5104,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index43 +
+                                                        _index41 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5301,14 +5128,14 @@ export const test_validate_UltimateUnion = _test_validate(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index44: number) =>
+                                            (elem: any, _index42: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index44 +
+                                                            _index42 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5318,7 +5145,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index44 +
+                                                            _index42 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -5326,7 +5153,215 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
+                                                        _index42 +
+                                                        "]",
+                                                    expected: "IJsDocTagInfo",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-jsDocTags"]',
+                                    expected:
+                                        "(Array<IJsDocTagInfo> | undefined)",
+                                    value: input["x-typia-jsDocTags"],
+                                }),
+                            undefined === input["x-typia-required"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-required"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-required"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-required"],
+                                }),
+                            undefined === input["x-typia-optional"] ||
+                                "boolean" ===
+                                    typeof input["x-typia-optional"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-optional"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-optional"],
+                                }),
+                            undefined === input["x-typia-rest"] ||
+                                "boolean" === typeof input["x-typia-rest"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-rest"]',
+                                    expected: "(boolean | undefined)",
+                                    value: input["x-typia-rest"],
+                                }),
+                            undefined === input.$id ||
+                                "string" === typeof input.$id ||
+                                $report(_exceptionable, {
+                                    path: _path + ".$id",
+                                    expected: "(string | undefined)",
+                                    value: input.$id,
+                                }),
+                            undefined === input.$recursiveAnchor ||
+                                "boolean" === typeof input.$recursiveAnchor ||
+                                $report(_exceptionable, {
+                                    path: _path + ".$recursiveAnchor",
+                                    expected: "(boolean | undefined)",
+                                    value: input.$recursiveAnchor,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo37 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            ((Array.isArray(input["enum"]) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                })) &&
+                                input["enum"]
+                                    .map(
+                                        (elem: any, _index43: number) =>
+                                            "string" === typeof elem ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    '["enum"][' +
+                                                    _index43 +
+                                                    "]",
+                                                expected: "string",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["enum"]',
+                                    expected: "Array<string>",
+                                    value: input["enum"],
+                                }),
+                            undefined === input["default"] ||
+                                "string" === typeof input["default"] ||
+                                $report(_exceptionable, {
+                                    path: _path + '["default"]',
+                                    expected: "(string | undefined)",
+                                    value: input["default"],
+                                }),
+                            "string" === input.type ||
+                                $report(_exceptionable, {
+                                    path: _path + ".type",
+                                    expected: '"string"',
+                                    value: input.type,
+                                }),
+                            undefined === input.nullable ||
+                                "boolean" === typeof input.nullable ||
+                                $report(_exceptionable, {
+                                    path: _path + ".nullable",
+                                    expected: "(boolean | undefined)",
+                                    value: input.nullable,
+                                }),
+                            undefined === input.deprecated ||
+                                "boolean" === typeof input.deprecated ||
+                                $report(_exceptionable, {
+                                    path: _path + ".deprecated",
+                                    expected: "(boolean | undefined)",
+                                    value: input.deprecated,
+                                }),
+                            undefined === input.title ||
+                                "string" === typeof input.title ||
+                                $report(_exceptionable, {
+                                    path: _path + ".title",
+                                    expected: "(string | undefined)",
+                                    value: input.title,
+                                }),
+                            undefined === input.description ||
+                                "string" === typeof input.description ||
+                                $report(_exceptionable, {
+                                    path: _path + ".description",
+                                    expected: "(string | undefined)",
+                                    value: input.description,
+                                }),
+                            undefined === input["x-typia-metaTags"] ||
+                                ((Array.isArray(input["x-typia-metaTags"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-metaTags"]',
+                                        expected:
+                                            "(Array<IMetadataTag> | undefined)",
+                                        value: input["x-typia-metaTags"],
+                                    })) &&
+                                    input["x-typia-metaTags"]
+                                        .map(
+                                            (elem: any, _index44: number) =>
+                                                ((("object" === typeof elem &&
+                                                    null !== elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-metaTags"][' +
+                                                            _index44 +
+                                                            "]",
+                                                        expected:
+                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                        value: elem,
+                                                    })) &&
+                                                    $vu1(
+                                                        elem,
+                                                        _path +
+                                                            '["x-typia-metaTags"][' +
+                                                            _index44 +
+                                                            "]",
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-metaTags"][' +
                                                         _index44 +
+                                                        "]",
+                                                    expected:
+                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + '["x-typia-metaTags"]',
+                                    expected:
+                                        "(Array<IMetadataTag> | undefined)",
+                                    value: input["x-typia-metaTags"],
+                                }),
+                            undefined === input["x-typia-jsDocTags"] ||
+                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-jsDocTags"]',
+                                        expected:
+                                            "(Array<IJsDocTagInfo> | undefined)",
+                                        value: input["x-typia-jsDocTags"],
+                                    })) &&
+                                    input["x-typia-jsDocTags"]
+                                        .map(
+                                            (elem: any, _index45: number) =>
+                                                ((("object" === typeof elem &&
+                                                    null !== elem) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-jsDocTags"][' +
+                                                            _index45 +
+                                                            "]",
+                                                        expected:
+                                                            "IJsDocTagInfo",
+                                                        value: elem,
+                                                    })) &&
+                                                    $vo17(
+                                                        elem,
+                                                        _path +
+                                                            '["x-typia-jsDocTags"][' +
+                                                            _index45 +
+                                                            "]",
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["x-typia-jsDocTags"][' +
+                                                        _index45 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -5383,43 +5418,17 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((Array.isArray(input["enum"]) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                })) &&
-                                input["enum"]
-                                    .map(
-                                        (elem: any, _index45: number) =>
-                                            "string" === typeof elem ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    '["enum"][' +
-                                                    _index45 +
-                                                    "]",
-                                                expected: "string",
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["enum"]',
-                                    expected: "Array<string>",
-                                    value: input["enum"],
-                                }),
                             undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
+                                "boolean" === typeof input["default"] ||
                                 $report(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(string | undefined)",
+                                    expected: "(boolean | undefined)",
                                     value: input["default"],
                                 }),
-                            "string" === input.type ||
+                            "boolean" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"boolean"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -5591,17 +5600,77 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
+                            undefined === input.minimum ||
+                                ("number" === typeof input.minimum &&
+                                    Number.isFinite(input.minimum) &&
+                                    (parseInt(input.minimum) ===
+                                        input.minimum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "(number | undefined)",
+                                    value: input.minimum,
+                                }),
+                            undefined === input.maximum ||
+                                ("number" === typeof input.maximum &&
+                                    Number.isFinite(input.maximum) &&
+                                    (parseInt(input.maximum) ===
+                                        input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "(number | undefined)",
+                                    value: input.maximum,
+                                }),
+                            undefined === input.exclusiveMinimum ||
+                                "boolean" === typeof input.exclusiveMinimum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMinimum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMinimum,
+                                }),
+                            undefined === input.exclusiveMaximum ||
+                                "boolean" === typeof input.exclusiveMaximum ||
+                                $report(_exceptionable, {
+                                    path: _path + ".exclusiveMaximum",
+                                    expected: "(boolean | undefined)",
+                                    value: input.exclusiveMaximum,
+                                }),
+                            undefined === input.multipleOf ||
+                                ("number" === typeof input.multipleOf &&
+                                    Number.isFinite(input.multipleOf) &&
+                                    (parseInt(input.multipleOf) ===
+                                        input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "(number | undefined)",
+                                    value: input.multipleOf,
+                                }),
                             undefined === input["default"] ||
-                                "boolean" === typeof input["default"] ||
+                                ("number" === typeof input["default"] &&
+                                    Number.isFinite(input["default"])) ||
                                 $report(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(boolean | undefined)",
+                                    expected: "(number | undefined)",
                                     value: input["default"],
                                 }),
-                            "boolean" === input.type ||
+                            "integer" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"boolean"',
+                                    expected: '"integer"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -5775,14 +5844,7 @@ export const test_validate_UltimateUnion = _test_validate(
                         [
                             undefined === input.minimum ||
                                 ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum) &&
-                                    (parseInt(input.minimum) ===
-                                        input.minimum ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".minimum",
-                                            expected: "number (@type int)",
-                                            value: input.minimum,
-                                        }))) ||
+                                    Number.isFinite(input.minimum)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
                                     expected: "(number | undefined)",
@@ -5790,14 +5852,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                 }),
                             undefined === input.maximum ||
                                 ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum) &&
-                                    (parseInt(input.maximum) ===
-                                        input.maximum ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".maximum",
-                                            expected: "number (@type int)",
-                                            value: input.maximum,
-                                        }))) ||
+                                    Number.isFinite(input.maximum)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "(number | undefined)",
@@ -5819,14 +5874,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                 }),
                             undefined === input.multipleOf ||
                                 ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf) &&
-                                    (parseInt(input.multipleOf) ===
-                                        input.multipleOf ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".multipleOf",
-                                            expected: "number (@type int)",
-                                            value: input.multipleOf,
-                                        }))) ||
+                                    Number.isFinite(input.multipleOf)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "(number | undefined)",
@@ -5840,10 +5888,10 @@ export const test_validate_UltimateUnion = _test_validate(
                                     expected: "(number | undefined)",
                                     value: input["default"],
                                 }),
-                            "integer" === input.type ||
+                            "number" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"integer"',
+                                    expected: '"number"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -6015,56 +6063,73 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            undefined === input.minimum ||
-                                ("number" === typeof input.minimum &&
-                                    Number.isFinite(input.minimum)) ||
+                            undefined === input.minLength ||
+                                ("number" === typeof input.minLength &&
+                                    Number.isFinite(input.minLength) &&
+                                    (parseInt(input.minLength) ===
+                                        input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        })) &&
+                                    (0 <= input.minLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
+                                        }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".minimum",
+                                    path: _path + ".minLength",
                                     expected: "(number | undefined)",
-                                    value: input.minimum,
+                                    value: input.minLength,
                                 }),
-                            undefined === input.maximum ||
-                                ("number" === typeof input.maximum &&
-                                    Number.isFinite(input.maximum)) ||
+                            undefined === input.maxLength ||
+                                ("number" === typeof input.maxLength &&
+                                    Number.isFinite(input.maxLength) &&
+                                    (parseInt(input.maxLength) ===
+                                        input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".maximum",
+                                    path: _path + ".maxLength",
                                     expected: "(number | undefined)",
-                                    value: input.maximum,
+                                    value: input.maxLength,
                                 }),
-                            undefined === input.exclusiveMinimum ||
-                                "boolean" === typeof input.exclusiveMinimum ||
+                            undefined === input.pattern ||
+                                "string" === typeof input.pattern ||
                                 $report(_exceptionable, {
-                                    path: _path + ".exclusiveMinimum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMinimum,
+                                    path: _path + ".pattern",
+                                    expected: "(string | undefined)",
+                                    value: input.pattern,
                                 }),
-                            undefined === input.exclusiveMaximum ||
-                                "boolean" === typeof input.exclusiveMaximum ||
+                            undefined === input.format ||
+                                "string" === typeof input.format ||
                                 $report(_exceptionable, {
-                                    path: _path + ".exclusiveMaximum",
-                                    expected: "(boolean | undefined)",
-                                    value: input.exclusiveMaximum,
-                                }),
-                            undefined === input.multipleOf ||
-                                ("number" === typeof input.multipleOf &&
-                                    Number.isFinite(input.multipleOf)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".multipleOf",
-                                    expected: "(number | undefined)",
-                                    value: input.multipleOf,
+                                    path: _path + ".format",
+                                    expected: "(string | undefined)",
+                                    value: input.format,
                                 }),
                             undefined === input["default"] ||
-                                ("number" === typeof input["default"] &&
-                                    Number.isFinite(input["default"])) ||
+                                "string" === typeof input["default"] ||
                                 $report(_exceptionable, {
                                     path: _path + '["default"]',
-                                    expected: "(number | undefined)",
+                                    expected: "(string | undefined)",
                                     value: input["default"],
                                 }),
-                            "number" === input.type ||
+                            "string" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"number"',
+                                    expected: '"string"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -6236,73 +6301,92 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            undefined === input.minLength ||
-                                ("number" === typeof input.minLength &&
-                                    Number.isFinite(input.minLength) &&
-                                    (parseInt(input.minLength) ===
-                                        input.minLength ||
+                            ((("object" === typeof input.items &&
+                                null !== input.items &&
+                                false === Array.isArray(input.items)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                })) &&
+                                $vu0(
+                                    input.items,
+                                    _path + ".items",
+                                    true && _exceptionable,
+                                )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".items",
+                                    expected:
+                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    value: input.items,
+                                }),
+                            undefined === input.minItems ||
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         })) &&
-                                    (0 <= input.minLength ||
+                                    (0 <= input.minItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".minLength",
+                                            path: _path + ".minItems",
                                             expected: "number (@type uint)",
-                                            value: input.minLength,
+                                            value: input.minItems,
                                         }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".minLength",
+                                    path: _path + ".minItems",
                                     expected: "(number | undefined)",
-                                    value: input.minLength,
+                                    value: input.minItems,
                                 }),
-                            undefined === input.maxLength ||
-                                ("number" === typeof input.maxLength &&
-                                    Number.isFinite(input.maxLength) &&
-                                    (parseInt(input.maxLength) ===
-                                        input.maxLength ||
+                            undefined === input.maxItems ||
+                                ("number" === typeof input.maxItems &&
+                                    Number.isFinite(input.maxItems) &&
+                                    (parseInt(input.maxItems) ===
+                                        input.maxItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         })) &&
-                                    (0 <= input.maxLength ||
+                                    (0 <= input.maxItems ||
                                         $report(_exceptionable, {
-                                            path: _path + ".maxLength",
+                                            path: _path + ".maxItems",
                                             expected: "number (@type uint)",
-                                            value: input.maxLength,
+                                            value: input.maxItems,
                                         }))) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".maxLength",
+                                    path: _path + ".maxItems",
                                     expected: "(number | undefined)",
-                                    value: input.maxLength,
+                                    value: input.maxItems,
                                 }),
-                            undefined === input.pattern ||
-                                "string" === typeof input.pattern ||
+                            undefined === input["x-typia-tuple"] ||
+                                ((("object" === typeof input["x-typia-tuple"] &&
+                                    null !== input["x-typia-tuple"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-tuple"]',
+                                        expected:
+                                            "(IJsonSchema.ITuple | undefined)",
+                                        value: input["x-typia-tuple"],
+                                    })) &&
+                                    $vo26(
+                                        input["x-typia-tuple"],
+                                        _path + '["x-typia-tuple"]',
+                                        true && _exceptionable,
+                                    )) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".pattern",
-                                    expected: "(string | undefined)",
-                                    value: input.pattern,
+                                    path: _path + '["x-typia-tuple"]',
+                                    expected:
+                                        "(IJsonSchema.ITuple | undefined)",
+                                    value: input["x-typia-tuple"],
                                 }),
-                            undefined === input.format ||
-                                "string" === typeof input.format ||
-                                $report(_exceptionable, {
-                                    path: _path + ".format",
-                                    expected: "(string | undefined)",
-                                    value: input.format,
-                                }),
-                            undefined === input["default"] ||
-                                "string" === typeof input["default"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["default"]',
-                                    expected: "(string | undefined)",
-                                    value: input["default"],
-                                }),
-                            "string" === input.type ||
+                            "array" === input.type ||
                                 $report(_exceptionable, {
                                     path: _path + ".type",
-                                    expected: '"string"',
+                                    expected: '"array"',
                                     value: input.type,
                                 }),
                             undefined === input.nullable ||
@@ -6474,45 +6558,71 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((("object" === typeof input.items &&
-                                null !== input.items &&
-                                false === Array.isArray(input.items)) ||
+                            ((Array.isArray(input.items) ||
                                 $report(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 })) &&
-                                $vu0(
-                                    input.items,
-                                    _path + ".items",
-                                    true && _exceptionable,
-                                )) ||
+                                input.items
+                                    .map(
+                                        (elem: any, _index56: number) =>
+                                            ((("object" === typeof elem &&
+                                                null !== elem &&
+                                                false ===
+                                                    Array.isArray(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index56 +
+                                                        "]",
+                                                    expected:
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    value: elem,
+                                                })) &&
+                                                $vu0(
+                                                    elem,
+                                                    _path +
+                                                        ".items[" +
+                                                        _index56 +
+                                                        "]",
+                                                    true && _exceptionable,
+                                                )) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".items[" +
+                                                    _index56 +
+                                                    "]",
+                                                expected:
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".items",
-                                    expected:
-                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                    expected: "Array<IJsonSchema>",
                                     value: input.items,
                                 }),
-                            undefined === input.minItems ||
-                                ("number" === typeof input.minItems &&
-                                    Number.isFinite(input.minItems) &&
-                                    (parseInt(input.minItems) ===
-                                        input.minItems ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        })) &&
-                                    (0 <= input.minItems ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".minItems",
-                                            expected: "number (@type uint)",
-                                            value: input.minItems,
-                                        }))) ||
+                            ("number" === typeof input.minItems &&
+                                Number.isFinite(input.minItems) &&
+                                (parseInt(input.minItems) === input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    })) &&
+                                (0 <= input.minItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
+                                    }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
-                                    expected: "(number | undefined)",
+                                    expected: "number",
                                     value: input.minItems,
                                 }),
                             undefined === input.maxItems ||
@@ -6535,26 +6645,6 @@ export const test_validate_UltimateUnion = _test_validate(
                                     path: _path + ".maxItems",
                                     expected: "(number | undefined)",
                                     value: input.maxItems,
-                                }),
-                            undefined === input["x-typia-tuple"] ||
-                                ((("object" === typeof input["x-typia-tuple"] &&
-                                    null !== input["x-typia-tuple"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-tuple"]',
-                                        expected:
-                                            "(IJsonSchema.ITuple | undefined)",
-                                        value: input["x-typia-tuple"],
-                                    })) &&
-                                    $vo26(
-                                        input["x-typia-tuple"],
-                                        _path + '["x-typia-tuple"]',
-                                        true && _exceptionable,
-                                    )) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-tuple"]',
-                                    expected:
-                                        "(IJsonSchema.ITuple | undefined)",
-                                    value: input["x-typia-tuple"],
                                 }),
                             "array" === input.type ||
                                 $report(_exceptionable, {
@@ -6600,14 +6690,14 @@ export const test_validate_UltimateUnion = _test_validate(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index56: number) =>
+                                            (elem: any, _index57: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index56 +
+                                                            _index57 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6617,7 +6707,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index56 +
+                                                            _index57 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6625,7 +6715,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index56 +
+                                                        _index57 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6649,14 +6739,14 @@ export const test_validate_UltimateUnion = _test_validate(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index57: number) =>
+                                            (elem: any, _index58: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index57 +
+                                                            _index58 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -6666,7 +6756,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index57 +
+                                                            _index58 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6674,7 +6764,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index57 +
+                                                        _index58 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6731,15 +6821,15 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((Array.isArray(input.items) ||
+                            ((Array.isArray(input.oneOf) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
+                                    value: input.oneOf,
                                 })) &&
-                                input.items
+                                input.oneOf
                                     .map(
-                                        (elem: any, _index58: number) =>
+                                        (elem: any, _index59: number) =>
                                             ((("object" === typeof elem &&
                                                 null !== elem &&
                                                 false ===
@@ -6747,50 +6837,37 @@ export const test_validate_UltimateUnion = _test_validate(
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
-                                                        ".items[" +
-                                                        _index58 +
+                                                        ".oneOf[" +
+                                                        _index59 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 })) &&
                                                 $vu0(
                                                     elem,
                                                     _path +
-                                                        ".items[" +
-                                                        _index58 +
+                                                        ".oneOf[" +
+                                                        _index59 +
                                                         "]",
                                                     true && _exceptionable,
                                                 )) ||
                                             $report(_exceptionable, {
                                                 path:
                                                     _path +
-                                                    ".items[" +
-                                                    _index58 +
+                                                    ".oneOf[" +
+                                                    _index59 +
                                                     "]",
                                                 expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                 value: elem,
                                             }),
                                     )
                                     .every((flag: boolean) => flag)) ||
                                 $report(_exceptionable, {
-                                    path: _path + ".items",
+                                    path: _path + ".oneOf",
                                     expected: "Array<IJsonSchema>",
-                                    value: input.items,
-                                }),
-                            "array" === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"array"',
-                                    value: input.type,
-                                }),
-                            undefined === input.nullable ||
-                                "boolean" === typeof input.nullable ||
-                                $report(_exceptionable, {
-                                    path: _path + ".nullable",
-                                    expected: "(boolean | undefined)",
-                                    value: input.nullable,
+                                    value: input.oneOf,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -6823,14 +6900,14 @@ export const test_validate_UltimateUnion = _test_validate(
                                     })) &&
                                     input["x-typia-metaTags"]
                                         .map(
-                                            (elem: any, _index59: number) =>
+                                            (elem: any, _index60: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index59 +
+                                                            _index60 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6840,7 +6917,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         elem,
                                                         _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index59 +
+                                                            _index60 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6848,7 +6925,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     path:
                                                         _path +
                                                         '["x-typia-metaTags"][' +
-                                                        _index59 +
+                                                        _index60 +
                                                         "]",
                                                     expected:
                                                         "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -6872,14 +6949,14 @@ export const test_validate_UltimateUnion = _test_validate(
                                     })) &&
                                     input["x-typia-jsDocTags"]
                                         .map(
-                                            (elem: any, _index60: number) =>
+                                            (elem: any, _index61: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem) ||
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index60 +
+                                                            _index61 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -6889,7 +6966,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                         elem,
                                                         _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index60 +
+                                                            _index61 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
@@ -6897,7 +6974,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                     path:
                                                         _path +
                                                         '["x-typia-jsDocTags"][' +
-                                                        _index60 +
+                                                        _index61 +
                                                         "]",
                                                     expected: "IJsDocTagInfo",
                                                     value: elem,
@@ -6954,53 +7031,11 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            ((Array.isArray(input.oneOf) ||
+                            "string" === typeof input.$ref ||
                                 $report(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
-                                })) &&
-                                input.oneOf
-                                    .map(
-                                        (elem: any, _index61: number) =>
-                                            ((("object" === typeof elem &&
-                                                null !== elem &&
-                                                false ===
-                                                    Array.isArray(elem)) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        ".oneOf[" +
-                                                        _index61 +
-                                                        "]",
-                                                    expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                    value: elem,
-                                                })) &&
-                                                $vu0(
-                                                    elem,
-                                                    _path +
-                                                        ".oneOf[" +
-                                                        _index61 +
-                                                        "]",
-                                                    true && _exceptionable,
-                                                )) ||
-                                            $report(_exceptionable, {
-                                                path:
-                                                    _path +
-                                                    ".oneOf[" +
-                                                    _index61 +
-                                                    "]",
-                                                expected:
-                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                value: elem,
-                                            }),
-                                    )
-                                    .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".oneOf",
-                                    expected: "Array<IJsonSchema>",
-                                    value: input.oneOf,
+                                    path: _path + ".$ref",
+                                    expected: "string",
+                                    value: input.$ref,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7164,11 +7199,11 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "string" === typeof input.$ref ||
+                            "null" === input.type ||
                                 $report(_exceptionable, {
-                                    path: _path + ".$ref",
-                                    expected: "string",
-                                    value: input.$ref,
+                                    path: _path + ".type",
+                                    expected: '"null"',
+                                    value: input.type,
                                 }),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
@@ -7332,12 +7367,18 @@ export const test_validate_UltimateUnion = _test_validate(
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
-                            "string" === typeof input.$recursiveRef ||
+                            (null !== input.type ||
                                 $report(_exceptionable, {
-                                    path: _path + ".$recursiveRef",
-                                    expected: "string",
-                                    value: input.$recursiveRef,
-                                }),
+                                    path: _path + ".type",
+                                    expected: "undefined",
+                                    value: input.type,
+                                })) &&
+                                (undefined === input.type ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".type",
+                                        expected: "undefined",
+                                        value: input.type,
+                                    })),
                             undefined === input.deprecated ||
                                 "boolean" === typeof input.deprecated ||
                                 $report(_exceptionable, {
@@ -7494,348 +7535,6 @@ export const test_validate_UltimateUnion = _test_validate(
                                     value: input.$recursiveAnchor,
                                 }),
                         ].every((flag: boolean) => flag);
-                    const $vo48 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            "null" === input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: '"null"',
-                                    value: input.type,
-                                }),
-                            undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $report(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                }),
-                            undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $report(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                }),
-                            undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $report(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                }),
-                            undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"]
-                                        .map(
-                                            (elem: any, _index68: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index68 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu1(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index68 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index68 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                }),
-                            undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"]
-                                        .map(
-                                            (elem: any, _index69: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index69 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vo17(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index69 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index69 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                }),
-                            undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                }),
-                            undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                }),
-                            undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }),
-                            undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                }),
-                            undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }),
-                        ].every((flag: boolean) => flag);
-                    const $vo49 = (
-                        input: any,
-                        _path: string,
-                        _exceptionable: boolean = true,
-                    ): boolean =>
-                        [
-                            (null !== input.type ||
-                                $report(_exceptionable, {
-                                    path: _path + ".type",
-                                    expected: "undefined",
-                                    value: input.type,
-                                })) &&
-                                (undefined === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: "undefined",
-                                        value: input.type,
-                                    })),
-                            undefined === input.deprecated ||
-                                "boolean" === typeof input.deprecated ||
-                                $report(_exceptionable, {
-                                    path: _path + ".deprecated",
-                                    expected: "(boolean | undefined)",
-                                    value: input.deprecated,
-                                }),
-                            undefined === input.title ||
-                                "string" === typeof input.title ||
-                                $report(_exceptionable, {
-                                    path: _path + ".title",
-                                    expected: "(string | undefined)",
-                                    value: input.title,
-                                }),
-                            undefined === input.description ||
-                                "string" === typeof input.description ||
-                                $report(_exceptionable, {
-                                    path: _path + ".description",
-                                    expected: "(string | undefined)",
-                                    value: input.description,
-                                }),
-                            undefined === input["x-typia-metaTags"] ||
-                                ((Array.isArray(input["x-typia-metaTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    })) &&
-                                    input["x-typia-metaTags"]
-                                        .map(
-                                            (elem: any, _index70: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index70 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu1(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index70 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-metaTags"][' +
-                                                        _index70 +
-                                                        "]",
-                                                    expected:
-                                                        "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-metaTags"]',
-                                    expected:
-                                        "(Array<IMetadataTag> | undefined)",
-                                    value: input["x-typia-metaTags"],
-                                }),
-                            undefined === input["x-typia-jsDocTags"] ||
-                                ((Array.isArray(input["x-typia-jsDocTags"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    })) &&
-                                    input["x-typia-jsDocTags"]
-                                        .map(
-                                            (elem: any, _index71: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index71 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    })) &&
-                                                    $vo17(
-                                                        elem,
-                                                        _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index71 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["x-typia-jsDocTags"][' +
-                                                        _index71 +
-                                                        "]",
-                                                    expected: "IJsDocTagInfo",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-jsDocTags"]',
-                                    expected:
-                                        "(Array<IJsDocTagInfo> | undefined)",
-                                    value: input["x-typia-jsDocTags"],
-                                }),
-                            undefined === input["x-typia-required"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-required"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-required"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-required"],
-                                }),
-                            undefined === input["x-typia-optional"] ||
-                                "boolean" ===
-                                    typeof input["x-typia-optional"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-optional"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-optional"],
-                                }),
-                            undefined === input["x-typia-rest"] ||
-                                "boolean" === typeof input["x-typia-rest"] ||
-                                $report(_exceptionable, {
-                                    path: _path + '["x-typia-rest"]',
-                                    expected: "(boolean | undefined)",
-                                    value: input["x-typia-rest"],
-                                }),
-                            undefined === input.$id ||
-                                "string" === typeof input.$id ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$id",
-                                    expected: "(string | undefined)",
-                                    value: input.$id,
-                                }),
-                            undefined === input.$recursiveAnchor ||
-                                "boolean" === typeof input.$recursiveAnchor ||
-                                $report(_exceptionable, {
-                                    path: _path + ".$recursiveAnchor",
-                                    expected: "(boolean | undefined)",
-                                    value: input.$recursiveAnchor,
-                                }),
-                        ].every((flag: boolean) => flag);
                     const $vu0 = (
                         input: any,
                         _path: string,
@@ -7867,7 +7566,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                 Array.isArray(input.items) &&
                                 input.items
                                     .map(
-                                        (elem: any, _index72: number) =>
+                                        (elem: any, _index68: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -7875,7 +7574,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index72 +
+                                                    _index68 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
@@ -7899,14 +7598,8 @@ export const test_validate_UltimateUnion = _test_validate(
                                     _path,
                                     true && _exceptionable,
                                 );
-                            if (undefined !== input.$recursiveRef)
-                                return $vo29(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
                             if ("null" === input.type)
-                                return $vo30(
+                                return $vo29(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -7918,7 +7611,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                 $vo21(input, _path, false && _exceptionable) ||
                                 $vo23(input, _path, false && _exceptionable) ||
                                 $vo24(input, _path, false && _exceptionable) ||
-                                $vo31(input, _path, false && _exceptionable)
+                                $vo30(input, _path, false && _exceptionable)
                             );
                         })();
                     const $vu1 = (
@@ -8031,13 +7724,13 @@ export const test_validate_UltimateUnion = _test_validate(
                     ): any =>
                         (() => {
                             if ("object" === input.type)
-                                return $vo34(
+                                return $vo33(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("integer" === input.type)
-                                return $vo40(
+                                return $vo39(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -8052,7 +7745,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                     false && _exceptionable,
                                 )
                             )
-                                return $vo43(
+                                return $vo42(
                                     input,
                                     _path,
                                     true && _exceptionable,
@@ -8061,7 +7754,7 @@ export const test_validate_UltimateUnion = _test_validate(
                                 Array.isArray(input.items) &&
                                 input.items
                                     .map(
-                                        (elem: any, _index73: number) =>
+                                        (elem: any, _index69: number) =>
                                             "object" === typeof elem &&
                                             null !== elem &&
                                             false === Array.isArray(elem) &&
@@ -8069,50 +7762,44 @@ export const test_validate_UltimateUnion = _test_validate(
                                                 elem,
                                                 _path +
                                                     ".items[" +
-                                                    _index73 +
+                                                    _index69 +
                                                     "]",
                                                 false && _exceptionable,
                                             ),
                                     )
                                     .every((flag: boolean) => flag)
                             )
-                                return $vo44(
+                                return $vo43(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.oneOf)
-                                return $vo45(
+                                return $vo44(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if (undefined !== input.$ref)
-                                return $vo46(
-                                    input,
-                                    _path,
-                                    true && _exceptionable,
-                                );
-                            if (undefined !== input.$recursiveRef)
-                                return $vo47(
+                                return $vo45(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             if ("null" === input.type)
-                                return $vo48(
+                                return $vo46(
                                     input,
                                     _path,
                                     true && _exceptionable,
                                 );
                             return (
-                                $vo38(input, _path, false && _exceptionable) ||
                                 $vo37(input, _path, false && _exceptionable) ||
                                 $vo36(input, _path, false && _exceptionable) ||
-                                $vo39(input, _path, false && _exceptionable) ||
+                                $vo35(input, _path, false && _exceptionable) ||
+                                $vo38(input, _path, false && _exceptionable) ||
+                                $vo40(input, _path, false && _exceptionable) ||
                                 $vo41(input, _path, false && _exceptionable) ||
-                                $vo42(input, _path, false && _exceptionable) ||
-                                $vo49(input, _path, false && _exceptionable)
+                                $vo47(input, _path, false && _exceptionable)
                             );
                         })();
                     return (

--- a/test/generated/output/validateClone/test_validateClone_UltimateUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_UltimateUnion.ts
@@ -31,7 +31,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "object" === typeof input.components &&
                         null !== input.components &&
                         false === Array.isArray(input.components) &&
-                        $io32(input.components) &&
+                        $io31(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose);
                     const $io1 = (input: any): boolean =>
@@ -468,6 +468,15 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -567,36 +576,6 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
                     const $io29 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]);
-                    const $io30 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -626,7 +605,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io31 = (input: any): boolean =>
+                    const $io30 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -657,13 +636,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io32 = (input: any): boolean =>
+                    const $io31 = (input: any): boolean =>
                         undefined === input.schemas ||
                         ("object" === typeof input.schemas &&
                             null !== input.schemas &&
                             false === Array.isArray(input.schemas) &&
-                            $io33(input.schemas));
-                    const $io33 = (input: any): boolean =>
+                            $io32(input.schemas));
+                    const $io32 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -676,24 +655,22 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 );
                             return true;
                         });
-                    const $io34 = (input: any): boolean =>
+                    const $io33 = (input: any): boolean =>
                         (undefined === input.$id ||
                             "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
-                        $io35(input.properties) &&
+                        $io34(input.properties) &&
                         (undefined === input.patternProperties ||
                             ("object" === typeof input.patternProperties &&
                                 null !== input.patternProperties &&
                                 false ===
                                     Array.isArray(input.patternProperties) &&
-                                $io35(input.patternProperties))) &&
+                                $io34(input.patternProperties))) &&
                         (undefined === input.additionalProperties ||
                             ("object" === typeof input.additionalProperties &&
                                 null !== input.additionalProperties &&
@@ -723,7 +700,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     Array.isArray(
                                         input["x-typia-patternProperties"],
                                     ) &&
-                                $io35(input["x-typia-patternProperties"]))) &&
+                                $io34(input["x-typia-patternProperties"]))) &&
                         (undefined === input["x-typia-additionalProperties"] ||
                             ("object" ===
                                 typeof input["x-typia-additionalProperties"] &&
@@ -734,7 +711,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         input["x-typia-additionalProperties"],
                                     ) &&
                                 $iu0(input["x-typia-additionalProperties"])));
-                    const $io35 = (input: any): boolean =>
+                    const $io34 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -747,7 +724,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 );
                             return true;
                         });
-                    const $io36 = (input: any): boolean =>
+                    const $io35 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "boolean" === typeof elem,
@@ -789,7 +766,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io37 = (input: any): boolean =>
+                    const $io36 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) =>
@@ -834,7 +811,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io38 = (input: any): boolean =>
+                    const $io37 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "string" === typeof elem,
@@ -876,7 +853,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io39 = (input: any): boolean =>
+                    const $io38 = (input: any): boolean =>
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
@@ -914,7 +891,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io40 = (input: any): boolean =>
+                    const $io39 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
@@ -970,7 +947,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io41 = (input: any): boolean =>
+                    const $io40 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum))) &&
@@ -1022,7 +999,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io42 = (input: any): boolean =>
+                    const $io41 = (input: any): boolean =>
                         (undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
@@ -1074,7 +1051,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io43 = (input: any): boolean =>
+                    const $io42 = (input: any): boolean =>
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
@@ -1128,7 +1105,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io44 = (input: any): boolean =>
+                    const $io43 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         input.items.every(
                             (elem: any) =>
@@ -1137,6 +1114,15 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -1172,7 +1158,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io45 = (input: any): boolean =>
+                    const $io44 = (input: any): boolean =>
                         Array.isArray(input.oneOf) &&
                         input.oneOf.every(
                             (elem: any) =>
@@ -1213,7 +1199,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io46 = (input: any): boolean =>
+                    const $io45 = (input: any): boolean =>
                         "string" === typeof input.$ref &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1247,41 +1233,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io47 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor);
-                    const $io48 = (input: any): boolean =>
+                    const $io46 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1315,7 +1267,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io49 = (input: any): boolean =>
+                    const $io47 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -1373,9 +1325,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 return $io26(input);
                             if (undefined !== input.oneOf) return $io27(input);
                             if (undefined !== input.$ref) return $io28(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io29(input);
-                            if ("null" === input.type) return $io30(input);
+                            if ("null" === input.type) return $io29(input);
                             return (() => {
                                 if ($io20(input)) return $io20(input);
                                 if ($io19(input)) return $io19(input);
@@ -1383,7 +1333,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 if ($io21(input)) return $io21(input);
                                 if ($io23(input)) return $io23(input);
                                 if ($io24(input)) return $io24(input);
-                                if ($io31(input)) return $io31(input);
+                                if ($io30(input)) return $io30(input);
                                 return false;
                             })();
                         })();
@@ -1410,15 +1360,15 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         })();
                     const $iu2 = (input: any): any =>
                         (() => {
-                            if ("object" === input.type) return $io34(input);
-                            if ("integer" === input.type) return $io40(input);
+                            if ("object" === input.type) return $io33(input);
+                            if ("integer" === input.type) return $io39(input);
                             if (
                                 "object" === typeof input.items &&
                                 null !== input.items &&
                                 false === Array.isArray(input.items) &&
                                 $iu0(input.items)
                             )
-                                return $io43(input);
+                                return $io42(input);
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
@@ -1429,20 +1379,18 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         $iu0(elem),
                                 )
                             )
-                                return $io44(input);
-                            if (undefined !== input.oneOf) return $io45(input);
-                            if (undefined !== input.$ref) return $io46(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io47(input);
-                            if ("null" === input.type) return $io48(input);
+                                return $io43(input);
+                            if (undefined !== input.oneOf) return $io44(input);
+                            if (undefined !== input.$ref) return $io45(input);
+                            if ("null" === input.type) return $io46(input);
                             return (() => {
-                                if ($io38(input)) return $io38(input);
                                 if ($io37(input)) return $io37(input);
                                 if ($io36(input)) return $io36(input);
-                                if ($io39(input)) return $io39(input);
+                                if ($io35(input)) return $io35(input);
+                                if ($io38(input)) return $io38(input);
+                                if ($io40(input)) return $io40(input);
                                 if ($io41(input)) return $io41(input);
-                                if ($io42(input)) return $io42(input);
-                                if ($io49(input)) return $io49(input);
+                                if ($io47(input)) return $io47(input);
                                 return false;
                             })();
                         })();
@@ -1490,7 +1438,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             _index2 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -1508,7 +1456,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         _index2 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -1527,7 +1475,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: "IJsonComponents",
                                         value: input.components,
                                     })) &&
-                                    $vo32(
+                                    $vo31(
                                         input.components,
                                         _path + ".components",
                                         true && _exceptionable,
@@ -3489,7 +3437,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     $report(_exceptionable, {
                                         path: _path + ".items",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: input.items,
                                     })) &&
                                     $vu0(
@@ -3500,7 +3448,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     $report(_exceptionable, {
                                         path: _path + ".items",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: input.items,
                                     }),
                                 undefined === input.minItems ||
@@ -3765,7 +3713,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             _index23 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -3783,7 +3731,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         _index23 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -3792,6 +3740,47 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         path: _path + ".items",
                                         expected: "Array<IJsonSchema>",
                                         value: input.items,
+                                    }),
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number",
+                                        value: input.minItems,
+                                    }),
+                                undefined === input.maxItems ||
+                                    ("number" === typeof input.maxItems &&
+                                        Number.isFinite(input.maxItems) &&
+                                        (parseInt(input.maxItems) ===
+                                            input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "(number | undefined)",
+                                        value: input.maxItems,
                                     }),
                                 "array" === input.type ||
                                     $report(_exceptionable, {
@@ -3992,7 +3981,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             _index26 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -4010,7 +3999,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         _index26 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -4358,11 +4347,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$recursiveRef ||
+                                "null" === input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$recursiveRef",
-                                        expected: "string",
-                                        value: input.$recursiveRef,
+                                        path: _path + ".type",
+                                        expected: '"null"',
+                                        value: input.type,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -4530,12 +4519,18 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "null" === input.type ||
+                                (null !== input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"null"',
+                                        expected: "undefined",
                                         value: input.type,
-                                    }),
+                                    })) &&
+                                    (undefined === input.type ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".type",
+                                            expected: "undefined",
+                                            value: input.type,
+                                        })),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
                                     $report(_exceptionable, {
@@ -4702,31 +4697,202 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                (null !== input.type ||
+                                undefined === input.schemas ||
+                                    ((("object" === typeof input.schemas &&
+                                        null !== input.schemas &&
+                                        false ===
+                                            Array.isArray(input.schemas)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".schemas",
+                                            expected:
+                                                "(Record<string, IObject | IAlias> | undefined)",
+                                            value: input.schemas,
+                                        })) &&
+                                        $vo32(
+                                            input.schemas,
+                                            _path + ".schemas",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".schemas",
+                                        expected:
+                                            "(Record<string, IObject | IAlias> | undefined)",
+                                        value: input.schemas,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo32 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                false === _exceptionable ||
+                                    Object.keys(input)
+                                        .map((key: any) => {
+                                            const value = input[key];
+                                            if (undefined === value)
+                                                return true;
+                                            if (RegExp(/(.*)/).test(key))
+                                                return (
+                                                    ((("object" ===
+                                                        typeof value &&
+                                                        null !== value &&
+                                                        false ===
+                                                            Array.isArray(
+                                                                value,
+                                                            )) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    $join(key),
+                                                                expected:
+                                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                                value: value,
+                                                            },
+                                                        )) &&
+                                                        $vu2(
+                                                            value,
+                                                            _path + $join(key),
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path + $join(key),
+                                                        expected:
+                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                        value: value,
+                                                    })
+                                                );
+                                            return true;
+                                        })
+                                        .every((flag: boolean) => flag),
+                            ].every((flag: boolean) => flag);
+                        const $vo33 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.$id ||
+                                    "string" === typeof input.$id ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$id",
+                                        expected: "(string | undefined)",
+                                        value: input.$id,
+                                    }),
+                                "object" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: "undefined",
+                                        expected: '"object"',
                                         value: input.type,
-                                    })) &&
-                                    (undefined === input.type ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".type",
-                                            expected: "undefined",
-                                            value: input.type,
-                                        })),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
                                     }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
+                                        path: _path + ".nullable",
+                                        expected: "(boolean | undefined)",
+                                        value: input.nullable,
+                                    }),
+                                ((("object" === typeof input.properties &&
+                                    null !== input.properties &&
+                                    false ===
+                                        Array.isArray(input.properties)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".properties",
+                                        expected: "Record<string, IJsonSchema>",
+                                        value: input.properties,
+                                    })) &&
+                                    $vo34(
+                                        input.properties,
+                                        _path + ".properties",
+                                        true && _exceptionable,
+                                    )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".properties",
+                                        expected: "Record<string, IJsonSchema>",
+                                        value: input.properties,
+                                    }),
+                                undefined === input.patternProperties ||
+                                    ((("object" ===
+                                        typeof input.patternProperties &&
+                                        null !== input.patternProperties &&
+                                        false ===
+                                            Array.isArray(
+                                                input.patternProperties,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".patternProperties",
+                                            expected:
+                                                "(Record<string, IJsonSchema> | undefined)",
+                                            value: input.patternProperties,
+                                        })) &&
+                                        $vo34(
+                                            input.patternProperties,
+                                            _path + ".patternProperties",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".patternProperties",
+                                        expected:
+                                            "(Record<string, IJsonSchema> | undefined)",
+                                        value: input.patternProperties,
+                                    }),
+                                undefined === input.additionalProperties ||
+                                    ((("object" ===
+                                        typeof input.additionalProperties &&
+                                        null !== input.additionalProperties &&
+                                        false ===
+                                            Array.isArray(
+                                                input.additionalProperties,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + ".additionalProperties",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            value: input.additionalProperties,
+                                        })) &&
+                                        $vu0(
+                                            input.additionalProperties,
+                                            _path + ".additionalProperties",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".additionalProperties",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        value: input.additionalProperties,
+                                    }),
+                                undefined === input.required ||
+                                    ((Array.isArray(input.required) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".required",
+                                            expected:
+                                                "(Array<string> | undefined)",
+                                            value: input.required,
+                                        })) &&
+                                        input.required
+                                            .map(
+                                                (elem: any, _index35: number) =>
+                                                    "string" === typeof elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".required[" +
+                                                            _index35 +
+                                                            "]",
+                                                        expected: "string",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".required",
+                                        expected: "(Array<string> | undefined)",
+                                        value: input.required,
                                     }),
                                 undefined === input.description ||
                                     "string" === typeof input.description ||
@@ -4734,63 +4900,6 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         path: _path + ".description",
                                         expected: "(string | undefined)",
                                         value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index35: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index35 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index35 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index35 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
                                     }),
                                 undefined === input["x-typia-jsDocTags"] ||
                                     ((Array.isArray(
@@ -4849,306 +4958,6 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                             "(Array<IJsDocTagInfo> | undefined)",
                                         value: input["x-typia-jsDocTags"],
                                     }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo32 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                undefined === input.schemas ||
-                                    ((("object" === typeof input.schemas &&
-                                        null !== input.schemas &&
-                                        false ===
-                                            Array.isArray(input.schemas)) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".schemas",
-                                            expected:
-                                                "(Record<string, IObject | IAlias> | undefined)",
-                                            value: input.schemas,
-                                        })) &&
-                                        $vo33(
-                                            input.schemas,
-                                            _path + ".schemas",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".schemas",
-                                        expected:
-                                            "(Record<string, IObject | IAlias> | undefined)",
-                                        value: input.schemas,
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo33 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                false === _exceptionable ||
-                                    Object.keys(input)
-                                        .map((key: any) => {
-                                            const value = input[key];
-                                            if (undefined === value)
-                                                return true;
-                                            if (RegExp(/(.*)/).test(key))
-                                                return (
-                                                    ((("object" ===
-                                                        typeof value &&
-                                                        null !== value &&
-                                                        false ===
-                                                            Array.isArray(
-                                                                value,
-                                                            )) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    $join(key),
-                                                                expected:
-                                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                                value: value,
-                                                            },
-                                                        )) &&
-                                                        $vu2(
-                                                            value,
-                                                            _path + $join(key),
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path + $join(key),
-                                                        expected:
-                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                        value: value,
-                                                    })
-                                                );
-                                            return true;
-                                        })
-                                        .every((flag: boolean) => flag),
-                            ].every((flag: boolean) => flag);
-                        const $vo34 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                                "object" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"object"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.nullable ||
-                                    "boolean" === typeof input.nullable ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".nullable",
-                                        expected: "(boolean | undefined)",
-                                        value: input.nullable,
-                                    }),
-                                ((("object" === typeof input.properties &&
-                                    null !== input.properties &&
-                                    false ===
-                                        Array.isArray(input.properties)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".properties",
-                                        expected: "Record<string, IJsonSchema>",
-                                        value: input.properties,
-                                    })) &&
-                                    $vo35(
-                                        input.properties,
-                                        _path + ".properties",
-                                        true && _exceptionable,
-                                    )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".properties",
-                                        expected: "Record<string, IJsonSchema>",
-                                        value: input.properties,
-                                    }),
-                                undefined === input.patternProperties ||
-                                    ((("object" ===
-                                        typeof input.patternProperties &&
-                                        null !== input.patternProperties &&
-                                        false ===
-                                            Array.isArray(
-                                                input.patternProperties,
-                                            )) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".patternProperties",
-                                            expected:
-                                                "(Record<string, IJsonSchema> | undefined)",
-                                            value: input.patternProperties,
-                                        })) &&
-                                        $vo35(
-                                            input.patternProperties,
-                                            _path + ".patternProperties",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".patternProperties",
-                                        expected:
-                                            "(Record<string, IJsonSchema> | undefined)",
-                                        value: input.patternProperties,
-                                    }),
-                                undefined === input.additionalProperties ||
-                                    ((("object" ===
-                                        typeof input.additionalProperties &&
-                                        null !== input.additionalProperties &&
-                                        false ===
-                                            Array.isArray(
-                                                input.additionalProperties,
-                                            )) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + ".additionalProperties",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                            value: input.additionalProperties,
-                                        })) &&
-                                        $vu0(
-                                            input.additionalProperties,
-                                            _path + ".additionalProperties",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".additionalProperties",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                        value: input.additionalProperties,
-                                    }),
-                                undefined === input.required ||
-                                    ((Array.isArray(input.required) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".required",
-                                            expected:
-                                                "(Array<string> | undefined)",
-                                            value: input.required,
-                                        })) &&
-                                        input.required
-                                            .map(
-                                                (elem: any, _index37: number) =>
-                                                    "string" === typeof elem ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            ".required[" +
-                                                            _index37 +
-                                                            "]",
-                                                        expected: "string",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".required",
-                                        expected: "(Array<string> | undefined)",
-                                        value: input.required,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index38: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index38 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index38 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index38 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
                                 undefined ===
                                     input["x-typia-patternProperties"] ||
                                     ((("object" ===
@@ -5175,7 +4984,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 "x-typia-patternProperties"
                                             ],
                                         })) &&
-                                        $vo35(
+                                        $vo34(
                                             input["x-typia-patternProperties"],
                                             _path +
                                                 '["x-typia-patternProperties"]',
@@ -5212,7 +5021,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 _path +
                                                 '["x-typia-additionalProperties"]',
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                             value: input[
                                                 "x-typia-additionalProperties"
                                             ],
@@ -5230,13 +5039,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                             _path +
                                             '["x-typia-additionalProperties"]',
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                         value: input[
                                             "x-typia-additionalProperties"
                                         ],
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo35 = (
+                        const $vo34 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5264,7 +5073,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                                     _path +
                                                                     $join(key),
                                                                 expected:
-                                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                                 value: value,
                                                             },
                                                         )) &&
@@ -5278,7 +5087,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         path:
                                                             _path + $join(key),
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: value,
                                                     })
                                                 );
@@ -5286,7 +5095,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         })
                                         .every((flag: boolean) => flag),
                             ].every((flag: boolean) => flag);
-                        const $vo36 = (
+                        const $vo35 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5300,13 +5109,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     })) &&
                                     input["enum"]
                                         .map(
-                                            (elem: any, _index39: number) =>
+                                            (elem: any, _index37: number) =>
                                                 "boolean" === typeof elem ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["enum"][' +
-                                                        _index39 +
+                                                        _index37 +
                                                         "]",
                                                     expected: "boolean",
                                                     value: elem,
@@ -5372,7 +5181,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index40: number) =>
+                                                (elem: any, _index38: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5382,7 +5191,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index40 +
+                                                                    _index38 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5393,7 +5202,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index40 +
+                                                                _index38 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5402,7 +5211,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index40 +
+                                                            _index38 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5429,7 +5238,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index41: number) =>
+                                                (elem: any, _index39: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5439,7 +5248,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index41 +
+                                                                    _index39 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -5450,7 +5259,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index41 +
+                                                                _index39 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5459,7 +5268,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index41 +
+                                                            _index39 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5513,7 +5322,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         value: input.$recursiveAnchor,
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo37 = (
+                        const $vo36 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5527,14 +5336,14 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     })) &&
                                     input["enum"]
                                         .map(
-                                            (elem: any, _index42: number) =>
+                                            (elem: any, _index40: number) =>
                                                 ("number" === typeof elem &&
                                                     Number.isFinite(elem)) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["enum"][' +
-                                                        _index42 +
+                                                        _index40 +
                                                         "]",
                                                     expected: "number",
                                                     value: elem,
@@ -5601,7 +5410,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index43: number) =>
+                                                (elem: any, _index41: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5611,7 +5420,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index43 +
+                                                                    _index41 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5622,7 +5431,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index43 +
+                                                                _index41 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5631,7 +5440,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index43 +
+                                                            _index41 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5658,7 +5467,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index44: number) =>
+                                                (elem: any, _index42: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5668,7 +5477,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index44 +
+                                                                    _index42 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -5679,7 +5488,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index44 +
+                                                                _index42 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5688,7 +5497,234 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
+                                                            _index42 +
+                                                            "]",
+                                                        expected:
+                                                            "IJsDocTagInfo",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-jsDocTags"]',
+                                        expected:
+                                            "(Array<IJsDocTagInfo> | undefined)",
+                                        value: input["x-typia-jsDocTags"],
+                                    }),
+                                undefined === input["x-typia-required"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-required"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-required"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-required"],
+                                    }),
+                                undefined === input["x-typia-optional"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-optional"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-optional"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-optional"],
+                                    }),
+                                undefined === input["x-typia-rest"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-rest"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-rest"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-rest"],
+                                    }),
+                                undefined === input.$id ||
+                                    "string" === typeof input.$id ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$id",
+                                        expected: "(string | undefined)",
+                                        value: input.$id,
+                                    }),
+                                undefined === input.$recursiveAnchor ||
+                                    "boolean" ===
+                                        typeof input.$recursiveAnchor ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$recursiveAnchor",
+                                        expected: "(boolean | undefined)",
+                                        value: input.$recursiveAnchor,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo37 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                ((Array.isArray(input["enum"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["enum"]',
+                                        expected: "Array<string>",
+                                        value: input["enum"],
+                                    })) &&
+                                    input["enum"]
+                                        .map(
+                                            (elem: any, _index43: number) =>
+                                                "string" === typeof elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["enum"][' +
+                                                        _index43 +
+                                                        "]",
+                                                    expected: "string",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["enum"]',
+                                        expected: "Array<string>",
+                                        value: input["enum"],
+                                    }),
+                                undefined === input["default"] ||
+                                    "string" === typeof input["default"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["default"]',
+                                        expected: "(string | undefined)",
+                                        value: input["default"],
+                                    }),
+                                "string" === input.type ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".type",
+                                        expected: '"string"',
+                                        value: input.type,
+                                    }),
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".nullable",
+                                        expected: "(boolean | undefined)",
+                                        value: input.nullable,
+                                    }),
+                                undefined === input.deprecated ||
+                                    "boolean" === typeof input.deprecated ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".deprecated",
+                                        expected: "(boolean | undefined)",
+                                        value: input.deprecated,
+                                    }),
+                                undefined === input.title ||
+                                    "string" === typeof input.title ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".title",
+                                        expected: "(string | undefined)",
+                                        value: input.title,
+                                    }),
+                                undefined === input.description ||
+                                    "string" === typeof input.description ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".description",
+                                        expected: "(string | undefined)",
+                                        value: input.description,
+                                    }),
+                                undefined === input["x-typia-metaTags"] ||
+                                    ((Array.isArray(
+                                        input["x-typia-metaTags"],
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + '["x-typia-metaTags"]',
+                                            expected:
+                                                "(Array<IMetadataTag> | undefined)",
+                                            value: input["x-typia-metaTags"],
+                                        })) &&
+                                        input["x-typia-metaTags"]
+                                            .map(
+                                                (elem: any, _index44: number) =>
+                                                    ((("object" ===
+                                                        typeof elem &&
+                                                        null !== elem) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    '["x-typia-metaTags"][' +
+                                                                    _index44 +
+                                                                    "]",
+                                                                expected:
+                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                        $vu1(
+                                                            elem,
+                                                            _path +
+                                                                '["x-typia-metaTags"][' +
+                                                                _index44 +
+                                                                "]",
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-metaTags"][' +
                                                             _index44 +
+                                                            "]",
+                                                        expected:
+                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-metaTags"]',
+                                        expected:
+                                            "(Array<IMetadataTag> | undefined)",
+                                        value: input["x-typia-metaTags"],
+                                    }),
+                                undefined === input["x-typia-jsDocTags"] ||
+                                    ((Array.isArray(
+                                        input["x-typia-jsDocTags"],
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + '["x-typia-jsDocTags"]',
+                                            expected:
+                                                "(Array<IJsDocTagInfo> | undefined)",
+                                            value: input["x-typia-jsDocTags"],
+                                        })) &&
+                                        input["x-typia-jsDocTags"]
+                                            .map(
+                                                (elem: any, _index45: number) =>
+                                                    ((("object" ===
+                                                        typeof elem &&
+                                                        null !== elem) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    '["x-typia-jsDocTags"][' +
+                                                                    _index45 +
+                                                                    "]",
+                                                                expected:
+                                                                    "IJsDocTagInfo",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                        $vo17(
+                                                            elem,
+                                                            _path +
+                                                                '["x-typia-jsDocTags"][' +
+                                                                _index45 +
+                                                                "]",
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-jsDocTags"][' +
+                                                            _index45 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5748,43 +5784,17 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input["enum"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["enum"]',
-                                        expected: "Array<string>",
-                                        value: input["enum"],
-                                    })) &&
-                                    input["enum"]
-                                        .map(
-                                            (elem: any, _index45: number) =>
-                                                "string" === typeof elem ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["enum"][' +
-                                                        _index45 +
-                                                        "]",
-                                                    expected: "string",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["enum"]',
-                                        expected: "Array<string>",
-                                        value: input["enum"],
-                                    }),
                                 undefined === input["default"] ||
-                                    "string" === typeof input["default"] ||
+                                    "boolean" === typeof input["default"] ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(string | undefined)",
+                                        expected: "(boolean | undefined)",
                                         value: input["default"],
                                     }),
-                                "string" === input.type ||
+                                "boolean" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"string"',
+                                        expected: '"boolean"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -5975,17 +5985,79 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
+                                undefined === input.minimum ||
+                                    ("number" === typeof input.minimum &&
+                                        Number.isFinite(input.minimum) &&
+                                        (parseInt(input.minimum) ===
+                                            input.minimum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "(number | undefined)",
+                                        value: input.minimum,
+                                    }),
+                                undefined === input.maximum ||
+                                    ("number" === typeof input.maximum &&
+                                        Number.isFinite(input.maximum) &&
+                                        (parseInt(input.maximum) ===
+                                            input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "(number | undefined)",
+                                        value: input.maximum,
+                                    }),
+                                undefined === input.exclusiveMinimum ||
+                                    "boolean" ===
+                                        typeof input.exclusiveMinimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected: "(boolean | undefined)",
+                                        value: input.exclusiveMinimum,
+                                    }),
+                                undefined === input.exclusiveMaximum ||
+                                    "boolean" ===
+                                        typeof input.exclusiveMaximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMaximum",
+                                        expected: "(boolean | undefined)",
+                                        value: input.exclusiveMaximum,
+                                    }),
+                                undefined === input.multipleOf ||
+                                    ("number" === typeof input.multipleOf &&
+                                        Number.isFinite(input.multipleOf) &&
+                                        (parseInt(input.multipleOf) ===
+                                            input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "(number | undefined)",
+                                        value: input.multipleOf,
+                                    }),
                                 undefined === input["default"] ||
-                                    "boolean" === typeof input["default"] ||
+                                    ("number" === typeof input["default"] &&
+                                        Number.isFinite(input["default"])) ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(boolean | undefined)",
+                                        expected: "(number | undefined)",
                                         value: input["default"],
                                     }),
-                                "boolean" === input.type ||
+                                "integer" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"boolean"',
+                                        expected: '"integer"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6178,14 +6250,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             [
                                 undefined === input.minimum ||
                                     ("number" === typeof input.minimum &&
-                                        Number.isFinite(input.minimum) &&
-                                        (parseInt(input.minimum) ===
-                                            input.minimum ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minimum",
-                                                expected: "number (@type int)",
-                                                value: input.minimum,
-                                            }))) ||
+                                        Number.isFinite(input.minimum)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
                                         expected: "(number | undefined)",
@@ -6193,14 +6258,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     }),
                                 undefined === input.maximum ||
                                     ("number" === typeof input.maximum &&
-                                        Number.isFinite(input.maximum) &&
-                                        (parseInt(input.maximum) ===
-                                            input.maximum ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".maximum",
-                                                expected: "number (@type int)",
-                                                value: input.maximum,
-                                            }))) ||
+                                        Number.isFinite(input.maximum)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "(number | undefined)",
@@ -6224,14 +6282,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     }),
                                 undefined === input.multipleOf ||
                                     ("number" === typeof input.multipleOf &&
-                                        Number.isFinite(input.multipleOf) &&
-                                        (parseInt(input.multipleOf) ===
-                                            input.multipleOf ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".multipleOf",
-                                                expected: "number (@type int)",
-                                                value: input.multipleOf,
-                                            }))) ||
+                                        Number.isFinite(input.multipleOf)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "(number | undefined)",
@@ -6245,10 +6296,10 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         expected: "(number | undefined)",
                                         value: input["default"],
                                     }),
-                                "integer" === input.type ||
+                                "number" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"integer"',
+                                        expected: '"number"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6439,58 +6490,73 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                undefined === input.minimum ||
-                                    ("number" === typeof input.minimum &&
-                                        Number.isFinite(input.minimum)) ||
+                                undefined === input.minLength ||
+                                    ("number" === typeof input.minLength &&
+                                        Number.isFinite(input.minLength) &&
+                                        (parseInt(input.minLength) ===
+                                            input.minLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
+                                            })) &&
+                                        (0 <= input.minLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
+                                            }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".minimum",
+                                        path: _path + ".minLength",
                                         expected: "(number | undefined)",
-                                        value: input.minimum,
+                                        value: input.minLength,
                                     }),
-                                undefined === input.maximum ||
-                                    ("number" === typeof input.maximum &&
-                                        Number.isFinite(input.maximum)) ||
+                                undefined === input.maxLength ||
+                                    ("number" === typeof input.maxLength &&
+                                        Number.isFinite(input.maxLength) &&
+                                        (parseInt(input.maxLength) ===
+                                            input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".maximum",
+                                        path: _path + ".maxLength",
                                         expected: "(number | undefined)",
-                                        value: input.maximum,
+                                        value: input.maxLength,
                                     }),
-                                undefined === input.exclusiveMinimum ||
-                                    "boolean" ===
-                                        typeof input.exclusiveMinimum ||
+                                undefined === input.pattern ||
+                                    "string" === typeof input.pattern ||
                                     $report(_exceptionable, {
-                                        path: _path + ".exclusiveMinimum",
-                                        expected: "(boolean | undefined)",
-                                        value: input.exclusiveMinimum,
+                                        path: _path + ".pattern",
+                                        expected: "(string | undefined)",
+                                        value: input.pattern,
                                     }),
-                                undefined === input.exclusiveMaximum ||
-                                    "boolean" ===
-                                        typeof input.exclusiveMaximum ||
+                                undefined === input.format ||
+                                    "string" === typeof input.format ||
                                     $report(_exceptionable, {
-                                        path: _path + ".exclusiveMaximum",
-                                        expected: "(boolean | undefined)",
-                                        value: input.exclusiveMaximum,
-                                    }),
-                                undefined === input.multipleOf ||
-                                    ("number" === typeof input.multipleOf &&
-                                        Number.isFinite(input.multipleOf)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".multipleOf",
-                                        expected: "(number | undefined)",
-                                        value: input.multipleOf,
+                                        path: _path + ".format",
+                                        expected: "(string | undefined)",
+                                        value: input.format,
                                     }),
                                 undefined === input["default"] ||
-                                    ("number" === typeof input["default"] &&
-                                        Number.isFinite(input["default"])) ||
+                                    "string" === typeof input["default"] ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(number | undefined)",
+                                        expected: "(string | undefined)",
                                         value: input["default"],
                                     }),
-                                "number" === input.type ||
+                                "string" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"number"',
+                                        expected: '"string"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6681,73 +6747,93 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                undefined === input.minLength ||
-                                    ("number" === typeof input.minLength &&
-                                        Number.isFinite(input.minLength) &&
-                                        (parseInt(input.minLength) ===
-                                            input.minLength ||
+                                ((("object" === typeof input.items &&
+                                    null !== input.items &&
+                                    false === Array.isArray(input.items)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: input.items,
+                                    })) &&
+                                    $vu0(
+                                        input.items,
+                                        _path + ".items",
+                                        true && _exceptionable,
+                                    )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: input.items,
+                                    }),
+                                undefined === input.minItems ||
+                                    ("number" === typeof input.minItems &&
+                                        Number.isFinite(input.minItems) &&
+                                        (parseInt(input.minItems) ===
+                                            input.minItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".minLength",
+                                                path: _path + ".minItems",
                                                 expected: "number (@type uint)",
-                                                value: input.minLength,
+                                                value: input.minItems,
                                             })) &&
-                                        (0 <= input.minLength ||
+                                        (0 <= input.minItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".minLength",
+                                                path: _path + ".minItems",
                                                 expected: "number (@type uint)",
-                                                value: input.minLength,
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "(number | undefined)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     }),
-                                undefined === input.maxLength ||
-                                    ("number" === typeof input.maxLength &&
-                                        Number.isFinite(input.maxLength) &&
-                                        (parseInt(input.maxLength) ===
-                                            input.maxLength ||
+                                undefined === input.maxItems ||
+                                    ("number" === typeof input.maxItems &&
+                                        Number.isFinite(input.maxItems) &&
+                                        (parseInt(input.maxItems) ===
+                                            input.maxItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".maxLength",
+                                                path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
-                                                value: input.maxLength,
+                                                value: input.maxItems,
                                             })) &&
-                                        (0 <= input.maxLength ||
+                                        (0 <= input.maxItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".maxLength",
+                                                path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
-                                                value: input.maxLength,
+                                                value: input.maxItems,
                                             }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "(number | undefined)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     }),
-                                undefined === input.pattern ||
-                                    "string" === typeof input.pattern ||
+                                undefined === input["x-typia-tuple"] ||
+                                    ((("object" ===
+                                        typeof input["x-typia-tuple"] &&
+                                        null !== input["x-typia-tuple"]) ||
+                                        $report(_exceptionable, {
+                                            path: _path + '["x-typia-tuple"]',
+                                            expected:
+                                                "(IJsonSchema.ITuple | undefined)",
+                                            value: input["x-typia-tuple"],
+                                        })) &&
+                                        $vo26(
+                                            input["x-typia-tuple"],
+                                            _path + '["x-typia-tuple"]',
+                                            true && _exceptionable,
+                                        )) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".pattern",
-                                        expected: "(string | undefined)",
-                                        value: input.pattern,
+                                        path: _path + '["x-typia-tuple"]',
+                                        expected:
+                                            "(IJsonSchema.ITuple | undefined)",
+                                        value: input["x-typia-tuple"],
                                     }),
-                                undefined === input.format ||
-                                    "string" === typeof input.format ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".format",
-                                        expected: "(string | undefined)",
-                                        value: input.format,
-                                    }),
-                                undefined === input["default"] ||
-                                    "string" === typeof input["default"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["default"]',
-                                        expected: "(string | undefined)",
-                                        value: input["default"],
-                                    }),
-                                "string" === input.type ||
+                                "array" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"string"',
+                                        expected: '"array"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6938,45 +7024,72 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((("object" === typeof input.items &&
-                                    null !== input.items &&
-                                    false === Array.isArray(input.items)) ||
+                                ((Array.isArray(input.items) ||
                                     $report(_exceptionable, {
                                         path: _path + ".items",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        expected: "Array<IJsonSchema>",
                                         value: input.items,
                                     })) &&
-                                    $vu0(
-                                        input.items,
-                                        _path + ".items",
-                                        true && _exceptionable,
-                                    )) ||
+                                    input.items
+                                        .map(
+                                            (elem: any, _index56: number) =>
+                                                ((("object" === typeof elem &&
+                                                    null !== elem &&
+                                                    false ===
+                                                        Array.isArray(elem)) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".items[" +
+                                                            _index56 +
+                                                            "]",
+                                                        expected:
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        value: elem,
+                                                    })) &&
+                                                    $vu0(
+                                                        elem,
+                                                        _path +
+                                                            ".items[" +
+                                                            _index56 +
+                                                            "]",
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index56 +
+                                                        "]",
+                                                    expected:
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".items",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        expected: "Array<IJsonSchema>",
                                         value: input.items,
                                     }),
-                                undefined === input.minItems ||
-                                    ("number" === typeof input.minItems &&
-                                        Number.isFinite(input.minItems) &&
-                                        (parseInt(input.minItems) ===
-                                            input.minItems ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minItems",
-                                                expected: "number (@type uint)",
-                                                value: input.minItems,
-                                            })) &&
-                                        (0 <= input.minItems ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minItems",
-                                                expected: "number (@type uint)",
-                                                value: input.minItems,
-                                            }))) ||
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
-                                        expected: "(number | undefined)",
+                                        expected: "number",
                                         value: input.minItems,
                                     }),
                                 undefined === input.maxItems ||
@@ -6999,27 +7112,6 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         path: _path + ".maxItems",
                                         expected: "(number | undefined)",
                                         value: input.maxItems,
-                                    }),
-                                undefined === input["x-typia-tuple"] ||
-                                    ((("object" ===
-                                        typeof input["x-typia-tuple"] &&
-                                        null !== input["x-typia-tuple"]) ||
-                                        $report(_exceptionable, {
-                                            path: _path + '["x-typia-tuple"]',
-                                            expected:
-                                                "(IJsonSchema.ITuple | undefined)",
-                                            value: input["x-typia-tuple"],
-                                        })) &&
-                                        $vo26(
-                                            input["x-typia-tuple"],
-                                            _path + '["x-typia-tuple"]',
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-tuple"]',
-                                        expected:
-                                            "(IJsonSchema.ITuple | undefined)",
-                                        value: input["x-typia-tuple"],
                                     }),
                                 "array" === input.type ||
                                     $report(_exceptionable, {
@@ -7068,7 +7160,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index56: number) =>
+                                                (elem: any, _index57: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7078,7 +7170,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index56 +
+                                                                    _index57 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7089,7 +7181,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index56 +
+                                                                _index57 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7098,7 +7190,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index56 +
+                                                            _index57 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7125,7 +7217,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index57: number) =>
+                                                (elem: any, _index58: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7135,7 +7227,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index57 +
+                                                                    _index58 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -7146,7 +7238,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index57 +
+                                                                _index58 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7155,7 +7247,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index57 +
+                                                            _index58 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -7215,15 +7307,15 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input.items) ||
+                                ((Array.isArray(input.oneOf) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".items",
+                                        path: _path + ".oneOf",
                                         expected: "Array<IJsonSchema>",
-                                        value: input.items,
+                                        value: input.oneOf,
                                     })) &&
-                                    input.items
+                                    input.oneOf
                                         .map(
-                                            (elem: any, _index58: number) =>
+                                            (elem: any, _index59: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem &&
                                                     false ===
@@ -7231,50 +7323,37 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
-                                                            ".items[" +
-                                                            _index58 +
+                                                            ".oneOf[" +
+                                                            _index59 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
                                                         elem,
                                                         _path +
-                                                            ".items[" +
-                                                            _index58 +
+                                                            ".oneOf[" +
+                                                            _index59 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
-                                                        ".items[" +
-                                                        _index58 +
+                                                        ".oneOf[" +
+                                                        _index59 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
                                         .every((flag: boolean) => flag)) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".items",
+                                        path: _path + ".oneOf",
                                         expected: "Array<IJsonSchema>",
-                                        value: input.items,
-                                    }),
-                                "array" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"array"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.nullable ||
-                                    "boolean" === typeof input.nullable ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".nullable",
-                                        expected: "(boolean | undefined)",
-                                        value: input.nullable,
+                                        value: input.oneOf,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7310,7 +7389,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index59: number) =>
+                                                (elem: any, _index60: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7320,7 +7399,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index59 +
+                                                                    _index60 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7331,7 +7410,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index59 +
+                                                                _index60 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7340,7 +7419,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index59 +
+                                                            _index60 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7367,7 +7446,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index60: number) =>
+                                                (elem: any, _index61: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7377,7 +7456,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index60 +
+                                                                    _index61 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -7388,7 +7467,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index60 +
+                                                                _index61 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7397,7 +7476,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index60 +
+                                                            _index61 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -7457,53 +7536,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input.oneOf) ||
+                                "string" === typeof input.$ref ||
                                     $report(_exceptionable, {
-                                        path: _path + ".oneOf",
-                                        expected: "Array<IJsonSchema>",
-                                        value: input.oneOf,
-                                    })) &&
-                                    input.oneOf
-                                        .map(
-                                            (elem: any, _index61: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem &&
-                                                    false ===
-                                                        Array.isArray(elem)) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            ".oneOf[" +
-                                                            _index61 +
-                                                            "]",
-                                                        expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu0(
-                                                        elem,
-                                                        _path +
-                                                            ".oneOf[" +
-                                                            _index61 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        ".oneOf[" +
-                                                        _index61 +
-                                                        "]",
-                                                    expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".oneOf",
-                                        expected: "Array<IJsonSchema>",
-                                        value: input.oneOf,
+                                        path: _path + ".$ref",
+                                        expected: "string",
+                                        value: input.$ref,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7686,11 +7723,11 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$ref ||
+                                "null" === input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$ref",
-                                        expected: "string",
-                                        value: input.$ref,
+                                        path: _path + ".type",
+                                        expected: '"null"',
+                                        value: input.type,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7873,12 +7910,18 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$recursiveRef ||
+                                (null !== input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$recursiveRef",
-                                        expected: "string",
-                                        value: input.$recursiveRef,
-                                    }),
+                                        path: _path + ".type",
+                                        expected: "undefined",
+                                        value: input.type,
+                                    })) &&
+                                    (undefined === input.type ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".type",
+                                            expected: "undefined",
+                                            value: input.type,
+                                        })),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
                                     $report(_exceptionable, {
@@ -8054,386 +8097,6 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         value: input.$recursiveAnchor,
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo48 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                "null" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"null"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
-                                    }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index68: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index68 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index68 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index68 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index69: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index69 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index69 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index69 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo49 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                (null !== input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: "undefined",
-                                        value: input.type,
-                                    })) &&
-                                    (undefined === input.type ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".type",
-                                            expected: "undefined",
-                                            value: input.type,
-                                        })),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
-                                    }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index70: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index70 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index70 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index70 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index71: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index71 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index71 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index71 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                            ].every((flag: boolean) => flag);
                         const $vu0 = (
                             input: any,
                             _path: string,
@@ -8465,7 +8128,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     Array.isArray(input.items) &&
                                     input.items
                                         .map(
-                                            (elem: any, _index72: number) =>
+                                            (elem: any, _index68: number) =>
                                                 "object" === typeof elem &&
                                                 null !== elem &&
                                                 false === Array.isArray(elem) &&
@@ -8473,7 +8136,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                     elem,
                                                     _path +
                                                         ".items[" +
-                                                        _index72 +
+                                                        _index68 +
                                                         "]",
                                                     false && _exceptionable,
                                                 ),
@@ -8497,14 +8160,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         _path,
                                         true && _exceptionable,
                                     );
-                                if (undefined !== input.$recursiveRef)
-                                    return $vo29(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
                                 if ("null" === input.type)
-                                    return $vo30(
+                                    return $vo29(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8540,7 +8197,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo31(input, _path, false && _exceptionable)
+                                    $vo30(input, _path, false && _exceptionable)
                                 );
                             })();
                         const $vu1 = (
@@ -8653,13 +8310,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         ): any =>
                             (() => {
                                 if ("object" === input.type)
-                                    return $vo34(
+                                    return $vo33(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("integer" === input.type)
-                                    return $vo40(
+                                    return $vo39(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8674,7 +8331,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         false && _exceptionable,
                                     )
                                 )
-                                    return $vo43(
+                                    return $vo42(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8683,7 +8340,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     Array.isArray(input.items) &&
                                     input.items
                                         .map(
-                                            (elem: any, _index73: number) =>
+                                            (elem: any, _index69: number) =>
                                                 "object" === typeof elem &&
                                                 null !== elem &&
                                                 false === Array.isArray(elem) &&
@@ -8691,48 +8348,37 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                     elem,
                                                     _path +
                                                         ".items[" +
-                                                        _index73 +
+                                                        _index69 +
                                                         "]",
                                                     false && _exceptionable,
                                                 ),
                                         )
                                         .every((flag: boolean) => flag)
                                 )
-                                    return $vo44(
+                                    return $vo43(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.oneOf)
-                                    return $vo45(
+                                    return $vo44(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.$ref)
-                                    return $vo46(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
-                                if (undefined !== input.$recursiveRef)
-                                    return $vo47(
+                                    return $vo45(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("null" === input.type)
-                                    return $vo48(
+                                    return $vo46(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 return (
-                                    $vo38(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
                                     $vo37(
                                         input,
                                         _path,
@@ -8743,7 +8389,17 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo39(
+                                    $vo35(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $vo38(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $vo40(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -8753,12 +8409,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo42(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
-                                    $vo49(input, _path, false && _exceptionable)
+                                    $vo47(input, _path, false && _exceptionable)
                                 );
                             })();
                         return (
@@ -9214,6 +8865,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9313,36 +8971,6 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -9372,7 +9000,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -9403,13 +9031,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -9422,23 +9050,21 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -9468,7 +9094,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -9478,7 +9104,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -9491,7 +9117,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -9533,7 +9159,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "number" === typeof elem,
@@ -9575,7 +9201,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -9617,7 +9243,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -9655,7 +9281,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             parseInt(input.minimum) === input.minimum)) &&
@@ -9706,7 +9332,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         "number" === typeof input.minimum) &&
                     (undefined === input.maximum ||
@@ -9754,7 +9380,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             parseInt(input.minLength) === input.minLength &&
@@ -9804,7 +9430,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -9856,7 +9482,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -9865,6 +9491,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9900,7 +9533,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -9941,7 +9574,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -9975,41 +9608,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -10043,7 +9642,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -10101,9 +9700,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (
                             $io20(input) ||
                             $io19(input) ||
@@ -10111,7 +9708,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             $io21(input) ||
                             $io23(input) ||
                             $io24(input) ||
-                            $io31(input)
+                            $io30(input)
                         );
                     })();
                 const $iu1 = (input: any): any =>
@@ -10137,15 +9734,15 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -10156,20 +9753,18 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (
-                            $io38(input) ||
                             $io37(input) ||
                             $io36(input) ||
-                            $io39(input) ||
+                            $io35(input) ||
+                            $io38(input) ||
+                            $io40(input) ||
                             $io41(input) ||
-                            $io42(input) ||
-                            $io49(input)
+                            $io47(input)
                         );
                     })();
                 const $join = (typia.validateClone as any).join;
@@ -10217,7 +9812,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     components:
                         "object" === typeof input.components &&
                         null !== input.components
-                            ? $co32(input.components)
+                            ? $co31(input.components)
                             : (input.components as any),
                     purpose: input.purpose as any,
                 });
@@ -10480,6 +10075,8 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     items: Array.isArray(input.items)
                         ? $cp1(input.items)
                         : (input.items as any),
+                    minItems: input.minItems as any,
+                    maxItems: input.maxItems as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
                     deprecated: input.deprecated as any,
@@ -10534,7 +10131,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     "x-typia-rest": input["x-typia-rest"] as any,
                 });
                 const $co29 = (input: any): any => ({
-                    $recursiveRef: input.$recursiveRef as any,
+                    type: input.type as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
                     description: input.description as any,
@@ -10568,30 +10165,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     "x-typia-rest": input["x-typia-rest"] as any,
                 });
                 const $co31 = (input: any): any => ({
-                    type: input.type as any,
-                    deprecated: input.deprecated as any,
-                    title: input.title as any,
-                    description: input.description as any,
-                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                        ? $cp3(input["x-typia-metaTags"])
-                        : (input["x-typia-metaTags"] as any),
-                    "x-typia-jsDocTags": Array.isArray(
-                        input["x-typia-jsDocTags"],
-                    )
-                        ? $cp4(input["x-typia-jsDocTags"])
-                        : (input["x-typia-jsDocTags"] as any),
-                    "x-typia-required": input["x-typia-required"] as any,
-                    "x-typia-optional": input["x-typia-optional"] as any,
-                    "x-typia-rest": input["x-typia-rest"] as any,
-                });
-                const $co32 = (input: any): any => ({
                     schemas:
                         "object" === typeof input.schemas &&
                         null !== input.schemas
-                            ? $co33(input.schemas)
+                            ? $co32(input.schemas)
                             : (input.schemas as any),
                 });
-                const $co33 = (input: any): any => {
+                const $co32 = (input: any): any => {
                     const output = {} as any;
                     for (const [key, value] of Object.entries(input)) {
                         if (RegExp(/(.*)/).test(key)) {
@@ -10604,20 +10184,19 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     }
                     return output;
                 };
-                const $co34 = (input: any): any => ({
+                const $co33 = (input: any): any => ({
                     $id: input.$id as any,
-                    $recursiveAnchor: input.$recursiveAnchor as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
                     properties:
                         "object" === typeof input.properties &&
                         null !== input.properties
-                            ? $co35(input.properties)
+                            ? $co34(input.properties)
                             : (input.properties as any),
                     patternProperties:
                         "object" === typeof input.patternProperties &&
                         null !== input.patternProperties
-                            ? $co35(input.patternProperties)
+                            ? $co34(input.patternProperties)
                             : (input.patternProperties as any),
                     additionalProperties:
                         "object" === typeof input.additionalProperties &&
@@ -10637,7 +10216,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         "object" ===
                             typeof input["x-typia-patternProperties"] &&
                         null !== input["x-typia-patternProperties"]
-                            ? $co35(input["x-typia-patternProperties"])
+                            ? $co34(input["x-typia-patternProperties"])
                             : (input["x-typia-patternProperties"] as any),
                     "x-typia-additionalProperties":
                         "object" ===
@@ -10646,7 +10225,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             ? $cu0(input["x-typia-additionalProperties"])
                             : (input["x-typia-additionalProperties"] as any),
                 });
-                const $co35 = (input: any): any => {
+                const $co34 = (input: any): any => {
                     const output = {} as any;
                     for (const [key, value] of Object.entries(input)) {
                         if (RegExp(/(.*)/).test(key)) {
@@ -10659,7 +10238,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     }
                     return output;
                 };
-                const $co36 = (input: any): any => ({
+                const $co35 = (input: any): any => ({
                     enum: Array.isArray(input["enum"])
                         ? $cp2(input["enum"])
                         : (input["enum"] as any),
@@ -10683,7 +10262,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co37 = (input: any): any => ({
+                const $co36 = (input: any): any => ({
                     enum: Array.isArray(input["enum"])
                         ? $cp6(input["enum"])
                         : (input["enum"] as any),
@@ -10707,7 +10286,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co38 = (input: any): any => ({
+                const $co37 = (input: any): any => ({
                     enum: Array.isArray(input["enum"])
                         ? $cp7(input["enum"])
                         : (input["enum"] as any),
@@ -10731,7 +10310,33 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
+                const $co38 = (input: any): any => ({
+                    default: input["default"] as any,
+                    type: input.type as any,
+                    nullable: input.nullable as any,
+                    deprecated: input.deprecated as any,
+                    title: input.title as any,
+                    description: input.description as any,
+                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
+                        ? $cp3(input["x-typia-metaTags"])
+                        : (input["x-typia-metaTags"] as any),
+                    "x-typia-jsDocTags": Array.isArray(
+                        input["x-typia-jsDocTags"],
+                    )
+                        ? $cp4(input["x-typia-jsDocTags"])
+                        : (input["x-typia-jsDocTags"] as any),
+                    "x-typia-required": input["x-typia-required"] as any,
+                    "x-typia-optional": input["x-typia-optional"] as any,
+                    "x-typia-rest": input["x-typia-rest"] as any,
+                    $id: input.$id as any,
+                    $recursiveAnchor: input.$recursiveAnchor as any,
+                });
                 const $co39 = (input: any): any => ({
+                    minimum: input.minimum as any,
+                    maximum: input.maximum as any,
+                    exclusiveMinimum: input.exclusiveMinimum as any,
+                    exclusiveMaximum: input.exclusiveMaximum as any,
+                    multipleOf: input.multipleOf as any,
                     default: input["default"] as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
@@ -10779,32 +10384,6 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
                 const $co41 = (input: any): any => ({
-                    minimum: input.minimum as any,
-                    maximum: input.maximum as any,
-                    exclusiveMinimum: input.exclusiveMinimum as any,
-                    exclusiveMaximum: input.exclusiveMaximum as any,
-                    multipleOf: input.multipleOf as any,
-                    default: input["default"] as any,
-                    type: input.type as any,
-                    nullable: input.nullable as any,
-                    deprecated: input.deprecated as any,
-                    title: input.title as any,
-                    description: input.description as any,
-                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                        ? $cp3(input["x-typia-metaTags"])
-                        : (input["x-typia-metaTags"] as any),
-                    "x-typia-jsDocTags": Array.isArray(
-                        input["x-typia-jsDocTags"],
-                    )
-                        ? $cp4(input["x-typia-jsDocTags"])
-                        : (input["x-typia-jsDocTags"] as any),
-                    "x-typia-required": input["x-typia-required"] as any,
-                    "x-typia-optional": input["x-typia-optional"] as any,
-                    "x-typia-rest": input["x-typia-rest"] as any,
-                    $id: input.$id as any,
-                    $recursiveAnchor: input.$recursiveAnchor as any,
-                });
-                const $co42 = (input: any): any => ({
                     minLength: input.minLength as any,
                     maxLength: input.maxLength as any,
                     pattern: input.pattern as any,
@@ -10829,7 +10408,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co43 = (input: any): any => ({
+                const $co42 = (input: any): any => ({
                     items:
                         "object" === typeof input.items && null !== input.items
                             ? $cu0(input.items)
@@ -10860,10 +10439,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co44 = (input: any): any => ({
+                const $co43 = (input: any): any => ({
                     items: Array.isArray(input.items)
                         ? $cp1(input.items)
                         : (input.items as any),
+                    minItems: input.minItems as any,
+                    maxItems: input.maxItems as any,
                     type: input.type as any,
                     nullable: input.nullable as any,
                     deprecated: input.deprecated as any,
@@ -10883,7 +10464,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co45 = (input: any): any => ({
+                const $co44 = (input: any): any => ({
                     oneOf: Array.isArray(input.oneOf)
                         ? $cp1(input.oneOf)
                         : (input.oneOf as any),
@@ -10904,7 +10485,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co46 = (input: any): any => ({
+                const $co45 = (input: any): any => ({
                     $ref: input.$ref as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
@@ -10923,26 +10504,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co47 = (input: any): any => ({
-                    $recursiveRef: input.$recursiveRef as any,
-                    deprecated: input.deprecated as any,
-                    title: input.title as any,
-                    description: input.description as any,
-                    "x-typia-metaTags": Array.isArray(input["x-typia-metaTags"])
-                        ? $cp3(input["x-typia-metaTags"])
-                        : (input["x-typia-metaTags"] as any),
-                    "x-typia-jsDocTags": Array.isArray(
-                        input["x-typia-jsDocTags"],
-                    )
-                        ? $cp4(input["x-typia-jsDocTags"])
-                        : (input["x-typia-jsDocTags"] as any),
-                    "x-typia-required": input["x-typia-required"] as any,
-                    "x-typia-optional": input["x-typia-optional"] as any,
-                    "x-typia-rest": input["x-typia-rest"] as any,
-                    $id: input.$id as any,
-                    $recursiveAnchor: input.$recursiveAnchor as any,
-                });
-                const $co48 = (input: any): any => ({
+                const $co46 = (input: any): any => ({
                     type: input.type as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
@@ -10961,7 +10523,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     $id: input.$id as any,
                     $recursiveAnchor: input.$recursiveAnchor as any,
                 });
-                const $co49 = (input: any): any => ({
+                const $co47 = (input: any): any => ({
                     type: input.type as any,
                     deprecated: input.deprecated as any,
                     title: input.title as any,
@@ -11003,9 +10565,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             return $co26(input);
                         if (undefined !== input.oneOf) return $co27(input);
                         if (undefined !== input.$ref) return $co28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $co29(input);
-                        if ("null" === input.type) return $co30(input);
+                        if ("null" === input.type) return $co29(input);
                         return (() => {
                             if ($io20(input)) return $co20(input);
                             if ($io19(input)) return $co19(input);
@@ -11013,7 +10573,7 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             if ($io21(input)) return $co21(input);
                             if ($io23(input)) return $co23(input);
                             if ($io24(input)) return $co24(input);
-                            if ($io31(input)) return $co31(input);
+                            if ($io30(input)) return $co30(input);
                             $throws({
                                 expected:
                                     '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -11048,15 +10608,15 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     })();
                 const $cu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $co34(input);
-                        if ("integer" === input.type) return $co40(input);
+                        if ("object" === input.type) return $co33(input);
+                        if ("integer" === input.type) return $co39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $co43(input);
+                            return $co42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -11067,20 +10627,18 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                     $iu0(elem),
                             )
                         )
-                            return $co44(input);
-                        if (undefined !== input.oneOf) return $co45(input);
-                        if (undefined !== input.$ref) return $co46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $co47(input);
-                        if ("null" === input.type) return $co48(input);
+                            return $co43(input);
+                        if (undefined !== input.oneOf) return $co44(input);
+                        if (undefined !== input.$ref) return $co45(input);
+                        if ("null" === input.type) return $co46(input);
                         return (() => {
-                            if ($io38(input)) return $co38(input);
                             if ($io37(input)) return $co37(input);
                             if ($io36(input)) return $co36(input);
-                            if ($io39(input)) return $co39(input);
+                            if ($io35(input)) return $co35(input);
+                            if ($io38(input)) return $co38(input);
+                            if ($io40(input)) return $co40(input);
                             if ($io41(input)) return $co41(input);
-                            if ($io42(input)) return $co42(input);
-                            if ($io49(input)) return $co49(input);
+                            if ($io47(input)) return $co47(input);
                             $throws({
                                 expected:
                                     '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/generated/output/validateParse/test_validateParse_UltimateUnion.ts
+++ b/test/generated/output/validateParse/test_validateParse_UltimateUnion.ts
@@ -23,7 +23,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         "object" === typeof input.components &&
                         null !== input.components &&
                         false === Array.isArray(input.components) &&
-                        $io32(input.components) &&
+                        $io31(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose);
                     const $io1 = (input: any): boolean =>
@@ -460,6 +460,15 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -559,36 +568,6 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
                     const $io29 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]);
-                    const $io30 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -618,7 +597,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io31 = (input: any): boolean =>
+                    const $io30 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -649,13 +628,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io32 = (input: any): boolean =>
+                    const $io31 = (input: any): boolean =>
                         undefined === input.schemas ||
                         ("object" === typeof input.schemas &&
                             null !== input.schemas &&
                             false === Array.isArray(input.schemas) &&
-                            $io33(input.schemas));
-                    const $io33 = (input: any): boolean =>
+                            $io32(input.schemas));
+                    const $io32 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -668,24 +647,22 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                 );
                             return true;
                         });
-                    const $io34 = (input: any): boolean =>
+                    const $io33 = (input: any): boolean =>
                         (undefined === input.$id ||
                             "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
-                        $io35(input.properties) &&
+                        $io34(input.properties) &&
                         (undefined === input.patternProperties ||
                             ("object" === typeof input.patternProperties &&
                                 null !== input.patternProperties &&
                                 false ===
                                     Array.isArray(input.patternProperties) &&
-                                $io35(input.patternProperties))) &&
+                                $io34(input.patternProperties))) &&
                         (undefined === input.additionalProperties ||
                             ("object" === typeof input.additionalProperties &&
                                 null !== input.additionalProperties &&
@@ -715,7 +692,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                     Array.isArray(
                                         input["x-typia-patternProperties"],
                                     ) &&
-                                $io35(input["x-typia-patternProperties"]))) &&
+                                $io34(input["x-typia-patternProperties"]))) &&
                         (undefined === input["x-typia-additionalProperties"] ||
                             ("object" ===
                                 typeof input["x-typia-additionalProperties"] &&
@@ -726,7 +703,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         input["x-typia-additionalProperties"],
                                     ) &&
                                 $iu0(input["x-typia-additionalProperties"])));
-                    const $io35 = (input: any): boolean =>
+                    const $io34 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -739,7 +716,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                 );
                             return true;
                         });
-                    const $io36 = (input: any): boolean =>
+                    const $io35 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "boolean" === typeof elem,
@@ -781,7 +758,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io37 = (input: any): boolean =>
+                    const $io36 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) =>
@@ -826,7 +803,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io38 = (input: any): boolean =>
+                    const $io37 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "string" === typeof elem,
@@ -868,7 +845,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io39 = (input: any): boolean =>
+                    const $io38 = (input: any): boolean =>
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
@@ -906,7 +883,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io40 = (input: any): boolean =>
+                    const $io39 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
@@ -962,7 +939,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io41 = (input: any): boolean =>
+                    const $io40 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum))) &&
@@ -1014,7 +991,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io42 = (input: any): boolean =>
+                    const $io41 = (input: any): boolean =>
                         (undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
@@ -1066,7 +1043,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io43 = (input: any): boolean =>
+                    const $io42 = (input: any): boolean =>
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
@@ -1120,7 +1097,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io44 = (input: any): boolean =>
+                    const $io43 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         input.items.every(
                             (elem: any) =>
@@ -1129,6 +1106,15 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -1164,7 +1150,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io45 = (input: any): boolean =>
+                    const $io44 = (input: any): boolean =>
                         Array.isArray(input.oneOf) &&
                         input.oneOf.every(
                             (elem: any) =>
@@ -1205,7 +1191,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io46 = (input: any): boolean =>
+                    const $io45 = (input: any): boolean =>
                         "string" === typeof input.$ref &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1239,41 +1225,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io47 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor);
-                    const $io48 = (input: any): boolean =>
+                    const $io46 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1307,7 +1259,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io49 = (input: any): boolean =>
+                    const $io47 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -1365,9 +1317,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                 return $io26(input);
                             if (undefined !== input.oneOf) return $io27(input);
                             if (undefined !== input.$ref) return $io28(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io29(input);
-                            if ("null" === input.type) return $io30(input);
+                            if ("null" === input.type) return $io29(input);
                             return (() => {
                                 if ($io20(input)) return $io20(input);
                                 if ($io19(input)) return $io19(input);
@@ -1375,7 +1325,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                 if ($io21(input)) return $io21(input);
                                 if ($io23(input)) return $io23(input);
                                 if ($io24(input)) return $io24(input);
-                                if ($io31(input)) return $io31(input);
+                                if ($io30(input)) return $io30(input);
                                 return false;
                             })();
                         })();
@@ -1402,15 +1352,15 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         })();
                     const $iu2 = (input: any): any =>
                         (() => {
-                            if ("object" === input.type) return $io34(input);
-                            if ("integer" === input.type) return $io40(input);
+                            if ("object" === input.type) return $io33(input);
+                            if ("integer" === input.type) return $io39(input);
                             if (
                                 "object" === typeof input.items &&
                                 null !== input.items &&
                                 false === Array.isArray(input.items) &&
                                 $iu0(input.items)
                             )
-                                return $io43(input);
+                                return $io42(input);
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
@@ -1421,20 +1371,18 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         $iu0(elem),
                                 )
                             )
-                                return $io44(input);
-                            if (undefined !== input.oneOf) return $io45(input);
-                            if (undefined !== input.$ref) return $io46(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io47(input);
-                            if ("null" === input.type) return $io48(input);
+                                return $io43(input);
+                            if (undefined !== input.oneOf) return $io44(input);
+                            if (undefined !== input.$ref) return $io45(input);
+                            if ("null" === input.type) return $io46(input);
                             return (() => {
-                                if ($io38(input)) return $io38(input);
                                 if ($io37(input)) return $io37(input);
                                 if ($io36(input)) return $io36(input);
-                                if ($io39(input)) return $io39(input);
+                                if ($io35(input)) return $io35(input);
+                                if ($io38(input)) return $io38(input);
+                                if ($io40(input)) return $io40(input);
                                 if ($io41(input)) return $io41(input);
-                                if ($io42(input)) return $io42(input);
-                                if ($io49(input)) return $io49(input);
+                                if ($io47(input)) return $io47(input);
                                 return false;
                             })();
                         })();
@@ -1482,7 +1430,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             _index2 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -1500,7 +1448,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         _index2 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -1519,7 +1467,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: "IJsonComponents",
                                         value: input.components,
                                     })) &&
-                                    $vo32(
+                                    $vo31(
                                         input.components,
                                         _path + ".components",
                                         true && _exceptionable,
@@ -3481,7 +3429,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                     $report(_exceptionable, {
                                         path: _path + ".items",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: input.items,
                                     })) &&
                                     $vu0(
@@ -3492,7 +3440,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                     $report(_exceptionable, {
                                         path: _path + ".items",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: input.items,
                                     }),
                                 undefined === input.minItems ||
@@ -3757,7 +3705,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             _index23 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -3775,7 +3723,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         _index23 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -3784,6 +3732,47 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         path: _path + ".items",
                                         expected: "Array<IJsonSchema>",
                                         value: input.items,
+                                    }),
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number",
+                                        value: input.minItems,
+                                    }),
+                                undefined === input.maxItems ||
+                                    ("number" === typeof input.maxItems &&
+                                        Number.isFinite(input.maxItems) &&
+                                        (parseInt(input.maxItems) ===
+                                            input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "(number | undefined)",
+                                        value: input.maxItems,
                                     }),
                                 "array" === input.type ||
                                     $report(_exceptionable, {
@@ -3984,7 +3973,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             _index26 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -4002,7 +3991,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         _index26 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -4350,11 +4339,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$recursiveRef ||
+                                "null" === input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$recursiveRef",
-                                        expected: "string",
-                                        value: input.$recursiveRef,
+                                        path: _path + ".type",
+                                        expected: '"null"',
+                                        value: input.type,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -4522,12 +4511,18 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "null" === input.type ||
+                                (null !== input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"null"',
+                                        expected: "undefined",
                                         value: input.type,
-                                    }),
+                                    })) &&
+                                    (undefined === input.type ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".type",
+                                            expected: "undefined",
+                                            value: input.type,
+                                        })),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
                                     $report(_exceptionable, {
@@ -4694,31 +4689,202 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                (null !== input.type ||
+                                undefined === input.schemas ||
+                                    ((("object" === typeof input.schemas &&
+                                        null !== input.schemas &&
+                                        false ===
+                                            Array.isArray(input.schemas)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".schemas",
+                                            expected:
+                                                "(Record<string, IObject | IAlias> | undefined)",
+                                            value: input.schemas,
+                                        })) &&
+                                        $vo32(
+                                            input.schemas,
+                                            _path + ".schemas",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".schemas",
+                                        expected:
+                                            "(Record<string, IObject | IAlias> | undefined)",
+                                        value: input.schemas,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo32 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                false === _exceptionable ||
+                                    Object.keys(input)
+                                        .map((key: any) => {
+                                            const value = input[key];
+                                            if (undefined === value)
+                                                return true;
+                                            if (RegExp(/(.*)/).test(key))
+                                                return (
+                                                    ((("object" ===
+                                                        typeof value &&
+                                                        null !== value &&
+                                                        false ===
+                                                            Array.isArray(
+                                                                value,
+                                                            )) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    $join(key),
+                                                                expected:
+                                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                                value: value,
+                                                            },
+                                                        )) &&
+                                                        $vu2(
+                                                            value,
+                                                            _path + $join(key),
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path + $join(key),
+                                                        expected:
+                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                        value: value,
+                                                    })
+                                                );
+                                            return true;
+                                        })
+                                        .every((flag: boolean) => flag),
+                            ].every((flag: boolean) => flag);
+                        const $vo33 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.$id ||
+                                    "string" === typeof input.$id ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$id",
+                                        expected: "(string | undefined)",
+                                        value: input.$id,
+                                    }),
+                                "object" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: "undefined",
+                                        expected: '"object"',
                                         value: input.type,
-                                    })) &&
-                                    (undefined === input.type ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".type",
-                                            expected: "undefined",
-                                            value: input.type,
-                                        })),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
                                     }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
+                                        path: _path + ".nullable",
+                                        expected: "(boolean | undefined)",
+                                        value: input.nullable,
+                                    }),
+                                ((("object" === typeof input.properties &&
+                                    null !== input.properties &&
+                                    false ===
+                                        Array.isArray(input.properties)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".properties",
+                                        expected: "Record<string, IJsonSchema>",
+                                        value: input.properties,
+                                    })) &&
+                                    $vo34(
+                                        input.properties,
+                                        _path + ".properties",
+                                        true && _exceptionable,
+                                    )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".properties",
+                                        expected: "Record<string, IJsonSchema>",
+                                        value: input.properties,
+                                    }),
+                                undefined === input.patternProperties ||
+                                    ((("object" ===
+                                        typeof input.patternProperties &&
+                                        null !== input.patternProperties &&
+                                        false ===
+                                            Array.isArray(
+                                                input.patternProperties,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".patternProperties",
+                                            expected:
+                                                "(Record<string, IJsonSchema> | undefined)",
+                                            value: input.patternProperties,
+                                        })) &&
+                                        $vo34(
+                                            input.patternProperties,
+                                            _path + ".patternProperties",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".patternProperties",
+                                        expected:
+                                            "(Record<string, IJsonSchema> | undefined)",
+                                        value: input.patternProperties,
+                                    }),
+                                undefined === input.additionalProperties ||
+                                    ((("object" ===
+                                        typeof input.additionalProperties &&
+                                        null !== input.additionalProperties &&
+                                        false ===
+                                            Array.isArray(
+                                                input.additionalProperties,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + ".additionalProperties",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            value: input.additionalProperties,
+                                        })) &&
+                                        $vu0(
+                                            input.additionalProperties,
+                                            _path + ".additionalProperties",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".additionalProperties",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        value: input.additionalProperties,
+                                    }),
+                                undefined === input.required ||
+                                    ((Array.isArray(input.required) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".required",
+                                            expected:
+                                                "(Array<string> | undefined)",
+                                            value: input.required,
+                                        })) &&
+                                        input.required
+                                            .map(
+                                                (elem: any, _index35: number) =>
+                                                    "string" === typeof elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".required[" +
+                                                            _index35 +
+                                                            "]",
+                                                        expected: "string",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".required",
+                                        expected: "(Array<string> | undefined)",
+                                        value: input.required,
                                     }),
                                 undefined === input.description ||
                                     "string" === typeof input.description ||
@@ -4726,63 +4892,6 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         path: _path + ".description",
                                         expected: "(string | undefined)",
                                         value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index35: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index35 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index35 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index35 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
                                     }),
                                 undefined === input["x-typia-jsDocTags"] ||
                                     ((Array.isArray(
@@ -4841,306 +4950,6 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                             "(Array<IJsDocTagInfo> | undefined)",
                                         value: input["x-typia-jsDocTags"],
                                     }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo32 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                undefined === input.schemas ||
-                                    ((("object" === typeof input.schemas &&
-                                        null !== input.schemas &&
-                                        false ===
-                                            Array.isArray(input.schemas)) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".schemas",
-                                            expected:
-                                                "(Record<string, IObject | IAlias> | undefined)",
-                                            value: input.schemas,
-                                        })) &&
-                                        $vo33(
-                                            input.schemas,
-                                            _path + ".schemas",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".schemas",
-                                        expected:
-                                            "(Record<string, IObject | IAlias> | undefined)",
-                                        value: input.schemas,
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo33 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                false === _exceptionable ||
-                                    Object.keys(input)
-                                        .map((key: any) => {
-                                            const value = input[key];
-                                            if (undefined === value)
-                                                return true;
-                                            if (RegExp(/(.*)/).test(key))
-                                                return (
-                                                    ((("object" ===
-                                                        typeof value &&
-                                                        null !== value &&
-                                                        false ===
-                                                            Array.isArray(
-                                                                value,
-                                                            )) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    $join(key),
-                                                                expected:
-                                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                                value: value,
-                                                            },
-                                                        )) &&
-                                                        $vu2(
-                                                            value,
-                                                            _path + $join(key),
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path + $join(key),
-                                                        expected:
-                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                        value: value,
-                                                    })
-                                                );
-                                            return true;
-                                        })
-                                        .every((flag: boolean) => flag),
-                            ].every((flag: boolean) => flag);
-                        const $vo34 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                                "object" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"object"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.nullable ||
-                                    "boolean" === typeof input.nullable ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".nullable",
-                                        expected: "(boolean | undefined)",
-                                        value: input.nullable,
-                                    }),
-                                ((("object" === typeof input.properties &&
-                                    null !== input.properties &&
-                                    false ===
-                                        Array.isArray(input.properties)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".properties",
-                                        expected: "Record<string, IJsonSchema>",
-                                        value: input.properties,
-                                    })) &&
-                                    $vo35(
-                                        input.properties,
-                                        _path + ".properties",
-                                        true && _exceptionable,
-                                    )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".properties",
-                                        expected: "Record<string, IJsonSchema>",
-                                        value: input.properties,
-                                    }),
-                                undefined === input.patternProperties ||
-                                    ((("object" ===
-                                        typeof input.patternProperties &&
-                                        null !== input.patternProperties &&
-                                        false ===
-                                            Array.isArray(
-                                                input.patternProperties,
-                                            )) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".patternProperties",
-                                            expected:
-                                                "(Record<string, IJsonSchema> | undefined)",
-                                            value: input.patternProperties,
-                                        })) &&
-                                        $vo35(
-                                            input.patternProperties,
-                                            _path + ".patternProperties",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".patternProperties",
-                                        expected:
-                                            "(Record<string, IJsonSchema> | undefined)",
-                                        value: input.patternProperties,
-                                    }),
-                                undefined === input.additionalProperties ||
-                                    ((("object" ===
-                                        typeof input.additionalProperties &&
-                                        null !== input.additionalProperties &&
-                                        false ===
-                                            Array.isArray(
-                                                input.additionalProperties,
-                                            )) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + ".additionalProperties",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                            value: input.additionalProperties,
-                                        })) &&
-                                        $vu0(
-                                            input.additionalProperties,
-                                            _path + ".additionalProperties",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".additionalProperties",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                        value: input.additionalProperties,
-                                    }),
-                                undefined === input.required ||
-                                    ((Array.isArray(input.required) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".required",
-                                            expected:
-                                                "(Array<string> | undefined)",
-                                            value: input.required,
-                                        })) &&
-                                        input.required
-                                            .map(
-                                                (elem: any, _index37: number) =>
-                                                    "string" === typeof elem ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            ".required[" +
-                                                            _index37 +
-                                                            "]",
-                                                        expected: "string",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".required",
-                                        expected: "(Array<string> | undefined)",
-                                        value: input.required,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index38: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index38 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index38 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index38 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
                                 undefined ===
                                     input["x-typia-patternProperties"] ||
                                     ((("object" ===
@@ -5167,7 +4976,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 "x-typia-patternProperties"
                                             ],
                                         })) &&
-                                        $vo35(
+                                        $vo34(
                                             input["x-typia-patternProperties"],
                                             _path +
                                                 '["x-typia-patternProperties"]',
@@ -5204,7 +5013,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 _path +
                                                 '["x-typia-additionalProperties"]',
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                             value: input[
                                                 "x-typia-additionalProperties"
                                             ],
@@ -5222,13 +5031,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                             _path +
                                             '["x-typia-additionalProperties"]',
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                         value: input[
                                             "x-typia-additionalProperties"
                                         ],
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo35 = (
+                        const $vo34 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5256,7 +5065,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                                     _path +
                                                                     $join(key),
                                                                 expected:
-                                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                                 value: value,
                                                             },
                                                         )) &&
@@ -5270,7 +5079,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         path:
                                                             _path + $join(key),
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: value,
                                                     })
                                                 );
@@ -5278,7 +5087,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         })
                                         .every((flag: boolean) => flag),
                             ].every((flag: boolean) => flag);
-                        const $vo36 = (
+                        const $vo35 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5292,13 +5101,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                     })) &&
                                     input["enum"]
                                         .map(
-                                            (elem: any, _index39: number) =>
+                                            (elem: any, _index37: number) =>
                                                 "boolean" === typeof elem ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["enum"][' +
-                                                        _index39 +
+                                                        _index37 +
                                                         "]",
                                                     expected: "boolean",
                                                     value: elem,
@@ -5364,7 +5173,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index40: number) =>
+                                                (elem: any, _index38: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5374,7 +5183,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index40 +
+                                                                    _index38 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5385,7 +5194,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index40 +
+                                                                _index38 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5394,7 +5203,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index40 +
+                                                            _index38 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5421,7 +5230,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index41: number) =>
+                                                (elem: any, _index39: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5431,7 +5240,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index41 +
+                                                                    _index39 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -5442,7 +5251,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index41 +
+                                                                _index39 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5451,7 +5260,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index41 +
+                                                            _index39 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5505,7 +5314,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         value: input.$recursiveAnchor,
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo37 = (
+                        const $vo36 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5519,14 +5328,14 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                     })) &&
                                     input["enum"]
                                         .map(
-                                            (elem: any, _index42: number) =>
+                                            (elem: any, _index40: number) =>
                                                 ("number" === typeof elem &&
                                                     Number.isFinite(elem)) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["enum"][' +
-                                                        _index42 +
+                                                        _index40 +
                                                         "]",
                                                     expected: "number",
                                                     value: elem,
@@ -5593,7 +5402,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index43: number) =>
+                                                (elem: any, _index41: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5603,7 +5412,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index43 +
+                                                                    _index41 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5614,7 +5423,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index43 +
+                                                                _index41 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5623,7 +5432,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index43 +
+                                                            _index41 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5650,7 +5459,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index44: number) =>
+                                                (elem: any, _index42: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5660,7 +5469,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index44 +
+                                                                    _index42 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -5671,7 +5480,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index44 +
+                                                                _index42 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5680,7 +5489,234 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
+                                                            _index42 +
+                                                            "]",
+                                                        expected:
+                                                            "IJsDocTagInfo",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-jsDocTags"]',
+                                        expected:
+                                            "(Array<IJsDocTagInfo> | undefined)",
+                                        value: input["x-typia-jsDocTags"],
+                                    }),
+                                undefined === input["x-typia-required"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-required"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-required"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-required"],
+                                    }),
+                                undefined === input["x-typia-optional"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-optional"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-optional"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-optional"],
+                                    }),
+                                undefined === input["x-typia-rest"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-rest"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-rest"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-rest"],
+                                    }),
+                                undefined === input.$id ||
+                                    "string" === typeof input.$id ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$id",
+                                        expected: "(string | undefined)",
+                                        value: input.$id,
+                                    }),
+                                undefined === input.$recursiveAnchor ||
+                                    "boolean" ===
+                                        typeof input.$recursiveAnchor ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$recursiveAnchor",
+                                        expected: "(boolean | undefined)",
+                                        value: input.$recursiveAnchor,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo37 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                ((Array.isArray(input["enum"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["enum"]',
+                                        expected: "Array<string>",
+                                        value: input["enum"],
+                                    })) &&
+                                    input["enum"]
+                                        .map(
+                                            (elem: any, _index43: number) =>
+                                                "string" === typeof elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["enum"][' +
+                                                        _index43 +
+                                                        "]",
+                                                    expected: "string",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["enum"]',
+                                        expected: "Array<string>",
+                                        value: input["enum"],
+                                    }),
+                                undefined === input["default"] ||
+                                    "string" === typeof input["default"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["default"]',
+                                        expected: "(string | undefined)",
+                                        value: input["default"],
+                                    }),
+                                "string" === input.type ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".type",
+                                        expected: '"string"',
+                                        value: input.type,
+                                    }),
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".nullable",
+                                        expected: "(boolean | undefined)",
+                                        value: input.nullable,
+                                    }),
+                                undefined === input.deprecated ||
+                                    "boolean" === typeof input.deprecated ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".deprecated",
+                                        expected: "(boolean | undefined)",
+                                        value: input.deprecated,
+                                    }),
+                                undefined === input.title ||
+                                    "string" === typeof input.title ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".title",
+                                        expected: "(string | undefined)",
+                                        value: input.title,
+                                    }),
+                                undefined === input.description ||
+                                    "string" === typeof input.description ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".description",
+                                        expected: "(string | undefined)",
+                                        value: input.description,
+                                    }),
+                                undefined === input["x-typia-metaTags"] ||
+                                    ((Array.isArray(
+                                        input["x-typia-metaTags"],
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + '["x-typia-metaTags"]',
+                                            expected:
+                                                "(Array<IMetadataTag> | undefined)",
+                                            value: input["x-typia-metaTags"],
+                                        })) &&
+                                        input["x-typia-metaTags"]
+                                            .map(
+                                                (elem: any, _index44: number) =>
+                                                    ((("object" ===
+                                                        typeof elem &&
+                                                        null !== elem) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    '["x-typia-metaTags"][' +
+                                                                    _index44 +
+                                                                    "]",
+                                                                expected:
+                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                        $vu1(
+                                                            elem,
+                                                            _path +
+                                                                '["x-typia-metaTags"][' +
+                                                                _index44 +
+                                                                "]",
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-metaTags"][' +
                                                             _index44 +
+                                                            "]",
+                                                        expected:
+                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-metaTags"]',
+                                        expected:
+                                            "(Array<IMetadataTag> | undefined)",
+                                        value: input["x-typia-metaTags"],
+                                    }),
+                                undefined === input["x-typia-jsDocTags"] ||
+                                    ((Array.isArray(
+                                        input["x-typia-jsDocTags"],
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + '["x-typia-jsDocTags"]',
+                                            expected:
+                                                "(Array<IJsDocTagInfo> | undefined)",
+                                            value: input["x-typia-jsDocTags"],
+                                        })) &&
+                                        input["x-typia-jsDocTags"]
+                                            .map(
+                                                (elem: any, _index45: number) =>
+                                                    ((("object" ===
+                                                        typeof elem &&
+                                                        null !== elem) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    '["x-typia-jsDocTags"][' +
+                                                                    _index45 +
+                                                                    "]",
+                                                                expected:
+                                                                    "IJsDocTagInfo",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                        $vo17(
+                                                            elem,
+                                                            _path +
+                                                                '["x-typia-jsDocTags"][' +
+                                                                _index45 +
+                                                                "]",
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-jsDocTags"][' +
+                                                            _index45 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5740,43 +5776,17 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input["enum"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["enum"]',
-                                        expected: "Array<string>",
-                                        value: input["enum"],
-                                    })) &&
-                                    input["enum"]
-                                        .map(
-                                            (elem: any, _index45: number) =>
-                                                "string" === typeof elem ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["enum"][' +
-                                                        _index45 +
-                                                        "]",
-                                                    expected: "string",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["enum"]',
-                                        expected: "Array<string>",
-                                        value: input["enum"],
-                                    }),
                                 undefined === input["default"] ||
-                                    "string" === typeof input["default"] ||
+                                    "boolean" === typeof input["default"] ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(string | undefined)",
+                                        expected: "(boolean | undefined)",
                                         value: input["default"],
                                     }),
-                                "string" === input.type ||
+                                "boolean" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"string"',
+                                        expected: '"boolean"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -5967,17 +5977,79 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
+                                undefined === input.minimum ||
+                                    ("number" === typeof input.minimum &&
+                                        Number.isFinite(input.minimum) &&
+                                        (parseInt(input.minimum) ===
+                                            input.minimum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "(number | undefined)",
+                                        value: input.minimum,
+                                    }),
+                                undefined === input.maximum ||
+                                    ("number" === typeof input.maximum &&
+                                        Number.isFinite(input.maximum) &&
+                                        (parseInt(input.maximum) ===
+                                            input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "(number | undefined)",
+                                        value: input.maximum,
+                                    }),
+                                undefined === input.exclusiveMinimum ||
+                                    "boolean" ===
+                                        typeof input.exclusiveMinimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected: "(boolean | undefined)",
+                                        value: input.exclusiveMinimum,
+                                    }),
+                                undefined === input.exclusiveMaximum ||
+                                    "boolean" ===
+                                        typeof input.exclusiveMaximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMaximum",
+                                        expected: "(boolean | undefined)",
+                                        value: input.exclusiveMaximum,
+                                    }),
+                                undefined === input.multipleOf ||
+                                    ("number" === typeof input.multipleOf &&
+                                        Number.isFinite(input.multipleOf) &&
+                                        (parseInt(input.multipleOf) ===
+                                            input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "(number | undefined)",
+                                        value: input.multipleOf,
+                                    }),
                                 undefined === input["default"] ||
-                                    "boolean" === typeof input["default"] ||
+                                    ("number" === typeof input["default"] &&
+                                        Number.isFinite(input["default"])) ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(boolean | undefined)",
+                                        expected: "(number | undefined)",
                                         value: input["default"],
                                     }),
-                                "boolean" === input.type ||
+                                "integer" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"boolean"',
+                                        expected: '"integer"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6170,14 +6242,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             [
                                 undefined === input.minimum ||
                                     ("number" === typeof input.minimum &&
-                                        Number.isFinite(input.minimum) &&
-                                        (parseInt(input.minimum) ===
-                                            input.minimum ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minimum",
-                                                expected: "number (@type int)",
-                                                value: input.minimum,
-                                            }))) ||
+                                        Number.isFinite(input.minimum)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
                                         expected: "(number | undefined)",
@@ -6185,14 +6250,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                     }),
                                 undefined === input.maximum ||
                                     ("number" === typeof input.maximum &&
-                                        Number.isFinite(input.maximum) &&
-                                        (parseInt(input.maximum) ===
-                                            input.maximum ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".maximum",
-                                                expected: "number (@type int)",
-                                                value: input.maximum,
-                                            }))) ||
+                                        Number.isFinite(input.maximum)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "(number | undefined)",
@@ -6216,14 +6274,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                     }),
                                 undefined === input.multipleOf ||
                                     ("number" === typeof input.multipleOf &&
-                                        Number.isFinite(input.multipleOf) &&
-                                        (parseInt(input.multipleOf) ===
-                                            input.multipleOf ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".multipleOf",
-                                                expected: "number (@type int)",
-                                                value: input.multipleOf,
-                                            }))) ||
+                                        Number.isFinite(input.multipleOf)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "(number | undefined)",
@@ -6237,10 +6288,10 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         expected: "(number | undefined)",
                                         value: input["default"],
                                     }),
-                                "integer" === input.type ||
+                                "number" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"integer"',
+                                        expected: '"number"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6431,58 +6482,73 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                undefined === input.minimum ||
-                                    ("number" === typeof input.minimum &&
-                                        Number.isFinite(input.minimum)) ||
+                                undefined === input.minLength ||
+                                    ("number" === typeof input.minLength &&
+                                        Number.isFinite(input.minLength) &&
+                                        (parseInt(input.minLength) ===
+                                            input.minLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
+                                            })) &&
+                                        (0 <= input.minLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
+                                            }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".minimum",
+                                        path: _path + ".minLength",
                                         expected: "(number | undefined)",
-                                        value: input.minimum,
+                                        value: input.minLength,
                                     }),
-                                undefined === input.maximum ||
-                                    ("number" === typeof input.maximum &&
-                                        Number.isFinite(input.maximum)) ||
+                                undefined === input.maxLength ||
+                                    ("number" === typeof input.maxLength &&
+                                        Number.isFinite(input.maxLength) &&
+                                        (parseInt(input.maxLength) ===
+                                            input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".maximum",
+                                        path: _path + ".maxLength",
                                         expected: "(number | undefined)",
-                                        value: input.maximum,
+                                        value: input.maxLength,
                                     }),
-                                undefined === input.exclusiveMinimum ||
-                                    "boolean" ===
-                                        typeof input.exclusiveMinimum ||
+                                undefined === input.pattern ||
+                                    "string" === typeof input.pattern ||
                                     $report(_exceptionable, {
-                                        path: _path + ".exclusiveMinimum",
-                                        expected: "(boolean | undefined)",
-                                        value: input.exclusiveMinimum,
+                                        path: _path + ".pattern",
+                                        expected: "(string | undefined)",
+                                        value: input.pattern,
                                     }),
-                                undefined === input.exclusiveMaximum ||
-                                    "boolean" ===
-                                        typeof input.exclusiveMaximum ||
+                                undefined === input.format ||
+                                    "string" === typeof input.format ||
                                     $report(_exceptionable, {
-                                        path: _path + ".exclusiveMaximum",
-                                        expected: "(boolean | undefined)",
-                                        value: input.exclusiveMaximum,
-                                    }),
-                                undefined === input.multipleOf ||
-                                    ("number" === typeof input.multipleOf &&
-                                        Number.isFinite(input.multipleOf)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".multipleOf",
-                                        expected: "(number | undefined)",
-                                        value: input.multipleOf,
+                                        path: _path + ".format",
+                                        expected: "(string | undefined)",
+                                        value: input.format,
                                     }),
                                 undefined === input["default"] ||
-                                    ("number" === typeof input["default"] &&
-                                        Number.isFinite(input["default"])) ||
+                                    "string" === typeof input["default"] ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(number | undefined)",
+                                        expected: "(string | undefined)",
                                         value: input["default"],
                                     }),
-                                "number" === input.type ||
+                                "string" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"number"',
+                                        expected: '"string"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6673,73 +6739,93 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                undefined === input.minLength ||
-                                    ("number" === typeof input.minLength &&
-                                        Number.isFinite(input.minLength) &&
-                                        (parseInt(input.minLength) ===
-                                            input.minLength ||
+                                ((("object" === typeof input.items &&
+                                    null !== input.items &&
+                                    false === Array.isArray(input.items)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: input.items,
+                                    })) &&
+                                    $vu0(
+                                        input.items,
+                                        _path + ".items",
+                                        true && _exceptionable,
+                                    )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: input.items,
+                                    }),
+                                undefined === input.minItems ||
+                                    ("number" === typeof input.minItems &&
+                                        Number.isFinite(input.minItems) &&
+                                        (parseInt(input.minItems) ===
+                                            input.minItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".minLength",
+                                                path: _path + ".minItems",
                                                 expected: "number (@type uint)",
-                                                value: input.minLength,
+                                                value: input.minItems,
                                             })) &&
-                                        (0 <= input.minLength ||
+                                        (0 <= input.minItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".minLength",
+                                                path: _path + ".minItems",
                                                 expected: "number (@type uint)",
-                                                value: input.minLength,
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "(number | undefined)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     }),
-                                undefined === input.maxLength ||
-                                    ("number" === typeof input.maxLength &&
-                                        Number.isFinite(input.maxLength) &&
-                                        (parseInt(input.maxLength) ===
-                                            input.maxLength ||
+                                undefined === input.maxItems ||
+                                    ("number" === typeof input.maxItems &&
+                                        Number.isFinite(input.maxItems) &&
+                                        (parseInt(input.maxItems) ===
+                                            input.maxItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".maxLength",
+                                                path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
-                                                value: input.maxLength,
+                                                value: input.maxItems,
                                             })) &&
-                                        (0 <= input.maxLength ||
+                                        (0 <= input.maxItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".maxLength",
+                                                path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
-                                                value: input.maxLength,
+                                                value: input.maxItems,
                                             }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "(number | undefined)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     }),
-                                undefined === input.pattern ||
-                                    "string" === typeof input.pattern ||
+                                undefined === input["x-typia-tuple"] ||
+                                    ((("object" ===
+                                        typeof input["x-typia-tuple"] &&
+                                        null !== input["x-typia-tuple"]) ||
+                                        $report(_exceptionable, {
+                                            path: _path + '["x-typia-tuple"]',
+                                            expected:
+                                                "(IJsonSchema.ITuple | undefined)",
+                                            value: input["x-typia-tuple"],
+                                        })) &&
+                                        $vo26(
+                                            input["x-typia-tuple"],
+                                            _path + '["x-typia-tuple"]',
+                                            true && _exceptionable,
+                                        )) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".pattern",
-                                        expected: "(string | undefined)",
-                                        value: input.pattern,
+                                        path: _path + '["x-typia-tuple"]',
+                                        expected:
+                                            "(IJsonSchema.ITuple | undefined)",
+                                        value: input["x-typia-tuple"],
                                     }),
-                                undefined === input.format ||
-                                    "string" === typeof input.format ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".format",
-                                        expected: "(string | undefined)",
-                                        value: input.format,
-                                    }),
-                                undefined === input["default"] ||
-                                    "string" === typeof input["default"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["default"]',
-                                        expected: "(string | undefined)",
-                                        value: input["default"],
-                                    }),
-                                "string" === input.type ||
+                                "array" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"string"',
+                                        expected: '"array"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6930,45 +7016,72 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((("object" === typeof input.items &&
-                                    null !== input.items &&
-                                    false === Array.isArray(input.items)) ||
+                                ((Array.isArray(input.items) ||
                                     $report(_exceptionable, {
                                         path: _path + ".items",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        expected: "Array<IJsonSchema>",
                                         value: input.items,
                                     })) &&
-                                    $vu0(
-                                        input.items,
-                                        _path + ".items",
-                                        true && _exceptionable,
-                                    )) ||
+                                    input.items
+                                        .map(
+                                            (elem: any, _index56: number) =>
+                                                ((("object" === typeof elem &&
+                                                    null !== elem &&
+                                                    false ===
+                                                        Array.isArray(elem)) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".items[" +
+                                                            _index56 +
+                                                            "]",
+                                                        expected:
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        value: elem,
+                                                    })) &&
+                                                    $vu0(
+                                                        elem,
+                                                        _path +
+                                                            ".items[" +
+                                                            _index56 +
+                                                            "]",
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index56 +
+                                                        "]",
+                                                    expected:
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".items",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        expected: "Array<IJsonSchema>",
                                         value: input.items,
                                     }),
-                                undefined === input.minItems ||
-                                    ("number" === typeof input.minItems &&
-                                        Number.isFinite(input.minItems) &&
-                                        (parseInt(input.minItems) ===
-                                            input.minItems ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minItems",
-                                                expected: "number (@type uint)",
-                                                value: input.minItems,
-                                            })) &&
-                                        (0 <= input.minItems ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minItems",
-                                                expected: "number (@type uint)",
-                                                value: input.minItems,
-                                            }))) ||
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
-                                        expected: "(number | undefined)",
+                                        expected: "number",
                                         value: input.minItems,
                                     }),
                                 undefined === input.maxItems ||
@@ -6991,27 +7104,6 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         path: _path + ".maxItems",
                                         expected: "(number | undefined)",
                                         value: input.maxItems,
-                                    }),
-                                undefined === input["x-typia-tuple"] ||
-                                    ((("object" ===
-                                        typeof input["x-typia-tuple"] &&
-                                        null !== input["x-typia-tuple"]) ||
-                                        $report(_exceptionable, {
-                                            path: _path + '["x-typia-tuple"]',
-                                            expected:
-                                                "(IJsonSchema.ITuple | undefined)",
-                                            value: input["x-typia-tuple"],
-                                        })) &&
-                                        $vo26(
-                                            input["x-typia-tuple"],
-                                            _path + '["x-typia-tuple"]',
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-tuple"]',
-                                        expected:
-                                            "(IJsonSchema.ITuple | undefined)",
-                                        value: input["x-typia-tuple"],
                                     }),
                                 "array" === input.type ||
                                     $report(_exceptionable, {
@@ -7060,7 +7152,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index56: number) =>
+                                                (elem: any, _index57: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7070,7 +7162,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index56 +
+                                                                    _index57 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7081,7 +7173,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index56 +
+                                                                _index57 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7090,7 +7182,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index56 +
+                                                            _index57 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7117,7 +7209,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index57: number) =>
+                                                (elem: any, _index58: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7127,7 +7219,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index57 +
+                                                                    _index58 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -7138,7 +7230,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index57 +
+                                                                _index58 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7147,7 +7239,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index57 +
+                                                            _index58 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -7207,15 +7299,15 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input.items) ||
+                                ((Array.isArray(input.oneOf) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".items",
+                                        path: _path + ".oneOf",
                                         expected: "Array<IJsonSchema>",
-                                        value: input.items,
+                                        value: input.oneOf,
                                     })) &&
-                                    input.items
+                                    input.oneOf
                                         .map(
-                                            (elem: any, _index58: number) =>
+                                            (elem: any, _index59: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem &&
                                                     false ===
@@ -7223,50 +7315,37 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
-                                                            ".items[" +
-                                                            _index58 +
+                                                            ".oneOf[" +
+                                                            _index59 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
                                                         elem,
                                                         _path +
-                                                            ".items[" +
-                                                            _index58 +
+                                                            ".oneOf[" +
+                                                            _index59 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
-                                                        ".items[" +
-                                                        _index58 +
+                                                        ".oneOf[" +
+                                                        _index59 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
                                         .every((flag: boolean) => flag)) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".items",
+                                        path: _path + ".oneOf",
                                         expected: "Array<IJsonSchema>",
-                                        value: input.items,
-                                    }),
-                                "array" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"array"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.nullable ||
-                                    "boolean" === typeof input.nullable ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".nullable",
-                                        expected: "(boolean | undefined)",
-                                        value: input.nullable,
+                                        value: input.oneOf,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7302,7 +7381,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index59: number) =>
+                                                (elem: any, _index60: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7312,7 +7391,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index59 +
+                                                                    _index60 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7323,7 +7402,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index59 +
+                                                                _index60 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7332,7 +7411,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index59 +
+                                                            _index60 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7359,7 +7438,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index60: number) =>
+                                                (elem: any, _index61: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7369,7 +7448,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index60 +
+                                                                    _index61 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -7380,7 +7459,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index60 +
+                                                                _index61 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7389,7 +7468,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index60 +
+                                                            _index61 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -7449,53 +7528,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input.oneOf) ||
+                                "string" === typeof input.$ref ||
                                     $report(_exceptionable, {
-                                        path: _path + ".oneOf",
-                                        expected: "Array<IJsonSchema>",
-                                        value: input.oneOf,
-                                    })) &&
-                                    input.oneOf
-                                        .map(
-                                            (elem: any, _index61: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem &&
-                                                    false ===
-                                                        Array.isArray(elem)) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            ".oneOf[" +
-                                                            _index61 +
-                                                            "]",
-                                                        expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu0(
-                                                        elem,
-                                                        _path +
-                                                            ".oneOf[" +
-                                                            _index61 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        ".oneOf[" +
-                                                        _index61 +
-                                                        "]",
-                                                    expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".oneOf",
-                                        expected: "Array<IJsonSchema>",
-                                        value: input.oneOf,
+                                        path: _path + ".$ref",
+                                        expected: "string",
+                                        value: input.$ref,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7678,11 +7715,11 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$ref ||
+                                "null" === input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$ref",
-                                        expected: "string",
-                                        value: input.$ref,
+                                        path: _path + ".type",
+                                        expected: '"null"',
+                                        value: input.type,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7865,12 +7902,18 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$recursiveRef ||
+                                (null !== input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$recursiveRef",
-                                        expected: "string",
-                                        value: input.$recursiveRef,
-                                    }),
+                                        path: _path + ".type",
+                                        expected: "undefined",
+                                        value: input.type,
+                                    })) &&
+                                    (undefined === input.type ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".type",
+                                            expected: "undefined",
+                                            value: input.type,
+                                        })),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
                                     $report(_exceptionable, {
@@ -8046,386 +8089,6 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         value: input.$recursiveAnchor,
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo48 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                "null" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"null"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
-                                    }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index68: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index68 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index68 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index68 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index69: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index69 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index69 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index69 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo49 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                (null !== input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: "undefined",
-                                        value: input.type,
-                                    })) &&
-                                    (undefined === input.type ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".type",
-                                            expected: "undefined",
-                                            value: input.type,
-                                        })),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
-                                    }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index70: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index70 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index70 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index70 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index71: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index71 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index71 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index71 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                            ].every((flag: boolean) => flag);
                         const $vu0 = (
                             input: any,
                             _path: string,
@@ -8457,7 +8120,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                     Array.isArray(input.items) &&
                                     input.items
                                         .map(
-                                            (elem: any, _index72: number) =>
+                                            (elem: any, _index68: number) =>
                                                 "object" === typeof elem &&
                                                 null !== elem &&
                                                 false === Array.isArray(elem) &&
@@ -8465,7 +8128,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                     elem,
                                                     _path +
                                                         ".items[" +
-                                                        _index72 +
+                                                        _index68 +
                                                         "]",
                                                     false && _exceptionable,
                                                 ),
@@ -8489,14 +8152,8 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         _path,
                                         true && _exceptionable,
                                     );
-                                if (undefined !== input.$recursiveRef)
-                                    return $vo29(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
                                 if ("null" === input.type)
-                                    return $vo30(
+                                    return $vo29(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8532,7 +8189,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo31(input, _path, false && _exceptionable)
+                                    $vo30(input, _path, false && _exceptionable)
                                 );
                             })();
                         const $vu1 = (
@@ -8645,13 +8302,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         ): any =>
                             (() => {
                                 if ("object" === input.type)
-                                    return $vo34(
+                                    return $vo33(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("integer" === input.type)
-                                    return $vo40(
+                                    return $vo39(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8666,7 +8323,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         false && _exceptionable,
                                     )
                                 )
-                                    return $vo43(
+                                    return $vo42(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8675,7 +8332,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                     Array.isArray(input.items) &&
                                     input.items
                                         .map(
-                                            (elem: any, _index73: number) =>
+                                            (elem: any, _index69: number) =>
                                                 "object" === typeof elem &&
                                                 null !== elem &&
                                                 false === Array.isArray(elem) &&
@@ -8683,48 +8340,37 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                     elem,
                                                     _path +
                                                         ".items[" +
-                                                        _index73 +
+                                                        _index69 +
                                                         "]",
                                                     false && _exceptionable,
                                                 ),
                                         )
                                         .every((flag: boolean) => flag)
                                 )
-                                    return $vo44(
+                                    return $vo43(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.oneOf)
-                                    return $vo45(
+                                    return $vo44(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.$ref)
-                                    return $vo46(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
-                                if (undefined !== input.$recursiveRef)
-                                    return $vo47(
+                                    return $vo45(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("null" === input.type)
-                                    return $vo48(
+                                    return $vo46(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 return (
-                                    $vo38(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
                                     $vo37(
                                         input,
                                         _path,
@@ -8735,7 +8381,17 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo39(
+                                    $vo35(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $vo38(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $vo40(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -8745,12 +8401,7 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo42(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
-                                    $vo49(input, _path, false && _exceptionable)
+                                    $vo47(input, _path, false && _exceptionable)
                                 );
                             })();
                         return (

--- a/test/generated/output/validateStringify/test_validateStringify_UltimateUnion.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_UltimateUnion.ts
@@ -27,7 +27,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "object" === typeof input.components &&
                         null !== input.components &&
                         false === Array.isArray(input.components) &&
-                        $io32(input.components) &&
+                        $io31(input.components) &&
                         ("ajv" === input.purpose ||
                             "swagger" === input.purpose);
                     const $io1 = (input: any): boolean =>
@@ -464,6 +464,15 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -563,36 +572,6 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
                     const $io29 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]);
-                    const $io30 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -622,7 +601,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io31 = (input: any): boolean =>
+                    const $io30 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -653,13 +632,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "boolean" === typeof input["x-typia-optional"]) &&
                         (undefined === input["x-typia-rest"] ||
                             "boolean" === typeof input["x-typia-rest"]);
-                    const $io32 = (input: any): boolean =>
+                    const $io31 = (input: any): boolean =>
                         undefined === input.schemas ||
                         ("object" === typeof input.schemas &&
                             null !== input.schemas &&
                             false === Array.isArray(input.schemas) &&
-                            $io33(input.schemas));
-                    const $io33 = (input: any): boolean =>
+                            $io32(input.schemas));
+                    const $io32 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -672,24 +651,22 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 );
                             return true;
                         });
-                    const $io34 = (input: any): boolean =>
+                    const $io33 = (input: any): boolean =>
                         (undefined === input.$id ||
                             "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor) &&
                         "object" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
                         "object" === typeof input.properties &&
                         null !== input.properties &&
                         false === Array.isArray(input.properties) &&
-                        $io35(input.properties) &&
+                        $io34(input.properties) &&
                         (undefined === input.patternProperties ||
                             ("object" === typeof input.patternProperties &&
                                 null !== input.patternProperties &&
                                 false ===
                                     Array.isArray(input.patternProperties) &&
-                                $io35(input.patternProperties))) &&
+                                $io34(input.patternProperties))) &&
                         (undefined === input.additionalProperties ||
                             ("object" === typeof input.additionalProperties &&
                                 null !== input.additionalProperties &&
@@ -719,7 +696,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     Array.isArray(
                                         input["x-typia-patternProperties"],
                                     ) &&
-                                $io35(input["x-typia-patternProperties"]))) &&
+                                $io34(input["x-typia-patternProperties"]))) &&
                         (undefined === input["x-typia-additionalProperties"] ||
                             ("object" ===
                                 typeof input["x-typia-additionalProperties"] &&
@@ -730,7 +707,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         input["x-typia-additionalProperties"],
                                     ) &&
                                 $iu0(input["x-typia-additionalProperties"])));
-                    const $io35 = (input: any): boolean =>
+                    const $io34 = (input: any): boolean =>
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
@@ -743,7 +720,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 );
                             return true;
                         });
-                    const $io36 = (input: any): boolean =>
+                    const $io35 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "boolean" === typeof elem,
@@ -785,7 +762,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io37 = (input: any): boolean =>
+                    const $io36 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) =>
@@ -830,7 +807,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io38 = (input: any): boolean =>
+                    const $io37 = (input: any): boolean =>
                         Array.isArray(input["enum"]) &&
                         input["enum"].every(
                             (elem: any) => "string" === typeof elem,
@@ -872,7 +849,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io39 = (input: any): boolean =>
+                    const $io38 = (input: any): boolean =>
                         (undefined === input["default"] ||
                             "boolean" === typeof input["default"]) &&
                         "boolean" === input.type &&
@@ -910,7 +887,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io40 = (input: any): boolean =>
+                    const $io39 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
@@ -966,7 +943,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io41 = (input: any): boolean =>
+                    const $io40 = (input: any): boolean =>
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum))) &&
@@ -1018,7 +995,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io42 = (input: any): boolean =>
+                    const $io41 = (input: any): boolean =>
                         (undefined === input.minLength ||
                             ("number" === typeof input.minLength &&
                                 Number.isFinite(input.minLength) &&
@@ -1070,7 +1047,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io43 = (input: any): boolean =>
+                    const $io42 = (input: any): boolean =>
                         "object" === typeof input.items &&
                         null !== input.items &&
                         false === Array.isArray(input.items) &&
@@ -1124,7 +1101,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io44 = (input: any): boolean =>
+                    const $io43 = (input: any): boolean =>
                         Array.isArray(input.items) &&
                         input.items.every(
                             (elem: any) =>
@@ -1133,6 +1110,15 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 false === Array.isArray(elem) &&
                                 $iu0(elem),
                         ) &&
+                        "number" === typeof input.minItems &&
+                        Number.isFinite(input.minItems) &&
+                        parseInt(input.minItems) === input.minItems &&
+                        0 <= input.minItems &&
+                        (undefined === input.maxItems ||
+                            ("number" === typeof input.maxItems &&
+                                Number.isFinite(input.maxItems) &&
+                                parseInt(input.maxItems) === input.maxItems &&
+                                0 <= input.maxItems)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -1168,7 +1154,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io45 = (input: any): boolean =>
+                    const $io44 = (input: any): boolean =>
                         Array.isArray(input.oneOf) &&
                         input.oneOf.every(
                             (elem: any) =>
@@ -1209,7 +1195,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io46 = (input: any): boolean =>
+                    const $io45 = (input: any): boolean =>
                         "string" === typeof input.$ref &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1243,41 +1229,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io47 = (input: any): boolean =>
-                        "string" === typeof input.$recursiveRef &&
-                        (undefined === input.deprecated ||
-                            "boolean" === typeof input.deprecated) &&
-                        (undefined === input.title ||
-                            "string" === typeof input.title) &&
-                        (undefined === input.description ||
-                            "string" === typeof input.description) &&
-                        (undefined === input["x-typia-metaTags"] ||
-                            (Array.isArray(input["x-typia-metaTags"]) &&
-                                input["x-typia-metaTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $iu1(elem),
-                                ))) &&
-                        (undefined === input["x-typia-jsDocTags"] ||
-                            (Array.isArray(input["x-typia-jsDocTags"]) &&
-                                input["x-typia-jsDocTags"].every(
-                                    (elem: any) =>
-                                        "object" === typeof elem &&
-                                        null !== elem &&
-                                        $io17(elem),
-                                ))) &&
-                        (undefined === input["x-typia-required"] ||
-                            "boolean" === typeof input["x-typia-required"]) &&
-                        (undefined === input["x-typia-optional"] ||
-                            "boolean" === typeof input["x-typia-optional"]) &&
-                        (undefined === input["x-typia-rest"] ||
-                            "boolean" === typeof input["x-typia-rest"]) &&
-                        (undefined === input.$id ||
-                            "string" === typeof input.$id) &&
-                        (undefined === input.$recursiveAnchor ||
-                            "boolean" === typeof input.$recursiveAnchor);
-                    const $io48 = (input: any): boolean =>
+                    const $io46 = (input: any): boolean =>
                         "null" === input.type &&
                         (undefined === input.deprecated ||
                             "boolean" === typeof input.deprecated) &&
@@ -1311,7 +1263,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             "string" === typeof input.$id) &&
                         (undefined === input.$recursiveAnchor ||
                             "boolean" === typeof input.$recursiveAnchor);
-                    const $io49 = (input: any): boolean =>
+                    const $io47 = (input: any): boolean =>
                         null !== input.type &&
                         undefined === input.type &&
                         (undefined === input.deprecated ||
@@ -1369,9 +1321,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 return $io26(input);
                             if (undefined !== input.oneOf) return $io27(input);
                             if (undefined !== input.$ref) return $io28(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io29(input);
-                            if ("null" === input.type) return $io30(input);
+                            if ("null" === input.type) return $io29(input);
                             return (() => {
                                 if ($io20(input)) return $io20(input);
                                 if ($io19(input)) return $io19(input);
@@ -1379,7 +1329,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 if ($io21(input)) return $io21(input);
                                 if ($io23(input)) return $io23(input);
                                 if ($io24(input)) return $io24(input);
-                                if ($io31(input)) return $io31(input);
+                                if ($io30(input)) return $io30(input);
                                 return false;
                             })();
                         })();
@@ -1406,15 +1356,15 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         })();
                     const $iu2 = (input: any): any =>
                         (() => {
-                            if ("object" === input.type) return $io34(input);
-                            if ("integer" === input.type) return $io40(input);
+                            if ("object" === input.type) return $io33(input);
+                            if ("integer" === input.type) return $io39(input);
                             if (
                                 "object" === typeof input.items &&
                                 null !== input.items &&
                                 false === Array.isArray(input.items) &&
                                 $iu0(input.items)
                             )
-                                return $io43(input);
+                                return $io42(input);
                             if (
                                 Array.isArray(input.items) &&
                                 input.items.every(
@@ -1425,20 +1375,18 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         $iu0(elem),
                                 )
                             )
-                                return $io44(input);
-                            if (undefined !== input.oneOf) return $io45(input);
-                            if (undefined !== input.$ref) return $io46(input);
-                            if (undefined !== input.$recursiveRef)
-                                return $io47(input);
-                            if ("null" === input.type) return $io48(input);
+                                return $io43(input);
+                            if (undefined !== input.oneOf) return $io44(input);
+                            if (undefined !== input.$ref) return $io45(input);
+                            if ("null" === input.type) return $io46(input);
                             return (() => {
-                                if ($io38(input)) return $io38(input);
                                 if ($io37(input)) return $io37(input);
                                 if ($io36(input)) return $io36(input);
-                                if ($io39(input)) return $io39(input);
+                                if ($io35(input)) return $io35(input);
+                                if ($io38(input)) return $io38(input);
+                                if ($io40(input)) return $io40(input);
                                 if ($io41(input)) return $io41(input);
-                                if ($io42(input)) return $io42(input);
-                                if ($io49(input)) return $io49(input);
+                                if ($io47(input)) return $io47(input);
                                 return false;
                             })();
                         })();
@@ -1488,7 +1436,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             _index2 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -1506,7 +1454,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         _index2 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -1525,7 +1473,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: "IJsonComponents",
                                         value: input.components,
                                     })) &&
-                                    $vo32(
+                                    $vo31(
                                         input.components,
                                         _path + ".components",
                                         true && _exceptionable,
@@ -3487,7 +3435,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     $report(_exceptionable, {
                                         path: _path + ".items",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: input.items,
                                     })) &&
                                     $vu0(
@@ -3498,7 +3446,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     $report(_exceptionable, {
                                         path: _path + ".items",
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                         value: input.items,
                                     }),
                                 undefined === input.minItems ||
@@ -3763,7 +3711,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             _index23 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -3781,7 +3729,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         _index23 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -3790,6 +3738,47 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         path: _path + ".items",
                                         expected: "Array<IJsonSchema>",
                                         value: input.items,
+                                    }),
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number",
+                                        value: input.minItems,
+                                    }),
+                                undefined === input.maxItems ||
+                                    ("number" === typeof input.maxItems &&
+                                        Number.isFinite(input.maxItems) &&
+                                        (parseInt(input.maxItems) ===
+                                            input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "(number | undefined)",
+                                        value: input.maxItems,
                                     }),
                                 "array" === input.type ||
                                     $report(_exceptionable, {
@@ -3990,7 +3979,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             _index26 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
@@ -4008,7 +3997,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         _index26 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
@@ -4356,11 +4345,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$recursiveRef ||
+                                "null" === input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$recursiveRef",
-                                        expected: "string",
-                                        value: input.$recursiveRef,
+                                        path: _path + ".type",
+                                        expected: '"null"',
+                                        value: input.type,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -4528,12 +4517,18 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "null" === input.type ||
+                                (null !== input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"null"',
+                                        expected: "undefined",
                                         value: input.type,
-                                    }),
+                                    })) &&
+                                    (undefined === input.type ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".type",
+                                            expected: "undefined",
+                                            value: input.type,
+                                        })),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
                                     $report(_exceptionable, {
@@ -4700,31 +4695,202 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                (null !== input.type ||
+                                undefined === input.schemas ||
+                                    ((("object" === typeof input.schemas &&
+                                        null !== input.schemas &&
+                                        false ===
+                                            Array.isArray(input.schemas)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".schemas",
+                                            expected:
+                                                "(Record<string, IObject | IAlias> | undefined)",
+                                            value: input.schemas,
+                                        })) &&
+                                        $vo32(
+                                            input.schemas,
+                                            _path + ".schemas",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".schemas",
+                                        expected:
+                                            "(Record<string, IObject | IAlias> | undefined)",
+                                        value: input.schemas,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo32 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                false === _exceptionable ||
+                                    Object.keys(input)
+                                        .map((key: any) => {
+                                            const value = input[key];
+                                            if (undefined === value)
+                                                return true;
+                                            if (RegExp(/(.*)/).test(key))
+                                                return (
+                                                    ((("object" ===
+                                                        typeof value &&
+                                                        null !== value &&
+                                                        false ===
+                                                            Array.isArray(
+                                                                value,
+                                                            )) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    $join(key),
+                                                                expected:
+                                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                                value: value,
+                                                            },
+                                                        )) &&
+                                                        $vu2(
+                                                            value,
+                                                            _path + $join(key),
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path + $join(key),
+                                                        expected:
+                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
+                                                        value: value,
+                                                    })
+                                                );
+                                            return true;
+                                        })
+                                        .every((flag: boolean) => flag),
+                            ].every((flag: boolean) => flag);
+                        const $vo33 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.$id ||
+                                    "string" === typeof input.$id ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$id",
+                                        expected: "(string | undefined)",
+                                        value: input.$id,
+                                    }),
+                                "object" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: "undefined",
+                                        expected: '"object"',
                                         value: input.type,
-                                    })) &&
-                                    (undefined === input.type ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".type",
-                                            expected: "undefined",
-                                            value: input.type,
-                                        })),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
                                     }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
                                     $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
+                                        path: _path + ".nullable",
+                                        expected: "(boolean | undefined)",
+                                        value: input.nullable,
+                                    }),
+                                ((("object" === typeof input.properties &&
+                                    null !== input.properties &&
+                                    false ===
+                                        Array.isArray(input.properties)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".properties",
+                                        expected: "Record<string, IJsonSchema>",
+                                        value: input.properties,
+                                    })) &&
+                                    $vo34(
+                                        input.properties,
+                                        _path + ".properties",
+                                        true && _exceptionable,
+                                    )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".properties",
+                                        expected: "Record<string, IJsonSchema>",
+                                        value: input.properties,
+                                    }),
+                                undefined === input.patternProperties ||
+                                    ((("object" ===
+                                        typeof input.patternProperties &&
+                                        null !== input.patternProperties &&
+                                        false ===
+                                            Array.isArray(
+                                                input.patternProperties,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".patternProperties",
+                                            expected:
+                                                "(Record<string, IJsonSchema> | undefined)",
+                                            value: input.patternProperties,
+                                        })) &&
+                                        $vo34(
+                                            input.patternProperties,
+                                            _path + ".patternProperties",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".patternProperties",
+                                        expected:
+                                            "(Record<string, IJsonSchema> | undefined)",
+                                        value: input.patternProperties,
+                                    }),
+                                undefined === input.additionalProperties ||
+                                    ((("object" ===
+                                        typeof input.additionalProperties &&
+                                        null !== input.additionalProperties &&
+                                        false ===
+                                            Array.isArray(
+                                                input.additionalProperties,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + ".additionalProperties",
+                                            expected:
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            value: input.additionalProperties,
+                                        })) &&
+                                        $vu0(
+                                            input.additionalProperties,
+                                            _path + ".additionalProperties",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".additionalProperties",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                        value: input.additionalProperties,
+                                    }),
+                                undefined === input.required ||
+                                    ((Array.isArray(input.required) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".required",
+                                            expected:
+                                                "(Array<string> | undefined)",
+                                            value: input.required,
+                                        })) &&
+                                        input.required
+                                            .map(
+                                                (elem: any, _index35: number) =>
+                                                    "string" === typeof elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".required[" +
+                                                            _index35 +
+                                                            "]",
+                                                        expected: "string",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".required",
+                                        expected: "(Array<string> | undefined)",
+                                        value: input.required,
                                     }),
                                 undefined === input.description ||
                                     "string" === typeof input.description ||
@@ -4732,63 +4898,6 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         path: _path + ".description",
                                         expected: "(string | undefined)",
                                         value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index35: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index35 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index35 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index35 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
                                     }),
                                 undefined === input["x-typia-jsDocTags"] ||
                                     ((Array.isArray(
@@ -4847,306 +4956,6 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                             "(Array<IJsDocTagInfo> | undefined)",
                                         value: input["x-typia-jsDocTags"],
                                     }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo32 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                undefined === input.schemas ||
-                                    ((("object" === typeof input.schemas &&
-                                        null !== input.schemas &&
-                                        false ===
-                                            Array.isArray(input.schemas)) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".schemas",
-                                            expected:
-                                                "(Record<string, IObject | IAlias> | undefined)",
-                                            value: input.schemas,
-                                        })) &&
-                                        $vo33(
-                                            input.schemas,
-                                            _path + ".schemas",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".schemas",
-                                        expected:
-                                            "(Record<string, IObject | IAlias> | undefined)",
-                                        value: input.schemas,
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo33 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                false === _exceptionable ||
-                                    Object.keys(input)
-                                        .map((key: any) => {
-                                            const value = input[key];
-                                            if (undefined === value)
-                                                return true;
-                                            if (RegExp(/(.*)/).test(key))
-                                                return (
-                                                    ((("object" ===
-                                                        typeof value &&
-                                                        null !== value &&
-                                                        false ===
-                                                            Array.isArray(
-                                                                value,
-                                                            )) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    $join(key),
-                                                                expected:
-                                                                    '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                                value: value,
-                                                            },
-                                                        )) &&
-                                                        $vu2(
-                                                            value,
-                                                            _path + $join(key),
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path + $join(key),
-                                                        expected:
-                                                            '(IArray & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IInteger & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IJsonComponents.IObject | INullOnly & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IOneOf & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IRecursiveReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IReference & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | ITuple & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',
-                                                        value: value,
-                                                    })
-                                                );
-                                            return true;
-                                        })
-                                        .every((flag: boolean) => flag),
-                            ].every((flag: boolean) => flag);
-                        const $vo34 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                                "object" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"object"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.nullable ||
-                                    "boolean" === typeof input.nullable ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".nullable",
-                                        expected: "(boolean | undefined)",
-                                        value: input.nullable,
-                                    }),
-                                ((("object" === typeof input.properties &&
-                                    null !== input.properties &&
-                                    false ===
-                                        Array.isArray(input.properties)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".properties",
-                                        expected: "Record<string, IJsonSchema>",
-                                        value: input.properties,
-                                    })) &&
-                                    $vo35(
-                                        input.properties,
-                                        _path + ".properties",
-                                        true && _exceptionable,
-                                    )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".properties",
-                                        expected: "Record<string, IJsonSchema>",
-                                        value: input.properties,
-                                    }),
-                                undefined === input.patternProperties ||
-                                    ((("object" ===
-                                        typeof input.patternProperties &&
-                                        null !== input.patternProperties &&
-                                        false ===
-                                            Array.isArray(
-                                                input.patternProperties,
-                                            )) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".patternProperties",
-                                            expected:
-                                                "(Record<string, IJsonSchema> | undefined)",
-                                            value: input.patternProperties,
-                                        })) &&
-                                        $vo35(
-                                            input.patternProperties,
-                                            _path + ".patternProperties",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".patternProperties",
-                                        expected:
-                                            "(Record<string, IJsonSchema> | undefined)",
-                                        value: input.patternProperties,
-                                    }),
-                                undefined === input.additionalProperties ||
-                                    ((("object" ===
-                                        typeof input.additionalProperties &&
-                                        null !== input.additionalProperties &&
-                                        false ===
-                                            Array.isArray(
-                                                input.additionalProperties,
-                                            )) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + ".additionalProperties",
-                                            expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                            value: input.additionalProperties,
-                                        })) &&
-                                        $vu0(
-                                            input.additionalProperties,
-                                            _path + ".additionalProperties",
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".additionalProperties",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
-                                        value: input.additionalProperties,
-                                    }),
-                                undefined === input.required ||
-                                    ((Array.isArray(input.required) ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".required",
-                                            expected:
-                                                "(Array<string> | undefined)",
-                                            value: input.required,
-                                        })) &&
-                                        input.required
-                                            .map(
-                                                (elem: any, _index37: number) =>
-                                                    "string" === typeof elem ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            ".required[" +
-                                                            _index37 +
-                                                            "]",
-                                                        expected: "string",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".required",
-                                        expected: "(Array<string> | undefined)",
-                                        value: input.required,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index38: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index38 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index38 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index38 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
                                 undefined ===
                                     input["x-typia-patternProperties"] ||
                                     ((("object" ===
@@ -5173,7 +4982,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 "x-typia-patternProperties"
                                             ],
                                         })) &&
-                                        $vo35(
+                                        $vo34(
                                             input["x-typia-patternProperties"],
                                             _path +
                                                 '["x-typia-patternProperties"]',
@@ -5210,7 +5019,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 _path +
                                                 '["x-typia-additionalProperties"]',
                                             expected:
-                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                             value: input[
                                                 "x-typia-additionalProperties"
                                             ],
@@ -5228,13 +5037,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                             _path +
                                             '["x-typia-additionalProperties"]',
                                         expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown | undefined)',
                                         value: input[
                                             "x-typia-additionalProperties"
                                         ],
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo35 = (
+                        const $vo34 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5262,7 +5071,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                                     _path +
                                                                     $join(key),
                                                                 expected:
-                                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                                 value: value,
                                                             },
                                                         )) &&
@@ -5276,7 +5085,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         path:
                                                             _path + $join(key),
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: value,
                                                     })
                                                 );
@@ -5284,7 +5093,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         })
                                         .every((flag: boolean) => flag),
                             ].every((flag: boolean) => flag);
-                        const $vo36 = (
+                        const $vo35 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5298,13 +5107,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     })) &&
                                     input["enum"]
                                         .map(
-                                            (elem: any, _index39: number) =>
+                                            (elem: any, _index37: number) =>
                                                 "boolean" === typeof elem ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["enum"][' +
-                                                        _index39 +
+                                                        _index37 +
                                                         "]",
                                                     expected: "boolean",
                                                     value: elem,
@@ -5370,7 +5179,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index40: number) =>
+                                                (elem: any, _index38: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5380,7 +5189,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index40 +
+                                                                    _index38 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5391,7 +5200,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index40 +
+                                                                _index38 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5400,7 +5209,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index40 +
+                                                            _index38 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5427,7 +5236,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index41: number) =>
+                                                (elem: any, _index39: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5437,7 +5246,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index41 +
+                                                                    _index39 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -5448,7 +5257,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index41 +
+                                                                _index39 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5457,7 +5266,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index41 +
+                                                            _index39 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5511,7 +5320,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         value: input.$recursiveAnchor,
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo37 = (
+                        const $vo36 = (
                             input: any,
                             _path: string,
                             _exceptionable: boolean = true,
@@ -5525,14 +5334,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     })) &&
                                     input["enum"]
                                         .map(
-                                            (elem: any, _index42: number) =>
+                                            (elem: any, _index40: number) =>
                                                 ("number" === typeof elem &&
                                                     Number.isFinite(elem)) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
                                                         '["enum"][' +
-                                                        _index42 +
+                                                        _index40 +
                                                         "]",
                                                     expected: "number",
                                                     value: elem,
@@ -5599,7 +5408,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index43: number) =>
+                                                (elem: any, _index41: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5609,7 +5418,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index43 +
+                                                                    _index41 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5620,7 +5429,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index43 +
+                                                                _index41 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5629,7 +5438,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index43 +
+                                                            _index41 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -5656,7 +5465,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index44: number) =>
+                                                (elem: any, _index42: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -5666,7 +5475,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index44 +
+                                                                    _index42 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -5677,7 +5486,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index44 +
+                                                                _index42 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -5686,7 +5495,234 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
+                                                            _index42 +
+                                                            "]",
+                                                        expected:
+                                                            "IJsDocTagInfo",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-jsDocTags"]',
+                                        expected:
+                                            "(Array<IJsDocTagInfo> | undefined)",
+                                        value: input["x-typia-jsDocTags"],
+                                    }),
+                                undefined === input["x-typia-required"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-required"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-required"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-required"],
+                                    }),
+                                undefined === input["x-typia-optional"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-optional"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-optional"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-optional"],
+                                    }),
+                                undefined === input["x-typia-rest"] ||
+                                    "boolean" ===
+                                        typeof input["x-typia-rest"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-rest"]',
+                                        expected: "(boolean | undefined)",
+                                        value: input["x-typia-rest"],
+                                    }),
+                                undefined === input.$id ||
+                                    "string" === typeof input.$id ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$id",
+                                        expected: "(string | undefined)",
+                                        value: input.$id,
+                                    }),
+                                undefined === input.$recursiveAnchor ||
+                                    "boolean" ===
+                                        typeof input.$recursiveAnchor ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".$recursiveAnchor",
+                                        expected: "(boolean | undefined)",
+                                        value: input.$recursiveAnchor,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo37 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                ((Array.isArray(input["enum"]) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["enum"]',
+                                        expected: "Array<string>",
+                                        value: input["enum"],
+                                    })) &&
+                                    input["enum"]
+                                        .map(
+                                            (elem: any, _index43: number) =>
+                                                "string" === typeof elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        '["enum"][' +
+                                                        _index43 +
+                                                        "]",
+                                                    expected: "string",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["enum"]',
+                                        expected: "Array<string>",
+                                        value: input["enum"],
+                                    }),
+                                undefined === input["default"] ||
+                                    "string" === typeof input["default"] ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["default"]',
+                                        expected: "(string | undefined)",
+                                        value: input["default"],
+                                    }),
+                                "string" === input.type ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".type",
+                                        expected: '"string"',
+                                        value: input.type,
+                                    }),
+                                undefined === input.nullable ||
+                                    "boolean" === typeof input.nullable ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".nullable",
+                                        expected: "(boolean | undefined)",
+                                        value: input.nullable,
+                                    }),
+                                undefined === input.deprecated ||
+                                    "boolean" === typeof input.deprecated ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".deprecated",
+                                        expected: "(boolean | undefined)",
+                                        value: input.deprecated,
+                                    }),
+                                undefined === input.title ||
+                                    "string" === typeof input.title ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".title",
+                                        expected: "(string | undefined)",
+                                        value: input.title,
+                                    }),
+                                undefined === input.description ||
+                                    "string" === typeof input.description ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".description",
+                                        expected: "(string | undefined)",
+                                        value: input.description,
+                                    }),
+                                undefined === input["x-typia-metaTags"] ||
+                                    ((Array.isArray(
+                                        input["x-typia-metaTags"],
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + '["x-typia-metaTags"]',
+                                            expected:
+                                                "(Array<IMetadataTag> | undefined)",
+                                            value: input["x-typia-metaTags"],
+                                        })) &&
+                                        input["x-typia-metaTags"]
+                                            .map(
+                                                (elem: any, _index44: number) =>
+                                                    ((("object" ===
+                                                        typeof elem &&
+                                                        null !== elem) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    '["x-typia-metaTags"][' +
+                                                                    _index44 +
+                                                                    "]",
+                                                                expected:
+                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                        $vu1(
+                                                            elem,
+                                                            _path +
+                                                                '["x-typia-metaTags"][' +
+                                                                _index44 +
+                                                                "]",
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-metaTags"][' +
                                                             _index44 +
+                                                            "]",
+                                                        expected:
+                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + '["x-typia-metaTags"]',
+                                        expected:
+                                            "(Array<IMetadataTag> | undefined)",
+                                        value: input["x-typia-metaTags"],
+                                    }),
+                                undefined === input["x-typia-jsDocTags"] ||
+                                    ((Array.isArray(
+                                        input["x-typia-jsDocTags"],
+                                    ) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path + '["x-typia-jsDocTags"]',
+                                            expected:
+                                                "(Array<IJsDocTagInfo> | undefined)",
+                                            value: input["x-typia-jsDocTags"],
+                                        })) &&
+                                        input["x-typia-jsDocTags"]
+                                            .map(
+                                                (elem: any, _index45: number) =>
+                                                    ((("object" ===
+                                                        typeof elem &&
+                                                        null !== elem) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    '["x-typia-jsDocTags"][' +
+                                                                    _index45 +
+                                                                    "]",
+                                                                expected:
+                                                                    "IJsDocTagInfo",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                        $vo17(
+                                                            elem,
+                                                            _path +
+                                                                '["x-typia-jsDocTags"][' +
+                                                                _index45 +
+                                                                "]",
+                                                            true &&
+                                                                _exceptionable,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            '["x-typia-jsDocTags"][' +
+                                                            _index45 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -5746,43 +5782,17 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input["enum"]) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["enum"]',
-                                        expected: "Array<string>",
-                                        value: input["enum"],
-                                    })) &&
-                                    input["enum"]
-                                        .map(
-                                            (elem: any, _index45: number) =>
-                                                "string" === typeof elem ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        '["enum"][' +
-                                                        _index45 +
-                                                        "]",
-                                                    expected: "string",
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["enum"]',
-                                        expected: "Array<string>",
-                                        value: input["enum"],
-                                    }),
                                 undefined === input["default"] ||
-                                    "string" === typeof input["default"] ||
+                                    "boolean" === typeof input["default"] ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(string | undefined)",
+                                        expected: "(boolean | undefined)",
                                         value: input["default"],
                                     }),
-                                "string" === input.type ||
+                                "boolean" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"string"',
+                                        expected: '"boolean"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -5973,17 +5983,79 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
+                                undefined === input.minimum ||
+                                    ("number" === typeof input.minimum &&
+                                        Number.isFinite(input.minimum) &&
+                                        (parseInt(input.minimum) ===
+                                            input.minimum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "(number | undefined)",
+                                        value: input.minimum,
+                                    }),
+                                undefined === input.maximum ||
+                                    ("number" === typeof input.maximum &&
+                                        Number.isFinite(input.maximum) &&
+                                        (parseInt(input.maximum) ===
+                                            input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "(number | undefined)",
+                                        value: input.maximum,
+                                    }),
+                                undefined === input.exclusiveMinimum ||
+                                    "boolean" ===
+                                        typeof input.exclusiveMinimum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMinimum",
+                                        expected: "(boolean | undefined)",
+                                        value: input.exclusiveMinimum,
+                                    }),
+                                undefined === input.exclusiveMaximum ||
+                                    "boolean" ===
+                                        typeof input.exclusiveMaximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".exclusiveMaximum",
+                                        expected: "(boolean | undefined)",
+                                        value: input.exclusiveMaximum,
+                                    }),
+                                undefined === input.multipleOf ||
+                                    ("number" === typeof input.multipleOf &&
+                                        Number.isFinite(input.multipleOf) &&
+                                        (parseInt(input.multipleOf) ===
+                                            input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "(number | undefined)",
+                                        value: input.multipleOf,
+                                    }),
                                 undefined === input["default"] ||
-                                    "boolean" === typeof input["default"] ||
+                                    ("number" === typeof input["default"] &&
+                                        Number.isFinite(input["default"])) ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(boolean | undefined)",
+                                        expected: "(number | undefined)",
                                         value: input["default"],
                                     }),
-                                "boolean" === input.type ||
+                                "integer" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"boolean"',
+                                        expected: '"integer"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6176,14 +6248,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             [
                                 undefined === input.minimum ||
                                     ("number" === typeof input.minimum &&
-                                        Number.isFinite(input.minimum) &&
-                                        (parseInt(input.minimum) ===
-                                            input.minimum ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minimum",
-                                                expected: "number (@type int)",
-                                                value: input.minimum,
-                                            }))) ||
+                                        Number.isFinite(input.minimum)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
                                         expected: "(number | undefined)",
@@ -6191,14 +6256,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     }),
                                 undefined === input.maximum ||
                                     ("number" === typeof input.maximum &&
-                                        Number.isFinite(input.maximum) &&
-                                        (parseInt(input.maximum) ===
-                                            input.maximum ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".maximum",
-                                                expected: "number (@type int)",
-                                                value: input.maximum,
-                                            }))) ||
+                                        Number.isFinite(input.maximum)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "(number | undefined)",
@@ -6222,14 +6280,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     }),
                                 undefined === input.multipleOf ||
                                     ("number" === typeof input.multipleOf &&
-                                        Number.isFinite(input.multipleOf) &&
-                                        (parseInt(input.multipleOf) ===
-                                            input.multipleOf ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".multipleOf",
-                                                expected: "number (@type int)",
-                                                value: input.multipleOf,
-                                            }))) ||
+                                        Number.isFinite(input.multipleOf)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "(number | undefined)",
@@ -6243,10 +6294,10 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         expected: "(number | undefined)",
                                         value: input["default"],
                                     }),
-                                "integer" === input.type ||
+                                "number" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"integer"',
+                                        expected: '"number"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6437,58 +6488,73 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                undefined === input.minimum ||
-                                    ("number" === typeof input.minimum &&
-                                        Number.isFinite(input.minimum)) ||
+                                undefined === input.minLength ||
+                                    ("number" === typeof input.minLength &&
+                                        Number.isFinite(input.minLength) &&
+                                        (parseInt(input.minLength) ===
+                                            input.minLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
+                                            })) &&
+                                        (0 <= input.minLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
+                                            }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".minimum",
+                                        path: _path + ".minLength",
                                         expected: "(number | undefined)",
-                                        value: input.minimum,
+                                        value: input.minLength,
                                     }),
-                                undefined === input.maximum ||
-                                    ("number" === typeof input.maximum &&
-                                        Number.isFinite(input.maximum)) ||
+                                undefined === input.maxLength ||
+                                    ("number" === typeof input.maxLength &&
+                                        Number.isFinite(input.maxLength) &&
+                                        (parseInt(input.maxLength) ===
+                                            input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".maximum",
+                                        path: _path + ".maxLength",
                                         expected: "(number | undefined)",
-                                        value: input.maximum,
+                                        value: input.maxLength,
                                     }),
-                                undefined === input.exclusiveMinimum ||
-                                    "boolean" ===
-                                        typeof input.exclusiveMinimum ||
+                                undefined === input.pattern ||
+                                    "string" === typeof input.pattern ||
                                     $report(_exceptionable, {
-                                        path: _path + ".exclusiveMinimum",
-                                        expected: "(boolean | undefined)",
-                                        value: input.exclusiveMinimum,
+                                        path: _path + ".pattern",
+                                        expected: "(string | undefined)",
+                                        value: input.pattern,
                                     }),
-                                undefined === input.exclusiveMaximum ||
-                                    "boolean" ===
-                                        typeof input.exclusiveMaximum ||
+                                undefined === input.format ||
+                                    "string" === typeof input.format ||
                                     $report(_exceptionable, {
-                                        path: _path + ".exclusiveMaximum",
-                                        expected: "(boolean | undefined)",
-                                        value: input.exclusiveMaximum,
-                                    }),
-                                undefined === input.multipleOf ||
-                                    ("number" === typeof input.multipleOf &&
-                                        Number.isFinite(input.multipleOf)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".multipleOf",
-                                        expected: "(number | undefined)",
-                                        value: input.multipleOf,
+                                        path: _path + ".format",
+                                        expected: "(string | undefined)",
+                                        value: input.format,
                                     }),
                                 undefined === input["default"] ||
-                                    ("number" === typeof input["default"] &&
-                                        Number.isFinite(input["default"])) ||
+                                    "string" === typeof input["default"] ||
                                     $report(_exceptionable, {
                                         path: _path + '["default"]',
-                                        expected: "(number | undefined)",
+                                        expected: "(string | undefined)",
                                         value: input["default"],
                                     }),
-                                "number" === input.type ||
+                                "string" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"number"',
+                                        expected: '"string"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6679,73 +6745,93 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                undefined === input.minLength ||
-                                    ("number" === typeof input.minLength &&
-                                        Number.isFinite(input.minLength) &&
-                                        (parseInt(input.minLength) ===
-                                            input.minLength ||
+                                ((("object" === typeof input.items &&
+                                    null !== input.items &&
+                                    false === Array.isArray(input.items)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: input.items,
+                                    })) &&
+                                    $vu0(
+                                        input.items,
+                                        _path + ".items",
+                                        true && _exceptionable,
+                                    )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".items",
+                                        expected:
+                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        value: input.items,
+                                    }),
+                                undefined === input.minItems ||
+                                    ("number" === typeof input.minItems &&
+                                        Number.isFinite(input.minItems) &&
+                                        (parseInt(input.minItems) ===
+                                            input.minItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".minLength",
+                                                path: _path + ".minItems",
                                                 expected: "number (@type uint)",
-                                                value: input.minLength,
+                                                value: input.minItems,
                                             })) &&
-                                        (0 <= input.minLength ||
+                                        (0 <= input.minItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".minLength",
+                                                path: _path + ".minItems",
                                                 expected: "number (@type uint)",
-                                                value: input.minLength,
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".minLength",
+                                        path: _path + ".minItems",
                                         expected: "(number | undefined)",
-                                        value: input.minLength,
+                                        value: input.minItems,
                                     }),
-                                undefined === input.maxLength ||
-                                    ("number" === typeof input.maxLength &&
-                                        Number.isFinite(input.maxLength) &&
-                                        (parseInt(input.maxLength) ===
-                                            input.maxLength ||
+                                undefined === input.maxItems ||
+                                    ("number" === typeof input.maxItems &&
+                                        Number.isFinite(input.maxItems) &&
+                                        (parseInt(input.maxItems) ===
+                                            input.maxItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".maxLength",
+                                                path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
-                                                value: input.maxLength,
+                                                value: input.maxItems,
                                             })) &&
-                                        (0 <= input.maxLength ||
+                                        (0 <= input.maxItems ||
                                             $report(_exceptionable, {
-                                                path: _path + ".maxLength",
+                                                path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
-                                                value: input.maxLength,
+                                                value: input.maxItems,
                                             }))) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".maxLength",
+                                        path: _path + ".maxItems",
                                         expected: "(number | undefined)",
-                                        value: input.maxLength,
+                                        value: input.maxItems,
                                     }),
-                                undefined === input.pattern ||
-                                    "string" === typeof input.pattern ||
+                                undefined === input["x-typia-tuple"] ||
+                                    ((("object" ===
+                                        typeof input["x-typia-tuple"] &&
+                                        null !== input["x-typia-tuple"]) ||
+                                        $report(_exceptionable, {
+                                            path: _path + '["x-typia-tuple"]',
+                                            expected:
+                                                "(IJsonSchema.ITuple | undefined)",
+                                            value: input["x-typia-tuple"],
+                                        })) &&
+                                        $vo26(
+                                            input["x-typia-tuple"],
+                                            _path + '["x-typia-tuple"]',
+                                            true && _exceptionable,
+                                        )) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".pattern",
-                                        expected: "(string | undefined)",
-                                        value: input.pattern,
+                                        path: _path + '["x-typia-tuple"]',
+                                        expected:
+                                            "(IJsonSchema.ITuple | undefined)",
+                                        value: input["x-typia-tuple"],
                                     }),
-                                undefined === input.format ||
-                                    "string" === typeof input.format ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".format",
-                                        expected: "(string | undefined)",
-                                        value: input.format,
-                                    }),
-                                undefined === input["default"] ||
-                                    "string" === typeof input["default"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["default"]',
-                                        expected: "(string | undefined)",
-                                        value: input["default"],
-                                    }),
-                                "string" === input.type ||
+                                "array" === input.type ||
                                     $report(_exceptionable, {
                                         path: _path + ".type",
-                                        expected: '"string"',
+                                        expected: '"array"',
                                         value: input.type,
                                     }),
                                 undefined === input.nullable ||
@@ -6936,45 +7022,72 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((("object" === typeof input.items &&
-                                    null !== input.items &&
-                                    false === Array.isArray(input.items)) ||
+                                ((Array.isArray(input.items) ||
                                     $report(_exceptionable, {
                                         path: _path + ".items",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        expected: "Array<IJsonSchema>",
                                         value: input.items,
                                     })) &&
-                                    $vu0(
-                                        input.items,
-                                        _path + ".items",
-                                        true && _exceptionable,
-                                    )) ||
+                                    input.items
+                                        .map(
+                                            (elem: any, _index56: number) =>
+                                                ((("object" === typeof elem &&
+                                                    null !== elem &&
+                                                    false ===
+                                                        Array.isArray(elem)) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".items[" +
+                                                            _index56 +
+                                                            "]",
+                                                        expected:
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        value: elem,
+                                                    })) &&
+                                                    $vu0(
+                                                        elem,
+                                                        _path +
+                                                            ".items[" +
+                                                            _index56 +
+                                                            "]",
+                                                        true && _exceptionable,
+                                                    )) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".items[" +
+                                                        _index56 +
+                                                        "]",
+                                                    expected:
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".items",
-                                        expected:
-                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                        expected: "Array<IJsonSchema>",
                                         value: input.items,
                                     }),
-                                undefined === input.minItems ||
-                                    ("number" === typeof input.minItems &&
-                                        Number.isFinite(input.minItems) &&
-                                        (parseInt(input.minItems) ===
-                                            input.minItems ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minItems",
-                                                expected: "number (@type uint)",
-                                                value: input.minItems,
-                                            })) &&
-                                        (0 <= input.minItems ||
-                                            $report(_exceptionable, {
-                                                path: _path + ".minItems",
-                                                expected: "number (@type uint)",
-                                                value: input.minItems,
-                                            }))) ||
+                                ("number" === typeof input.minItems &&
+                                    Number.isFinite(input.minItems) &&
+                                    (parseInt(input.minItems) ===
+                                        input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        })) &&
+                                    (0 <= input.minItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
+                                        }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
-                                        expected: "(number | undefined)",
+                                        expected: "number",
                                         value: input.minItems,
                                     }),
                                 undefined === input.maxItems ||
@@ -6997,27 +7110,6 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         path: _path + ".maxItems",
                                         expected: "(number | undefined)",
                                         value: input.maxItems,
-                                    }),
-                                undefined === input["x-typia-tuple"] ||
-                                    ((("object" ===
-                                        typeof input["x-typia-tuple"] &&
-                                        null !== input["x-typia-tuple"]) ||
-                                        $report(_exceptionable, {
-                                            path: _path + '["x-typia-tuple"]',
-                                            expected:
-                                                "(IJsonSchema.ITuple | undefined)",
-                                            value: input["x-typia-tuple"],
-                                        })) &&
-                                        $vo26(
-                                            input["x-typia-tuple"],
-                                            _path + '["x-typia-tuple"]',
-                                            true && _exceptionable,
-                                        )) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-tuple"]',
-                                        expected:
-                                            "(IJsonSchema.ITuple | undefined)",
-                                        value: input["x-typia-tuple"],
                                     }),
                                 "array" === input.type ||
                                     $report(_exceptionable, {
@@ -7066,7 +7158,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index56: number) =>
+                                                (elem: any, _index57: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7076,7 +7168,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index56 +
+                                                                    _index57 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7087,7 +7179,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index56 +
+                                                                _index57 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7096,7 +7188,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index56 +
+                                                            _index57 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7123,7 +7215,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index57: number) =>
+                                                (elem: any, _index58: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7133,7 +7225,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index57 +
+                                                                    _index58 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -7144,7 +7236,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index57 +
+                                                                _index58 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7153,7 +7245,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index57 +
+                                                            _index58 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -7213,15 +7305,15 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input.items) ||
+                                ((Array.isArray(input.oneOf) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".items",
+                                        path: _path + ".oneOf",
                                         expected: "Array<IJsonSchema>",
-                                        value: input.items,
+                                        value: input.oneOf,
                                     })) &&
-                                    input.items
+                                    input.oneOf
                                         .map(
-                                            (elem: any, _index58: number) =>
+                                            (elem: any, _index59: number) =>
                                                 ((("object" === typeof elem &&
                                                     null !== elem &&
                                                     false ===
@@ -7229,50 +7321,37 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                     $report(_exceptionable, {
                                                         path:
                                                             _path +
-                                                            ".items[" +
-                                                            _index58 +
+                                                            ".oneOf[" +
+                                                            _index59 +
                                                             "]",
                                                         expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                         value: elem,
                                                     })) &&
                                                     $vu0(
                                                         elem,
                                                         _path +
-                                                            ".items[" +
-                                                            _index58 +
+                                                            ".oneOf[" +
+                                                            _index59 +
                                                             "]",
                                                         true && _exceptionable,
                                                     )) ||
                                                 $report(_exceptionable, {
                                                     path:
                                                         _path +
-                                                        ".items[" +
-                                                        _index58 +
+                                                        ".oneOf[" +
+                                                        _index59 +
                                                         "]",
                                                     expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                                                     value: elem,
                                                 }),
                                         )
                                         .every((flag: boolean) => flag)) ||
                                     $report(_exceptionable, {
-                                        path: _path + ".items",
+                                        path: _path + ".oneOf",
                                         expected: "Array<IJsonSchema>",
-                                        value: input.items,
-                                    }),
-                                "array" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"array"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.nullable ||
-                                    "boolean" === typeof input.nullable ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".nullable",
-                                        expected: "(boolean | undefined)",
-                                        value: input.nullable,
+                                        value: input.oneOf,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7308,7 +7387,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         })) &&
                                         input["x-typia-metaTags"]
                                             .map(
-                                                (elem: any, _index59: number) =>
+                                                (elem: any, _index60: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7318,7 +7397,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-metaTags"][' +
-                                                                    _index59 +
+                                                                    _index60 +
                                                                     "]",
                                                                 expected:
                                                                     "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7329,7 +7408,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-metaTags"][' +
-                                                                _index59 +
+                                                                _index60 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7338,7 +7417,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         path:
                                                             _path +
                                                             '["x-typia-metaTags"][' +
-                                                            _index59 +
+                                                            _index60 +
                                                             "]",
                                                         expected:
                                                             "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
@@ -7365,7 +7444,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         })) &&
                                         input["x-typia-jsDocTags"]
                                             .map(
-                                                (elem: any, _index60: number) =>
+                                                (elem: any, _index61: number) =>
                                                     ((("object" ===
                                                         typeof elem &&
                                                         null !== elem) ||
@@ -7375,7 +7454,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                                 path:
                                                                     _path +
                                                                     '["x-typia-jsDocTags"][' +
-                                                                    _index60 +
+                                                                    _index61 +
                                                                     "]",
                                                                 expected:
                                                                     "IJsDocTagInfo",
@@ -7386,7 +7465,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                             elem,
                                                             _path +
                                                                 '["x-typia-jsDocTags"][' +
-                                                                _index60 +
+                                                                _index61 +
                                                                 "]",
                                                             true &&
                                                                 _exceptionable,
@@ -7395,7 +7474,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                         path:
                                                             _path +
                                                             '["x-typia-jsDocTags"][' +
-                                                            _index60 +
+                                                            _index61 +
                                                             "]",
                                                         expected:
                                                             "IJsDocTagInfo",
@@ -7455,53 +7534,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                ((Array.isArray(input.oneOf) ||
+                                "string" === typeof input.$ref ||
                                     $report(_exceptionable, {
-                                        path: _path + ".oneOf",
-                                        expected: "Array<IJsonSchema>",
-                                        value: input.oneOf,
-                                    })) &&
-                                    input.oneOf
-                                        .map(
-                                            (elem: any, _index61: number) =>
-                                                ((("object" === typeof elem &&
-                                                    null !== elem &&
-                                                    false ===
-                                                        Array.isArray(elem)) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            ".oneOf[" +
-                                                            _index61 +
-                                                            "]",
-                                                        expected:
-                                                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                        value: elem,
-                                                    })) &&
-                                                    $vu0(
-                                                        elem,
-                                                        _path +
-                                                            ".oneOf[" +
-                                                            _index61 +
-                                                            "]",
-                                                        true && _exceptionable,
-                                                    )) ||
-                                                $report(_exceptionable, {
-                                                    path:
-                                                        _path +
-                                                        ".oneOf[" +
-                                                        _index61 +
-                                                        "]",
-                                                    expected:
-                                                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IOneOf | IJsonSchema.IRecursiveReference | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                                    value: elem,
-                                                }),
-                                        )
-                                        .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".oneOf",
-                                        expected: "Array<IJsonSchema>",
-                                        value: input.oneOf,
+                                        path: _path + ".$ref",
+                                        expected: "string",
+                                        value: input.$ref,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7684,11 +7721,11 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$ref ||
+                                "null" === input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$ref",
-                                        expected: "string",
-                                        value: input.$ref,
+                                        path: _path + ".type",
+                                        expected: '"null"',
+                                        value: input.type,
                                     }),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
@@ -7871,12 +7908,18 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
-                                "string" === typeof input.$recursiveRef ||
+                                (null !== input.type ||
                                     $report(_exceptionable, {
-                                        path: _path + ".$recursiveRef",
-                                        expected: "string",
-                                        value: input.$recursiveRef,
-                                    }),
+                                        path: _path + ".type",
+                                        expected: "undefined",
+                                        value: input.type,
+                                    })) &&
+                                    (undefined === input.type ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".type",
+                                            expected: "undefined",
+                                            value: input.type,
+                                        })),
                                 undefined === input.deprecated ||
                                     "boolean" === typeof input.deprecated ||
                                     $report(_exceptionable, {
@@ -8052,386 +8095,6 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         value: input.$recursiveAnchor,
                                     }),
                             ].every((flag: boolean) => flag);
-                        const $vo48 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                "null" === input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: '"null"',
-                                        value: input.type,
-                                    }),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
-                                    }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index68: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index68 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index68 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index68 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index69: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index69 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index69 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index69 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                            ].every((flag: boolean) => flag);
-                        const $vo49 = (
-                            input: any,
-                            _path: string,
-                            _exceptionable: boolean = true,
-                        ): boolean =>
-                            [
-                                (null !== input.type ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".type",
-                                        expected: "undefined",
-                                        value: input.type,
-                                    })) &&
-                                    (undefined === input.type ||
-                                        $report(_exceptionable, {
-                                            path: _path + ".type",
-                                            expected: "undefined",
-                                            value: input.type,
-                                        })),
-                                undefined === input.deprecated ||
-                                    "boolean" === typeof input.deprecated ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".deprecated",
-                                        expected: "(boolean | undefined)",
-                                        value: input.deprecated,
-                                    }),
-                                undefined === input.title ||
-                                    "string" === typeof input.title ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".title",
-                                        expected: "(string | undefined)",
-                                        value: input.title,
-                                    }),
-                                undefined === input.description ||
-                                    "string" === typeof input.description ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".description",
-                                        expected: "(string | undefined)",
-                                        value: input.description,
-                                    }),
-                                undefined === input["x-typia-metaTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-metaTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-metaTags"]',
-                                            expected:
-                                                "(Array<IMetadataTag> | undefined)",
-                                            value: input["x-typia-metaTags"],
-                                        })) &&
-                                        input["x-typia-metaTags"]
-                                            .map(
-                                                (elem: any, _index70: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-metaTags"][' +
-                                                                    _index70 +
-                                                                    "]",
-                                                                expected:
-                                                                    "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vu1(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-metaTags"][' +
-                                                                _index70 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-metaTags"][' +
-                                                            _index70 +
-                                                            "]",
-                                                        expected:
-                                                            "(IMetadataTag.IExclusiveMaximum | IMetadataTag.IExclusiveMinimum | IMetadataTag.IFormat | IMetadataTag.IItems | IMetadataTag.ILength | IMetadataTag.IMaxItems | IMetadataTag.IMaxLength | IMetadataTag.IMaximum | IMetadataTag.IMinItems | IMetadataTag.IMinLength | IMetadataTag.IMinimum | IMetadataTag.IMultipleOf | IMetadataTag.IPattern | IMetadataTag.IStep | IMetadataTag.IType)",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-metaTags"]',
-                                        expected:
-                                            "(Array<IMetadataTag> | undefined)",
-                                        value: input["x-typia-metaTags"],
-                                    }),
-                                undefined === input["x-typia-jsDocTags"] ||
-                                    ((Array.isArray(
-                                        input["x-typia-jsDocTags"],
-                                    ) ||
-                                        $report(_exceptionable, {
-                                            path:
-                                                _path + '["x-typia-jsDocTags"]',
-                                            expected:
-                                                "(Array<IJsDocTagInfo> | undefined)",
-                                            value: input["x-typia-jsDocTags"],
-                                        })) &&
-                                        input["x-typia-jsDocTags"]
-                                            .map(
-                                                (elem: any, _index71: number) =>
-                                                    ((("object" ===
-                                                        typeof elem &&
-                                                        null !== elem) ||
-                                                        $report(
-                                                            _exceptionable,
-                                                            {
-                                                                path:
-                                                                    _path +
-                                                                    '["x-typia-jsDocTags"][' +
-                                                                    _index71 +
-                                                                    "]",
-                                                                expected:
-                                                                    "IJsDocTagInfo",
-                                                                value: elem,
-                                                            },
-                                                        )) &&
-                                                        $vo17(
-                                                            elem,
-                                                            _path +
-                                                                '["x-typia-jsDocTags"][' +
-                                                                _index71 +
-                                                                "]",
-                                                            true &&
-                                                                _exceptionable,
-                                                        )) ||
-                                                    $report(_exceptionable, {
-                                                        path:
-                                                            _path +
-                                                            '["x-typia-jsDocTags"][' +
-                                                            _index71 +
-                                                            "]",
-                                                        expected:
-                                                            "IJsDocTagInfo",
-                                                        value: elem,
-                                                    }),
-                                            )
-                                            .every((flag: boolean) => flag)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-jsDocTags"]',
-                                        expected:
-                                            "(Array<IJsDocTagInfo> | undefined)",
-                                        value: input["x-typia-jsDocTags"],
-                                    }),
-                                undefined === input["x-typia-required"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-required"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-required"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-required"],
-                                    }),
-                                undefined === input["x-typia-optional"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-optional"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-optional"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-optional"],
-                                    }),
-                                undefined === input["x-typia-rest"] ||
-                                    "boolean" ===
-                                        typeof input["x-typia-rest"] ||
-                                    $report(_exceptionable, {
-                                        path: _path + '["x-typia-rest"]',
-                                        expected: "(boolean | undefined)",
-                                        value: input["x-typia-rest"],
-                                    }),
-                                undefined === input.$id ||
-                                    "string" === typeof input.$id ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$id",
-                                        expected: "(string | undefined)",
-                                        value: input.$id,
-                                    }),
-                                undefined === input.$recursiveAnchor ||
-                                    "boolean" ===
-                                        typeof input.$recursiveAnchor ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".$recursiveAnchor",
-                                        expected: "(boolean | undefined)",
-                                        value: input.$recursiveAnchor,
-                                    }),
-                            ].every((flag: boolean) => flag);
                         const $vu0 = (
                             input: any,
                             _path: string,
@@ -8463,7 +8126,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     Array.isArray(input.items) &&
                                     input.items
                                         .map(
-                                            (elem: any, _index72: number) =>
+                                            (elem: any, _index68: number) =>
                                                 "object" === typeof elem &&
                                                 null !== elem &&
                                                 false === Array.isArray(elem) &&
@@ -8471,7 +8134,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                     elem,
                                                     _path +
                                                         ".items[" +
-                                                        _index72 +
+                                                        _index68 +
                                                         "]",
                                                     false && _exceptionable,
                                                 ),
@@ -8495,14 +8158,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         _path,
                                         true && _exceptionable,
                                     );
-                                if (undefined !== input.$recursiveRef)
-                                    return $vo29(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
                                 if ("null" === input.type)
-                                    return $vo30(
+                                    return $vo29(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8538,7 +8195,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo31(input, _path, false && _exceptionable)
+                                    $vo30(input, _path, false && _exceptionable)
                                 );
                             })();
                         const $vu1 = (
@@ -8651,13 +8308,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         ): any =>
                             (() => {
                                 if ("object" === input.type)
-                                    return $vo34(
+                                    return $vo33(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("integer" === input.type)
-                                    return $vo40(
+                                    return $vo39(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8672,7 +8329,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         false && _exceptionable,
                                     )
                                 )
-                                    return $vo43(
+                                    return $vo42(
                                         input,
                                         _path,
                                         true && _exceptionable,
@@ -8681,7 +8338,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     Array.isArray(input.items) &&
                                     input.items
                                         .map(
-                                            (elem: any, _index73: number) =>
+                                            (elem: any, _index69: number) =>
                                                 "object" === typeof elem &&
                                                 null !== elem &&
                                                 false === Array.isArray(elem) &&
@@ -8689,48 +8346,37 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                     elem,
                                                     _path +
                                                         ".items[" +
-                                                        _index73 +
+                                                        _index69 +
                                                         "]",
                                                     false && _exceptionable,
                                                 ),
                                         )
                                         .every((flag: boolean) => flag)
                                 )
-                                    return $vo44(
+                                    return $vo43(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.oneOf)
-                                    return $vo45(
+                                    return $vo44(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if (undefined !== input.$ref)
-                                    return $vo46(
-                                        input,
-                                        _path,
-                                        true && _exceptionable,
-                                    );
-                                if (undefined !== input.$recursiveRef)
-                                    return $vo47(
+                                    return $vo45(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 if ("null" === input.type)
-                                    return $vo48(
+                                    return $vo46(
                                         input,
                                         _path,
                                         true && _exceptionable,
                                     );
                                 return (
-                                    $vo38(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
                                     $vo37(
                                         input,
                                         _path,
@@ -8741,7 +8387,17 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo39(
+                                    $vo35(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $vo38(
+                                        input,
+                                        _path,
+                                        false && _exceptionable,
+                                    ) ||
+                                    $vo40(
                                         input,
                                         _path,
                                         false && _exceptionable,
@@ -8751,12 +8407,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         _path,
                                         false && _exceptionable,
                                     ) ||
-                                    $vo42(
-                                        input,
-                                        _path,
-                                        false && _exceptionable,
-                                    ) ||
-                                    $vo49(input, _path, false && _exceptionable)
+                                    $vo47(input, _path, false && _exceptionable)
                                 );
                             })();
                         return (
@@ -9212,6 +8863,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9311,36 +8969,6 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
                 const $io29 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]);
-                const $io30 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -9370,7 +8998,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io31 = (input: any): boolean =>
+                const $io30 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -9401,13 +9029,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "boolean" === typeof input["x-typia-optional"]) &&
                     (undefined === input["x-typia-rest"] ||
                         "boolean" === typeof input["x-typia-rest"]);
-                const $io32 = (input: any): boolean =>
+                const $io31 = (input: any): boolean =>
                     undefined === input.schemas ||
                     ("object" === typeof input.schemas &&
                         null !== input.schemas &&
                         false === Array.isArray(input.schemas) &&
-                        $io33(input.schemas));
-                const $io33 = (input: any): boolean =>
+                        $io32(input.schemas));
+                const $io32 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -9420,23 +9048,21 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             );
                         return true;
                     });
-                const $io34 = (input: any): boolean =>
+                const $io33 = (input: any): boolean =>
                     (undefined === input.$id ||
                         "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor) &&
                     "object" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
                     "object" === typeof input.properties &&
                     null !== input.properties &&
                     false === Array.isArray(input.properties) &&
-                    $io35(input.properties) &&
+                    $io34(input.properties) &&
                     (undefined === input.patternProperties ||
                         ("object" === typeof input.patternProperties &&
                             null !== input.patternProperties &&
                             false === Array.isArray(input.patternProperties) &&
-                            $io35(input.patternProperties))) &&
+                            $io34(input.patternProperties))) &&
                     (undefined === input.additionalProperties ||
                         ("object" === typeof input.additionalProperties &&
                             null !== input.additionalProperties &&
@@ -9466,7 +9092,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 Array.isArray(
                                     input["x-typia-patternProperties"],
                                 ) &&
-                            $io35(input["x-typia-patternProperties"]))) &&
+                            $io34(input["x-typia-patternProperties"]))) &&
                     (undefined === input["x-typia-additionalProperties"] ||
                         ("object" ===
                             typeof input["x-typia-additionalProperties"] &&
@@ -9476,7 +9102,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     input["x-typia-additionalProperties"],
                                 ) &&
                             $iu0(input["x-typia-additionalProperties"])));
-                const $io35 = (input: any): boolean =>
+                const $io34 = (input: any): boolean =>
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
@@ -9489,7 +9115,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             );
                         return true;
                     });
-                const $io36 = (input: any): boolean =>
+                const $io35 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "boolean" === typeof elem,
@@ -9531,7 +9157,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io37 = (input: any): boolean =>
+                const $io36 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "number" === typeof elem,
@@ -9573,7 +9199,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io38 = (input: any): boolean =>
+                const $io37 = (input: any): boolean =>
                     Array.isArray(input["enum"]) &&
                     input["enum"].every(
                         (elem: any) => "string" === typeof elem,
@@ -9615,7 +9241,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io39 = (input: any): boolean =>
+                const $io38 = (input: any): boolean =>
                     (undefined === input["default"] ||
                         "boolean" === typeof input["default"]) &&
                     "boolean" === input.type &&
@@ -9653,7 +9279,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io40 = (input: any): boolean =>
+                const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             parseInt(input.minimum) === input.minimum)) &&
@@ -9704,7 +9330,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io41 = (input: any): boolean =>
+                const $io40 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         "number" === typeof input.minimum) &&
                     (undefined === input.maximum ||
@@ -9752,7 +9378,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io42 = (input: any): boolean =>
+                const $io41 = (input: any): boolean =>
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             parseInt(input.minLength) === input.minLength &&
@@ -9802,7 +9428,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io43 = (input: any): boolean =>
+                const $io42 = (input: any): boolean =>
                     "object" === typeof input.items &&
                     null !== input.items &&
                     false === Array.isArray(input.items) &&
@@ -9854,7 +9480,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io44 = (input: any): boolean =>
+                const $io43 = (input: any): boolean =>
                     Array.isArray(input.items) &&
                     input.items.every(
                         (elem: any) =>
@@ -9863,6 +9489,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             false === Array.isArray(elem) &&
                             $iu0(elem),
                     ) &&
+                    "number" === typeof input.minItems &&
+                    parseInt(input.minItems) === input.minItems &&
+                    0 <= input.minItems &&
+                    (undefined === input.maxItems ||
+                        ("number" === typeof input.maxItems &&
+                            parseInt(input.maxItems) === input.maxItems &&
+                            0 <= input.maxItems)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9898,7 +9531,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io45 = (input: any): boolean =>
+                const $io44 = (input: any): boolean =>
                     Array.isArray(input.oneOf) &&
                     input.oneOf.every(
                         (elem: any) =>
@@ -9939,7 +9572,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io46 = (input: any): boolean =>
+                const $io45 = (input: any): boolean =>
                     "string" === typeof input.$ref &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -9973,41 +9606,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io47 = (input: any): boolean =>
-                    "string" === typeof input.$recursiveRef &&
-                    (undefined === input.deprecated ||
-                        "boolean" === typeof input.deprecated) &&
-                    (undefined === input.title ||
-                        "string" === typeof input.title) &&
-                    (undefined === input.description ||
-                        "string" === typeof input.description) &&
-                    (undefined === input["x-typia-metaTags"] ||
-                        (Array.isArray(input["x-typia-metaTags"]) &&
-                            input["x-typia-metaTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $iu1(elem),
-                            ))) &&
-                    (undefined === input["x-typia-jsDocTags"] ||
-                        (Array.isArray(input["x-typia-jsDocTags"]) &&
-                            input["x-typia-jsDocTags"].every(
-                                (elem: any) =>
-                                    "object" === typeof elem &&
-                                    null !== elem &&
-                                    $io17(elem),
-                            ))) &&
-                    (undefined === input["x-typia-required"] ||
-                        "boolean" === typeof input["x-typia-required"]) &&
-                    (undefined === input["x-typia-optional"] ||
-                        "boolean" === typeof input["x-typia-optional"]) &&
-                    (undefined === input["x-typia-rest"] ||
-                        "boolean" === typeof input["x-typia-rest"]) &&
-                    (undefined === input.$id ||
-                        "string" === typeof input.$id) &&
-                    (undefined === input.$recursiveAnchor ||
-                        "boolean" === typeof input.$recursiveAnchor);
-                const $io48 = (input: any): boolean =>
+                const $io46 = (input: any): boolean =>
                     "null" === input.type &&
                     (undefined === input.deprecated ||
                         "boolean" === typeof input.deprecated) &&
@@ -10041,7 +9640,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         "string" === typeof input.$id) &&
                     (undefined === input.$recursiveAnchor ||
                         "boolean" === typeof input.$recursiveAnchor);
-                const $io49 = (input: any): boolean =>
+                const $io47 = (input: any): boolean =>
                     null !== input.type &&
                     undefined === input.type &&
                     (undefined === input.deprecated ||
@@ -10099,9 +9698,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             return $io26(input);
                         if (undefined !== input.oneOf) return $io27(input);
                         if (undefined !== input.$ref) return $io28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io29(input);
-                        if ("null" === input.type) return $io30(input);
+                        if ("null" === input.type) return $io29(input);
                         return (
                             $io20(input) ||
                             $io19(input) ||
@@ -10109,7 +9706,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             $io21(input) ||
                             $io23(input) ||
                             $io24(input) ||
-                            $io31(input)
+                            $io30(input)
                         );
                     })();
                 const $iu1 = (input: any): any =>
@@ -10135,15 +9732,15 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     })();
                 const $iu2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $io34(input);
-                        if ("integer" === input.type) return $io40(input);
+                        if ("object" === input.type) return $io33(input);
+                        if ("integer" === input.type) return $io39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $io43(input);
+                            return $io42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -10154,20 +9751,18 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     $iu0(elem),
                             )
                         )
-                            return $io44(input);
-                        if (undefined !== input.oneOf) return $io45(input);
-                        if (undefined !== input.$ref) return $io46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $io47(input);
-                        if ("null" === input.type) return $io48(input);
+                            return $io43(input);
+                        if (undefined !== input.oneOf) return $io44(input);
+                        if (undefined !== input.$ref) return $io45(input);
+                        if ("null" === input.type) return $io46(input);
                         return (
-                            $io38(input) ||
                             $io37(input) ||
                             $io36(input) ||
-                            $io39(input) ||
+                            $io35(input) ||
+                            $io38(input) ||
+                            $io40(input) ||
                             $io41(input) ||
-                            $io42(input) ||
-                            $io49(input)
+                            $io47(input)
                         );
                     })();
                 const $string = (typia.validateStringify as any).string;
@@ -10178,7 +9773,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                 const $so0 = (input: any): any =>
                     `{"schemas":${`[${input.schemas
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"components":${$so32(
+                        .join(",")}]`},"components":${$so31(
                         input.components,
                     )},"purpose":${(() => {
                         if ("string" === typeof input.purpose)
@@ -11289,6 +10884,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     })()}}`;
                 const $so26 = (input: any): any =>
                     `{${
+                        undefined === input.maxItems
+                            ? ""
+                            : `"maxItems":${
+                                  undefined !== input.maxItems
+                                      ? $number(input.maxItems)
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.nullable
                             ? ""
                             : `"nullable":${
@@ -11366,7 +10969,9 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                               },`
                     }"items":${`[${input.items
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"type":${(() => {
+                        .join(",")}]`},"minItems":${$number(
+                        input.minItems,
+                    )},"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
                         if ("string" === typeof input.type)
@@ -11587,76 +11192,6 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                       ? input["x-typia-rest"]
                                       : undefined
                               },`
-                    }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-                const $so30 = (input: any): any =>
-                    `{${
-                        undefined === input.deprecated
-                            ? ""
-                            : `"deprecated":${
-                                  undefined !== input.deprecated
-                                      ? input.deprecated
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.title
-                            ? ""
-                            : `"title":${
-                                  undefined !== input.title
-                                      ? $string(input.title)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.description
-                            ? ""
-                            : `"description":${
-                                  undefined !== input.description
-                                      ? $string(input.description)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-metaTags"]
-                            ? ""
-                            : `"x-typia-metaTags":${
-                                  undefined !== input["x-typia-metaTags"]
-                                      ? `[${input["x-typia-metaTags"]
-                                            .map((elem: any) => $su1(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-jsDocTags"]
-                            ? ""
-                            : `"x-typia-jsDocTags":${
-                                  undefined !== input["x-typia-jsDocTags"]
-                                      ? `[${input["x-typia-jsDocTags"]
-                                            .map((elem: any) => $so17(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-required"]
-                            ? ""
-                            : `"x-typia-required":${
-                                  undefined !== input["x-typia-required"]
-                                      ? input["x-typia-required"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-optional"]
-                            ? ""
-                            : `"x-typia-optional":${
-                                  undefined !== input["x-typia-optional"]
-                                      ? input["x-typia-optional"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-rest"]
-                            ? ""
-                            : `"x-typia-rest":${
-                                  undefined !== input["x-typia-rest"]
-                                      ? input["x-typia-rest"]
-                                      : undefined
-                              },`
                     }"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
@@ -11667,7 +11202,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so31 = (input: any): any =>
+                const $so30 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.deprecated
@@ -11739,19 +11274,19 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                   }`
                         }`,
                     )}}`;
-                const $so32 = (input: any): any =>
+                const $so31 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.schemas
                                 ? ""
                                 : `"schemas":${
                                       undefined !== input.schemas
-                                          ? $so33(input.schemas)
+                                          ? $so32(input.schemas)
                                           : undefined
                                   }`
                         }`,
                     )}}`;
-                const $so33 = (input: any): any =>
+                const $so32 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
@@ -11759,21 +11294,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;
-                const $so34 = (input: any): any =>
+                const $so33 = (input: any): any =>
                     `{${
                         undefined === input.$id
                             ? ""
                             : `"$id":${
                                   undefined !== input.$id
                                       ? $string(input.$id)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$recursiveAnchor
-                            ? ""
-                            : `"$recursiveAnchor":${
-                                  undefined !== input.$recursiveAnchor
-                                      ? input.$recursiveAnchor
                                       : undefined
                               },`
                     }${
@@ -11789,7 +11316,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             ? ""
                             : `"patternProperties":${
                                   undefined !== input.patternProperties
-                                      ? $so35(input.patternProperties)
+                                      ? $so34(input.patternProperties)
                                       : undefined
                               },`
                     }${
@@ -11834,7 +11361,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             : `"x-typia-patternProperties":${
                                   undefined !==
                                   input["x-typia-patternProperties"]
-                                      ? $so35(
+                                      ? $so34(
                                             input["x-typia-patternProperties"],
                                         )
                                       : undefined
@@ -11861,8 +11388,8 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             expected: '"object"',
                             value: input.type,
                         });
-                    })()},"properties":${$so35(input.properties)}}`;
-                const $so35 = (input: any): any =>
+                    })()},"properties":${$so34(input.properties)}}`;
+                const $so34 = (input: any): any =>
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
@@ -11870,7 +11397,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;
-                const $so36 = (input: any): any =>
+                const $so35 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -11983,7 +11510,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so37 = (input: any): any =>
+                const $so36 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -12096,7 +11623,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so38 = (input: any): any =>
+                const $so37 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -12209,7 +11736,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so39 = (input: any): any =>
+                const $so38 = (input: any): any =>
                     `{${
                         undefined === input["default"]
                             ? ""
@@ -12320,7 +11847,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so40 = (input: any): any =>
+                const $so39 = (input: any): any =>
                     `{${
                         undefined === input.minimum
                             ? ""
@@ -12471,7 +11998,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so41 = (input: any): any =>
+                const $so40 = (input: any): any =>
                     `{${
                         undefined === input.minimum
                             ? ""
@@ -12622,7 +12149,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so42 = (input: any): any =>
+                const $so41 = (input: any): any =>
                     `{${
                         undefined === input.minLength
                             ? ""
@@ -12765,7 +12292,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so43 = (input: any): any =>
+                const $so42 = (input: any): any =>
                     `{${
                         undefined === input.minItems
                             ? ""
@@ -12892,8 +12419,16 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so44 = (input: any): any =>
+                const $so43 = (input: any): any =>
                     `{${
+                        undefined === input.maxItems
+                            ? ""
+                            : `"maxItems":${
+                                  undefined !== input.maxItems
+                                      ? $number(input.maxItems)
+                                      : undefined
+                              },`
+                    }${
                         undefined === input.nullable
                             ? ""
                             : `"nullable":${
@@ -12987,7 +12522,9 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                               },`
                     }"items":${`[${input.items
                         .map((elem: any) => $su0(elem))
-                        .join(",")}]`},"type":${(() => {
+                        .join(",")}]`},"minItems":${$number(
+                        input.minItems,
+                    )},"type":${(() => {
                         if ("string" === typeof input.type)
                             return $string(input.type);
                         if ("string" === typeof input.type)
@@ -12997,7 +12534,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so45 = (input: any): any =>
+                const $so44 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -13085,7 +12622,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     }"oneOf":${`[${input.oneOf
                         .map((elem: any) => $su0(elem))
                         .join(",")}]`}}`;
-                const $so46 = (input: any): any =>
+                const $so45 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -13171,93 +12708,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                       : undefined
                               },`
                     }"$ref":${$string(input.$ref)}}`;
-                const $so47 = (input: any): any =>
-                    `{${
-                        undefined === input.deprecated
-                            ? ""
-                            : `"deprecated":${
-                                  undefined !== input.deprecated
-                                      ? input.deprecated
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.title
-                            ? ""
-                            : `"title":${
-                                  undefined !== input.title
-                                      ? $string(input.title)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.description
-                            ? ""
-                            : `"description":${
-                                  undefined !== input.description
-                                      ? $string(input.description)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-metaTags"]
-                            ? ""
-                            : `"x-typia-metaTags":${
-                                  undefined !== input["x-typia-metaTags"]
-                                      ? `[${input["x-typia-metaTags"]
-                                            .map((elem: any) => $su1(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-jsDocTags"]
-                            ? ""
-                            : `"x-typia-jsDocTags":${
-                                  undefined !== input["x-typia-jsDocTags"]
-                                      ? `[${input["x-typia-jsDocTags"]
-                                            .map((elem: any) => $so17(elem))
-                                            .join(",")}]`
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-required"]
-                            ? ""
-                            : `"x-typia-required":${
-                                  undefined !== input["x-typia-required"]
-                                      ? input["x-typia-required"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-optional"]
-                            ? ""
-                            : `"x-typia-optional":${
-                                  undefined !== input["x-typia-optional"]
-                                      ? input["x-typia-optional"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input["x-typia-rest"]
-                            ? ""
-                            : `"x-typia-rest":${
-                                  undefined !== input["x-typia-rest"]
-                                      ? input["x-typia-rest"]
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$id
-                            ? ""
-                            : `"$id":${
-                                  undefined !== input.$id
-                                      ? $string(input.$id)
-                                      : undefined
-                              },`
-                    }${
-                        undefined === input.$recursiveAnchor
-                            ? ""
-                            : `"$recursiveAnchor":${
-                                  undefined !== input.$recursiveAnchor
-                                      ? input.$recursiveAnchor
-                                      : undefined
-                              },`
-                    }"$recursiveRef":${$string(input.$recursiveRef)}}`;
-                const $so48 = (input: any): any =>
+                const $so46 = (input: any): any =>
                     `{${
                         undefined === input.deprecated
                             ? ""
@@ -13352,7 +12803,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             value: input.type,
                         });
                     })()}}`;
-                const $so49 = (input: any): any =>
+                const $so47 = (input: any): any =>
                     `{${$tail(
                         `${
                             undefined === input.deprecated
@@ -13463,9 +12914,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             return $so26(input);
                         if (undefined !== input.oneOf) return $so27(input);
                         if (undefined !== input.$ref) return $so28(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $so29(input);
-                        if ("null" === input.type) return $so30(input);
+                        if ("null" === input.type) return $so29(input);
                         return (() => {
                             if ($io20(input)) return $so20(input);
                             if ($io19(input)) return $so19(input);
@@ -13473,7 +12922,7 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             if ($io21(input)) return $so21(input);
                             if ($io23(input)) return $so23(input);
                             if ($io24(input)) return $so24(input);
-                            if ($io31(input)) return $so31(input);
+                            if ($io30(input)) return $so30(input);
                             $throws({
                                 expected:
                                     '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
@@ -13508,15 +12957,15 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     })();
                 const $su2 = (input: any): any =>
                     (() => {
-                        if ("object" === input.type) return $so34(input);
-                        if ("integer" === input.type) return $so40(input);
+                        if ("object" === input.type) return $so33(input);
+                        if ("integer" === input.type) return $so39(input);
                         if (
                             "object" === typeof input.items &&
                             null !== input.items &&
                             false === Array.isArray(input.items) &&
                             $iu0(input.items)
                         )
-                            return $so43(input);
+                            return $so42(input);
                         if (
                             Array.isArray(input.items) &&
                             input.items.every(
@@ -13527,20 +12976,18 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                     $iu0(elem),
                             )
                         )
-                            return $so44(input);
-                        if (undefined !== input.oneOf) return $so45(input);
-                        if (undefined !== input.$ref) return $so46(input);
-                        if (undefined !== input.$recursiveRef)
-                            return $so47(input);
-                        if ("null" === input.type) return $so48(input);
+                            return $so43(input);
+                        if (undefined !== input.oneOf) return $so44(input);
+                        if (undefined !== input.$ref) return $so45(input);
+                        if ("null" === input.type) return $so46(input);
                         return (() => {
-                            if ($io38(input)) return $so38(input);
                             if ($io37(input)) return $so37(input);
                             if ($io36(input)) return $so36(input);
-                            if ($io39(input)) return $so39(input);
+                            if ($io35(input)) return $so35(input);
+                            if ($io38(input)) return $so38(input);
+                            if ($io40(input)) return $so40(input);
                             if ($io41(input)) return $so41(input);
-                            if ($io42(input)) return $so42(input);
-                            if ($io49(input)) return $so49(input);
+                            if ($io47(input)) return $so47(input);
                             $throws({
                                 expected:
                                     '(IEnumeration<"string"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"number"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IEnumeration<"boolean"> & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IBoolean & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | INumber & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IString & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; } | IUnknown & { $id?: string | undefined; $recursiveAnchor?: boolean | undefined; })',

--- a/test/issues/ajv.js
+++ b/test/issues/ajv.js
@@ -1,0 +1,1746 @@
+function validate10(data, {instancePath="", parentData, parentDataProperty, rootData=data}={}){
+let vErrors = null;
+let errors = 0;
+if(!(validate11(data, {instancePath,parentData,parentDataProperty,rootData}))){
+vErrors = vErrors === null ? validate11.errors : vErrors.concat(validate11.errors);
+errors = vErrors.length;
+}
+else {
+}
+validate10.errors = vErrors;
+return errors === 0;
+}
+
+
+
+function validate0(data, {instancePath="", parentData, parentDataProperty, rootData=data}={}){
+/*# sourceURL="http://json-schema.org/draft-07/schema#" */;
+let vErrors = null;
+let errors = 0;
+if((!(data && typeof data == "object" && !Array.isArray(data))) && (typeof data !== "boolean")){
+validate0.errors = [{instancePath,schemaPath:"#/type",keyword:"type",params:{type: schema0.type},message:"must be object,boolean"}];
+return false;
+}
+const _errs0 = errors;
+if(errors === 0){
+if(data && typeof data == "object" && !Array.isArray(data)){
+if(data.$id !== undefined){
+let data0 = data.$id;
+const _errs1 = errors;
+const _errs2 = errors;
+if(errors === _errs1){
+if(typeof data0 == "number"){
+}
+if(errors === _errs1){
+if(typeof data0 === "string"){
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/$id",schemaPath:"#/properties/%24id/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+if(errors === _errs1){
+}
+}
+}
+var valid0 = _errs1 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.$schema !== undefined){
+let data1 = data.$schema;
+const _errs3 = errors;
+const _errs4 = errors;
+if(errors === _errs3){
+if(typeof data1 == "number"){
+}
+if(errors === _errs3){
+if(typeof data1 === "string"){
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/$schema",schemaPath:"#/properties/%24schema/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+if(errors === _errs3){
+}
+}
+}
+var valid0 = _errs3 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.$ref !== undefined){
+let data2 = data.$ref;
+const _errs5 = errors;
+const _errs6 = errors;
+if(errors === _errs5){
+if(typeof data2 == "number"){
+}
+if(errors === _errs5){
+if(typeof data2 === "string"){
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/$ref",schemaPath:"#/properties/%24ref/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+if(errors === _errs5){
+}
+}
+}
+var valid0 = _errs5 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.$comment !== undefined){
+let data3 = data.$comment;
+const _errs7 = errors;
+if(typeof data3 !== "string"){
+validate0.errors = [{instancePath:instancePath+"/$comment",schemaPath:"#/properties/%24comment/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+const _errs8 = errors;
+if(errors === _errs7){
+}
+var valid0 = _errs7 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.title !== undefined){
+let data4 = data.title;
+const _errs9 = errors;
+if(typeof data4 !== "string"){
+validate0.errors = [{instancePath:instancePath+"/title",schemaPath:"#/properties/title/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+const _errs10 = errors;
+if(errors === _errs9){
+}
+var valid0 = _errs9 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.description !== undefined){
+let data5 = data.description;
+const _errs11 = errors;
+if(typeof data5 !== "string"){
+validate0.errors = [{instancePath:instancePath+"/description",schemaPath:"#/properties/description/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+const _errs12 = errors;
+if(errors === _errs11){
+}
+var valid0 = _errs11 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.readOnly !== undefined){
+let data6 = data.readOnly;
+const _errs13 = errors;
+if(typeof data6 !== "boolean"){
+validate0.errors = [{instancePath:instancePath+"/readOnly",schemaPath:"#/properties/readOnly/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+return false;
+}
+const _errs14 = errors;
+if(errors === _errs13){
+}
+var valid0 = _errs13 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.examples !== undefined){
+let data7 = data.examples;
+const _errs15 = errors;
+const _errs16 = errors;
+if(errors === _errs15){
+if(Array.isArray(data7)){
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/examples",schemaPath:"#/properties/examples/type",keyword:"type",params:{type: "array"},message:"must be array"}];
+return false;
+}
+if(errors === _errs15){
+}
+}
+var valid0 = _errs15 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.multipleOf !== undefined){
+let data8 = data.multipleOf;
+const _errs17 = errors;
+const _errs18 = errors;
+if(errors === _errs17){
+if(typeof data8 == "number"){
+if(data8 <= 0 || isNaN(data8)){
+validate0.errors = [{instancePath:instancePath+"/multipleOf",schemaPath:"#/properties/multipleOf/exclusiveMinimum",keyword:"exclusiveMinimum",params:{comparison: ">", limit: 0},message:"must be > 0"}];
+return false;
+}
+else {
+}
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/multipleOf",schemaPath:"#/properties/multipleOf/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+if(errors === _errs17){
+}
+}
+var valid0 = _errs17 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.maximum !== undefined){
+let data9 = data.maximum;
+const _errs19 = errors;
+if(!(typeof data9 == "number")){
+validate0.errors = [{instancePath:instancePath+"/maximum",schemaPath:"#/properties/maximum/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs20 = errors;
+if(errors === _errs19){
+}
+var valid0 = _errs19 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.exclusiveMaximum !== undefined){
+let data10 = data.exclusiveMaximum;
+const _errs21 = errors;
+if(!(typeof data10 == "number")){
+validate0.errors = [{instancePath:instancePath+"/exclusiveMaximum",schemaPath:"#/properties/exclusiveMaximum/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs22 = errors;
+if(errors === _errs21){
+}
+var valid0 = _errs21 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.minimum !== undefined){
+let data11 = data.minimum;
+const _errs23 = errors;
+if(!(typeof data11 == "number")){
+validate0.errors = [{instancePath:instancePath+"/minimum",schemaPath:"#/properties/minimum/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs24 = errors;
+if(errors === _errs23){
+}
+var valid0 = _errs23 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.exclusiveMinimum !== undefined){
+let data12 = data.exclusiveMinimum;
+const _errs25 = errors;
+if(!(typeof data12 == "number")){
+validate0.errors = [{instancePath:instancePath+"/exclusiveMinimum",schemaPath:"#/properties/exclusiveMinimum/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs26 = errors;
+if(errors === _errs25){
+}
+var valid0 = _errs25 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.maxLength !== undefined){
+let data13 = data.maxLength;
+const _errs27 = errors;
+const _errs28 = errors;
+if(!((typeof data13 == "number") && (!(data13 % 1) && !isNaN(data13)))){
+validate0.errors = [{instancePath:instancePath+"/maxLength",schemaPath:"#/definitions/nonNegativeInteger/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
+return false;
+}
+const _errs29 = errors;
+if(errors === _errs28){
+if(typeof data13 == "number"){
+if(data13 < 0 || isNaN(data13)){
+validate0.errors = [{instancePath:instancePath+"/maxLength",schemaPath:"#/definitions/nonNegativeInteger/minimum",keyword:"minimum",params:{comparison: ">=", limit: 0},message:"must be >= 0"}];
+return false;
+}
+else {
+}
+}
+if(errors === _errs28){
+}
+}
+var valid1 = _errs28 === errors;
+if(valid1){
+}
+var valid0 = _errs27 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.minLength !== undefined){
+let data14 = data.minLength;
+const _errs30 = errors;
+if(!(validate1(data14, {instancePath:instancePath+"/minLength",parentData:data,parentDataProperty:"minLength",rootData}))){
+vErrors = vErrors === null ? validate1.errors : vErrors.concat(validate1.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs30 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.pattern !== undefined){
+let data15 = data.pattern;
+const _errs31 = errors;
+const _errs32 = errors;
+if(errors === _errs31){
+if(typeof data15 == "number"){
+}
+if(errors === _errs31){
+if(typeof data15 === "string"){
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/pattern",schemaPath:"#/properties/pattern/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+if(errors === _errs31){
+}
+}
+}
+var valid0 = _errs31 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.additionalItems !== undefined){
+let data16 = data.additionalItems;
+const _errs33 = errors;
+if(!(validate0(data16, {instancePath:instancePath+"/additionalItems",parentData:data,parentDataProperty:"additionalItems",rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs33 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.items !== undefined){
+let data17 = data.items;
+const _errs34 = errors;
+const _errs35 = errors;
+let valid2 = false;
+const _errs36 = errors;
+if(!(validate0(data17, {instancePath:instancePath+"/items",parentData:data,parentDataProperty:"items",rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var _valid0 = _errs36 === errors;
+valid2 = valid2 || _valid0;
+if(!valid2){
+const _errs37 = errors;
+if(!(validate3(data17, {instancePath:instancePath+"/items",parentData:data,parentDataProperty:"items",rootData}))){
+vErrors = vErrors === null ? validate3.errors : vErrors.concat(validate3.errors);
+errors = vErrors.length;
+}
+else {
+}
+var _valid0 = _errs37 === errors;
+valid2 = valid2 || _valid0;
+if(!valid2){
+}
+}
+if(!valid2){
+const err0 = {instancePath:instancePath+"/items",schemaPath:"#/properties/items/anyOf",keyword:"anyOf",params:{},message:"must match a schema in anyOf"};
+if(vErrors === null){
+vErrors = [err0];
+}
+else {
+vErrors.push(err0);
+}
+errors++;
+validate0.errors = vErrors;
+return false;
+}
+else {
+errors = _errs35;
+if(vErrors !== null){
+if(_errs35){
+vErrors.length = _errs35;
+}
+else {
+vErrors = null;
+}
+}
+}
+if(errors === _errs34){
+}
+var valid0 = _errs34 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.maxItems !== undefined){
+let data18 = data.maxItems;
+const _errs38 = errors;
+const _errs39 = errors;
+if(!((typeof data18 == "number") && (!(data18 % 1) && !isNaN(data18)))){
+validate0.errors = [{instancePath:instancePath+"/maxItems",schemaPath:"#/definitions/nonNegativeInteger/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
+return false;
+}
+const _errs40 = errors;
+if(errors === _errs39){
+if(typeof data18 == "number"){
+if(data18 < 0 || isNaN(data18)){
+validate0.errors = [{instancePath:instancePath+"/maxItems",schemaPath:"#/definitions/nonNegativeInteger/minimum",keyword:"minimum",params:{comparison: ">=", limit: 0},message:"must be >= 0"}];
+return false;
+}
+else {
+}
+}
+if(errors === _errs39){
+}
+}
+var valid3 = _errs39 === errors;
+if(valid3){
+}
+var valid0 = _errs38 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.minItems !== undefined){
+let data19 = data.minItems;
+const _errs41 = errors;
+if(!(validate1(data19, {instancePath:instancePath+"/minItems",parentData:data,parentDataProperty:"minItems",rootData}))){
+vErrors = vErrors === null ? validate1.errors : vErrors.concat(validate1.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs41 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.uniqueItems !== undefined){
+let data20 = data.uniqueItems;
+const _errs42 = errors;
+if(typeof data20 !== "boolean"){
+validate0.errors = [{instancePath:instancePath+"/uniqueItems",schemaPath:"#/properties/uniqueItems/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+return false;
+}
+const _errs43 = errors;
+if(errors === _errs42){
+}
+var valid0 = _errs42 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.contains !== undefined){
+let data21 = data.contains;
+const _errs44 = errors;
+if(!(validate0(data21, {instancePath:instancePath+"/contains",parentData:data,parentDataProperty:"contains",rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs44 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.maxProperties !== undefined){
+let data22 = data.maxProperties;
+const _errs45 = errors;
+const _errs46 = errors;
+if(!((typeof data22 == "number") && (!(data22 % 1) && !isNaN(data22)))){
+validate0.errors = [{instancePath:instancePath+"/maxProperties",schemaPath:"#/definitions/nonNegativeInteger/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
+return false;
+}
+const _errs47 = errors;
+if(errors === _errs46){
+if(typeof data22 == "number"){
+if(data22 < 0 || isNaN(data22)){
+validate0.errors = [{instancePath:instancePath+"/maxProperties",schemaPath:"#/definitions/nonNegativeInteger/minimum",keyword:"minimum",params:{comparison: ">=", limit: 0},message:"must be >= 0"}];
+return false;
+}
+else {
+}
+}
+if(errors === _errs46){
+}
+}
+var valid4 = _errs46 === errors;
+if(valid4){
+}
+var valid0 = _errs45 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.minProperties !== undefined){
+let data23 = data.minProperties;
+const _errs48 = errors;
+if(!(validate1(data23, {instancePath:instancePath+"/minProperties",parentData:data,parentDataProperty:"minProperties",rootData}))){
+vErrors = vErrors === null ? validate1.errors : vErrors.concat(validate1.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs48 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.required !== undefined){
+let data24 = data.required;
+const _errs49 = errors;
+const _errs50 = errors;
+const _errs51 = errors;
+if(errors === _errs50){
+if(Array.isArray(data24)){
+var valid6 = true;
+const len0 = data24.length;
+for(let i0=0; i0<len0; i0++){
+let data25 = data24[i0];
+const _errs52 = errors;
+if(typeof data25 !== "string"){
+validate0.errors = [{instancePath:instancePath+"/required/" + i0,schemaPath:"#/definitions/stringArray/items/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+const _errs53 = errors;
+if(errors === _errs52){
+}
+var valid6 = _errs52 === errors;
+if(!valid6){
+break;
+}
+}
+if(valid6){
+let valid7;
+let i1 = data24.length;
+let j0;
+valid7 = true;
+if(i1 > 1){
+const indices0 = {};
+for(;i1--;){
+let item0 = data24[i1];
+if(typeof item0 !== "string"){
+continue;
+}
+if(typeof indices0[item0] == "number"){
+j0 = indices0[item0];
+validate0.errors = [{instancePath:instancePath+"/required",schemaPath:"#/definitions/stringArray/uniqueItems",keyword:"uniqueItems",params:{i: i1, j: j0},message:"must NOT have duplicate items (items ## "+j0+" and "+i1+" are identical)"}];
+return false;
+valid7 = false;
+break;
+}
+indices0[item0] = i1;
+}
+}
+if(valid7){
+}
+}
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/required",schemaPath:"#/definitions/stringArray/type",keyword:"type",params:{type: "array"},message:"must be array"}];
+return false;
+}
+if(errors === _errs50){
+}
+}
+var valid5 = _errs50 === errors;
+if(valid5){
+}
+var valid0 = _errs49 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.additionalProperties !== undefined){
+let data26 = data.additionalProperties;
+const _errs54 = errors;
+if(!(validate0(data26, {instancePath:instancePath+"/additionalProperties",parentData:data,parentDataProperty:"additionalProperties",rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs54 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.definitions !== undefined){
+let data27 = data.definitions;
+const _errs55 = errors;
+const _errs56 = errors;
+if(errors === _errs55){
+if(data27 && typeof data27 == "object" && !Array.isArray(data27)){
+const _errs57 = errors;
+for(const key0 in data27){
+let data28 = data27[key0];
+const _errs58 = errors;
+if(!(validate0(data28, {instancePath:instancePath+"/definitions/" + key0.replace(/~/g, "~0").replace(/\//g, "~1"),parentData:data27,parentDataProperty:key0,rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid8 = _errs58 === errors;
+if(!valid8){
+break;
+}
+}
+if(_errs57 === errors){
+}
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/definitions",schemaPath:"#/properties/definitions/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+if(errors === _errs55){
+}
+}
+var valid0 = _errs55 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.properties !== undefined){
+let data29 = data.properties;
+const _errs59 = errors;
+const _errs60 = errors;
+if(errors === _errs59){
+if(data29 && typeof data29 == "object" && !Array.isArray(data29)){
+const _errs61 = errors;
+for(const key1 in data29){
+let data30 = data29[key1];
+const _errs62 = errors;
+if(!(validate0(data30, {instancePath:instancePath+"/properties/" + key1.replace(/~/g, "~0").replace(/\//g, "~1"),parentData:data29,parentDataProperty:key1,rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid9 = _errs62 === errors;
+if(!valid9){
+break;
+}
+}
+if(_errs61 === errors){
+}
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/properties",schemaPath:"#/properties/properties/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+if(errors === _errs59){
+}
+}
+var valid0 = _errs59 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.patternProperties !== undefined){
+let data31 = data.patternProperties;
+const _errs63 = errors;
+const _errs64 = errors;
+if(errors === _errs63){
+if(data31 && typeof data31 == "object" && !Array.isArray(data31)){
+for(const key2 in data31){
+const _errs65 = errors;
+if(typeof key2 == "number"){
+}
+if(errors === _errs65){
+if(typeof key2 === "string"){
+}
+if(errors === _errs65){
+}
+}
+var valid10 = _errs65 === errors;
+if(!valid10){
+const err1 = {instancePath:instancePath+"/patternProperties",schemaPath:"#/properties/patternProperties/propertyNames",keyword:"propertyNames",params:{propertyName: key2},message:"property name must be valid"};
+if(vErrors === null){
+vErrors = [err1];
+}
+else {
+vErrors.push(err1);
+}
+errors++;
+validate0.errors = vErrors;
+return false;
+break;
+}
+}
+if(valid10){
+const _errs66 = errors;
+for(const key3 in data31){
+let data32 = data31[key3];
+const _errs67 = errors;
+if(!(validate0(data32, {instancePath:instancePath+"/patternProperties/" + key3.replace(/~/g, "~0").replace(/\//g, "~1"),parentData:data31,parentDataProperty:key3,rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid11 = _errs67 === errors;
+if(!valid11){
+break;
+}
+}
+if(_errs66 === errors){
+}
+}
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/patternProperties",schemaPath:"#/properties/patternProperties/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+if(errors === _errs63){
+}
+}
+var valid0 = _errs63 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.dependencies !== undefined){
+let data33 = data.dependencies;
+const _errs68 = errors;
+const _errs69 = errors;
+if(errors === _errs68){
+if(data33 && typeof data33 == "object" && !Array.isArray(data33)){
+const _errs70 = errors;
+for(const key4 in data33){
+let data34 = data33[key4];
+const _errs71 = errors;
+const _errs72 = errors;
+let valid13 = false;
+const _errs73 = errors;
+if(!(validate0(data34, {instancePath:instancePath+"/dependencies/" + key4.replace(/~/g, "~0").replace(/\//g, "~1"),parentData:data33,parentDataProperty:key4,rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var _valid1 = _errs73 === errors;
+valid13 = valid13 || _valid1;
+if(!valid13){
+const _errs74 = errors;
+const _errs75 = errors;
+const _errs76 = errors;
+if(errors === _errs75){
+if(Array.isArray(data34)){
+var valid15 = true;
+const len1 = data34.length;
+for(let i2=0; i2<len1; i2++){
+let data35 = data34[i2];
+const _errs77 = errors;
+if(typeof data35 !== "string"){
+const err2 = {instancePath:instancePath+"/dependencies/" + key4.replace(/~/g, "~0").replace(/\//g, "~1")+"/" + i2,schemaPath:"#/definitions/stringArray/items/type",keyword:"type",params:{type: "string"},message:"must be string"};
+if(vErrors === null){
+vErrors = [err2];
+}
+else {
+vErrors.push(err2);
+}
+errors++;
+}
+const _errs78 = errors;
+if(errors === _errs77){
+}
+var valid15 = _errs77 === errors;
+if(!valid15){
+break;
+}
+}
+if(valid15){
+let valid16;
+let i3 = data34.length;
+let j1;
+valid16 = true;
+if(i3 > 1){
+const indices1 = {};
+for(;i3--;){
+let item1 = data34[i3];
+if(typeof item1 !== "string"){
+continue;
+}
+if(typeof indices1[item1] == "number"){
+j1 = indices1[item1];
+const err3 = {instancePath:instancePath+"/dependencies/" + key4.replace(/~/g, "~0").replace(/\//g, "~1"),schemaPath:"#/definitions/stringArray/uniqueItems",keyword:"uniqueItems",params:{i: i3, j: j1},message:"must NOT have duplicate items (items ## "+j1+" and "+i3+" are identical)"};
+if(vErrors === null){
+vErrors = [err3];
+}
+else {
+vErrors.push(err3);
+}
+errors++;
+valid16 = false;
+break;
+}
+indices1[item1] = i3;
+}
+}
+if(valid16){
+}
+}
+}
+else {
+const err4 = {instancePath:instancePath+"/dependencies/" + key4.replace(/~/g, "~0").replace(/\//g, "~1"),schemaPath:"#/definitions/stringArray/type",keyword:"type",params:{type: "array"},message:"must be array"};
+if(vErrors === null){
+vErrors = [err4];
+}
+else {
+vErrors.push(err4);
+}
+errors++;
+}
+if(errors === _errs75){
+}
+}
+var valid14 = _errs75 === errors;
+if(valid14){
+}
+var _valid1 = _errs74 === errors;
+valid13 = valid13 || _valid1;
+if(!valid13){
+}
+}
+if(!valid13){
+const err5 = {instancePath:instancePath+"/dependencies/" + key4.replace(/~/g, "~0").replace(/\//g, "~1"),schemaPath:"#/properties/dependencies/additionalProperties/anyOf",keyword:"anyOf",params:{},message:"must match a schema in anyOf"};
+if(vErrors === null){
+vErrors = [err5];
+}
+else {
+vErrors.push(err5);
+}
+errors++;
+validate0.errors = vErrors;
+return false;
+}
+else {
+errors = _errs72;
+if(vErrors !== null){
+if(_errs72){
+vErrors.length = _errs72;
+}
+else {
+vErrors = null;
+}
+}
+}
+if(errors === _errs71){
+}
+var valid12 = _errs71 === errors;
+if(!valid12){
+break;
+}
+}
+if(_errs70 === errors){
+}
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/dependencies",schemaPath:"#/properties/dependencies/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+if(errors === _errs68){
+}
+}
+var valid0 = _errs68 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.propertyNames !== undefined){
+let data36 = data.propertyNames;
+const _errs79 = errors;
+if(!(validate0(data36, {instancePath:instancePath+"/propertyNames",parentData:data,parentDataProperty:"propertyNames",rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs79 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.enum !== undefined){
+let data37 = data.enum;
+const _errs80 = errors;
+const _errs81 = errors;
+if(errors === _errs80){
+if(Array.isArray(data37)){
+if(data37.length < 1){
+validate0.errors = [{instancePath:instancePath+"/enum",schemaPath:"#/properties/enum/minItems",keyword:"minItems",params:{limit: 1},message:"must NOT have fewer than 1 items"}];
+return false;
+}
+else {
+let valid17;
+let i4 = data37.length;
+let j2;
+valid17 = true;
+if(i4 > 1){
+outer0:
+for(;i4--;){
+for(j2 = i4; j2--;){
+if(func0(data37[i4], data37[j2])){
+validate0.errors = [{instancePath:instancePath+"/enum",schemaPath:"#/properties/enum/uniqueItems",keyword:"uniqueItems",params:{i: i4, j: j2},message:"must NOT have duplicate items (items ## "+j2+" and "+i4+" are identical)"}];
+return false;
+valid17 = false;
+break outer0;
+}
+}
+}
+}
+if(valid17){
+}
+}
+}
+else {
+validate0.errors = [{instancePath:instancePath+"/enum",schemaPath:"#/properties/enum/type",keyword:"type",params:{type: "array"},message:"must be array"}];
+return false;
+}
+if(errors === _errs80){
+}
+}
+var valid0 = _errs80 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.type !== undefined){
+let data38 = data.type;
+const _errs82 = errors;
+const _errs83 = errors;
+let valid18 = false;
+const _errs84 = errors;
+const _errs85 = errors;
+const vSchema0 = schema9.enum;
+if(!(((((((data38 === "array") || (data38 === "boolean")) || (data38 === "integer")) || (data38 === "null")) || (data38 === "number")) || (data38 === "object")) || (data38 === "string"))){
+const err6 = {instancePath:instancePath+"/type",schemaPath:"#/definitions/simpleTypes/enum",keyword:"enum",params:{allowedValues: schema9.enum},message:"must be equal to one of the allowed values"};
+if(vErrors === null){
+vErrors = [err6];
+}
+else {
+vErrors.push(err6);
+}
+errors++;
+}
+else {
+}
+if(errors === _errs85){
+}
+var valid19 = _errs85 === errors;
+if(valid19){
+}
+var _valid2 = _errs84 === errors;
+valid18 = valid18 || _valid2;
+if(!valid18){
+const _errs86 = errors;
+const _errs87 = errors;
+if(errors === _errs86){
+if(Array.isArray(data38)){
+if(data38.length < 1){
+const err7 = {instancePath:instancePath+"/type",schemaPath:"#/properties/type/anyOf/1/minItems",keyword:"minItems",params:{limit: 1},message:"must NOT have fewer than 1 items"};
+if(vErrors === null){
+vErrors = [err7];
+}
+else {
+vErrors.push(err7);
+}
+errors++;
+}
+else {
+var valid20 = true;
+const len2 = data38.length;
+for(let i5=0; i5<len2; i5++){
+let data39 = data38[i5];
+const _errs88 = errors;
+const _errs89 = errors;
+const vSchema1 = schema9.enum;
+if(!(((((((data39 === "array") || (data39 === "boolean")) || (data39 === "integer")) || (data39 === "null")) || (data39 === "number")) || (data39 === "object")) || (data39 === "string"))){
+const err8 = {instancePath:instancePath+"/type/" + i5,schemaPath:"#/definitions/simpleTypes/enum",keyword:"enum",params:{allowedValues: schema9.enum},message:"must be equal to one of the allowed values"};
+if(vErrors === null){
+vErrors = [err8];
+}
+else {
+vErrors.push(err8);
+}
+errors++;
+}
+else {
+}
+if(errors === _errs89){
+}
+var valid21 = _errs89 === errors;
+if(valid21){
+}
+var valid20 = _errs88 === errors;
+if(!valid20){
+break;
+}
+}
+if(valid20){
+let valid22;
+let i6 = data38.length;
+let j3;
+valid22 = true;
+if(i6 > 1){
+outer1:
+for(;i6--;){
+for(j3 = i6; j3--;){
+if(func0(data38[i6], data38[j3])){
+const err9 = {instancePath:instancePath+"/type",schemaPath:"#/properties/type/anyOf/1/uniqueItems",keyword:"uniqueItems",params:{i: i6, j: j3},message:"must NOT have duplicate items (items ## "+j3+" and "+i6+" are identical)"};
+if(vErrors === null){
+vErrors = [err9];
+}
+else {
+vErrors.push(err9);
+}
+errors++;
+valid22 = false;
+break outer1;
+}
+}
+}
+}
+if(valid22){
+}
+}
+}
+}
+else {
+const err10 = {instancePath:instancePath+"/type",schemaPath:"#/properties/type/anyOf/1/type",keyword:"type",params:{type: "array"},message:"must be array"};
+if(vErrors === null){
+vErrors = [err10];
+}
+else {
+vErrors.push(err10);
+}
+errors++;
+}
+if(errors === _errs86){
+}
+}
+var _valid2 = _errs86 === errors;
+valid18 = valid18 || _valid2;
+if(!valid18){
+}
+}
+if(!valid18){
+const err11 = {instancePath:instancePath+"/type",schemaPath:"#/properties/type/anyOf",keyword:"anyOf",params:{},message:"must match a schema in anyOf"};
+if(vErrors === null){
+vErrors = [err11];
+}
+else {
+vErrors.push(err11);
+}
+errors++;
+validate0.errors = vErrors;
+return false;
+}
+else {
+errors = _errs83;
+if(vErrors !== null){
+if(_errs83){
+vErrors.length = _errs83;
+}
+else {
+vErrors = null;
+}
+}
+}
+if(errors === _errs82){
+}
+var valid0 = _errs82 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.format !== undefined){
+let data40 = data.format;
+const _errs90 = errors;
+if(typeof data40 !== "string"){
+validate0.errors = [{instancePath:instancePath+"/format",schemaPath:"#/properties/format/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+const _errs91 = errors;
+if(errors === _errs90){
+}
+var valid0 = _errs90 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.contentMediaType !== undefined){
+let data41 = data.contentMediaType;
+const _errs92 = errors;
+if(typeof data41 !== "string"){
+validate0.errors = [{instancePath:instancePath+"/contentMediaType",schemaPath:"#/properties/contentMediaType/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+const _errs93 = errors;
+if(errors === _errs92){
+}
+var valid0 = _errs92 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.contentEncoding !== undefined){
+let data42 = data.contentEncoding;
+const _errs94 = errors;
+if(typeof data42 !== "string"){
+validate0.errors = [{instancePath:instancePath+"/contentEncoding",schemaPath:"#/properties/contentEncoding/type",keyword:"type",params:{type: "string"},message:"must be string"}];
+return false;
+}
+const _errs95 = errors;
+if(errors === _errs94){
+}
+var valid0 = _errs94 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.if !== undefined){
+let data43 = data.if;
+const _errs96 = errors;
+if(!(validate0(data43, {instancePath:instancePath+"/if",parentData:data,parentDataProperty:"if",rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs96 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.then !== undefined){
+let data44 = data.then;
+const _errs97 = errors;
+if(!(validate0(data44, {instancePath:instancePath+"/then",parentData:data,parentDataProperty:"then",rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs97 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.else !== undefined){
+let data45 = data.else;
+const _errs98 = errors;
+if(!(validate0(data45, {instancePath:instancePath+"/else",parentData:data,parentDataProperty:"else",rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs98 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.allOf !== undefined){
+let data46 = data.allOf;
+const _errs99 = errors;
+if(!(validate3(data46, {instancePath:instancePath+"/allOf",parentData:data,parentDataProperty:"allOf",rootData}))){
+vErrors = vErrors === null ? validate3.errors : vErrors.concat(validate3.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs99 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.anyOf !== undefined){
+let data47 = data.anyOf;
+const _errs100 = errors;
+if(!(validate3(data47, {instancePath:instancePath+"/anyOf",parentData:data,parentDataProperty:"anyOf",rootData}))){
+vErrors = vErrors === null ? validate3.errors : vErrors.concat(validate3.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs100 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.oneOf !== undefined){
+let data48 = data.oneOf;
+const _errs101 = errors;
+if(!(validate3(data48, {instancePath:instancePath+"/oneOf",parentData:data,parentDataProperty:"oneOf",rootData}))){
+vErrors = vErrors === null ? validate3.errors : vErrors.concat(validate3.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs101 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.not !== undefined){
+let data49 = data.not;
+const _errs102 = errors;
+if(!(validate0(data49, {instancePath:instancePath+"/not",parentData:data,parentDataProperty:"not",rootData}))){
+vErrors = vErrors === null ? validate0.errors : vErrors.concat(validate0.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid0 = _errs102 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+if(errors === 0){
+}
+}
+validate0.errors = vErrors;
+return errors === 0;
+}
+
+
+
+function validate11(data, {instancePath="", parentData, parentDataProperty, rootData=data}={}){
+/*# sourceURL="#/components/schemas/Collection" */;
+let vErrors = null;
+let errors = 0;
+const _errs0 = errors;
+if(errors === 0){
+if(data && typeof data == "object" && !Array.isArray(data)){
+let missing0;
+if((data.data === undefined) && (missing0 = "data")){
+validate11.errors = [{instancePath,schemaPath:"#/required",keyword:"required",params:{missingProperty: missing0},message:"must have required property '"+missing0+"'"}];
+return false;
+}
+else {
+if(data.data !== undefined){
+let data0 = data.data;
+const _errs1 = errors;
+const _errs2 = errors;
+if(errors === _errs1){
+if(Array.isArray(data0)){
+var valid1 = true;
+const len0 = data0.length;
+for(let i0=0; i0<len0; i0++){
+let data1 = data0[i0];
+const _errs3 = errors;
+if(!(validate12(data1, {instancePath:instancePath+"/data/" + i0,parentData:data0,parentDataProperty:i0,rootData}))){
+vErrors = vErrors === null ? validate12.errors : vErrors.concat(validate12.errors);
+errors = vErrors.length;
+}
+else {
+}
+var valid1 = _errs3 === errors;
+if(!valid1){
+break;
+}
+}
+if(valid1){
+}
+}
+else {
+validate11.errors = [{instancePath:instancePath+"/data",schemaPath:"#/properties/data/type",keyword:"type",params:{type: "array"},message:"must be array"}];
+return false;
+}
+if(errors === _errs1){
+}
+}
+var valid0 = _errs1 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+}
+}
+}
+else {
+validate11.errors = [{instancePath,schemaPath:"#/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+if(errors === 0){
+}
+}
+validate11.errors = vErrors;
+return errors === 0;
+}
+
+
+
+function validate12(data, {instancePath="", parentData, parentDataProperty, rootData=data}={}){
+/*# sourceURL="#/components/schemas/ObjectSimple.IBox3D" */;
+let vErrors = null;
+let errors = 0;
+const _errs0 = errors;
+if(errors === 0){
+if(data && typeof data == "object" && !Array.isArray(data)){
+let missing0;
+if(((((data.scale === undefined) && (missing0 = "scale")) || ((data.position === undefined) && (missing0 = "position"))) || ((data.rotate === undefined) && (missing0 = "rotate"))) || ((data.pivot === undefined) && (missing0 = "pivot"))){
+validate12.errors = [{instancePath,schemaPath:"#/required",keyword:"required",params:{missingProperty: missing0},message:"must have required property '"+missing0+"'"}];
+return false;
+}
+else {
+if(data.scale !== undefined){
+let data0 = data.scale;
+const _errs1 = errors;
+const _errs2 = errors;
+const _errs3 = errors;
+if(errors === _errs2){
+if(data0 && typeof data0 == "object" && !Array.isArray(data0)){
+let missing1;
+if((((data0.x === undefined) && (missing1 = "x")) || ((data0.y === undefined) && (missing1 = "y"))) || ((data0.z === undefined) && (missing1 = "z"))){
+validate12.errors = [{instancePath:instancePath+"/scale",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/required",keyword:"required",params:{missingProperty: missing1},message:"must have required property '"+missing1+"'"}];
+return false;
+}
+else {
+if(data0.x !== undefined){
+let data1 = data0.x;
+const _errs4 = errors;
+if(!(typeof data1 == "number")){
+validate12.errors = [{instancePath:instancePath+"/scale/x",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/x/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs5 = errors;
+if(errors === _errs4){
+}
+var valid2 = _errs4 === errors;
+}
+else {
+var valid2 = true;
+}
+if(valid2){
+if(data0.y !== undefined){
+let data2 = data0.y;
+const _errs6 = errors;
+if(!(typeof data2 == "number")){
+validate12.errors = [{instancePath:instancePath+"/scale/y",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/y/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs7 = errors;
+if(errors === _errs6){
+}
+var valid2 = _errs6 === errors;
+}
+else {
+var valid2 = true;
+}
+if(valid2){
+if(data0.z !== undefined){
+let data3 = data0.z;
+const _errs8 = errors;
+if(!(typeof data3 == "number")){
+validate12.errors = [{instancePath:instancePath+"/scale/z",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/z/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs9 = errors;
+if(errors === _errs8){
+}
+var valid2 = _errs8 === errors;
+}
+else {
+var valid2 = true;
+}
+if(valid2){
+}
+}
+}
+}
+}
+else {
+validate12.errors = [{instancePath:instancePath+"/scale",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+if(errors === _errs2){
+}
+}
+var valid1 = _errs2 === errors;
+if(valid1){
+}
+var valid0 = _errs1 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.position !== undefined){
+let data4 = data.position;
+const _errs10 = errors;
+const _errs11 = errors;
+const _errs12 = errors;
+if(errors === _errs11){
+if(data4 && typeof data4 == "object" && !Array.isArray(data4)){
+let missing2;
+if((((data4.x === undefined) && (missing2 = "x")) || ((data4.y === undefined) && (missing2 = "y"))) || ((data4.z === undefined) && (missing2 = "z"))){
+validate12.errors = [{instancePath:instancePath+"/position",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/required",keyword:"required",params:{missingProperty: missing2},message:"must have required property '"+missing2+"'"}];
+return false;
+}
+else {
+if(data4.x !== undefined){
+let data5 = data4.x;
+const _errs13 = errors;
+if(!(typeof data5 == "number")){
+validate12.errors = [{instancePath:instancePath+"/position/x",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/x/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs14 = errors;
+if(errors === _errs13){
+}
+var valid4 = _errs13 === errors;
+}
+else {
+var valid4 = true;
+}
+if(valid4){
+if(data4.y !== undefined){
+let data6 = data4.y;
+const _errs15 = errors;
+if(!(typeof data6 == "number")){
+validate12.errors = [{instancePath:instancePath+"/position/y",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/y/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs16 = errors;
+if(errors === _errs15){
+}
+var valid4 = _errs15 === errors;
+}
+else {
+var valid4 = true;
+}
+if(valid4){
+if(data4.z !== undefined){
+let data7 = data4.z;
+const _errs17 = errors;
+if(!(typeof data7 == "number")){
+validate12.errors = [{instancePath:instancePath+"/position/z",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/z/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs18 = errors;
+if(errors === _errs17){
+}
+var valid4 = _errs17 === errors;
+}
+else {
+var valid4 = true;
+}
+if(valid4){
+}
+}
+}
+}
+}
+else {
+validate12.errors = [{instancePath:instancePath+"/position",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+if(errors === _errs11){
+}
+}
+var valid3 = _errs11 === errors;
+if(valid3){
+}
+var valid0 = _errs10 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.rotate !== undefined){
+let data8 = data.rotate;
+const _errs19 = errors;
+const _errs20 = errors;
+const _errs21 = errors;
+if(errors === _errs20){
+if(data8 && typeof data8 == "object" && !Array.isArray(data8)){
+let missing3;
+if((((data8.x === undefined) && (missing3 = "x")) || ((data8.y === undefined) && (missing3 = "y"))) || ((data8.z === undefined) && (missing3 = "z"))){
+validate12.errors = [{instancePath:instancePath+"/rotate",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/required",keyword:"required",params:{missingProperty: missing3},message:"must have required property '"+missing3+"'"}];
+return false;
+}
+else {
+if(data8.x !== undefined){
+let data9 = data8.x;
+const _errs22 = errors;
+if(!(typeof data9 == "number")){
+validate12.errors = [{instancePath:instancePath+"/rotate/x",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/x/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs23 = errors;
+if(errors === _errs22){
+}
+var valid6 = _errs22 === errors;
+}
+else {
+var valid6 = true;
+}
+if(valid6){
+if(data8.y !== undefined){
+let data10 = data8.y;
+const _errs24 = errors;
+if(!(typeof data10 == "number")){
+validate12.errors = [{instancePath:instancePath+"/rotate/y",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/y/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs25 = errors;
+if(errors === _errs24){
+}
+var valid6 = _errs24 === errors;
+}
+else {
+var valid6 = true;
+}
+if(valid6){
+if(data8.z !== undefined){
+let data11 = data8.z;
+const _errs26 = errors;
+if(!(typeof data11 == "number")){
+validate12.errors = [{instancePath:instancePath+"/rotate/z",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/z/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs27 = errors;
+if(errors === _errs26){
+}
+var valid6 = _errs26 === errors;
+}
+else {
+var valid6 = true;
+}
+if(valid6){
+}
+}
+}
+}
+}
+else {
+validate12.errors = [{instancePath:instancePath+"/rotate",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+if(errors === _errs20){
+}
+}
+var valid5 = _errs20 === errors;
+if(valid5){
+}
+var valid0 = _errs19 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.pivot !== undefined){
+let data12 = data.pivot;
+const _errs28 = errors;
+const _errs29 = errors;
+const _errs30 = errors;
+if(errors === _errs29){
+if(data12 && typeof data12 == "object" && !Array.isArray(data12)){
+let missing4;
+if((((data12.x === undefined) && (missing4 = "x")) || ((data12.y === undefined) && (missing4 = "y"))) || ((data12.z === undefined) && (missing4 = "z"))){
+validate12.errors = [{instancePath:instancePath+"/pivot",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/required",keyword:"required",params:{missingProperty: missing4},message:"must have required property '"+missing4+"'"}];
+return false;
+}
+else {
+if(data12.x !== undefined){
+let data13 = data12.x;
+const _errs31 = errors;
+if(!(typeof data13 == "number")){
+validate12.errors = [{instancePath:instancePath+"/pivot/x",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/x/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs32 = errors;
+if(errors === _errs31){
+}
+var valid8 = _errs31 === errors;
+}
+else {
+var valid8 = true;
+}
+if(valid8){
+if(data12.y !== undefined){
+let data14 = data12.y;
+const _errs33 = errors;
+if(!(typeof data14 == "number")){
+validate12.errors = [{instancePath:instancePath+"/pivot/y",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/y/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs34 = errors;
+if(errors === _errs33){
+}
+var valid8 = _errs33 === errors;
+}
+else {
+var valid8 = true;
+}
+if(valid8){
+if(data12.z !== undefined){
+let data15 = data12.z;
+const _errs35 = errors;
+if(!(typeof data15 == "number")){
+validate12.errors = [{instancePath:instancePath+"/pivot/z",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/properties/z/type",keyword:"type",params:{type: "number"},message:"must be number"}];
+return false;
+}
+const _errs36 = errors;
+if(errors === _errs35){
+}
+var valid8 = _errs35 === errors;
+}
+else {
+var valid8 = true;
+}
+if(valid8){
+}
+}
+}
+}
+}
+else {
+validate12.errors = [{instancePath:instancePath+"/pivot",schemaPath:"#/components/schemas/ObjectSimple.IPoint3D/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+if(errors === _errs29){
+}
+}
+var valid7 = _errs29 === errors;
+if(valid7){
+}
+var valid0 = _errs28 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+}
+}
+}
+}
+}
+}
+else {
+validate12.errors = [{instancePath,schemaPath:"#/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+if(errors === 0){
+}
+}
+validate12.errors = vErrors;
+return errors === 0;
+}
+
+
+

--- a/test/issues/ajv.ts
+++ b/test/issues/ajv.ts
@@ -1,0 +1,41 @@
+import Ajv from "ajv";
+import fs from "fs";
+import typia from "typia";
+
+import { ObjectSimple } from "../structures/ObjectSimple";
+
+type Collection = {
+    data: ObjectSimple[];
+};
+
+const app = typia.application<[Collection], "ajv">();
+const program = new Ajv({
+    schemas: Object.values(app.components.schemas ?? {}),
+    keywords: [
+        "x-typia-tuple",
+        "x-typia-metaTags",
+        "x-typia-jsDocTags",
+        "x-typia-required",
+        "x-typia-optional",
+        "x-typia-rest",
+    ],
+    strict: true,
+    strictNumbers: false,
+    code: {
+        es5: true,
+        lines: true,
+        source: true,
+        optimize: false,
+    },
+});
+const is = program.compile(app.schemas[0]);
+fs.writeFileSync(
+    __dirname + "/ajv.js",
+    [
+        is.source?.validateCode,
+        ...Object.values(program.schemas).map(
+            (s) => s?.validate?.source?.validateCode,
+        ),
+    ].join("\n\n\n"),
+    "utf8",
+);

--- a/test/schemas/json/ajv/ArrayAtomicAlias.json
+++ b/test/schemas/json/ajv/ArrayAtomicAlias.json
@@ -19,7 +19,9 @@
           {
             "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_string_gt_"
           }
-        ]
+        ],
+        "minItems": 3,
+        "maxItems": 3
       },
       "ArrayAtomicAlias.Alias_lt_boolean_gt_": {
         "$id": "#/components/schemas/ArrayAtomicAlias.Alias_lt_boolean_gt_",

--- a/test/schemas/json/ajv/ArrayAtomicSimple.json
+++ b/test/schemas/json/ajv/ArrayAtomicSimple.json
@@ -46,7 +46,9 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "minItems": 3,
+        "maxItems": 3
       }
     }
   },

--- a/test/schemas/json/ajv/ArrayRecursive.json
+++ b/test/schemas/json/ajv/ArrayRecursive.json
@@ -1,14 +1,13 @@
 {
   "schemas": [
     {
-      "$recursiveRef": "#/components/schemas/ArrayRecursive.ICategory"
+      "$ref": "#/components/schemas/ArrayRecursive.ICategory"
     }
   ],
   "components": {
     "schemas": {
       "ArrayRecursive.ICategory": {
         "$id": "#/components/schemas/ArrayRecursive.ICategory",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "children": {
@@ -16,7 +15,7 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$recursiveRef": "#/components/schemas/ArrayRecursive.ICategory"
+              "$ref": "#/components/schemas/ArrayRecursive.ICategory"
             }
           },
           "id": {

--- a/test/schemas/json/ajv/ArrayRecursiveUnionExplicit.json
+++ b/test/schemas/json/ajv/ArrayRecursiveUnionExplicit.json
@@ -17,7 +17,7 @@
         "$id": "#/components/schemas/ArrayRecursiveUnionExplicit.IBucket",
         "oneOf": [
           {
-            "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionExplicit.IDirectory"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IDirectory"
           },
           {
             "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IImageFile"
@@ -29,13 +29,12 @@
             "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IZipFile"
           },
           {
-            "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionExplicit.IShortcut"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionExplicit.IShortcut"
           }
         ]
       },
       "ArrayRecursiveUnionExplicit.IDirectory": {
         "$id": "#/components/schemas/ArrayRecursiveUnionExplicit.IDirectory",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "id": {
@@ -264,7 +263,6 @@
       },
       "ArrayRecursiveUnionExplicit.IShortcut": {
         "$id": "#/components/schemas/ArrayRecursiveUnionExplicit.IShortcut",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "id": {

--- a/test/schemas/json/ajv/ArrayRecursiveUnionImplicit.json
+++ b/test/schemas/json/ajv/ArrayRecursiveUnionImplicit.json
@@ -17,10 +17,10 @@
         "$id": "#/components/schemas/ArrayRecursiveUnionImplicit.IBucket",
         "oneOf": [
           {
-            "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory"
           },
           {
-            "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory"
           },
           {
             "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IImageFile"
@@ -32,13 +32,12 @@
             "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IZipFile"
           },
           {
-            "$recursiveRef": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut"
+            "$ref": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut"
           }
         ]
       },
       "ArrayRecursiveUnionImplicit.IDirectory": {
         "$id": "#/components/schemas/ArrayRecursiveUnionImplicit.IDirectory",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "id": {
@@ -75,7 +74,6 @@
       },
       "ArrayRecursiveUnionImplicit.ISharedDirectory": {
         "$id": "#/components/schemas/ArrayRecursiveUnionImplicit.ISharedDirectory",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "access": {
@@ -251,7 +249,6 @@
       },
       "ArrayRecursiveUnionImplicit.IShortcut": {
         "$id": "#/components/schemas/ArrayRecursiveUnionImplicit.IShortcut",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "id": {

--- a/test/schemas/json/ajv/ArrayRepeatedUnionWithTuple.json
+++ b/test/schemas/json/ajv/ArrayRepeatedUnionWithTuple.json
@@ -54,7 +54,9 @@
                 "x-typia-optional": false,
                 "type": "boolean"
               }
-            ]
+            ],
+            "minItems": 3,
+            "maxItems": 3
           },
           {
             "type": "array",
@@ -65,7 +67,9 @@
               {
                 "$ref": "#/components/schemas/ArrayRepeatedUnionWithTuple.IPoint3D"
               }
-            ]
+            ],
+            "minItems": 2,
+            "maxItems": 2
           }
         ]
       },

--- a/test/schemas/json/ajv/AtomicAlias.json
+++ b/test/schemas/json/ajv/AtomicAlias.json
@@ -28,7 +28,9 @@
             "x-typia-optional": false,
             "type": "string"
           }
-        ]
+        ],
+        "minItems": 3,
+        "maxItems": 3
       }
     }
   },

--- a/test/schemas/json/ajv/AtomicClass.json
+++ b/test/schemas/json/ajv/AtomicClass.json
@@ -64,7 +64,9 @@
             "x-typia-optional": false,
             "type": "string"
           }
-        ]
+        ],
+        "minItems": 9,
+        "maxItems": 9
       }
     }
   },

--- a/test/schemas/json/ajv/AtomicIntersection.json
+++ b/test/schemas/json/ajv/AtomicIntersection.json
@@ -19,7 +19,9 @@
           {
             "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_string_gt_"
           }
-        ]
+        ],
+        "minItems": 3,
+        "maxItems": 3
       },
       "AtomicIntersection.Wrapper_lt_boolean_gt_": {
         "$id": "#/components/schemas/AtomicIntersection.Wrapper_lt_boolean_gt_",

--- a/test/schemas/json/ajv/AtomicSimple.json
+++ b/test/schemas/json/ajv/AtomicSimple.json
@@ -28,7 +28,9 @@
             "x-typia-optional": false,
             "type": "string"
           }
-        ]
+        ],
+        "minItems": 3,
+        "maxItems": 3
       }
     }
   },

--- a/test/schemas/json/ajv/ConstantAtomicSimple.json
+++ b/test/schemas/json/ajv/ConstantAtomicSimple.json
@@ -46,7 +46,9 @@
               "three"
             ]
           }
-        ]
+        ],
+        "minItems": 4,
+        "maxItems": 4
       }
     }
   },

--- a/test/schemas/json/ajv/ConstantAtomicWrapper.json
+++ b/test/schemas/json/ajv/ConstantAtomicWrapper.json
@@ -19,7 +19,9 @@
           {
             "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_string_gt_"
           }
-        ]
+        ],
+        "minItems": 3,
+        "maxItems": 3
       },
       "ConstantAtomicWrapper.IPointer_lt_boolean_gt_": {
         "$id": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_boolean_gt_",

--- a/test/schemas/json/ajv/ConstantIntersection.json
+++ b/test/schemas/json/ajv/ConstantIntersection.json
@@ -19,7 +19,9 @@
           {
             "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_"
           }
-        ]
+        ],
+        "minItems": 3,
+        "maxItems": 3
       },
       "ConstantIntersection.Wrapper_lt_false_gt_": {
         "$id": "#/components/schemas/ConstantIntersection.Wrapper_lt_false_gt_",

--- a/test/schemas/json/ajv/DynamicTree.json
+++ b/test/schemas/json/ajv/DynamicTree.json
@@ -1,14 +1,13 @@
 {
   "schemas": [
     {
-      "$recursiveRef": "#/components/schemas/DynamicTree"
+      "$ref": "#/components/schemas/DynamicTree"
     }
   ],
   "components": {
     "schemas": {
       "DynamicTree": {
         "$id": "#/components/schemas/DynamicTree",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "id": {
@@ -22,7 +21,7 @@
             "type": "number"
           },
           "children": {
-            "$recursiveRef": "#/components/schemas/Record_lt_string_comma__space_DynamicTree_gt_"
+            "$ref": "#/components/schemas/Record_lt_string_comma__space_DynamicTree_gt_"
           }
         },
         "required": [
@@ -34,12 +33,11 @@
       },
       "Record_lt_string_comma__space_DynamicTree_gt_": {
         "$id": "#/components/schemas/Record_lt_string_comma__space_DynamicTree_gt_",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {},
         "x-typia-jsDocTags": [],
         "additionalProperties": {
-          "$recursiveRef": "#/components/schemas/DynamicTree"
+          "$ref": "#/components/schemas/DynamicTree"
         }
       }
     }

--- a/test/schemas/json/ajv/ObjectGeneric.json
+++ b/test/schemas/json/ajv/ObjectGeneric.json
@@ -19,7 +19,9 @@
           {
             "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_string_gt_"
           }
-        ]
+        ],
+        "minItems": 3,
+        "maxItems": 3
       },
       "ObjectGeneric.ISomething_lt_boolean_gt_": {
         "$id": "#/components/schemas/ObjectGeneric.ISomething_lt_boolean_gt_",

--- a/test/schemas/json/ajv/ObjectHierarchical.json
+++ b/test/schemas/json/ajv/ObjectHierarchical.json
@@ -85,7 +85,9 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "minItems": 4,
+            "maxItems": 4
           },
           "created_at": {
             "$ref": "#/components/schemas/ObjectHierarchical.ITimestamp"

--- a/test/schemas/json/ajv/ObjectNullable.json
+++ b/test/schemas/json/ajv/ObjectNullable.json
@@ -19,7 +19,9 @@
           {
             "$ref": "#/components/schemas/ObjectNullable.IProduct"
           }
-        ]
+        ],
+        "minItems": 3,
+        "maxItems": 3
       },
       "ObjectNullable.IProduct": {
         "$id": "#/components/schemas/ObjectNullable.IProduct",

--- a/test/schemas/json/ajv/ObjectPropertyNullable.json
+++ b/test/schemas/json/ajv/ObjectPropertyNullable.json
@@ -46,7 +46,9 @@
               "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_"
             }
           }
-        ]
+        ],
+        "minItems": 4,
+        "maxItems": 4
       },
       "ObjectPropertyNullable.IPointer_lt_boolean_gt_": {
         "$id": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_",

--- a/test/schemas/json/ajv/ObjectRecursive.json
+++ b/test/schemas/json/ajv/ObjectRecursive.json
@@ -1,14 +1,13 @@
 {
   "schemas": [
     {
-      "$recursiveRef": "#/components/schemas/ObjectRecursive.IDepartment"
+      "$ref": "#/components/schemas/ObjectRecursive.IDepartment"
     }
   ],
   "components": {
     "schemas": {
       "ObjectRecursive.IDepartment": {
         "$id": "#/components/schemas/ObjectRecursive.IDepartment",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "parent": {
@@ -19,7 +18,7 @@
                 "type": "null"
               },
               {
-                "$recursiveRef": "#/components/schemas/ObjectRecursive.IDepartment"
+                "$ref": "#/components/schemas/ObjectRecursive.IDepartment"
               }
             ],
             "x-typia-required": true,

--- a/test/schemas/json/ajv/ObjectTuple.json
+++ b/test/schemas/json/ajv/ObjectTuple.json
@@ -16,7 +16,9 @@
           {
             "$ref": "#/components/schemas/ObjectTuple.ICitizen"
           }
-        ]
+        ],
+        "minItems": 2,
+        "maxItems": 2
       },
       "ObjectTuple.ISection": {
         "$id": "#/components/schemas/ObjectTuple.ISection",

--- a/test/schemas/json/ajv/TagTuple.json
+++ b/test/schemas/json/ajv/TagTuple.json
@@ -644,7 +644,9 @@
               }
             ],
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "minItems": 4,
+            "maxItems": 4
           }
         },
         "required": [

--- a/test/schemas/json/ajv/ToJsonArray.json
+++ b/test/schemas/json/ajv/ToJsonArray.json
@@ -55,7 +55,9 @@
               "$ref": "#/components/schemas/ToJsonArray.IObject"
             }
           }
-        ]
+        ],
+        "minItems": 4,
+        "maxItems": 4
       },
       "ToJsonArray.IObject": {
         "$id": "#/components/schemas/ToJsonArray.IObject",

--- a/test/schemas/json/ajv/ToJsonAtomicSimple.json
+++ b/test/schemas/json/ajv/ToJsonAtomicSimple.json
@@ -28,7 +28,9 @@
             "x-typia-optional": false,
             "type": "string"
           }
-        ]
+        ],
+        "minItems": 3,
+        "maxItems": 3
       }
     }
   },

--- a/test/schemas/json/ajv/ToJsonTuple.json
+++ b/test/schemas/json/ajv/ToJsonTuple.json
@@ -31,7 +31,9 @@
           {
             "$ref": "#/components/schemas/ToJsonTuple.IObject"
           }
-        ]
+        ],
+        "minItems": 4,
+        "maxItems": 4
       },
       "ToJsonTuple.IObject": {
         "$id": "#/components/schemas/ToJsonTuple.IObject",

--- a/test/schemas/json/ajv/TupleHierarchical.json
+++ b/test/schemas/json/ajv/TupleHierarchical.json
@@ -70,17 +70,23 @@
                     ],
                     "x-typia-rest": false,
                     "x-typia-required": true,
-                    "x-typia-optional": false
+                    "x-typia-optional": false,
+                    "minItems": 2,
+                    "maxItems": 2
                   }
                 ],
                 "x-typia-rest": false,
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "minItems": 2,
+                "maxItems": 2
               }
             ],
             "x-typia-rest": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "minItems": 3,
+            "maxItems": 3
           },
           {
             "type": "array",
@@ -149,26 +155,36 @@
                             ],
                             "x-typia-rest": false,
                             "x-typia-required": true,
-                            "x-typia-optional": false
+                            "x-typia-optional": false,
+                            "minItems": 2,
+                            "maxItems": 2
                           }
                         ],
                         "x-typia-rest": false,
                         "x-typia-required": true,
-                        "x-typia-optional": false
+                        "x-typia-optional": false,
+                        "minItems": 3,
+                        "maxItems": 3
                       }
                     }
                   ],
                   "x-typia-rest": false,
                   "x-typia-required": true,
-                  "x-typia-optional": false
+                  "x-typia-optional": false,
+                  "minItems": 3,
+                  "maxItems": 3
                 }
               }
             ],
             "x-typia-rest": false,
             "x-typia-required": true,
-            "x-typia-optional": false
+            "x-typia-optional": false,
+            "minItems": 2,
+            "maxItems": 2
           }
-        ]
+        ],
+        "minItems": 5,
+        "maxItems": 5
       }
     }
   },

--- a/test/schemas/json/ajv/TupleRestArray.json
+++ b/test/schemas/json/ajv/TupleRestArray.json
@@ -9,32 +9,53 @@
       "TupleRestArray": {
         "$id": "#/components/schemas/TupleRestArray",
         "type": "array",
-        "items": [
-          {
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "boolean"
-          },
-          {
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          {
-            "x-typia-rest": true,
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "array",
-            "items": {
+        "items": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "minItems": 2,
+        "x-typia-tuple": {
+          "type": "array",
+          "items": [
+            {
+              "x-typia-rest": false,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "boolean"
+            },
+            {
+              "x-typia-rest": false,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            },
+            {
               "x-typia-rest": true,
               "x-typia-required": true,
               "x-typia-optional": false,
-              "type": "string"
+              "type": "array",
+              "items": {
+                "x-typia-rest": true,
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "string"
+              }
             }
-          }
-        ]
+          ],
+          "minItems": 2
+        }
       }
     }
   },

--- a/test/schemas/json/ajv/TupleRestAtomic.json
+++ b/test/schemas/json/ajv/TupleRestAtomic.json
@@ -9,26 +9,44 @@
       "TupleRestAtomic": {
         "$id": "#/components/schemas/TupleRestAtomic",
         "type": "array",
-        "items": [
-          {
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "boolean"
-          },
-          {
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          {
-            "x-typia-rest": true,
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string"
-          }
-        ]
+        "items": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "minItems": 2,
+        "x-typia-tuple": {
+          "type": "array",
+          "items": [
+            {
+              "x-typia-rest": false,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "boolean"
+            },
+            {
+              "x-typia-rest": false,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            },
+            {
+              "x-typia-rest": true,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string"
+            }
+          ],
+          "minItems": 2
+        }
       }
     }
   },

--- a/test/schemas/json/ajv/TupleRestObject.json
+++ b/test/schemas/json/ajv/TupleRestObject.json
@@ -9,23 +9,41 @@
       "TupleRestObject": {
         "$id": "#/components/schemas/TupleRestObject",
         "type": "array",
-        "items": [
-          {
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "boolean"
-          },
-          {
-            "x-typia-rest": false,
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          {
-            "$ref": "#/components/schemas/TupleRestObject.IObject"
-          }
-        ]
+        "items": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/components/schemas/TupleRestObject.IObject"
+            }
+          ]
+        },
+        "minItems": 2,
+        "x-typia-tuple": {
+          "type": "array",
+          "items": [
+            {
+              "x-typia-rest": false,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "boolean"
+            },
+            {
+              "x-typia-rest": false,
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            },
+            {
+              "$ref": "#/components/schemas/TupleRestObject.IObject"
+            }
+          ],
+          "minItems": 2
+        }
       },
       "TupleRestObject.IObject": {
         "$id": "#/components/schemas/TupleRestObject.IObject",

--- a/test/schemas/json/ajv/UltimateUnion.json
+++ b/test/schemas/json/ajv/UltimateUnion.json
@@ -70,19 +70,16 @@
             "$ref": "#/components/schemas/IJsonSchema.IString"
           },
           {
-            "$recursiveRef": "#/components/schemas/IJsonSchema.IArray"
+            "$ref": "#/components/schemas/IJsonSchema.IArray"
           },
           {
-            "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple"
+            "$ref": "#/components/schemas/IJsonSchema.ITuple"
           },
           {
-            "$recursiveRef": "#/components/schemas/IJsonSchema.IOneOf"
+            "$ref": "#/components/schemas/IJsonSchema.IOneOf"
           },
           {
             "$ref": "#/components/schemas/IJsonSchema.IReference"
-          },
-          {
-            "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference"
           },
           {
             "$ref": "#/components/schemas/IJsonSchema.INullOnly"
@@ -1283,7 +1280,6 @@
       },
       "IJsonSchema.IArray": {
         "$id": "#/components/schemas/IJsonSchema.IArray",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "items": {
@@ -1338,7 +1334,7 @@
             "minimum": 0
           },
           "x-typia-tuple": {
-            "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple"
+            "$ref": "#/components/schemas/IJsonSchema.ITuple"
           },
           "type": {
             "x-typia-required": true,
@@ -1410,7 +1406,6 @@
       },
       "IJsonSchema.ITuple": {
         "$id": "#/components/schemas/IJsonSchema.ITuple",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "items": {
@@ -1420,6 +1415,54 @@
             "items": {
               "$ref": "#/components/schemas/IJsonSchema"
             }
+          },
+          "minItems": {
+            "description": "@type uint",
+            "x-typia-metaTags": [
+              {
+                "kind": "type",
+                "value": "uint"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "type",
+                "text": [
+                  {
+                    "text": "uint",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "integer",
+            "minimum": 0
+          },
+          "maxItems": {
+            "description": "@type uint",
+            "x-typia-metaTags": [
+              {
+                "kind": "type",
+                "value": "uint"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "type",
+                "text": [
+                  {
+                    "text": "uint",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "integer",
+            "minimum": 0
           },
           "type": {
             "x-typia-required": true,
@@ -1484,13 +1527,14 @@
         },
         "required": [
           "items",
+          "minItems",
           "type"
         ],
+        "description": "@type uint",
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IOneOf": {
         "$id": "#/components/schemas/IJsonSchema.IOneOf",
-        "$recursiveAnchor": true,
         "type": "object",
         "properties": {
           "oneOf": {
@@ -1611,67 +1655,6 @@
         },
         "required": [
           "$ref"
-        ],
-        "x-typia-jsDocTags": []
-      },
-      "IJsonSchema.IRecursiveReference": {
-        "$id": "#/components/schemas/IJsonSchema.IRecursiveReference",
-        "type": "object",
-        "properties": {
-          "$recursiveRef": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string"
-          },
-          "deprecated": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "title": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "string"
-          },
-          "description": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "string"
-          },
-          "x-typia-metaTags": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IMetadataTag"
-            }
-          },
-          "x-typia-jsDocTags": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IJsDocTagInfo"
-            }
-          },
-          "x-typia-required": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "x-typia-optional": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "x-typia-rest": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "$recursiveRef"
         ],
         "x-typia-jsDocTags": []
       },
@@ -1846,9 +1829,6 @@
               "$ref": "#/components/schemas/IReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
             },
             {
-              "$ref": "#/components/schemas/IRecursiveReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
-            },
-            {
               "$ref": "#/components/schemas/IUnknown_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
             },
             {
@@ -1867,11 +1847,6 @@
             "x-typia-required": false,
             "x-typia-optional": true,
             "type": "string"
-          },
-          "$recursiveAnchor": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
           },
           "type": {
             "x-typia-required": true,
@@ -1917,19 +1892,16 @@
                 "$ref": "#/components/schemas/IJsonSchema.IString"
               },
               {
-                "$recursiveRef": "#/components/schemas/IJsonSchema.IArray"
+                "$ref": "#/components/schemas/IJsonSchema.IArray"
               },
               {
-                "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple"
+                "$ref": "#/components/schemas/IJsonSchema.ITuple"
               },
               {
-                "$recursiveRef": "#/components/schemas/IJsonSchema.IOneOf"
+                "$ref": "#/components/schemas/IJsonSchema.IOneOf"
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IReference"
-              },
-              {
-                "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference"
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IUnknown"
@@ -1991,19 +1963,16 @@
                 "$ref": "#/components/schemas/IJsonSchema.IString"
               },
               {
-                "$recursiveRef": "#/components/schemas/IJsonSchema.IArray"
+                "$ref": "#/components/schemas/IJsonSchema.IArray"
               },
               {
-                "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple"
+                "$ref": "#/components/schemas/IJsonSchema.ITuple"
               },
               {
-                "$recursiveRef": "#/components/schemas/IJsonSchema.IOneOf"
+                "$ref": "#/components/schemas/IJsonSchema.IOneOf"
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IReference"
-              },
-              {
-                "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference"
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IUnknown"
@@ -2878,7 +2847,7 @@
             "minimum": 0
           },
           "x-typia-tuple": {
-            "$recursiveRef": "#/components/schemas/IJsonSchema.ITuple"
+            "$ref": "#/components/schemas/IJsonSchema.ITuple"
           },
           "type": {
             "x-typia-required": true,
@@ -2969,6 +2938,54 @@
               "$ref": "#/components/schemas/IJsonSchema"
             }
           },
+          "minItems": {
+            "description": "@type uint",
+            "x-typia-metaTags": [
+              {
+                "kind": "type",
+                "value": "uint"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "type",
+                "text": [
+                  {
+                    "text": "uint",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "integer",
+            "minimum": 0
+          },
+          "maxItems": {
+            "description": "@type uint",
+            "x-typia-metaTags": [
+              {
+                "kind": "type",
+                "value": "uint"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "type",
+                "text": [
+                  {
+                    "text": "uint",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "integer",
+            "minimum": 0
+          },
           "type": {
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -3042,6 +3059,7 @@
         },
         "required": [
           "items",
+          "minItems",
           "type"
         ],
         "x-typia-jsDocTags": []
@@ -3188,77 +3206,6 @@
         },
         "required": [
           "$ref"
-        ],
-        "x-typia-jsDocTags": []
-      },
-      "IRecursiveReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IRecursiveReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
-        "type": "object",
-        "properties": {
-          "$recursiveRef": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string"
-          },
-          "deprecated": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "title": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "string"
-          },
-          "description": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "string"
-          },
-          "x-typia-metaTags": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IMetadataTag"
-            }
-          },
-          "x-typia-jsDocTags": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IJsDocTagInfo"
-            }
-          },
-          "x-typia-required": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "x-typia-optional": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "x-typia-rest": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "$id": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "string"
-          },
-          "$recursiveAnchor": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "$recursiveRef"
         ],
         "x-typia-jsDocTags": []
       },

--- a/test/schemas/json/swagger/ArrayAtomicAlias.json
+++ b/test/schemas/json/swagger/ArrayAtomicAlias.json
@@ -21,6 +21,8 @@
             }
           ]
         },
+        "minItems": 3,
+        "maxItems": 3,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -33,7 +35,9 @@
             {
               "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_string_gt_"
             }
-          ]
+          ],
+          "minItems": 3,
+          "maxItems": 3
         }
       },
       "ArrayAtomicAlias.Alias_lt_boolean_gt_": {

--- a/test/schemas/json/swagger/ArrayAtomicSimple.json
+++ b/test/schemas/json/swagger/ArrayAtomicSimple.json
@@ -30,6 +30,8 @@
             }
           ]
         },
+        "minItems": 3,
+        "maxItems": 3,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -69,7 +71,9 @@
                 "type": "string"
               }
             }
-          ]
+          ],
+          "minItems": 3,
+          "maxItems": 3
         }
       }
     }

--- a/test/schemas/json/swagger/ArrayRepeatedUnionWithTuple.json
+++ b/test/schemas/json/swagger/ArrayRepeatedUnionWithTuple.json
@@ -47,6 +47,8 @@
                 }
               ]
             },
+            "minItems": 3,
+            "maxItems": 3,
             "x-typia-tuple": {
               "type": "array",
               "items": [
@@ -68,7 +70,9 @@
                   "x-typia-optional": false,
                   "type": "boolean"
                 }
-              ]
+              ],
+              "minItems": 3,
+              "maxItems": 3
             }
           },
           {
@@ -83,6 +87,8 @@
                 }
               ]
             },
+            "minItems": 2,
+            "maxItems": 2,
             "x-typia-tuple": {
               "type": "array",
               "items": [
@@ -92,7 +98,9 @@
                 {
                   "$ref": "#/components/schemas/ArrayRepeatedUnionWithTuple.IPoint3D"
                 }
-              ]
+              ],
+              "minItems": 2,
+              "maxItems": 2
             }
           }
         ]

--- a/test/schemas/json/swagger/AtomicAlias.json
+++ b/test/schemas/json/swagger/AtomicAlias.json
@@ -21,6 +21,8 @@
             }
           ]
         },
+        "minItems": 3,
+        "maxItems": 3,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -42,7 +44,9 @@
               "x-typia-optional": false,
               "type": "string"
             }
-          ]
+          ],
+          "minItems": 3,
+          "maxItems": 3
         }
       }
     }

--- a/test/schemas/json/swagger/AtomicClass.json
+++ b/test/schemas/json/swagger/AtomicClass.json
@@ -21,6 +21,8 @@
             }
           ]
         },
+        "minItems": 9,
+        "maxItems": 9,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -78,7 +80,9 @@
               "x-typia-optional": false,
               "type": "string"
             }
-          ]
+          ],
+          "minItems": 9,
+          "maxItems": 9
         }
       }
     }

--- a/test/schemas/json/swagger/AtomicIntersection.json
+++ b/test/schemas/json/swagger/AtomicIntersection.json
@@ -21,6 +21,8 @@
             }
           ]
         },
+        "minItems": 3,
+        "maxItems": 3,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -33,7 +35,9 @@
             {
               "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_string_gt_"
             }
-          ]
+          ],
+          "minItems": 3,
+          "maxItems": 3
         }
       },
       "AtomicIntersection.Wrapper_lt_boolean_gt_": {

--- a/test/schemas/json/swagger/AtomicSimple.json
+++ b/test/schemas/json/swagger/AtomicSimple.json
@@ -21,6 +21,8 @@
             }
           ]
         },
+        "minItems": 3,
+        "maxItems": 3,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -42,7 +44,9 @@
               "x-typia-optional": false,
               "type": "string"
             }
-          ]
+          ],
+          "minItems": 3,
+          "maxItems": 3
         }
       }
     }

--- a/test/schemas/json/swagger/ConstantAtomicSimple.json
+++ b/test/schemas/json/swagger/ConstantAtomicSimple.json
@@ -31,6 +31,8 @@
             }
           ]
         },
+        "minItems": 4,
+        "maxItems": 4,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -70,7 +72,9 @@
                 "three"
               ]
             }
-          ]
+          ],
+          "minItems": 4,
+          "maxItems": 4
         }
       }
     }

--- a/test/schemas/json/swagger/ConstantAtomicWrapper.json
+++ b/test/schemas/json/swagger/ConstantAtomicWrapper.json
@@ -21,6 +21,8 @@
             }
           ]
         },
+        "minItems": 3,
+        "maxItems": 3,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -33,7 +35,9 @@
             {
               "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_string_gt_"
             }
-          ]
+          ],
+          "minItems": 3,
+          "maxItems": 3
         }
       },
       "ConstantAtomicWrapper.IPointer_lt_boolean_gt_": {

--- a/test/schemas/json/swagger/ConstantIntersection.json
+++ b/test/schemas/json/swagger/ConstantIntersection.json
@@ -21,6 +21,8 @@
             }
           ]
         },
+        "minItems": 3,
+        "maxItems": 3,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -33,7 +35,9 @@
             {
               "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_"
             }
-          ]
+          ],
+          "minItems": 3,
+          "maxItems": 3
         }
       },
       "ConstantIntersection.Wrapper_lt_false_gt_": {

--- a/test/schemas/json/swagger/ObjectGeneric.json
+++ b/test/schemas/json/swagger/ObjectGeneric.json
@@ -21,6 +21,8 @@
             }
           ]
         },
+        "minItems": 3,
+        "maxItems": 3,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -33,7 +35,9 @@
             {
               "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_string_gt_"
             }
-          ]
+          ],
+          "minItems": 3,
+          "maxItems": 3
         }
       },
       "ObjectGeneric.ISomething_lt_boolean_gt_": {

--- a/test/schemas/json/swagger/ObjectHierarchical.json
+++ b/test/schemas/json/swagger/ObjectHierarchical.json
@@ -42,6 +42,8 @@
             },
             "x-typia-required": true,
             "x-typia-optional": false,
+            "minItems": 4,
+            "maxItems": 4,
             "x-typia-tuple": {
               "type": "array",
               "items": [
@@ -71,7 +73,9 @@
                 }
               ],
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "minItems": 4,
+              "maxItems": 4
             }
           },
           "created_at": {

--- a/test/schemas/json/swagger/ObjectNullable.json
+++ b/test/schemas/json/swagger/ObjectNullable.json
@@ -11,6 +11,8 @@
         "items": {
           "$ref": "#/components/schemas/ObjectNullable.IProduct"
         },
+        "minItems": 3,
+        "maxItems": 3,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -23,7 +25,9 @@
             {
               "$ref": "#/components/schemas/ObjectNullable.IProduct"
             }
-          ]
+          ],
+          "minItems": 3,
+          "maxItems": 3
         }
       },
       "ObjectNullable.IProduct": {

--- a/test/schemas/json/swagger/ObjectPropertyNullable.json
+++ b/test/schemas/json/swagger/ObjectPropertyNullable.json
@@ -36,6 +36,8 @@
             }
           ]
         },
+        "minItems": 4,
+        "maxItems": 4,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -75,7 +77,9 @@
                 "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_"
               }
             }
-          ]
+          ],
+          "minItems": 4,
+          "maxItems": 4
         }
       },
       "ObjectPropertyNullable.IPointer_lt_boolean_gt_": {

--- a/test/schemas/json/swagger/ObjectTuple.json
+++ b/test/schemas/json/swagger/ObjectTuple.json
@@ -18,6 +18,8 @@
             }
           ]
         },
+        "minItems": 2,
+        "maxItems": 2,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -27,7 +29,9 @@
             {
               "$ref": "#/components/schemas/ObjectTuple.ICitizen"
             }
-          ]
+          ],
+          "minItems": 2,
+          "maxItems": 2
         }
       },
       "ObjectTuple.ISection": {

--- a/test/schemas/json/swagger/TagTuple.json
+++ b/test/schemas/json/swagger/TagTuple.json
@@ -725,6 +725,8 @@
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
+            "minItems": 4,
+            "maxItems": 4,
             "x-typia-tuple": {
               "type": "array",
               "items": [
@@ -1359,7 +1361,9 @@
                 }
               ],
               "x-typia-required": true,
-              "x-typia-optional": false
+              "x-typia-optional": false,
+              "minItems": 4,
+              "maxItems": 4
             }
           }
         },

--- a/test/schemas/json/swagger/ToJsonArray.json
+++ b/test/schemas/json/swagger/ToJsonArray.json
@@ -36,6 +36,8 @@
             }
           ]
         },
+        "minItems": 4,
+        "maxItems": 4,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -84,7 +86,9 @@
                 "$ref": "#/components/schemas/ToJsonArray.IObject"
               }
             }
-          ]
+          ],
+          "minItems": 4,
+          "maxItems": 4
         }
       },
       "ToJsonArray.IObject": {

--- a/test/schemas/json/swagger/ToJsonAtomicSimple.json
+++ b/test/schemas/json/swagger/ToJsonAtomicSimple.json
@@ -21,6 +21,8 @@
             }
           ]
         },
+        "minItems": 3,
+        "maxItems": 3,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -42,7 +44,9 @@
               "x-typia-optional": false,
               "type": "string"
             }
-          ]
+          ],
+          "minItems": 3,
+          "maxItems": 3
         }
       }
     }

--- a/test/schemas/json/swagger/ToJsonTuple.json
+++ b/test/schemas/json/swagger/ToJsonTuple.json
@@ -24,6 +24,8 @@
             }
           ]
         },
+        "minItems": 4,
+        "maxItems": 4,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -48,7 +50,9 @@
             {
               "$ref": "#/components/schemas/ToJsonTuple.IObject"
             }
-          ]
+          ],
+          "minItems": 4,
+          "maxItems": 4
         }
       },
       "ToJsonTuple.IObject": {

--- a/test/schemas/json/swagger/TupleHierarchical.json
+++ b/test/schemas/json/swagger/TupleHierarchical.json
@@ -45,6 +45,8 @@
                               }
                             ]
                           },
+                          "minItems": 2,
+                          "maxItems": 2,
                           "x-typia-tuple": {
                             "type": "array",
                             "items": [
@@ -60,11 +62,15 @@
                                 "x-typia-optional": false,
                                 "type": "string"
                               }
-                            ]
+                            ],
+                            "minItems": 2,
+                            "maxItems": 2
                           }
                         }
                       ]
                     },
+                    "minItems": 2,
+                    "maxItems": 2,
                     "x-typia-tuple": {
                       "type": "array",
                       "items": [
@@ -98,6 +104,8 @@
                           "x-typia-rest": false,
                           "x-typia-required": true,
                           "x-typia-optional": false,
+                          "minItems": 2,
+                          "maxItems": 2,
                           "x-typia-tuple": {
                             "type": "array",
                             "items": [
@@ -116,15 +124,21 @@
                             ],
                             "x-typia-rest": false,
                             "x-typia-required": true,
-                            "x-typia-optional": false
+                            "x-typia-optional": false,
+                            "minItems": 2,
+                            "maxItems": 2
                           }
                         }
-                      ]
+                      ],
+                      "minItems": 2,
+                      "maxItems": 2
                     },
                     "nullable": true
                   }
                 ]
               },
+              "minItems": 3,
+              "maxItems": 3,
               "x-typia-tuple": {
                 "type": "array",
                 "items": [
@@ -174,6 +188,8 @@
                           "x-typia-rest": false,
                           "x-typia-required": true,
                           "x-typia-optional": false,
+                          "minItems": 2,
+                          "maxItems": 2,
                           "x-typia-tuple": {
                             "type": "array",
                             "items": [
@@ -192,7 +208,9 @@
                             ],
                             "x-typia-rest": false,
                             "x-typia-required": true,
-                            "x-typia-optional": false
+                            "x-typia-optional": false,
+                            "minItems": 2,
+                            "maxItems": 2
                           }
                         }
                       ],
@@ -203,6 +221,8 @@
                     "x-typia-rest": false,
                     "x-typia-required": true,
                     "x-typia-optional": false,
+                    "minItems": 2,
+                    "maxItems": 2,
                     "x-typia-tuple": {
                       "type": "array",
                       "items": [
@@ -236,6 +256,8 @@
                           "x-typia-rest": false,
                           "x-typia-required": true,
                           "x-typia-optional": false,
+                          "minItems": 2,
+                          "maxItems": 2,
                           "x-typia-tuple": {
                             "type": "array",
                             "items": [
@@ -254,16 +276,22 @@
                             ],
                             "x-typia-rest": false,
                             "x-typia-required": true,
-                            "x-typia-optional": false
+                            "x-typia-optional": false,
+                            "minItems": 2,
+                            "maxItems": 2
                           }
                         }
                       ],
                       "x-typia-rest": false,
                       "x-typia-required": true,
-                      "x-typia-optional": false
+                      "x-typia-optional": false,
+                      "minItems": 2,
+                      "maxItems": 2
                     }
                   }
-                ]
+                ],
+                "minItems": 3,
+                "maxItems": 3
               },
               "nullable": true
             },
@@ -307,6 +335,8 @@
                                         }
                                       ]
                                     },
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -322,11 +352,15 @@
                                           "x-typia-optional": false,
                                           "type": "string"
                                         }
-                                      ]
+                                      ],
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ]
                               },
+                              "minItems": 3,
+                              "maxItems": 3,
                               "x-typia-tuple": {
                                 "type": "array",
                                 "items": [
@@ -366,6 +400,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -384,15 +420,21 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
-                                ]
+                                ],
+                                "minItems": 3,
+                                "maxItems": 3
                               }
                             }
                           }
                         ]
                       },
+                      "minItems": 3,
+                      "maxItems": 3,
                       "x-typia-tuple": {
                         "type": "array",
                         "items": [
@@ -447,6 +489,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -465,7 +509,9 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
@@ -476,6 +522,8 @@
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false,
+                              "minItems": 3,
+                              "maxItems": 3,
                               "x-typia-tuple": {
                                 "type": "array",
                                 "items": [
@@ -515,6 +563,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -533,22 +583,30 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
                                 "x-typia-rest": false,
                                 "x-typia-required": true,
-                                "x-typia-optional": false
+                                "x-typia-optional": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               }
                             }
                           }
-                        ]
+                        ],
+                        "minItems": 3,
+                        "maxItems": 3
                       }
                     }
                   }
                 ]
               },
+              "minItems": 2,
+              "maxItems": 2,
               "x-typia-tuple": {
                 "type": "array",
                 "items": [
@@ -618,6 +676,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -636,7 +696,9 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
@@ -647,6 +709,8 @@
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false,
+                              "minItems": 3,
+                              "maxItems": 3,
                               "x-typia-tuple": {
                                 "type": "array",
                                 "items": [
@@ -686,6 +750,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -704,13 +770,17 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
                                 "x-typia-rest": false,
                                 "x-typia-required": true,
-                                "x-typia-optional": false
+                                "x-typia-optional": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               }
                             }
                           }
@@ -722,6 +792,8 @@
                       "x-typia-rest": false,
                       "x-typia-required": true,
                       "x-typia-optional": false,
+                      "minItems": 3,
+                      "maxItems": 3,
                       "x-typia-tuple": {
                         "type": "array",
                         "items": [
@@ -776,6 +848,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -794,7 +868,9 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
@@ -805,6 +881,8 @@
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false,
+                              "minItems": 3,
+                              "maxItems": 3,
                               "x-typia-tuple": {
                                 "type": "array",
                                 "items": [
@@ -844,6 +922,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -862,29 +942,39 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
                                 "x-typia-rest": false,
                                 "x-typia-required": true,
-                                "x-typia-optional": false
+                                "x-typia-optional": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               }
                             }
                           }
                         ],
                         "x-typia-rest": false,
                         "x-typia-required": true,
-                        "x-typia-optional": false
+                        "x-typia-optional": false,
+                        "minItems": 3,
+                        "maxItems": 3
                       }
                     }
                   }
-                ]
+                ],
+                "minItems": 2,
+                "maxItems": 2
               },
               "nullable": true
             }
           ]
         },
+        "minItems": 5,
+        "maxItems": 5,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -951,6 +1041,8 @@
                           "x-typia-rest": false,
                           "x-typia-required": true,
                           "x-typia-optional": false,
+                          "minItems": 2,
+                          "maxItems": 2,
                           "x-typia-tuple": {
                             "type": "array",
                             "items": [
@@ -969,7 +1061,9 @@
                             ],
                             "x-typia-rest": false,
                             "x-typia-required": true,
-                            "x-typia-optional": false
+                            "x-typia-optional": false,
+                            "minItems": 2,
+                            "maxItems": 2
                           }
                         }
                       ],
@@ -980,6 +1074,8 @@
                     "x-typia-rest": false,
                     "x-typia-required": true,
                     "x-typia-optional": false,
+                    "minItems": 2,
+                    "maxItems": 2,
                     "x-typia-tuple": {
                       "type": "array",
                       "items": [
@@ -1013,6 +1109,8 @@
                           "x-typia-rest": false,
                           "x-typia-required": true,
                           "x-typia-optional": false,
+                          "minItems": 2,
+                          "maxItems": 2,
                           "x-typia-tuple": {
                             "type": "array",
                             "items": [
@@ -1031,13 +1129,17 @@
                             ],
                             "x-typia-rest": false,
                             "x-typia-required": true,
-                            "x-typia-optional": false
+                            "x-typia-optional": false,
+                            "minItems": 2,
+                            "maxItems": 2
                           }
                         }
                       ],
                       "x-typia-rest": false,
                       "x-typia-required": true,
-                      "x-typia-optional": false
+                      "x-typia-optional": false,
+                      "minItems": 2,
+                      "maxItems": 2
                     },
                     "nullable": true
                   }
@@ -1049,6 +1151,8 @@
               "x-typia-rest": false,
               "x-typia-required": true,
               "x-typia-optional": false,
+              "minItems": 3,
+              "maxItems": 3,
               "x-typia-tuple": {
                 "type": "array",
                 "items": [
@@ -1098,6 +1202,8 @@
                           "x-typia-rest": false,
                           "x-typia-required": true,
                           "x-typia-optional": false,
+                          "minItems": 2,
+                          "maxItems": 2,
                           "x-typia-tuple": {
                             "type": "array",
                             "items": [
@@ -1116,7 +1222,9 @@
                             ],
                             "x-typia-rest": false,
                             "x-typia-required": true,
-                            "x-typia-optional": false
+                            "x-typia-optional": false,
+                            "minItems": 2,
+                            "maxItems": 2
                           }
                         }
                       ],
@@ -1127,6 +1235,8 @@
                     "x-typia-rest": false,
                     "x-typia-required": true,
                     "x-typia-optional": false,
+                    "minItems": 2,
+                    "maxItems": 2,
                     "x-typia-tuple": {
                       "type": "array",
                       "items": [
@@ -1160,6 +1270,8 @@
                           "x-typia-rest": false,
                           "x-typia-required": true,
                           "x-typia-optional": false,
+                          "minItems": 2,
+                          "maxItems": 2,
                           "x-typia-tuple": {
                             "type": "array",
                             "items": [
@@ -1178,19 +1290,25 @@
                             ],
                             "x-typia-rest": false,
                             "x-typia-required": true,
-                            "x-typia-optional": false
+                            "x-typia-optional": false,
+                            "minItems": 2,
+                            "maxItems": 2
                           }
                         }
                       ],
                       "x-typia-rest": false,
                       "x-typia-required": true,
-                      "x-typia-optional": false
+                      "x-typia-optional": false,
+                      "minItems": 2,
+                      "maxItems": 2
                     }
                   }
                 ],
                 "x-typia-rest": false,
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "minItems": 3,
+                "maxItems": 3
               }
             },
             {
@@ -1263,6 +1381,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -1281,7 +1401,9 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
@@ -1292,6 +1414,8 @@
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false,
+                              "minItems": 3,
+                              "maxItems": 3,
                               "x-typia-tuple": {
                                 "type": "array",
                                 "items": [
@@ -1331,6 +1455,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -1349,13 +1475,17 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
                                 "x-typia-rest": false,
                                 "x-typia-required": true,
-                                "x-typia-optional": false
+                                "x-typia-optional": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               }
                             }
                           }
@@ -1367,6 +1497,8 @@
                       "x-typia-rest": false,
                       "x-typia-required": true,
                       "x-typia-optional": false,
+                      "minItems": 3,
+                      "maxItems": 3,
                       "x-typia-tuple": {
                         "type": "array",
                         "items": [
@@ -1421,6 +1553,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -1439,7 +1573,9 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
@@ -1450,6 +1586,8 @@
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false,
+                              "minItems": 3,
+                              "maxItems": 3,
                               "x-typia-tuple": {
                                 "type": "array",
                                 "items": [
@@ -1489,6 +1627,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -1507,20 +1647,26 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
                                 "x-typia-rest": false,
                                 "x-typia-required": true,
-                                "x-typia-optional": false
+                                "x-typia-optional": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               }
                             }
                           }
                         ],
                         "x-typia-rest": false,
                         "x-typia-required": true,
-                        "x-typia-optional": false
+                        "x-typia-optional": false,
+                        "minItems": 3,
+                        "maxItems": 3
                       }
                     }
                   }
@@ -1532,6 +1678,8 @@
               "x-typia-rest": false,
               "x-typia-required": true,
               "x-typia-optional": false,
+              "minItems": 2,
+              "maxItems": 2,
               "x-typia-tuple": {
                 "type": "array",
                 "items": [
@@ -1601,6 +1749,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -1619,7 +1769,9 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
@@ -1630,6 +1782,8 @@
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false,
+                              "minItems": 3,
+                              "maxItems": 3,
                               "x-typia-tuple": {
                                 "type": "array",
                                 "items": [
@@ -1669,6 +1823,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -1687,13 +1843,17 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
                                 "x-typia-rest": false,
                                 "x-typia-required": true,
-                                "x-typia-optional": false
+                                "x-typia-optional": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               }
                             }
                           }
@@ -1705,6 +1865,8 @@
                       "x-typia-rest": false,
                       "x-typia-required": true,
                       "x-typia-optional": false,
+                      "minItems": 3,
+                      "maxItems": 3,
                       "x-typia-tuple": {
                         "type": "array",
                         "items": [
@@ -1759,6 +1921,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -1777,7 +1941,9 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
@@ -1788,6 +1954,8 @@
                               "x-typia-rest": false,
                               "x-typia-required": true,
                               "x-typia-optional": false,
+                              "minItems": 3,
+                              "maxItems": 3,
                               "x-typia-tuple": {
                                 "type": "array",
                                 "items": [
@@ -1827,6 +1995,8 @@
                                     "x-typia-rest": false,
                                     "x-typia-required": true,
                                     "x-typia-optional": false,
+                                    "minItems": 2,
+                                    "maxItems": 2,
                                     "x-typia-tuple": {
                                       "type": "array",
                                       "items": [
@@ -1845,30 +2015,40 @@
                                       ],
                                       "x-typia-rest": false,
                                       "x-typia-required": true,
-                                      "x-typia-optional": false
+                                      "x-typia-optional": false,
+                                      "minItems": 2,
+                                      "maxItems": 2
                                     }
                                   }
                                 ],
                                 "x-typia-rest": false,
                                 "x-typia-required": true,
-                                "x-typia-optional": false
+                                "x-typia-optional": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               }
                             }
                           }
                         ],
                         "x-typia-rest": false,
                         "x-typia-required": true,
-                        "x-typia-optional": false
+                        "x-typia-optional": false,
+                        "minItems": 3,
+                        "maxItems": 3
                       }
                     }
                   }
                 ],
                 "x-typia-rest": false,
                 "x-typia-required": true,
-                "x-typia-optional": false
+                "x-typia-optional": false,
+                "minItems": 2,
+                "maxItems": 2
               }
             }
-          ]
+          ],
+          "minItems": 5,
+          "maxItems": 5
         }
       }
     }

--- a/test/schemas/json/swagger/TupleRestArray.json
+++ b/test/schemas/json/swagger/TupleRestArray.json
@@ -24,6 +24,7 @@
             }
           ]
         },
+        "minItems": 2,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -51,7 +52,8 @@
                 "type": "string"
               }
             }
-          ]
+          ],
+          "minItems": 2
         }
       }
     }

--- a/test/schemas/json/swagger/TupleRestAtomic.json
+++ b/test/schemas/json/swagger/TupleRestAtomic.json
@@ -21,6 +21,7 @@
             }
           ]
         },
+        "minItems": 2,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -42,7 +43,8 @@
               "x-typia-optional": false,
               "type": "string"
             }
-          ]
+          ],
+          "minItems": 2
         }
       }
     }

--- a/test/schemas/json/swagger/TupleRestObject.json
+++ b/test/schemas/json/swagger/TupleRestObject.json
@@ -21,6 +21,7 @@
             }
           ]
         },
+        "minItems": 2,
         "x-typia-tuple": {
           "type": "array",
           "items": [
@@ -39,7 +40,8 @@
             {
               "$ref": "#/components/schemas/TupleRestObject.IObject"
             }
-          ]
+          ],
+          "minItems": 2
         }
       },
       "TupleRestObject.IObject": {

--- a/test/schemas/json/swagger/UltimateUnion.json
+++ b/test/schemas/json/swagger/UltimateUnion.json
@@ -80,9 +80,6 @@
             "$ref": "#/components/schemas/IJsonSchema.IReference"
           },
           {
-            "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference"
-          },
-          {
             "$ref": "#/components/schemas/IJsonSchema.INullOnly"
           },
           {
@@ -1415,6 +1412,54 @@
               "$ref": "#/components/schemas/IJsonSchema"
             }
           },
+          "minItems": {
+            "description": "@type uint",
+            "x-typia-metaTags": [
+              {
+                "kind": "type",
+                "value": "uint"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "type",
+                "text": [
+                  {
+                    "text": "uint",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "integer",
+            "minimum": 0
+          },
+          "maxItems": {
+            "description": "@type uint",
+            "x-typia-metaTags": [
+              {
+                "kind": "type",
+                "value": "uint"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "type",
+                "text": [
+                  {
+                    "text": "uint",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "integer",
+            "minimum": 0
+          },
           "type": {
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -1479,8 +1524,10 @@
         "nullable": false,
         "required": [
           "items",
+          "minItems",
           "type"
         ],
+        "description": "@type uint",
         "x-typia-jsDocTags": []
       },
       "IJsonSchema.IOneOf": {
@@ -1605,67 +1652,6 @@
         "nullable": false,
         "required": [
           "$ref"
-        ],
-        "x-typia-jsDocTags": []
-      },
-      "IJsonSchema.IRecursiveReference": {
-        "type": "object",
-        "properties": {
-          "$recursiveRef": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string"
-          },
-          "deprecated": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "title": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "string"
-          },
-          "description": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "string"
-          },
-          "x-typia-metaTags": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IMetadataTag"
-            }
-          },
-          "x-typia-jsDocTags": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IJsDocTagInfo"
-            }
-          },
-          "x-typia-required": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "x-typia-optional": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "x-typia-rest": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          }
-        },
-        "nullable": false,
-        "required": [
-          "$recursiveRef"
         ],
         "x-typia-jsDocTags": []
       },
@@ -1840,9 +1826,6 @@
               "$ref": "#/components/schemas/IReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
             },
             {
-              "$ref": "#/components/schemas/IRecursiveReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
-            },
-            {
               "$ref": "#/components/schemas/IUnknown_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
             },
             {
@@ -1891,9 +1874,6 @@
               "$ref": "#/components/schemas/IReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
             },
             {
-              "$ref": "#/components/schemas/IRecursiveReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
-            },
-            {
               "$ref": "#/components/schemas/IUnknown_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
             },
             {
@@ -1911,11 +1891,6 @@
             "x-typia-required": false,
             "x-typia-optional": true,
             "type": "string"
-          },
-          "$recursiveAnchor": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
           },
           "type": {
             "x-typia-required": true,
@@ -1971,9 +1946,6 @@
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IReference"
-              },
-              {
-                "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference"
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IUnknown"
@@ -2045,9 +2017,6 @@
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IReference"
-              },
-              {
-                "$ref": "#/components/schemas/IJsonSchema.IRecursiveReference"
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IUnknown"
@@ -3016,6 +2985,54 @@
               "$ref": "#/components/schemas/IJsonSchema"
             }
           },
+          "minItems": {
+            "description": "@type uint",
+            "x-typia-metaTags": [
+              {
+                "kind": "type",
+                "value": "uint"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "type",
+                "text": [
+                  {
+                    "text": "uint",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "integer",
+            "minimum": 0
+          },
+          "maxItems": {
+            "description": "@type uint",
+            "x-typia-metaTags": [
+              {
+                "kind": "type",
+                "value": "uint"
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "type",
+                "text": [
+                  {
+                    "text": "uint",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": false,
+            "x-typia-optional": true,
+            "type": "integer",
+            "minimum": 0
+          },
           "type": {
             "x-typia-required": true,
             "x-typia-optional": false,
@@ -3090,6 +3107,7 @@
         "nullable": false,
         "required": [
           "items",
+          "minItems",
           "type"
         ],
         "x-typia-jsDocTags": []
@@ -3236,77 +3254,6 @@
         "nullable": false,
         "required": [
           "$ref"
-        ],
-        "x-typia-jsDocTags": []
-      },
-      "IRecursiveReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "type": "object",
-        "properties": {
-          "$recursiveRef": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string"
-          },
-          "deprecated": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "title": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "string"
-          },
-          "description": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "string"
-          },
-          "x-typia-metaTags": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IMetadataTag"
-            }
-          },
-          "x-typia-jsDocTags": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IJsDocTagInfo"
-            }
-          },
-          "x-typia-required": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "x-typia-optional": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "x-typia-rest": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          },
-          "$id": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "string"
-          },
-          "$recursiveAnchor": {
-            "x-typia-required": false,
-            "x-typia-optional": true,
-            "type": "boolean"
-          }
-        },
-        "nullable": false,
-        "required": [
-          "$recursiveRef"
         ],
         "x-typia-jsDocTags": []
       },


### PR DESCRIPTION
From some moment, `ajv` had not used `IJsonSchema.IRecursiveReference` type more. So removed that type from `IJsonSchema` type.

Also, when defining `IJsonSchema.ITuple` type, strict mode of `ajv` forces to define both `minItems` and `maxItems`. Thus, I've defined `IJsonSchema.ITuple` to have and always define those properties