### PR TITLE
Fix #744 - change setup wizard to deprecate `yarn berry`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.1.16",
+  "version": "4.2.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -128,7 +128,7 @@
     "zod": "^3.19.1"
   },
   "stackblitzs": {
-    "startCommand": "npm run prepare && npm run build && npm run build:test && npm run test"
+    "startCommand": "npm run postinstall && npm run build && npm run build:test && npm run test"
   },
   "files": [
     "LICENSE",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.1.16",
+  "version": "4.2.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,13 +68,13 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.1.16"
+    "typia": "4.2.0"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"
   },
   "stackblitzs": {
-    "startCommand": "npm run prepare && npm run build && npm run build:test && npm run test"
+    "startCommand": "npm run postinstall && npm run build && npm run build:test && npm run test"
   },
   "files": [
     "LICENSE",

--- a/src/executable/setup/CommandExecutor.ts
+++ b/src/executable/setup/CommandExecutor.ts
@@ -3,6 +3,7 @@ import cp from "child_process";
 export namespace CommandExecutor {
     export const run = (str: string): void => {
         console.log(str);
-        cp.execSync(str, { stdio: "ignore" });
+        cp.execSync(str, { stdio: "inherit" });
+        // @todo - rollback to ignore
     };
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -21,7 +21,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "5.1.6",
-        "typia": "^4.1.14"
+        "typia": "^4.2.0"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.1.1",
@@ -5763,9 +5763,9 @@
       }
     },
     "node_modules/typia": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-4.1.14.tgz",
-      "integrity": "sha512-/YxlOogdO9JyzfzxdO9w9ivUWCiuyIRIZdaWZiBs0lG1T7BTdbjKvKlVEnkUQxPKP6TUVKqXMW+GmVBfbzCtJw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-4.2.0.tgz",
+      "integrity": "sha512-ya3IvCsBVbTRVjnMa50glQBZO75ztuOXnMmlY3iRgY+iKtEIfQnhutuQ09RdQSQKDsCH4IK1zj+HWlncTxXhQw==",
       "dependencies": {
         "commander": "^10.0.0",
         "comment-json": "^4.2.3",

--- a/website/package.json
+++ b/website/package.json
@@ -31,7 +31,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "5.1.6",
-    "typia": "^4.1.14"
+    "typia": "^4.2.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -5,10 +5,27 @@ import AlertTitle from '@mui/material/AlertTitle';
 
 # Setup
 ## Summary
+<Tabs items={['npm', 'pnpm', 'yarn']}>
+    <Tab>
 ```bash filename="Terminal" showLineNumbers copy
 npm install typia
 npx typia setup
 ```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" showLineNumbers copy
+pnpm install typia
+pnpm typia setup
+```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" showLineNumbers copy
+# YARN BERRY IS NOT SUPPORTED
+yarn add typia
+yarn typia setup --manager yarn
+```
+    </Tab>
+</Tabs>
 
 If you're using standard TypeScript compiler, you can use [transform mode](#transformation).
 
@@ -16,6 +33,8 @@ Just run `npx typia setup` command, then everything be prepared.
 
   - Standard TypeScript Compiler: [Microsoft/TypeScript](https://github.com/microsoft/typescript)
 
+<Tabs items={['npm', 'pnpm', 'yarn']}>
+    <Tab>
 ```bash filename="Terminal" showLineNumbers copy
 npm install typia
 npm install --save-dev typescript
@@ -25,6 +44,30 @@ npx typia generate \
     --output src/generated \
     --project tsconfig.json
 ```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" showLineNumbers copy
+pnpm install typia
+pnpm install --save-dev typescript
+
+pnpm typia generate \
+    --input src/templates \
+    --output src/generated \
+    --project tsconfig.json
+```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" showLineNumbers copy
+yarn add typia
+yarn add -D typescript
+
+yarn typia generate \
+    --input src/templates \
+    --output src/generated \
+    --project tsconfig.json
+```
+    </Tab>
+</Tabs>
 
 Otherwise you are using non-standard TypeScript compiler, then you can't use [transformation](#transformation) mode. 
 
@@ -93,20 +136,54 @@ export const check = input => {
 </Tabs>
 
 ### Setup Wizard
+<Tabs items={['npm', 'pnpm', 'yarn']}>
+    <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 npm install --save typia
 npx typia setup
 ```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" copy showLineNumbers
+pnpm install --save typia
+pnpm typia setup
+```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" copy showLineNumbers
+# YARN BERRY IS NOT SUPPORTED
+yarn add typia
+yarn typia setup
+```
+    </Tab>
+</Tabs>
 
 You can turn on transformation mode just by running `npx typia setup` command.
 
 Setup wizard would be executed, and it will do everything for the transformation.
 
 ### Manual Setup
+<Tabs items={['npm', 'pnpm', 'yarn']}>
+    <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 npm install --save typia
 npm install --save-dev typescript ts-patch ts-node
 ```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" copy showLineNumbers
+pnpm install --save typia
+pnpm install --save-dev typescript ts-patch ts-node
+```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" copy showLineNumbers
+# YARN BERRY IS NOT SUPPORTED
+yarn add typia
+yarn add -D typescript ts-patch ts-node
+```
+    </Tab>
+</Tabs>
 
 If you want to install `typia` manually, just follow the steps.
 
@@ -131,7 +208,7 @@ As `typia` generates optimal operation code through transformation, you've to co
 ```json filename="package.json" copy showLineNumbers {2-4}
 {
   "scripts": {
-    "prepare": "ts-patch install"
+    "postinstall": "ts-patch install"
   },
   "dependencies": {
     "typia": "^4.1.8"
@@ -144,13 +221,28 @@ As `typia` generates optimal operation code through transformation, you've to co
 }
 ```
 
+<Tabs items={['npm', 'pnpm', 'yarn']}>
+    <Tab>
 ```bash filename="Terminal" copy showLineNumbers
-npm run prepare
+npm run postinstall
 ```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" copy showLineNumbers
+pnpm postinstall
+```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" copy showLineNumbers
+# YARN BERRY IS NOT SUPPORTED
+yarn postinstall
+```
+    </Tab>
+</Tabs>
 
-At last, open `package.json` file and configure `npm run prepare` command like above. 
+At last, open `package.json` file and configure `npm run postinstall` command like above.
 
-Of course, you've to run the `npm run prepare` command after the configuration. 
+Of course, you've to run the `npm run postinstall` command after the configuration. 
 
 For reference, [`ts-patch`](https://github.com/nonara/ts-patch) is an helper library of TypeScript compiler that supporting custom transformations by plugins. From now on, whenever you run `tsc` command, your `typia` function call statements would be transformed to the optimal operation codes in the compiled JavaScript files.
 
@@ -158,6 +250,8 @@ For reference, [`ts-patch`](https://github.com/nonara/ts-patch) is an helper lib
 
 
 ## Generation
+<Tabs items={['npm', 'pnpm', 'yarn']}>
+    <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 # INSTALL TYPIA
 npm install --save typia
@@ -169,6 +263,34 @@ npx typia generate \
     --output src/generated \
     --project tsconfig.json
 ```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" copy showLineNumbers
+# INSTALL TYPIA
+pnpm install --save typia
+pnpm install --save-dev typescript
+
+# GENERATE TRANSFORMED TYPESCRIPT CODES
+pnpm typia generate \
+    --input src/templates \
+    --output src/generated \
+    --project tsconfig.json
+```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" copy showLineNumbers
+# INSTALL TYPIA
+yarn add typia
+yarn add -D typescript
+
+# GENERATE TRANSFORMED TYPESCRIPT CODES
+yarn typia generate \
+    --input src/templates \
+    --output src/generated \
+    --project tsconfig.json
+```
+    </Tab>
+</Tabs>
 
 For frontend projects.
 
@@ -253,6 +375,8 @@ export default defineConfig({
 
 
 ## Webpack
+<Tabs items={['npm', 'pnpm', 'yarn']}>
+    <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 # TYPIA
 npm install typia
@@ -262,6 +386,33 @@ npx typia setup
 npm install --save-dev ts-loader
 npm install --save-dev webpack webpack-cli
 ```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" copy showLineNumbers
+# TYPIA
+pnpm install typia
+pnpm typia setup
+
+# WEBPACK + TS-LOADER
+pnpm install --save-dev ts-loader
+pnpm install --save-dev webpack webpack-cli
+```
+    </Tab>
+    <Tab>
+```bash filename="Terminal" copy showLineNumbers
+##############################
+# YARN BERRY IS NOT SUPPORTED
+##############################
+# TYPIA
+yarn add typia
+yarn typia setup
+
+# WEBPACK + TS-LOADER
+yarn add -D ts-loader
+yarn add -D webpack webpack-cli
+```
+    </Tab>
+</Tabs>
 
 When you're using `webpack` as a bundler, you can still utilize the [transformation](#transformation) mode.
 

--- a/website/public/sitemap-0.xml
+++ b/website/public/sitemap-0.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://typia.io/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/miscellaneous/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/playground/</loc><lastmod>2023-08-02T09:01:58.728Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/miscellaneous/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/playground/</loc><lastmod>2023-08-07T08:56:20.582Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
Thanks to @enyineer for reporting.

  - Changed setup wizard
  - Introduce not to support `yarn berry`
  - Use `npm run postinstall` command instead

Unfortunately, `ts-patch` does not support `yarn berry`. Therefore, it is not possible to use transform mode of `typia` in the `yarn berry`. Therefore, to inform it and recommend not to use `yarn berry` in `typia`, I've changed setup wizard program. This change would be rolled back when `ts-patch` starts supporting the `yarn berry`.

Also, `yarn berry` does not support the `npm run prepare` command. I think this nonsensible story because the `npm run prepare` command is a standard feature of NPM, but this is the reality, so I can't help it. By the way, if `ts-patch` starts supporting `yarn berry`, configuring `npm run prepare` command by setup wizard can be a big problem. So, I've changed setup wizard to use `npm run postinstall` command instead of the previous `npm run prepare` command.