### PR TITLE
Exact swagger generation for alias types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.1.6"
+    "typia": "4.1.7"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/factories/MetadataCollection.ts
+++ b/src/factories/MetadataCollection.ts
@@ -135,6 +135,7 @@ export class MetadataCollection {
             description: CommentFactory.description(symbol) ?? null,
             recursive: null!,
             nullables: [],
+            tags: [],
             jsDocTags: symbol.getJsDocTags() ?? [],
         });
         this.aliases_.set(type, alias);

--- a/src/factories/internal/metadata/emplace_metadata_alias.ts
+++ b/src/factories/internal/metadata/emplace_metadata_alias.ts
@@ -7,9 +7,10 @@ import { ArrayUtil } from "../../../utils/ArrayUtil";
 
 import { MetadataCollection } from "../../MetadataCollection";
 import { MetadataFactory } from "../../MetadataFactory";
+import { MetadataTagFactory } from "../../MetadataTagFactory";
 import { explore_metadata } from "./explore_metadata";
 
-export const emplace_metadata_definition =
+export const emplace_metadata_alias =
     (checker: ts.TypeChecker) =>
     (options: MetadataFactory.IOptions) =>
     (collection: MetadataCollection) =>
@@ -30,6 +31,10 @@ export const emplace_metadata_definition =
             true,
         );
         closure(value);
-
+        alias.tags.push(
+            ...MetadataTagFactory.generate(value)(alias.jsDocTags)(
+                () => alias.name,
+            ),
+        );
         return alias;
     };

--- a/src/factories/internal/metadata/iterate_metadata_alias.ts
+++ b/src/factories/internal/metadata/iterate_metadata_alias.ts
@@ -7,7 +7,7 @@ import { ArrayUtil } from "../../../utils/ArrayUtil";
 
 import { MetadataCollection } from "../../MetadataCollection";
 import { MetadataFactory } from "../../MetadataFactory";
-import { emplace_metadata_definition } from "./emplace_metadata_definition";
+import { emplace_metadata_alias } from "./emplace_metadata_alias";
 
 export const iterate_metadata_alias =
     (checker: ts.TypeChecker) =>
@@ -22,9 +22,9 @@ export const iterate_metadata_alias =
         if (node === undefined) return false;
 
         // CONSTRUCT DEFINITION
-        const alias: MetadataAlias = emplace_metadata_definition(checker)(
-            options,
-        )(collection)(type, meta.nullable);
+        const alias: MetadataAlias = emplace_metadata_alias(checker)(options)(
+            collection,
+        )(type, meta.nullable);
         ArrayUtil.add(meta.aliases, alias, (elem) => elem.name === alias.name);
         return true;
     };

--- a/src/factories/internal/metadata/iterate_metadata_collection.ts
+++ b/src/factories/internal/metadata/iterate_metadata_collection.ts
@@ -48,8 +48,8 @@ const isArrayRecursive =
             meta.arrays.some(
                 (a) => a === array || isArrayRecursive(visited)(array)(a.value),
             ) ||
-            meta.aliases.some((d) =>
-                isArrayRecursive(visited)(array)(d.value),
+            meta.aliases.some((alias) =>
+                isArrayRecursive(visited)(array)(alias.value),
             ) ||
             meta.tuples.some(
                 (t) =>
@@ -83,8 +83,8 @@ const isTupleRecursive =
             ) ||
             meta.maps.some((m) => isTupleRecursive(visited)(tuple)(m.value)) ||
             meta.sets.some((s) => isTupleRecursive(visited)(tuple)(s)) ||
-            meta.aliases.some((d) =>
-                isTupleRecursive(visited)(tuple)(d.value),
+            meta.aliases.some((alias) =>
+                isTupleRecursive(visited)(tuple)(alias.value),
             ) ||
             (meta.resolved !== null &&
                 isTupleRecursive(visited)(tuple)(meta.resolved.returns)) ||

--- a/src/metadata/IMetadataAlias.ts
+++ b/src/metadata/IMetadataAlias.ts
@@ -1,12 +1,14 @@
 import { IJsDocTagInfo } from "./IJsDocTagInfo";
 import { IMetadata } from "./IMetadata";
+import { IMetadataTag } from "./IMetadataTag";
 
 export interface IMetadataAlias {
     name: string;
     value: IMetadata;
+    nullables: boolean[];
 
     description: string | null;
+    tags: IMetadataTag[];
     jsDocTags: IJsDocTagInfo[];
     recursive: boolean;
-    nullables: boolean[];
 }

--- a/src/metadata/MetadataAlias.ts
+++ b/src/metadata/MetadataAlias.ts
@@ -2,12 +2,14 @@ import { ClassProperties } from "../typings/ClassProperties";
 
 import { IJsDocTagInfo } from "./IJsDocTagInfo";
 import { IMetadataAlias } from "./IMetadataAlias";
+import { IMetadataTag } from "./IMetadataTag";
 import { Metadata } from "./Metadata";
 
 export class MetadataAlias {
     public readonly name: string;
     public readonly value: Metadata;
     public readonly description: string | null;
+    public readonly tags: IMetadataTag[];
     public readonly jsDocTags: IJsDocTagInfo[];
     public readonly recursive: boolean;
     public readonly nullables: boolean[];
@@ -22,6 +24,7 @@ export class MetadataAlias {
         this.name = props.name;
         this.value = props.value;
         this.description = props.description;
+        this.tags = props.tags;
         this.jsDocTags = props.jsDocTags;
         this.recursive = props.recursive;
         this.nullables = props.nullables;
@@ -43,6 +46,7 @@ export class MetadataAlias {
             value: null!,
             description: props.description,
             recursive: props.recursive,
+            tags: props.tags.slice(),
             jsDocTags: props.jsDocTags.slice(),
             nullables: props.nullables.slice(),
         });
@@ -54,7 +58,8 @@ export class MetadataAlias {
             value: this.value.toJSON(),
             description: this.description,
             recursive: this.recursive,
-            jsDocTags: this.jsDocTags,
+            tags: this.tags.slice(),
+            jsDocTags: this.jsDocTags.slice(),
             nullables: this.nullables.slice(),
         };
     }

--- a/src/programmers/LiteralsProgrammer.ts
+++ b/src/programmers/LiteralsProgrammer.ts
@@ -33,13 +33,14 @@ export namespace LiteralsProgrammer {
             ...(meta.atomics.filter((type) => type === "boolean").length
                 ? [true, false]
                 : []),
-            ...meta.nullable ? [null] : []
+            ...(meta.nullable ? [null] : []),
         ]);
         return ts.factory.createAsExpression(
             ts.factory.createArrayLiteralExpression(
                 [...values].map((v) =>
-                    v === null ? ts.factory.createNull()
-                    : typeof v === "boolean"
+                    v === null
+                        ? ts.factory.createNull()
+                        : typeof v === "boolean"
                         ? v
                             ? ts.factory.createTrue()
                             : ts.factory.createFalse()

--- a/src/programmers/internal/application_alias.ts
+++ b/src/programmers/internal/application_alias.ts
@@ -1,3 +1,6 @@
+import { CommentFactory } from "../../factories/CommentFactory";
+
+import { IJsDocTagInfo } from "../../metadata/IJsDocTagInfo";
 import { MetadataAlias } from "../../metadata/MetadataAlias";
 import { IJsonComponents } from "../../schemas/IJsonComponents";
 
@@ -34,7 +37,23 @@ export const application_alias =
             // GENERATE SCHEM
             const schema: IJsonSchema = application_schema(options)(blockNever)(
                 components,
-            )(alias.value)({})!;
+            )(alias.value)({
+                deprecated:
+                    alias.jsDocTags.some((tag) => tag.name === "deprecated") ||
+                    undefined,
+                title: (() => {
+                    const info: IJsDocTagInfo | undefined =
+                        alias.jsDocTags.find((tag) => tag.name === "title");
+                    return info?.text?.length
+                        ? CommentFactory.merge(info.text)
+                        : undefined;
+                })(),
+                description: alias.description ?? undefined,
+                "x-typia-metaTags": alias.tags.length ? alias.tags : undefined,
+                "x-typia-jsDocTags": alias.jsDocTags.length
+                    ? alias.jsDocTags
+                    : undefined,
+            })!;
             components.schemas ??= {};
             components.schemas[key] = {
                 $id: options.purpose === "ajv" ? $id : undefined,

--- a/src/programmers/internal/application_object.ts
+++ b/src/programmers/internal/application_object.ts
@@ -55,7 +55,7 @@ export const application_object =
                 true,
             )(components)(property.value)({
                 deprecated:
-                    !!property.jsDocTags.find(
+                    property.jsDocTags.some(
                         (tag) => tag.name === "deprecated",
                     ) || undefined,
                 title: (() => {

--- a/test/features/literals/test_literals_WithNull.ts
+++ b/test/features/literals/test_literals_WithNull.ts
@@ -1,13 +1,8 @@
-import typia from '../../../src';
-import { _test_literals } from '../../internal/_test_literals';
-
-const areArraysEqual = <T>(a: T[], b: T[]): boolean => a.length === b.length && a.every((elem, i) => elem === b[i]);
+import typia from "../../../src";
+import { _test_literals } from "../../internal/_test_literals";
 
 export const test_literals_WithNull = _test_literals(
-    'WithNull',
-    () => 'A' as 'A' | 'B' | null,
-    (input) => {
-        const generatedArray = typia.literals<typeof input>();
-        return areArraysEqual(generatedArray, ['A', 'B', null]);
-    }
+    "WithNull",
+    () => typia.literals<"A" | "B" | null>(),
+    ["A", "B", null],
 );

--- a/test/features/literals/test_literals_WithStrings.ts
+++ b/test/features/literals/test_literals_WithStrings.ts
@@ -1,10 +1,8 @@
-import typia from '../../../src';
-import { _test_literals } from '../../internal/_test_literals';
-
-const areArraysEqual = <T>(a: T[], b: T[]): boolean => a.length === b.length && a.every((elem, i) => elem === b[i]);
+import typia from "../../../src";
+import { _test_literals } from "../../internal/_test_literals";
 
 export const test_literals_WithStrings = _test_literals(
-    'WithStrings',
-    () => 'A' as 'A' | 'B',
-    (input) => areArraysEqual(typia.literals<typeof input>(), ['A', 'B'])
+    "WithStrings",
+    () => typia.literals<"A" | "B">(),
+    ["A", "B"],
 );

--- a/test/generated/output/literals/test_literals_WithNull.ts
+++ b/test/generated/output/literals/test_literals_WithNull.ts
@@ -1,0 +1,8 @@
+import typia from "../../../../src";
+import { _test_literals } from "../../../internal/_test_literals";
+
+export const test_literals_WithNull = _test_literals(
+    "WithNull",
+    () => ["A", "B", null] as const,
+    ["A", "B", null],
+);

--- a/test/generated/output/literals/test_literals_WithStrings.ts
+++ b/test/generated/output/literals/test_literals_WithStrings.ts
@@ -1,0 +1,8 @@
+import typia from "../../../../src";
+import { _test_literals } from "../../../internal/_test_literals";
+
+export const test_literals_WithStrings = _test_literals(
+    "WithStrings",
+    () => ["A", "B"] as const,
+    ["A", "B"],
+);

--- a/test/internal/_test_literals.ts
+++ b/test/internal/_test_literals.ts
@@ -1,5 +1,16 @@
-export function _test_literals<T>(name: string, generator: () => T, validator: (input: T) => boolean): () => void {
+export function _test_literals<T>(
+    name: string,
+    generator: () => readonly T[],
+    expected: readonly T[],
+): () => void {
     return () => {
-        if (validator(generator()) === false) throw new Error(`Bug on typia.literals() for ${ name }: array is different than expected`);
+        const result: readonly T[] = generator();
+        if (
+            result.length !== expected.length ||
+            result.some((elem, i) => elem !== expected[i])
+        )
+            throw new Error(
+                `Bug on typia.literals() for ${name}: array is different than expected`,
+            );
     };
 }

--- a/test/issues/literals.ts
+++ b/test/issues/literals.ts
@@ -1,5 +1,3 @@
 import typia from "typia";
 
-console.log(
-    typia.literals<"A"|"B"|3|false|null>()
-)
+console.log(typia.literals<"A" | "B" | 3 | false | null>());

--- a/test/issues/tag.ts
+++ b/test/issues/tag.ts
@@ -1,39 +1,21 @@
-import typia, { IJsonComponents } from "typia";
+import fs from "fs";
+import typia from "typia";
 
-interface Something {
-    /**
-     * @type {int}
-     */
-    int: number;
+/**
+ * @minimum 3
+ * @maximum 7
+ * @format uuid
+ */
+type MyAlias = number | string;
 
+interface MyObject {
     /**
-     * @type {uint}
+     * @minimum 3
+     * @maximum 7
+     * @format uuid
      */
-    uint: number;
+    value: string | number;
 }
 
-// console.log(
-//     typia
-//         .metadata<[Something]>()
-//         .collection.objects[0].properties.map((p) =>
-//             JSON.stringify([p.tags, p.jsDocTags], null, 4),
-//         ),
-// );
-
-const props = Object.values(
-    (
-        typia.application<[Something]>().components.schemas
-            ?.Something as IJsonComponents.IObject
-    ).properties!,
-);
-console.log(
-    JSON.stringify(
-        props.map((p) => [
-            (p as any).type,
-            p["x-typia-metaTags"],
-            p["x-typia-jsDocTags"],
-        ]),
-        null,
-        4,
-    ),
-);
+const app = typia.application<[MyAlias, MyObject]>();
+fs.writeFileSync(__dirname + "/tag.json", JSON.stringify(app, null, 4), "utf8");


### PR DESCRIPTION
When alias type has comment tags, previous `typia` could not catch it when generating JSON schema. 

Therefore, I fixed it and published the new patch version `4.1.7`.

```typescript
/**
 * @minimum 3
 * @maximum 7
 * @format uuid
 */
type MyAlias = number | string;
```