### PR TITLE
Fix #704 - comment tags when repeated type comes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Check out the document in the [website](https://typia.io/docs/):
     - [`parse()` functions](https://typia.io/docs/json/parse/)
     - [JSON Schema](https://typia.io/docs/json/schema)
   - [Random Generator](https://typia.io/docs/random/)
+  - [Miscellaneous](https://typia.io/docs/miscellaneous/)
 
 ### 🔗 Appendix
   - Utillization Cases

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -78,6 +78,7 @@ Check out the document in the [website](https://typia.io/docs/):
     - [`parse()` functions](https://typia.io/docs/json/parse/)
     - [JSON Schema](https://typia.io/docs/json/schema)
   - [Random Generator](https://typia.io/docs/random/)
+  - [Miscellaneous](https://typia.io/docs/miscellaneous/)
 
 ### 🔗 Appendix
   - Utillization Cases

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.1.2"
+    "typia": "4.1.3"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/factories/internal/metadata/emplace_metadata_object.ts
+++ b/src/factories/internal/metadata/emplace_metadata_object.ts
@@ -11,7 +11,6 @@ import { ArrayUtil } from "../../../utils/ArrayUtil";
 import { CommentFactory } from "../../CommentFactory";
 import { MetadataCollection } from "../../MetadataCollection";
 import { MetadataFactory } from "../../MetadataFactory";
-import { MetadataTagFactory } from "../../MetadataTagFactory";
 import { MetadataHelper } from "./MetadataHelper";
 import { explore_metadata } from "./explore_metadata";
 
@@ -44,7 +43,6 @@ export const emplace_metadata_object =
         const insert =
             (key: Metadata) =>
             (value: Metadata) =>
-            (identifier: () => string) =>
             (
                 symbol: ts.Symbol | undefined,
                 filter?: (doc: ts.JSDocTagInfo) => boolean,
@@ -63,9 +61,7 @@ export const emplace_metadata_object =
                     value,
                     description,
                     jsDocTags,
-                    tags: MetadataTagFactory.generate(value)(jsDocTags)(() =>
-                        identifier(),
-                    ),
+                    tags: [],
                 });
                 obj.properties.push(property);
                 return property;
@@ -109,7 +105,7 @@ export const emplace_metadata_object =
             // OPTIONAL, BUT CAN BE RQUIRED BY `Required<T>` TYPE
             if (node?.questionToken && (value.required === false || value.any))
                 Writable(value).optional = true;
-            insert(key)(value)(() => `${obj.name}.${prop.name}`)(prop);
+            insert(key)(value)(prop);
         }
 
         //----
@@ -123,13 +119,14 @@ export const emplace_metadata_object =
             const value: Metadata = analyzer(index.type);
 
             // INSERT WITH REQUIRED CONFIGURATION
-            insert(key)(value)(() => `${obj.name}[${key.getName()}]`)(
+            insert(key)(value)(
                 index.declaration?.parent
                     ? checker.getSymbolAtLocation(index.declaration.parent)
                     : undefined,
                 (doc) => doc.name !== "default",
             );
         }
+
         return obj;
     };
 

--- a/src/factories/internal/metadata/iterate_metadata_collection.ts
+++ b/src/factories/internal/metadata/iterate_metadata_collection.ts
@@ -4,6 +4,7 @@ import { MetadataObject } from "../../../metadata/MetadataObject";
 import { MetadataTuple } from "../../../metadata/MetadataTuple";
 
 import { MetadataCollection } from "../../MetadataCollection";
+import { iterate_metadata_tag } from "./iterate_metadata_tag";
 
 export const iterate_metadata_collection = (
     collection: MetadataCollection,
@@ -22,7 +23,8 @@ export const iterate_metadata_collection = (
                 tuple.elements.some(isTupleRecursive(visited)(tuple)),
             );
         }
-    for (const obj of collection.objects())
+    for (const obj of collection.objects()) {
+        iterate_metadata_tag(obj);
         if (obj.recursive === null) {
             const visited: Set<Metadata> = new Set();
             collection.setObjectRecursive(
@@ -32,6 +34,7 @@ export const iterate_metadata_collection = (
                 ),
             );
         }
+    }
 };
 
 const isArrayRecursive =

--- a/src/factories/internal/metadata/iterate_metadata_tag.ts
+++ b/src/factories/internal/metadata/iterate_metadata_tag.ts
@@ -1,0 +1,31 @@
+import { MetadataObject } from "../../../metadata/MetadataObject";
+
+import { Writable } from "../../../typings/Writable";
+
+import { Escaper } from "../../../utils/Escaper";
+
+import { MetadataTagFactory } from "../../MetadataTagFactory";
+
+export const iterate_metadata_tag = (obj: MetadataObject) => {
+    if (obj.tagged_ === true) return;
+    obj.tagged_ = true;
+
+    for (const prop of obj.properties) {
+        const key: string = prop.key.getName();
+        const variable: string | null =
+            key.length >= 3 &&
+            key[0] === '"' &&
+            key[key.length - 1] === '"' &&
+            Escaper.variable(key.slice(1, -1))
+                ? key.slice(1, -1)
+                : null;
+
+        Writable(prop).tags = MetadataTagFactory.generate(prop.value)(
+            prop.jsDocTags,
+        )(
+            variable !== null
+                ? () => `${obj.name}.${variable}`
+                : () => `${obj.name}[${key}]`,
+        );
+    }
+};

--- a/src/metadata/MetadataObject.ts
+++ b/src/metadata/MetadataObject.ts
@@ -15,13 +15,20 @@ export class MetadataObject {
     public recursive: boolean;
     public nullables: boolean[] = [];
 
+    /**
+     * @internal
+     */
+    public tagged_: boolean = false;
+
     /* -----------------------------------------------------------
         CONSTRUCTORS
     ----------------------------------------------------------- */
     /**
      * @hidden
      */
-    private constructor(props: ClassProperties<MetadataObject>) {
+    private constructor(
+        props: Omit<ClassProperties<MetadataObject>, "tagged_">,
+    ) {
         this.name = props.name;
         this.properties = props.properties;
         this.description = props.description;
@@ -31,12 +38,16 @@ export class MetadataObject {
         this.validated = props.validated;
         this.recursive = props.recursive;
         this.nullables = [];
+
+        this.tagged_ = false;
     }
 
     /**
      * @internal
      */
-    public static create(props: ClassProperties<MetadataObject>) {
+    public static create(
+        props: Omit<ClassProperties<MetadataObject>, "tagged_">,
+    ) {
         return new MetadataObject(props);
     }
 

--- a/test/issues/704.js
+++ b/test/issues/704.js
@@ -1,0 +1,71 @@
+input => {
+    const __is = input => {
+        const $is_custom = typia_1.default.createAssert.is_custom;
+        const $join = typia_1.default.createAssert.join;
+        const $io0 = input => Array.isArray(input.list) && $is_custom("memberof", "array", "MyInterface", input.list) && input.list.every(elem => "object" === typeof elem && null !== elem && $io0(elem)) && Object.keys(input).every(key => {
+            const value = input[key];
+            if (undefined === value)
+                return true;
+            if (RegExp(/(.*)/).test(key))
+                return "number" === typeof value && Number.isFinite(value);
+            return true;
+        });
+        return Array.isArray(input) && input.every(elem => "object" === typeof elem && null !== elem && $io0(elem));
+    };
+    if (false === __is(input))
+        ((input, _path, _exceptionable = true) => {
+            const $guard = typia_1.default.createAssert.guard;
+            const $is_custom = typia_1.default.createAssert.is_custom;
+            const $join = typia_1.default.createAssert.join;
+            const $ao0 = (input, _path, _exceptionable = true) => ((Array.isArray(input.list) && ($is_custom("memberof", "array", "MyInterface", input.list) || $guard(_exceptionable, {
+                path: _path + ".list",
+                expected: "Array (@memberof MyInterface)",
+                value: input.list
+            })) || $guard(_exceptionable, {
+                path: _path + ".list",
+                expected: "Array<MyInterface>",
+                value: input.list
+            })) && input.list.every((elem, _index2) => ("object" === typeof elem && null !== elem || $guard(_exceptionable, {
+                path: _path + ".list[" + _index2 + "]",
+                expected: "MyInterface",
+                value: elem
+            })) && $ao0(elem, _path + ".list[" + _index2 + "]", true && _exceptionable) || $guard(_exceptionable, {
+                path: _path + ".list[" + _index2 + "]",
+                expected: "MyInterface",
+                value: elem
+            })) || $guard(_exceptionable, {
+                path: _path + ".list",
+                expected: "Array<MyInterface>",
+                value: input.list
+            })) && (false === _exceptionable || Object.keys(input).every(key => {
+                const value = input[key];
+                if (undefined === value)
+                    return true;
+                if (RegExp(/(.*)/).test(key))
+                    return "number" === typeof value && Number.isFinite(value) || $guard(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "number",
+                        value: value
+                    });
+                return true;
+            }));
+            return (Array.isArray(input) || $guard(true, {
+                path: _path + "",
+                expected: "Array<MyInterface>",
+                value: input
+            })) && input.every((elem, _index1) => ("object" === typeof elem && null !== elem || $guard(true, {
+                path: _path + "[" + _index1 + "]",
+                expected: "MyInterface",
+                value: elem
+            })) && $ao0(elem, _path + "[" + _index1 + "]", true) || $guard(true, {
+                path: _path + "[" + _index1 + "]",
+                expected: "MyInterface",
+                value: elem
+            })) || $guard(true, {
+                path: _path + "",
+                expected: "Array<MyInterface>",
+                value: input
+            });
+        })(input, "$input", true);
+    return input;
+}

--- a/test/issues/704.ts
+++ b/test/issues/704.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import typia from "typia";
+
+type MyInterface = {
+    /**
+     * @type {Array<MyInterface>}
+     * @memberof MyInterface
+     */
+    list: MyInterface[];
+};
+
+const func = typia.createAssert<MyInterface[]>();
+fs.writeFileSync(__dirname + "/704.js", func.toString());

--- a/website/build/raw.js
+++ b/website/build/raw.js
@@ -70,8 +70,8 @@ const external = (container) => (props) => (lib) => {
       if (props.index) {
         write(`${lib}_index`)(`${__dirname}/../raw/${lib}/index.ts`)(
           [
-            `export * from "./${path};`,
             `import * as ${lib} from "./${path}";`,
+            `export * from "./${path}";`,
             `export default ${lib};`,
           ].join("\n"),
         );

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -21,7 +21,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "^5.1.3",
-        "typia": "latest"
+        "typia": "^4.1.3"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.1.1",
@@ -6453,9 +6453,9 @@
       }
     },
     "node_modules/typia": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-4.1.1.tgz",
-      "integrity": "sha512-TzuuAMUU3qLeyFaddfOJI0+CTXmjGpciUQMFSjVi4mmzEvFjR2lYveJvkGtq1hu4nP7nDl0WII0i3UK01/aUiA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-4.1.3.tgz",
+      "integrity": "sha512-4x9atecNJfPScW7XsVVrhNMi1MtBLcpqzIj/PVu24S6CXb3RSv8QGdpTNli24SlrqG4GPivJGS2a7zGl/48HIw==",
       "dependencies": {
         "commander": "^10.0.0",
         "comment-json": "^4.2.3",

--- a/website/package.json
+++ b/website/package.json
@@ -31,7 +31,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.1.3",
-    "typia": "latest"
+    "typia": "^4.1.3"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/website/public/sitemap-0.xml
+++ b/website/public/sitemap-0.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://typia.io/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/miscellaneous/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/playground/</loc><lastmod>2023-07-03T09:07:24.964Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/miscellaneous/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/playground/</loc><lastmod>2023-07-04T13:02:52.708Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/website/src/utils/Compiler.ts
+++ b/website/src/utils/Compiler.ts
@@ -101,10 +101,11 @@ export namespace Compiler {
   export const OPTIONS: ts.CompilerOptions = {
     target: ts.ScriptTarget.ES2015,
     module: ts.ModuleKind.CommonJS,
-    // lib: ["DOM", "ES5"],
+    lib: ["DOM", "ES5"],
     esModuleInterop: true,
+    downlevelIteration: true,
     forceConsistentCasingInFileNames: true,
     strict: true,
-    // skipLibCheck: true,
+    skipLibCheck: true,
   };
 }


### PR DESCRIPTION
When repeated type comes recurrying both Array and Object types at the same time, comment tags could not be parsed.

Fixed such bug since 4.1.3 update.
