### PR TITLE
Add `package` word on reserved keywords.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.1.5"
+    "typia": "4.1.6"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/utils/Escaper.ts
+++ b/src/utils/Escaper.ts
@@ -2,7 +2,7 @@ export namespace Escaper {
     export const variable = (str: string): boolean =>
         reserved(str) === false && /^[a-zA-Z_$][a-zA-Z_$0-9]*$/g.test(str);
 
-    const reserved = (str: string): boolean => RESERVED.has(str);
+    export const reserved = (str: string): boolean => RESERVED.has(str);
 }
 
 const RESERVED: Set<string> = new Set([
@@ -30,6 +30,7 @@ const RESERVED: Set<string> = new Set([
     "instanceof",
     "new",
     "null",
+    "package",
     "return",
     "super",
     "switch",


### PR DESCRIPTION
In TypeScript, the word `package` was one of reserved keywords that could not declare as a variable. 

Have not known it for a long time \o/.