### PR TITLE
Complement #726 - `JSDocParameterTag` case.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.1.10"
+    "typia": "4.1.11"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/factories/CommentFactory.ts
+++ b/src/factories/CommentFactory.ts
@@ -66,8 +66,11 @@ export namespace CommentFactory {
 }
 
 const parseJSDocTag = (tag: ts.JSDocTag): string => {
+    const name: string | undefined = (
+        tag as ts.JSDocParameterTag
+    ).name?.getText();
     const parsed: string | undefined = ts.getTextOfJSDocComment(tag.comment);
-    return parsed?.length
-        ? `@${tag.tagName.text} ${parsed}`
-        : `@${tag.tagName.text}`;
+    return [`@${tag.tagName.text}`, name, parsed]
+        .filter((str) => !!str?.length)
+        .join(" ");
 };

--- a/test/issues/comment-function.ts
+++ b/test/issues/comment-function.ts
@@ -1,0 +1,19 @@
+import typia from "typia";
+
+export interface IWrapper {
+    /**
+     * Compute two variables.
+     *
+     * @param x The first value
+     * @param y The second value
+     * @returns The result of computation
+     */
+    compute: (x: number, y: number) => number;
+}
+
+const article = typia.metadata<[IWrapper]>().collection.objects[0];
+
+console.log(
+    article.properties.find((p) => p.key.constants[0]?.values[0] === "compute")
+        ?.description,
+);


### PR DESCRIPTION
New JSDoc API of TypeScript 5.1 is so difficult than expected.

Maybe there will be a few more patches after that.