### PR TITLE
Fix #736 - bug of undefined `length` problem.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.1.15",
+  "version": "4.1.16",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.1.15",
+  "version": "4.1.16",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.1.15"
+    "typia": "4.1.16"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/functional/$string.ts
+++ b/src/functional/$string.ts
@@ -13,7 +13,9 @@
  */
 export const $string = (str: string): string => {
     if (STR_ESCAPE.test(str) === false) return `"${str}"`;
-    if (str.length > 41) return JSON.stringify(str);
+
+    const length: number = str.length;
+    if (length > 41) return JSON.stringify(str);
 
     let result = "";
     let last = -1;

--- a/test/features/issues/test_issue_long_string_stringify.ts
+++ b/test/features/issues/test_issue_long_string_stringify.ts
@@ -1,0 +1,14 @@
+import typia from "typia";
+
+import { RandomGenerator } from "typia/lib/utils/RandomGenerator";
+
+export const test_issue_long_string_stringify = (): void => {
+    const str: string = RandomGenerator.string(1000);
+    const stringified: string = typia.stringify(str);
+    const decoded: string = JSON.parse(stringified);
+
+    if (str !== decoded)
+        throw new Error(
+            `Bug on typia.stringify(): failed to stringify long string.`,
+        );
+};

--- a/test/generated/output/issues/test_issue_long_string_stringify.ts
+++ b/test/generated/output/issues/test_issue_long_string_stringify.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+import { RandomGenerator } from "typia/lib/utils/RandomGenerator";
+
+export const test_issue_long_string_stringify = (): void => {
+    const str: string = RandomGenerator.string(1000);
+    const stringified: string = typia.stringify(str);
+    const decoded: string = JSON.parse(stringified);
+    if (str !== decoded)
+        throw new Error(
+            `Bug on typia.stringify(): failed to stringify long string.`,
+        );
+};


### PR DESCRIPTION
Global variable `length` exists in DOM, and did a mistake to use the global variable `length` instead of using `String.length` property.