### PR TITLE
Fix #734 - union type predicator broken when native type like `Date`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.1.13",
+  "version": "4.1.14",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.1.13",
+  "version": "4.1.14",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.1.13"
+    "typia": "4.1.14"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/metadata/Metadata.ts
+++ b/src/metadata/Metadata.ts
@@ -363,6 +363,11 @@ export namespace Metadata {
         if (x.objects.length && y.objects.length) return true;
         if (x.aliases.length && y.aliases.length) return true;
 
+        // NATIVES
+        if (x.natives.length && y.natives.length)
+            if (x.natives.some((xn) => y.natives.some((yn) => xn === yn)))
+                return true;
+
         //----
         // VALUES
         //----

--- a/test/features/issues/test_issue_native_union_property.ts
+++ b/test/features/issues/test_issue_native_union_property.ts
@@ -1,0 +1,28 @@
+import typia from "typia";
+
+type A = {
+    createdAt: Date;
+    value: number;
+};
+type B = {
+    createdAt: Date;
+    value: string;
+};
+type AB = A | B;
+
+export const test_issue_native_union_property = () => {
+    const matched: boolean[] = [
+        {
+            createdAt: new Date(),
+            value: 10,
+        },
+        {
+            createdAt: new Date(),
+            value: "test",
+        },
+    ].map((input) => typia.is<AB>(input));
+    if (matched.some((v) => v === false))
+        throw new Error(
+            "Bug on typia.is: failed to understand the native union property.",
+        );
+};

--- a/test/generated/output/issues/test_issue_native_union_property.ts
+++ b/test/generated/output/issues/test_issue_native_union_property.ts
@@ -1,0 +1,27 @@
+import typia from "typia";
+
+type A = {
+    createdAt: Date;
+    value: number;
+};
+type B = {
+    createdAt: Date;
+    value: string;
+};
+type AB = A | B;
+export const test_issue_native_union_property = () => {
+    const matched: boolean[] = [
+        {
+            createdAt: new Date(),
+            value: 10,
+        },
+        {
+            createdAt: new Date(),
+            value: "test",
+        },
+    ].map((input) => typia.is<AB>(input));
+    if (matched.some((v) => v === false))
+        throw new Error(
+            "Bug on typia.is: failed to understand the native union property.",
+        );
+};

--- a/test/issues/native-union-property.ts
+++ b/test/issues/native-union-property.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+type A = {
+    createdAt: Date;
+    value: number;
+};
+type B = {
+    createdAt: Date;
+    value: string;
+};
+type AB = A | B;
+
+console.log(typia.createIs<AB>().toString());

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -21,7 +21,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "5.1.6",
-        "typia": "^4.1.12"
+        "typia": "^4.1.14"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.1.1",
@@ -5763,9 +5763,9 @@
       }
     },
     "node_modules/typia": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-4.1.12.tgz",
-      "integrity": "sha512-uRz1g6QtITc8Ibr0Si6uDmur2FjYFJP+z2+hqt1L1YUb3jp9a4FtMd1eVPj7Sa2awXj9fdEboi4OXaFFg35nWg==",
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-4.1.14.tgz",
+      "integrity": "sha512-/YxlOogdO9JyzfzxdO9w9ivUWCiuyIRIZdaWZiBs0lG1T7BTdbjKvKlVEnkUQxPKP6TUVKqXMW+GmVBfbzCtJw==",
       "dependencies": {
         "commander": "^10.0.0",
         "comment-json": "^4.2.3",

--- a/website/package.json
+++ b/website/package.json
@@ -31,7 +31,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "5.1.6",
-    "typia": "^4.1.12"
+    "typia": "^4.1.14"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/website/public/sitemap-0.xml
+++ b/website/public/sitemap-0.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://typia.io/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/miscellaneous/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/playground/</loc><lastmod>2023-07-31T08:47:27.998Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/miscellaneous/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/playground/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
Fixed that bug, and new version is `4.1.14`.

The bug had been occured by ommission of native types in intersection algorithm of `Metadata`.