### PR TITLE
Fix #737 - remove cursing from random any type

### DIFF
--- a/src/programmers/RandomProgrammer.ts
+++ b/src/programmers/RandomProgrammer.ts
@@ -220,7 +220,7 @@ export namespace RandomProgrammer {
             if (meta.any)
                 expressions.push(
                     ts.factory.createStringLiteral(
-                        "fucking any type exists...",
+                        "any type used...",
                     ),
                 );
 

--- a/test/generated/output/createRandom/test_createRandom_ArrayAny.ts
+++ b/test/generated/output/createRandom/test_createRandom_ArrayAny.ts
@@ -14,34 +14,34 @@ export const test_createRandom_ArrayAny = _test_random(
             _depth: number = 0,
         ): any => ({
             anys: (generator?.array ?? $generator.array)(
-                () => "fucking any type exists...",
+                () => "any type used...",
             ),
             undefindable1: $pick([
                 () => undefined,
                 () =>
                     (generator?.array ?? $generator.array)(
-                        () => "fucking any type exists...",
+                        () => "any type used...",
                     ),
             ])(),
             undefindable2: $pick([
                 () => undefined,
                 () =>
                     (generator?.array ?? $generator.array)(
-                        () => "fucking any type exists...",
+                        () => "any type used...",
                     ),
             ])(),
             nullables1: $pick([
                 () => null,
                 () =>
                     (generator?.array ?? $generator.array)(
-                        () => "fucking any type exists...",
+                        () => "any type used...",
                     ),
             ])(),
             nullables2: $pick([
                 () => null,
                 () =>
                     (generator?.array ?? $generator.array)(
-                        () => "fucking any type exists...",
+                        () => "any type used...",
                     ),
             ])(),
             both1: $pick([
@@ -49,7 +49,7 @@ export const test_createRandom_ArrayAny = _test_random(
                 () => null,
                 () =>
                     (generator?.array ?? $generator.array)(
-                        () => "fucking any type exists...",
+                        () => "any type used...",
                     ),
             ])(),
             both2: $pick([
@@ -57,7 +57,7 @@ export const test_createRandom_ArrayAny = _test_random(
                 () => null,
                 () =>
                     (generator?.array ?? $generator.array)(
-                        () => "fucking any type exists...",
+                        () => "any type used...",
                     ),
             ])(),
             both3: $pick([
@@ -65,11 +65,11 @@ export const test_createRandom_ArrayAny = _test_random(
                 () => null,
                 () =>
                     (generator?.array ?? $generator.array)(
-                        () => "fucking any type exists...",
+                        () => "any type used...",
                     ),
             ])(),
             union: (generator?.array ?? $generator.array)(
-                () => "fucking any type exists...",
+                () => "any type used...",
             ),
         });
         return $ro0();

--- a/test/generated/output/createRandom/test_createRandom_ObjectUndefined.ts
+++ b/test/generated/output/createRandom/test_createRandom_ObjectUndefined.ts
@@ -36,7 +36,7 @@ export const test_createRandom_ObjectUndefined = _test_random(
                     (generator?.number ?? $generator.number)(0, 100),
             ])(),
             nothing: undefined,
-            unknown: "fucking any type exists...",
+            unknown: "any type used...",
             never: undefined,
         });
         const $ro1 = (

--- a/test/generated/output/random/test_random_ArrayAny.ts
+++ b/test/generated/output/random/test_random_ArrayAny.ts
@@ -15,34 +15,34 @@ export const test_random_ArrayAny = _test_random(
                 _depth: number = 0,
             ): any => ({
                 anys: (generator?.array ?? $generator.array)(
-                    () => "fucking any type exists...",
+                    () => "any type used...",
                 ),
                 undefindable1: $pick([
                     () => undefined,
                     () =>
                         (generator?.array ?? $generator.array)(
-                            () => "fucking any type exists...",
+                            () => "any type used...",
                         ),
                 ])(),
                 undefindable2: $pick([
                     () => undefined,
                     () =>
                         (generator?.array ?? $generator.array)(
-                            () => "fucking any type exists...",
+                            () => "any type used...",
                         ),
                 ])(),
                 nullables1: $pick([
                     () => null,
                     () =>
                         (generator?.array ?? $generator.array)(
-                            () => "fucking any type exists...",
+                            () => "any type used...",
                         ),
                 ])(),
                 nullables2: $pick([
                     () => null,
                     () =>
                         (generator?.array ?? $generator.array)(
-                            () => "fucking any type exists...",
+                            () => "any type used...",
                         ),
                 ])(),
                 both1: $pick([
@@ -50,7 +50,7 @@ export const test_random_ArrayAny = _test_random(
                     () => null,
                     () =>
                         (generator?.array ?? $generator.array)(
-                            () => "fucking any type exists...",
+                            () => "any type used...",
                         ),
                 ])(),
                 both2: $pick([
@@ -58,7 +58,7 @@ export const test_random_ArrayAny = _test_random(
                     () => null,
                     () =>
                         (generator?.array ?? $generator.array)(
-                            () => "fucking any type exists...",
+                            () => "any type used...",
                         ),
                 ])(),
                 both3: $pick([
@@ -66,11 +66,11 @@ export const test_random_ArrayAny = _test_random(
                     () => null,
                     () =>
                         (generator?.array ?? $generator.array)(
-                            () => "fucking any type exists...",
+                            () => "any type used...",
                         ),
                 ])(),
                 union: (generator?.array ?? $generator.array)(
-                    () => "fucking any type exists...",
+                    () => "any type used...",
                 ),
             });
             return $ro0();

--- a/test/generated/output/random/test_random_ObjectUndefined.ts
+++ b/test/generated/output/random/test_random_ObjectUndefined.ts
@@ -40,7 +40,7 @@ export const test_random_ObjectUndefined = _test_random(
                         ) ?? (generator?.number ?? $generator.number)(0, 100),
                 ])(),
                 nothing: undefined,
-                unknown: "fucking any type exists...",
+                unknown: "any type used...",
                 never: undefined,
             });
             const $ro1 = (


### PR DESCRIPTION
Removes cursing from the result of a generated `any` type as discussed in the related issue.